### PR TITLE
fix: default INVALID_TOOL_MSG_TEMPLATE

### DIFF
--- a/langgraph/src/prebuilt/tool_executor.ts
+++ b/langgraph/src/prebuilt/tool_executor.ts
@@ -5,7 +5,7 @@ import {
 } from "@langchain/core/runnables";
 import { StructuredTool } from "@langchain/core/tools";
 
-const INVALID_TOOL_MSG_TEMPLATE = `{requestedToolName} is not a valid tool, try one of [availableToolNamesString].`;
+const INVALID_TOOL_MSG_TEMPLATE = `{requestedToolName} is not a valid tool, try one of {availableToolNamesString}.`;
 
 export interface ToolExecutorArgs {
   tools: Array<StructuredTool>;


### PR DESCRIPTION
The default template in tool_executor is incorrect and has not properly replaced availableToolNamesString.
