### PR TITLE
Replace Tool by StructuredTool in tool_executor.ts

### DIFF
--- a/langgraph/src/prebuilt/chat_agent_executor.ts
+++ b/langgraph/src/prebuilt/chat_agent_executor.ts
@@ -1,4 +1,4 @@
-import { Tool } from "@langchain/core/tools";
+import { StructuredTool } from "@langchain/core/tools";
 import { convertToOpenAIFunction } from "@langchain/core/utils/function_calling";
 import { AgentAction } from "@langchain/core/agents";
 import { FunctionMessage, BaseMessage } from "@langchain/core/messages";
@@ -14,10 +14,10 @@ export function createFunctionCallingExecutor<Model extends object>({
   tools,
 }: {
   model: Model;
-  tools: Array<Tool> | ToolExecutor;
+  tools: Array<StructuredTool> | ToolExecutor;
 }) {
   let toolExecutor: ToolExecutor;
-  let toolClasses: Array<Tool>;
+  let toolClasses: Array<StructuredTool>;
   if (!Array.isArray(tools)) {
     toolExecutor = tools;
     toolClasses = tools.tools;

--- a/langgraph/src/prebuilt/tool_executor.ts
+++ b/langgraph/src/prebuilt/tool_executor.ts
@@ -3,12 +3,12 @@ import {
   RunnableConfig,
   RunnableLambda,
 } from "@langchain/core/runnables";
-import { Tool } from "@langchain/core/tools";
+import { StructuredTool } from "@langchain/core/tools";
 
 const INVALID_TOOL_MSG_TEMPLATE = `{requestedToolName} is not a valid tool, try one of [availableToolNamesString].`;
 
 export interface ToolExecutorArgs {
-  tools: Array<Tool>;
+  tools: Array<StructuredTool>;
   /**
    * @default {INVALID_TOOL_MSG_TEMPLATE}
    */
@@ -35,9 +35,9 @@ export class ToolExecutor extends RunnableBinding<
 > {
   lc_graph_name = "ToolExecutor";
 
-  tools: Array<Tool>;
+  tools: Array<StructuredTool>;
 
-  toolMap: Record<string, Tool>;
+  toolMap: Record<string, StructuredTool>;
 
   invalidToolMsgTemplate: string;
 
@@ -61,7 +61,7 @@ export class ToolExecutor extends RunnableBinding<
     this.toolMap = this.tools.reduce((acc, tool) => {
       acc[tool.name] = tool;
       return acc;
-    }, {} as Record<string, Tool>);
+    }, {} as Record<string, StructuredTool>);
   }
 
   async _execute(


### PR DESCRIPTION
<!--
Thank you for contributing to LangGraph.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langgraphjs/blob/main/CONTRIBUTING.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

Because the `Tool` abstract class extends the `StructuredTool` abstract class, using a `DynamicStructuredTool` would not be usable in the `ToolExecutor`.

https://api.js.langchain.com/classes/langchain_core_tools.StructuredTool.html 

Fixes #40 

~~**Note:** I did not clone the repo locally or tested that.~~