### PR TITLE
Added "should handle checkpoints correctly" Unit Tests + Fix 2 Bugs That Were Preventing Them From Passing

### DIFF
--- a/langgraph/src/channels/base.ts
+++ b/langgraph/src/channels/base.ts
@@ -93,7 +93,7 @@ export async function createCheckpoint<Value>(
       newCheckpoint.channelValues[k] = await channels[k].checkpoint();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
-      if ("name" in error && error.name === EmptyChannelError.name) {
+      if (error.name === EmptyChannelError.name) {
         // no-op
       } else {
         throw error; // Rethrow unexpected errors

--- a/langgraph/src/channels/base.ts
+++ b/langgraph/src/channels/base.ts
@@ -89,16 +89,16 @@ export async function createCheckpoint<Value>(
     versionsSeen: { ...checkpoint.versionsSeen },
   };
   for (const k of Object.keys(channels)) {
-      try {
-        newCheckpoint.channelValues[k] = await channels[k].checkpoint();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (error: any) {
-        if ("name" in error && error.name === EmptyChannelError.name) {
-          // no-op
-        } else {
-          throw error; // Rethrow unexpected errors
-        }
+    try {
+      newCheckpoint.channelValues[k] = await channels[k].checkpoint();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      if ("name" in error && error.name === EmptyChannelError.name) {
+        // no-op
+      } else {
+        throw error; // Rethrow unexpected errors
       }
+    }
   }
   return newCheckpoint;
 }

--- a/langgraph/src/channels/base.ts
+++ b/langgraph/src/channels/base.ts
@@ -88,8 +88,7 @@ export async function createCheckpoint<Value>(
     channelVersions: { ...checkpoint.channelVersions },
     versionsSeen: { ...checkpoint.versionsSeen },
   };
-  for (const k in channels) {
-    if (newCheckpoint.channelValues[k] === undefined) {
+  for (const k of Object.keys(channels)) {
       try {
         newCheckpoint.channelValues[k] = await channels[k].checkpoint();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -100,7 +99,6 @@ export async function createCheckpoint<Value>(
           throw error; // Rethrow unexpected errors
         }
       }
-    }
   }
   return newCheckpoint;
 }

--- a/langgraph/src/channels/binop.ts
+++ b/langgraph/src/channels/binop.ts
@@ -29,11 +29,14 @@ export class BinaryOperatorAggregate<Value> extends BaseChannel<
     this.value = initialValueFactory?.();
   }
 
-  public empty(_?: Value): BinaryOperatorAggregate<Value> {
+  public empty(checkpoint?: Value): BinaryOperatorAggregate<Value> {
     const empty = new BinaryOperatorAggregate(
       this.operator,
       this.initialValueFactory
     );
+    if (checkpoint) {
+      empty.value = checkpoint;
+    }
     return empty;
   }
 
@@ -61,7 +64,7 @@ export class BinaryOperatorAggregate<Value> extends BaseChannel<
   }
 
   public checkpoint(): Value {
-    if (!this.value) {
+    if (this.value === undefined) {
       throw new EmptyChannelError();
     }
     return this.value;

--- a/langgraph/src/tests/pregel.test.ts
+++ b/langgraph/src/tests/pregel.test.ts
@@ -205,7 +205,6 @@ it("should invoke two processes and get correct output", async () => {
   }
 });
 
-
 // API is not yet implemented. Implement test once Nuno finishes on PY side.
 // it.skip("should modify inbox value and get different output", async () => {
 //   const addOne = jest.fn((x: number): number => x + 1);

--- a/langgraph/src/tests/pregel.test.ts
+++ b/langgraph/src/tests/pregel.test.ts
@@ -205,6 +205,36 @@ it("should invoke two processes and get correct output", async () => {
   }
 });
 
+
+// API is not yet implemented. Implement test once Nuno finishes on PY side.
+// it.skip("should modify inbox value and get different output", async () => {
+//   const addOne = jest.fn((x: number): number => x + 1);
+
+//   const one = Channel.subscribeTo("input")
+//     .pipe(addOne)
+//     .pipe(Channel.writeTo("inbox"));
+//   const two = Channel.subscribeTo("inbox")
+//     .pipe(addOne)
+//     .pipe(Channel.writeTo("output"));
+
+//   const app = new Pregel({
+//     nodes: { one, two },
+//   });
+
+//   let step = 0;
+//   for await (const values of await app.stream(2)) {
+//     if (step === 0) {
+//       expect(values).toEqual({ inbox: 3 });
+//       // modify inbox value
+//       // values.inbox = 5;
+//     } else if (step === 1) {
+//       // output is different now
+//       expect(values).toEqual({ output: 6 });
+//     }
+//     step += 1;
+//   }
+// });
+
 it("should process two processes with object input and output", async () => {
   const addOne = jest.fn((x: number): number => x + 1);
   const one = Channel.subscribeTo("input")

--- a/langgraph/src/tests/pregel.test.ts
+++ b/langgraph/src/tests/pregel.test.ts
@@ -205,35 +205,6 @@ it("should invoke two processes and get correct output", async () => {
   }
 });
 
-// API is not yet implemented. Implement test once Nuno finishes on PY side.
-// it.skip("should modify inbox value and get different output", async () => {
-//   const addOne = jest.fn((x: number): number => x + 1);
-
-//   const one = Channel.subscribeTo("input")
-//     .pipe(addOne)
-//     .pipe(Channel.writeTo("inbox"));
-//   const two = Channel.subscribeTo("inbox")
-//     .pipe(addOne)
-//     .pipe(Channel.writeTo("output"));
-
-//   const app = new Pregel({
-//     nodes: { one, two },
-//   });
-
-//   let step = 0;
-//   for await (const values of await app.stream(2)) {
-//     if (step === 0) {
-//       expect(values).toEqual({ inbox: 3 });
-//       // modify inbox value
-//       // values.inbox = 5;
-//     } else if (step === 1) {
-//       // output is different now
-//       expect(values).toEqual({ output: 6 });
-//     }
-//     step += 1;
-//   }
-// });
-
 it("should process two processes with object input and output", async () => {
   const addOne = jest.fn((x: number): number => x + 1);
   const one = Channel.subscribeTo("input")

--- a/langgraph/src/tests/pregel.test.ts
+++ b/langgraph/src/tests/pregel.test.ts
@@ -386,7 +386,7 @@ it("should process two inputs to two outputs validly", async () => {
   expect(await app.invoke(2)).toEqual([3, 3]);
 });
 
-it.skip("should handle checkpoints correctly", async () => {
+it("should handle checkpoints correctly", async () => {
   const addOne = jest.fn(
     (x: { total: number; input: number }): number => x.total + x.input
   );


### PR DESCRIPTION
The `should handle checkpoints correctly` unit test was initially skipped because it didn't pass. 
This PR fixes the two bugs that were preventing it from passing. 

1. `BinaryOperatorAggregate` Channel did not implement `empty()` (aka - snapshot) correctly. The issue was that the old checkpoint's value was not being saved as the initial value leading to a lossy channel that stored state in correctly 

2. `Checkpoint` was not implemented correctly, because it would only update the checkpoint's channel value if it had never been set before. Updated the code such that it _always_ update's the checkpoint value based on the latest channel value 

Now that these have been fixed, add the checkpointing test back in!