### PR TITLE
Type-safety of Channel.subscribeTo

### DIFF
--- a/langgraph/src/pregel/index.ts
+++ b/langgraph/src/pregel/index.ts
@@ -68,7 +68,6 @@ export class Channel {
   static subscribeTo(
     channels: string[],
     options?: {
-      key?: string;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       when?: (arg: any) => boolean;
       tags?: string[];

--- a/langgraph/src/tests/pregel.test.ts
+++ b/langgraph/src/tests/pregel.test.ts
@@ -562,6 +562,13 @@ it("should throw an error when no input channel is provided", () => {
   expect(() => new Pregel({ nodes: { one, two } })).toThrowError();
 });
 
+it("should type-error when Channel.subscribeTo would throw at runtime", () => {
+  expect(() => {
+    // @ts-expect-error - this would throw at runtime and thus we want it to become a type-error
+    Channel.subscribeTo(["input"], { key: "key" });
+  }).toThrow();
+});
+
 describe("StateGraph", () => {
   class SearchAPI extends Tool {
     name = "search_api";


### PR DESCRIPTION
Ensure `Channel.subscribeTo(["input"], { key: "key" })` which throws at runtime is a type-error.