### PR TITLE
Include Pregel PDF link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,7 +225,7 @@ If you are contributing to this code base, then you need to be familiar with som
 
 #### Pregel
 
-Let's start with Pregel. [Pregel](https://research.google/pubs/pregel-a-system-for-large-scale-graph-processing/) is an API for building graphs. 
+Let's start with Pregel. [Pregel](https://research.google/pubs/pregel-a-system-for-large-scale-graph-processing/) ([PDF](https://15799.courses.cs.cmu.edu/fall2013/static/papers/p135-malewicz.pdf)) is an API for building graphs. 
 
 Some key concepts: 
 - Pregel graphs take an `input` and `output` as parameters which represent where the graph starts and ends


### PR DESCRIPTION
Just make it one tiny bit easier for people curious about Pregel to read the paper, since the current Google link only goes to ACM which requires access, but CMU provides the paper.