### PR TITLE
Adds Documentation about Channels, Checkpoints, and Pregel Graphs to `CONTRIBUTING.md`

### DIFF
--- a/langgraph/src/channels/base.ts
+++ b/langgraph/src/channels/base.ts
@@ -12,7 +12,7 @@ export abstract class BaseChannel<
 
   /**
    * Return a new identical channel, optionally initialized from a checkpoint.
-   * Can be thought of as a "restoration" from a checkpoint which is a "snapshot" of the channel's state.  
+   * Can be thought of as a "restoration" from a checkpoint which is a "snapshot" of the channel's state.
    *
    * @param {C | undefined} checkpoint
    * @param {C | undefined} initialValue

--- a/langgraph/src/channels/base.ts
+++ b/langgraph/src/channels/base.ts
@@ -2,8 +2,8 @@ import { Checkpoint } from "../checkpoint/index.js";
 
 export abstract class BaseChannel<
   Value = unknown,
-  Update = unknown,
-  C = unknown
+  Update = unknown, // Expected type of the parameter `update` is called with.
+  C = unknown // Type of the channel's checkpoint
 > {
   /**
    * The name of the channel.
@@ -12,6 +12,7 @@ export abstract class BaseChannel<
 
   /**
    * Return a new identical channel, optionally initialized from a checkpoint.
+   * Can be thought of as a "restoration" from a checkpoint which is a "snapshot" of the channel's state.  
    *
    * @param {C | undefined} checkpoint
    * @param {C | undefined} initialValue

--- a/langgraph/src/tests/pregel.test.ts
+++ b/langgraph/src/tests/pregel.test.ts
@@ -387,7 +387,7 @@ it("should process two inputs to two outputs validly", async () => {
 });
 
 it.skip("should handle checkpoints correctly", async () => {
-  const addOne = jest.fn(
+  const inputPlusTotal = jest.fn(
     (x: { total: number; input: number }): number => x.total + x.input
   );
   const raiseIfAbove10 = (input: number): number => {
@@ -399,7 +399,7 @@ it.skip("should handle checkpoints correctly", async () => {
 
   const one = Channel.subscribeTo(["input"])
     .join(["total"])
-    .pipe(addOne)
+    .pipe(inputPlusTotal)
     .pipe(Channel.writeTo("output", "total"))
     .pipe(raiseIfAbove10);
 


### PR DESCRIPTION
Based on conversations with @nfcampos yesterday, learned a lot about the underlying behavior of LangGraph 

This information is pretty crucial to be able to contribute meaningfully in this code base, so added this information to the CONTRIBUTING.md 

While I was here, made some flyby changes to help clarify things that I thought were confusing