### PR TITLE
fix: state graph new node validation

### DIFF
--- a/langgraph/src/graph/state.ts
+++ b/langgraph/src/graph/state.ts
@@ -43,7 +43,7 @@ export class StateGraph<
   }
 
   addNode(key: string, action: RunnableLike) {
-    if (Object.keys(this.nodes).some((key) => key in this.channels)) {
+    if (key in this.channels) {
       throw new Error(
         `${key} is already being used as a state attribute (a.k.a. a channel), cannot also be used as a node name.`
       );

--- a/langgraph/src/tests/graph.test.ts
+++ b/langgraph/src/tests/graph.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "@jest/globals";
+import { StateGraph } from "../graph/state.js";
+
+describe("State", () => {
+  it("should validate a new node key correctly ", () => {
+    const stateGraph = new StateGraph({
+      channels: { existingStateAttributeKey: { value: null } },
+    });
+    expect(() => {
+      stateGraph.addNode("existingStateAttributeKey", () => {});
+    }).toThrow("existingStateAttributeKey");
+
+    expect(() => {
+      stateGraph.addNode("newNodeKey", () => {});
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
Fixes a new node key validation for StateGraph.

In the previous implementation, it validated existing nodes instead of new ones.

Python implementation reference: https://github.com/langchain-ai/langgraph/blob/main/langgraph/graph/state.py#L48
