### PR TITLE
pass RunnableConfig in ToolExecutor tool.invoke

### DIFF
--- a/langgraph/src/prebuilt/tool_executor.ts
+++ b/langgraph/src/prebuilt/tool_executor.ts
@@ -66,7 +66,7 @@ export class ToolExecutor extends RunnableBinding<
 
   async _execute(
     toolInvocation: ToolInvocationInterface,
-    _config?: RunnableConfig
+    config?: RunnableConfig
   ): Promise<string> {
     if (!(toolInvocation.tool in this.toolMap)) {
       return this.invalidToolMsgTemplate
@@ -77,7 +77,7 @@ export class ToolExecutor extends RunnableBinding<
         );
     } else {
       const tool = this.toolMap[toolInvocation.tool];
-      const output = await tool.invoke(toolInvocation.toolInput);
+      const output = await tool.invoke(toolInvocation.toolInput, config);
       return output;
     }
   }


### PR DESCRIPTION
noticed this was missing causing missing nested Traces in Langsmith

Fixes # https://github.com/langchain-ai/langgraphjs/issues/44
