### PR TITLE
Add a graph builder

### DIFF
--- a/langgraph/src/graph/builder.ts
+++ b/langgraph/src/graph/builder.ts
@@ -1,0 +1,252 @@
+import { RunnableLike } from "@langchain/core/runnables";
+import { END, Graph } from "./graph.js";
+import { Pregel } from "../pregel/index.js";
+import { BaseCheckpointSaver } from "../checkpoint/index.js";
+import { START, StateGraph } from "./state.js";
+
+/**
+ * @experimental This class is experimental
+ */
+export class GraphBuilder<
+  RunInput = unknown,
+  RunOutput = unknown,
+  const Nodes extends string = typeof END,
+  Compiled extends true | void = undefined
+> extends Graph<RunInput, RunOutput> {
+  private strictCompiled: Compiled;
+
+  private compileResult: Compiled extends true ? Pregel : never;
+
+  // Adds a node to the graph and returns a builder that's aware of that nodes existence
+  addNode<K extends string>(
+    this: GraphBuilder<RunInput, RunOutput, Nodes>,
+    key: K,
+    action: RunnableLike<RunInput, RunOutput>
+  ): GraphBuilder<RunInput, RunOutput, Nodes | K> {
+    super.addNode(key, action);
+    return this;
+  }
+
+  // `startKey` and `endKey` must be existing node keys
+  addEdge<SK extends Nodes, EK extends Nodes>(
+    this: GraphBuilder<RunInput, RunOutput, Nodes>,
+    startKey: SK,
+    endKey: EK
+  ): GraphBuilder<RunInput, RunOutput, Nodes> {
+    super.addEdge(startKey, endKey);
+    return this;
+  }
+
+  // `startKey` and return key of `condition` must be existing node keys
+  addConditionalEdges<SK extends Nodes>(
+    this: GraphBuilder<RunInput, RunOutput, Nodes>,
+    startKey: SK,
+    condition: (...args: unknown[]) => PromiseLike<Nodes> | Nodes
+  ): GraphBuilder<RunInput, RunOutput, Nodes>;
+
+  // `startKey` and all values in `conditionalEdgeMapping` must be existing node keys
+  addConditionalEdges<
+    SK extends Nodes,
+    const EK extends Nodes,
+    const Choices extends string
+  >(
+    this: GraphBuilder<RunInput, RunOutput, Nodes>,
+    startKey: SK,
+    condition: (...args: unknown[]) => PromiseLike<Choices> | Choices,
+    conditionalEdgeMapping: Record<Choices, EK>
+  ): GraphBuilder<RunInput, RunOutput, Nodes>;
+
+  addConditionalEdges<
+    SK extends Nodes,
+    const EK extends Nodes,
+    const Choices extends string,
+    const Mapping extends undefined | Record<Choices, EK>
+  >(
+    this: GraphBuilder<RunInput, RunOutput, Nodes>,
+    startKey: SK,
+    condition: (
+      ...args: unknown[]
+    ) => Mapping extends undefined ? Nodes : PromiseLike<Choices> | Choices,
+    conditionalEdgeMapping?: Mapping
+  ): GraphBuilder<RunInput, RunOutput, Nodes> {
+    super.addConditionalEdges(startKey, condition, conditionalEdgeMapping);
+    return this;
+  }
+
+  // `key` must be an existing node key
+  setEntryPoint<SK extends Nodes>(
+    this: GraphBuilder<RunInput, RunOutput, Nodes>,
+    key: SK
+  ): GraphBuilder<RunInput, RunOutput, Nodes> {
+    super.setEntryPoint(key);
+    return this;
+  }
+
+  // `key` must be an existing node key
+  setFinishPoint<EK extends Nodes>(
+    this: GraphBuilder<RunInput, RunOutput, Nodes>,
+    key: EK
+  ): GraphBuilder<RunInput, RunOutput, Nodes> {
+    super.setFinishPoint(key);
+    return this;
+  }
+
+  // Puts the builder into a completed state
+  done(
+    this: GraphBuilder<RunInput, RunOutput, Nodes>,
+    checkpointer?: BaseCheckpointSaver
+  ): GraphBuilder<RunInput, RunOutput, Nodes, true> {
+    const that = this as unknown as GraphBuilder<
+      RunInput,
+      RunOutput,
+      Nodes,
+      true
+    >;
+    that.strictCompiled = true;
+    that.compileResult = super.compile(checkpointer);
+    return that;
+  }
+
+  // Unless we have called .done(), compile will throw, this is communicated at
+  // the type-level by the return type of `never`
+  compile(
+    this: GraphBuilder<RunInput, RunOutput, Nodes>,
+    ...args: Parameters<Graph<RunInput, RunOutput>["compile"]>
+  ): never;
+
+  // Builder instances which have been completed with .done() result in the
+  // expected `Pregel` return type
+  compile(
+    this: GraphBuilder<RunInput, RunOutput, Nodes, true>,
+    ...args: Parameters<Graph<RunInput, RunOutput>["compile"]>
+  ): Pregel;
+
+  compile(this: GraphBuilder<RunInput, RunOutput, Nodes, true | void>): Pregel {
+    if (this.strictCompiled) {
+      return this.compileResult;
+    } else {
+      throw new Error("Compilation not set");
+    }
+  }
+}
+
+/**
+ * @experimental This class is experimental
+ */
+export class StateGraphBuilder<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Channels extends Record<string, unknown>,
+  const Nodes extends string = typeof START | typeof END,
+  Compiled extends true | void = undefined
+> extends StateGraph<Channels> {
+  private strictCompiled: Compiled;
+
+  private compileResult: Compiled extends true ? Pregel : never;
+
+  // Adds a node to the graph and returns a builder that's aware of that nodes existence
+  addNode<K extends string>(
+    this: StateGraphBuilder<Channels, Nodes>,
+    key: K,
+    action: RunnableLike<Channels>
+  ): StateGraphBuilder<Channels, Nodes | K> {
+    super.addNode(key, action);
+    return this;
+  }
+
+  // `startKey` and `endKey` must be existing node keys
+  addEdge<SK extends Nodes, EK extends Nodes>(
+    this: StateGraphBuilder<Channels, Nodes>,
+    startKey: SK,
+    endKey: EK
+  ): StateGraphBuilder<Channels, Nodes> {
+    super.addEdge(startKey, endKey);
+    return this;
+  }
+
+  // `startKey` and return key of `condition` must be existing node keys
+  addConditionalEdges<SK extends Nodes>(
+    this: StateGraphBuilder<Channels, Nodes>,
+    startKey: SK,
+    condition: (...args: unknown[]) => PromiseLike<Nodes> | Nodes
+  ): StateGraphBuilder<Channels, Nodes>;
+
+  // `startKey` and all values in `conditionalEdgeMapping` must be existing node keys
+  addConditionalEdges<
+    SK extends Nodes,
+    const EK extends Nodes,
+    const Choices extends string
+  >(
+    this: StateGraphBuilder<Channels, Nodes>,
+    startKey: SK,
+    condition: (...args: unknown[]) => PromiseLike<Choices> | Choices,
+    conditionalEdgeMapping: Record<Choices, EK>
+  ): StateGraphBuilder<Channels, Nodes>;
+
+  addConditionalEdges<
+    SK extends Nodes,
+    const EK extends Nodes,
+    const Choices extends string,
+    const Mapping extends undefined | Record<Choices, EK>
+  >(
+    this: StateGraphBuilder<Channels, Nodes>,
+    startKey: SK,
+    condition: (
+      ...args: unknown[]
+    ) => Mapping extends undefined ? Nodes : PromiseLike<Choices> | Choices,
+    conditionalEdgeMapping?: Mapping
+  ): StateGraphBuilder<Channels, Nodes> {
+    super.addConditionalEdges(startKey, condition, conditionalEdgeMapping);
+    return this;
+  }
+
+  // `key` must be an existing node key
+  setEntryPoint<SK extends Nodes>(
+    this: StateGraphBuilder<Channels, Nodes>,
+    key: SK
+  ): StateGraphBuilder<Channels, Nodes> {
+    super.setEntryPoint(key);
+    return this;
+  }
+
+  // `key` must be an existing node key
+  setFinishPoint<EK extends Nodes>(
+    this: StateGraphBuilder<Channels, Nodes>,
+    key: EK
+  ): StateGraphBuilder<Channels, Nodes> {
+    super.setFinishPoint(key);
+    return this;
+  }
+
+  // Puts the builder into a completed state
+  done(
+    this: StateGraphBuilder<Channels, Nodes>,
+    checkpointer?: BaseCheckpointSaver
+  ): StateGraphBuilder<Channels, Nodes, true> {
+    const that = this as unknown as StateGraphBuilder<Channels, Nodes, true>;
+    that.strictCompiled = true;
+    that.compileResult = super.compile(checkpointer);
+    return that;
+  }
+
+  // Unless we have called .done(), compile will throw, this is communicated at
+  // the type-level by the return type of `never`
+  compile(
+    this: StateGraphBuilder<Channels, Nodes>,
+    ...args: Parameters<Graph<Channels>["compile"]>
+  ): never;
+
+  // Builder instances which have been completed with .done() result in the
+  // expected `Pregel` return type
+  compile(
+    this: StateGraphBuilder<Channels, Nodes, true>,
+    ...args: Parameters<Graph<Channels>["compile"]>
+  ): Pregel;
+
+  compile(this: StateGraphBuilder<Channels, Nodes, true | void>): Pregel {
+    if (this.strictCompiled) {
+      return this.compileResult;
+    } else {
+      throw new Error("Compilation not set");
+    }
+  }
+}

--- a/langgraph/src/tests/graph-builder.test.ts
+++ b/langgraph/src/tests/graph-builder.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "@jest/globals";
+import { GraphBuilder, StateGraphBuilder } from "../graph/builder.js";
+import { END } from "../graph/graph.js";
+
+describe("GraphBuilder", () => {
+  it("can't `.addEdge` between nodes that haven't been declared yet", () => {
+    expect(() => {
+      new GraphBuilder()
+        .addNode("a", () => {})
+        .addNode("b", () => {})
+        // This is fine
+        .addEdge("a", "b")
+        // @ts-expect-error - this must type-error
+        .addEdge("b", "c");
+    }).toThrow();
+  });
+
+  describe(".addConditionalEdge", () => {
+    const builder = () =>
+      new GraphBuilder().addNode("a", () => {}).addNode("b", () => {});
+
+    // This is fine
+    builder().addConditionalEdges("a", () => "next", { next: "b" });
+
+    it("node mappings must point to existing nodes", () => {
+      expect(() => {
+        builder().addConditionalEdges("b", () => "next", {
+          next: "b",
+          // @ts-expect-error - this must type-error
+          missing: "missing",
+        });
+      }).toThrow();
+    });
+
+    it("condition return key must exists when no mapping is provided", () => {
+      // @ts-expect-error - this must type-error
+      builder().addConditionalEdges("b", () => "missing");
+    });
+
+    it("start node must exist", () => {
+      expect(() => {
+        // @ts-expect-error - this must type-error
+        builder().addConditionalEdges("missing", () => "next", { next: "b" });
+      }).toThrow();
+    });
+
+    it("condition return key must exists in node mapping", () => {
+      // @ts-expect-error - this must type-error
+      builder().addConditionalEdges("b", () => "next", { continue: "b" });
+    });
+
+    it("adding and end to END is always fine, regardless of added nodes", () => {
+      // This is fine
+      builder().addEdge("a", END);
+    });
+
+    it("condition return key must exists in node mapping - async", () => {
+      // TODO: When return is a promise, we don't get a type-error unless we
+      // explicitly `as const` the return value or provide an explicit return
+      // type
+
+      // TODO: This should be a type-error but it is not
+      builder().addConditionalEdges("b", async () => "next", { continue: "b" });
+
+      builder().addConditionalEdges("b", async () => "next" as const, {
+        // @ts-expect-error - this must type-error
+        continue: "b",
+      });
+
+      builder().addConditionalEdges("b", async (): Promise<"next"> => "next", {
+        // @ts-expect-error - this must type-error
+        continue: "b",
+      });
+    });
+  });
+
+  it("forking builders works at runtime but should type-error", () => {
+    const builder1 = new GraphBuilder().addNode("a", () => {});
+    const builder2 = new GraphBuilder().addNode("b", () => {});
+
+    expect(() => {
+      // @ts-expect-error - this must type-error
+      builder1.addEdge("a", "b");
+    }).toThrow();
+
+    expect(() => {
+      // @ts-expect-error - this must type-error
+      builder2.addEdge("a", "b");
+    }).toThrow();
+  });
+
+  it("must complete builder before compiling", () => {
+    const builder = new GraphBuilder()
+      .addNode("a", () => {})
+      .addNode("b", () => {})
+      .addEdge("a", "b")
+      .setEntryPoint("a")
+      .setFinishPoint("b");
+
+    // This is fine
+    builder.done().compile();
+
+    // @ts-expect-error - this must type-error
+    builder.compile().invoke({});
+  });
+});
+
+describe("StateGraphBuilder", () => {
+  const channels = () => ({ channels: {} });
+
+  it("can't `.addEdge` between nodes that haven't been declared yet", () => {
+    expect(() => {
+      new StateGraphBuilder(channels())
+        .addNode("a", () => {})
+        .addNode("b", () => {})
+        // This is fine
+        .addEdge("a", "b")
+        // @ts-expect-error - this must type-error
+        .addEdge("b", "c");
+    }).toThrow();
+  });
+
+  describe(".addConditionalEdge", () => {
+    const builder = () =>
+      new StateGraphBuilder(channels())
+        .addNode("a", () => {})
+        .addNode("b", () => {});
+
+    // This is fine
+    builder().addConditionalEdges("a", () => "next", { next: "b" });
+
+    it("node mappings must point to existing nodes", () => {
+      expect(() => {
+        builder().addConditionalEdges("b", () => "next", {
+          next: "b",
+          // @ts-expect-error - this must type-error
+          missing: "missing",
+        });
+      }).toThrow();
+    });
+
+    it("start node must exist", () => {
+      expect(() => {
+        // @ts-expect-error - this must type-error
+        builder().addConditionalEdges("missing", () => "next", { next: "b" });
+      }).toThrow();
+    });
+
+    it("condition return key must exists in node mapping", () => {
+      // @ts-expect-error - this must type-error
+      builder().addConditionalEdges("b", () => "next", { continue: "b" });
+    });
+
+    it("condition return key must exists when no mapping is provided", () => {
+      // @ts-expect-error - this must type-error
+      builder().addConditionalEdges("b", () => "missing");
+    });
+
+    it("adding and end to END is always fine, regardless of added nodes", () => {
+      // This is fine
+      builder().addEdge("a", END);
+    });
+
+    it("condition return key must exists in node mapping - async", () => {
+      // TODO: When return is a promise, we don't get a type-error unless we
+      // explicitly `as const` the return value or provide an explicit return
+      // type
+
+      // TODO: This should be a type-error but it is not
+      builder().addConditionalEdges("b", async () => "next", { continue: "b" });
+
+      builder().addConditionalEdges("b", async () => "next" as const, {
+        // @ts-expect-error - this must type-error
+        continue: "b",
+      });
+
+      builder().addConditionalEdges("b", async (): Promise<"next"> => "next", {
+        // @ts-expect-error - this must type-error
+        continue: "b",
+      });
+    });
+  });
+
+  it("forking builders works at runtime but should type-error", () => {
+    const builder1 = new StateGraphBuilder(channels()).addNode("a", () => {});
+    const builder2 = new StateGraphBuilder(channels()).addNode("b", () => {});
+
+    expect(() => {
+      // @ts-expect-error - this must type-error
+      builder1.addEdge("a", "b");
+    }).toThrow();
+
+    expect(() => {
+      // @ts-expect-error - this must type-error
+      builder2.addEdge("a", "b");
+    }).toThrow();
+  });
+
+  it("must complete builder before compiling", () => {
+    const builder = new StateGraphBuilder(channels())
+      .addNode("a", () => ({}))
+      .addNode("b", () => ({}))
+      .addEdge("a", "b")
+      .setEntryPoint("a")
+      .setFinishPoint("b");
+
+    // This is fine
+    builder.done().compile();
+
+    // @ts-expect-error - this must type-error
+    builder.compile().invoke({});
+  });
+});


### PR DESCRIPTION
This PR shows one possible way to construct a graph builder.

This graph builder turns what is now run-time errors during graph construction into type-errors. Meaning users get the same error feedback directly in their IDE as type errors without having to run the code. There is also the added benefit that they get some level of "intellisense" while writing the code.

The builder has the same API as `Graph`, with the addition of a `.done()` method and stricter input types.

One can peruse the [test file](https://github.com/functorism/langgraphjs/blob/graph-builder/langgraph/src/tests/graph-builder.test.ts) for examples of how to use the builder and what type of errors it catches at "compile-time".

The builder works via the fact that methods return the `this` instance with additional type information:

```typescript
  // Adds a node to the graph and returns a builder that's aware of that nodes existence
  addNode<K extends string>(
    this: GraphBuilder<RunInput, RunOutput, Nodes>,
    key: K,
    action: RunnableLike<RunInput, RunOutput>
  ): GraphBuilder<RunInput, RunOutput, Nodes | K> {
    super.addNode(key, action);
    return this;
  }
```

Which allows us to catch simple mistakes like:

```typescript
new GraphBuilder()
  .addNode("a", () => {})
  .addNode("b", () => {})
  // This is fine
  .addEdge("a", "b")
  // @ts-expect-error - this must type-error
  .addEdge("b", "c");
```

```typescript
new GraphBuilder()
  .addNode("a", () => {})
  .addNode("b", () => {})
  .addConditionalEdges("b", () => "next", {
    continue: "b",
 // ^^^^^^^^ - The type error will be localized here
 // Error: Object literal may only specify known properties,
 // and 'continue' does not exist in type 'Record<"next", "b">'
  });
```


The builder doesn't guarantee perfect safety due to limitations of what TypeScript's type system can express; but it does make it a lot easier to _do the right thing_.

A clear example of these limitations is that we have no way to "invalidate" references to "old" builder instances; if one creates ["forks" of the builder](https://github.com/functorism/langgraphjs/blob/graph-builder/langgraph/src/tests/graph-builder.test.ts#L77-L90), you'll run into unexpected behavior.

The code duplication for `GraphBuilder` and `StateGraphBuilder` is inelegant, but can be improved if this idea is deemed appealing!

Having access to a graph builder that provides "at construction time checking" sweetens the deal if one would want to move the runtime checks that exists in `Graph` into the `compile` function entirely. As suggested in this issue https://github.com/langchain-ai/langgraphjs/issues/88. If construction time checking is a type-level concern and compile time checking a runtime one; then it's possible to support both use cases. Making it possible to support construction methods that only have to be valid at compile time - then order of node and edge inserts does not matter. It only matters that the state is correct when calling compile. And for those wanting construction time validation (and "intellisense"), then the builder is available.

Thanks @davidfant for reviewing and helping to find a bug prior to opening this.