### PR TITLE
Update Pregel files to match Python implementation: `debug.ts`, `io.ts`, `read.ts`, `types.ts`, `write.ts`

### DIFF
--- a/langgraph/src/constants.ts
+++ b/langgraph/src/constants.ts
@@ -1,2 +1,4 @@
 export const CONFIG_KEY_SEND = "__pregel_send";
 export const CONFIG_KEY_READ = "__pregel_read";
+
+export const TAG_HIDDEN = "langsmith:hidden";

--- a/langgraph/src/graph/graph.ts
+++ b/langgraph/src/graph/graph.ts
@@ -5,7 +5,7 @@ import {
   RunnableLike,
   _coerceToRunnable,
 } from "@langchain/core/runnables";
-import { ChannelInvoke } from "../pregel/read.js";
+import { PregelNode } from "../pregel/read.js";
 import { Channel, Pregel } from "../pregel/index.js";
 import { BaseCheckpointSaver } from "../checkpoint/base.js";
 
@@ -179,7 +179,7 @@ export class Graph<
       outgoingEdges[start].push(end !== END ? `${end}:inbox` : END);
     });
 
-    const nodes: Record<string, ChannelInvoke<RunInput, RunOutput>> = {};
+    const nodes: Record<string, PregelNode<RunInput, RunOutput>> = {};
     for (const [key, node] of Object.entries(this.nodes)) {
       nodes[key] = Channel.subscribeTo(`${key}:inbox`)
         .pipe(node)

--- a/langgraph/src/graph/state.ts
+++ b/langgraph/src/graph/state.ts
@@ -6,7 +6,7 @@ import { LastValue } from "../channels/last_value.js";
 import { ChannelWrite, SKIP_WRITE } from "../pregel/write.js";
 import { BaseCheckpointSaver } from "../checkpoint/base.js";
 import { Pregel, Channel } from "../pregel/index.js";
-import { ChannelInvoke, ChannelRead } from "../pregel/read.js";
+import { PregelNode, ChannelRead } from "../pregel/read.js";
 import { NamedBarrierValue } from "../channels/named_barrier_value.js";
 import { AnyValue } from "../channels/any_value.js";
 import { EphemeralValue } from "../channels/ephemeral_value.js";
@@ -170,7 +170,7 @@ export class StateGraph<
       }
     }
 
-    const nodes: Record<string, ChannelInvoke> = {};
+    const nodes: Record<string, PregelNode> = {};
 
     for (const [key, node] of Object.entries(this.nodes)) {
       const triggers = [
@@ -179,7 +179,7 @@ export class StateGraph<
           .filter(([, , end]) => end === key)
           .map(([chan]) => chan),
       ];
-      nodes[key] = new ChannelInvoke({
+      nodes[key] = new PregelNode({
         triggers,
         channels: stateChannels,
       })
@@ -203,7 +203,7 @@ export class StateGraph<
       const outgoing = outgoingEdges[key];
       const edgesKey = `${key}:edges`;
       if (outgoing || this.branches[key]) {
-        nodes[edgesKey] = new ChannelInvoke({
+        nodes[edgesKey] = new PregelNode({
           triggers: [key],
           tags: ["langsmith:hidden"],
           channels: stateChannels,
@@ -240,7 +240,7 @@ export class StateGraph<
       ])
     );
 
-    nodes[`${START}:edges`] = new ChannelInvoke({
+    nodes[`${START}:edges`] = new PregelNode({
       triggers: [START],
       tags: ["langsmith:hidden"],
       channels: stateChannels,

--- a/langgraph/src/pregel/debug.ts
+++ b/langgraph/src/pregel/debug.ts
@@ -23,7 +23,10 @@ const COLORS_MAP: ConsoleColorMap = {
 const wrap = (color: ConsoleColors, text: string): string =>
   `${color.start}${text}${color.end}`;
 
-export function printStepStart(step: number, nextTasks: Array<PregelExecutableTask>): void {
+export function printStepStart(
+  step: number,
+  nextTasks: Array<PregelExecutableTask>
+): void {
   const nTasks = nextTasks.length;
   console.log(
     `${wrap(COLORS_MAP.blue, "[langgraph/step]")}`,

--- a/langgraph/src/pregel/debug.ts
+++ b/langgraph/src/pregel/debug.ts
@@ -1,5 +1,5 @@
-import { Runnable } from "@langchain/core/runnables";
 import { BaseChannel, EmptyChannelError } from "../channels/base.js";
+import { PregelExecutableTask } from "./types.js";
 
 type ConsoleColors = {
   start: string;
@@ -23,19 +23,15 @@ const COLORS_MAP: ConsoleColorMap = {
 const wrap = (color: ConsoleColors, text: string): string =>
   `${color.start}${text}${color.end}`;
 
-export function printStepStart(
-  step: number,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  nextTasks: Array<[Runnable, any, string]>
-): void {
+export function printStepStart(step: number, nextTasks: Array<PregelExecutableTask>): void {
   const nTasks = nextTasks.length;
   console.log(
-    `${wrap(COLORS_MAP.blue, "[pregel/step]")}`,
+    `${wrap(COLORS_MAP.blue, "[langgraph/step]")}`,
     `Starting step ${step} with ${nTasks} task${
       nTasks === 1 ? "" : "s"
     }. Next tasks:\n`,
     `\n${nextTasks
-      .map(([_, val, name]) => `- ${name}(${JSON.stringify(val, null, 2)})`)
+      .map((task) => `${task.name}(${JSON.stringify(task.input, null, 2)})`)
       .join("\n")}`
   );
 }
@@ -45,7 +41,7 @@ export function printCheckpoint<Value>(
   channels: Record<string, BaseChannel<Value>>
 ) {
   console.log(
-    `${wrap(COLORS_MAP.blue, "[pregel/checkpoint]")}`,
+    `${wrap(COLORS_MAP.blue, "[langgraph/checkpoint]")}`,
     `Finishing step ${step}. Channel values:\n`,
     `\n${JSON.stringify(
       Object.fromEntries(_readChannels<Value>(channels)),

--- a/langgraph/src/pregel/index.ts
+++ b/langgraph/src/pregel/index.ts
@@ -23,7 +23,7 @@ import {
   CheckpointAt,
   emptyCheckpoint,
 } from "../checkpoint/base.js";
-import { ChannelInvoke } from "./read.js";
+import { PregelNode } from "./read.js";
 import { validateGraph } from "./validate.js";
 import { ReservedChannelsMap } from "./reserved.js";
 import { mapInput, mapOutput } from "./io.js";
@@ -63,7 +63,7 @@ export class Channel {
       tags?: string[];
     }
   ): // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ChannelInvoke;
+  PregelNode;
 
   static subscribeTo(
     channels: string[],
@@ -72,7 +72,7 @@ export class Channel {
       when?: (arg: any) => boolean;
       tags?: string[];
     }
-  ): ChannelInvoke;
+  ): PregelNode;
 
   static subscribeTo(
     channels: string | string[],
@@ -82,7 +82,7 @@ export class Channel {
       when?: (arg: any) => boolean;
       tags?: string[];
     }
-  ): ChannelInvoke {
+  ): PregelNode {
     const { key, when, tags } = options ?? {};
     if (Array.isArray(channels) && key !== undefined) {
       throw new Error(
@@ -106,7 +106,7 @@ export class Channel {
 
     const triggers: string[] = Array.isArray(channels) ? channels : [channels];
 
-    return new ChannelInvoke({
+    return new PregelNode({
       channels: channelMappingOrString,
       triggers,
       when,
@@ -174,7 +174,7 @@ export interface PregelInterface {
    */
   interrupt?: string[];
 
-  nodes: Record<string, ChannelInvoke>;
+  nodes: Record<string, PregelNode>;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   checkpointer?: BaseCheckpointSaver<any>;
@@ -213,7 +213,7 @@ export class Pregel
 
   debug: boolean = false;
 
-  nodes: Record<string, ChannelInvoke>;
+  nodes: Record<string, PregelNode>;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   checkpointer?: BaseCheckpointSaver<any>;
@@ -550,14 +550,14 @@ function _applyWritesFromView(
 
 function _prepareNextTasks(
   checkpoint: Checkpoint,
-  processes: Record<string, ChannelInvoke>,
+  processes: Record<string, PregelNode>,
   channels: Record<string, BaseChannel>
 ): Array<[RunnableInterface, unknown, string]> {
   const tasks: Array<[RunnableInterface, unknown, string]> = [];
 
   // Check if any processes should be run in next step
   // If so, prepare the values to be passed to them
-  for (const [name, proc] of Object.entries<ChannelInvoke>(processes)) {
+  for (const [name, proc] of Object.entries<PregelNode>(processes)) {
     let seen: Record<string, number> = checkpoint.versionsSeen[name];
     if (!seen) {
       checkpoint.versionsSeen[name] = {};

--- a/langgraph/src/pregel/index.ts
+++ b/langgraph/src/pregel/index.ts
@@ -78,12 +78,10 @@ export class Channel {
     channels: string | string[],
     options?: {
       key?: string;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      when?: (arg: any) => boolean;
       tags?: string[];
     }
   ): PregelNode {
-    const { key, when, tags } = options ?? {};
+    const { key, tags } = options ?? {};
     if (Array.isArray(channels) && key !== undefined) {
       throw new Error(
         "Can't specify a key when subscribing to multiple channels"
@@ -109,7 +107,6 @@ export class Channel {
     return new PregelNode({
       channels: channelMappingOrString,
       triggers,
-      when,
       tags,
     });
   }
@@ -601,10 +598,8 @@ function _prepareNextTasks(
           }
         });
 
-        // skip if condition is not met
-        if (proc.when === undefined || proc.when(val)) {
-          tasks.push([proc, val, name]);
-        }
+        tasks.push([proc, val, name]);
+
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (error: any) {
         if (error.name === EmptyChannelError.name) {

--- a/langgraph/src/pregel/read.ts
+++ b/langgraph/src/pregel/read.ts
@@ -58,7 +58,7 @@ export class ChannelRead<
         default: null,
         // TODO FIX THIS
         annotation: "Callable[[BaseChannel], Any]",
-        isShared: true,
+        isShared: false,
         dependencies: null,
       },
     ];

--- a/langgraph/src/pregel/read.ts
+++ b/langgraph/src/pregel/read.ts
@@ -73,7 +73,7 @@ const defaultRunnableBound = /* #__PURE__ */ new RunnablePassthrough();
 
 interface PregelNodeArgs<RunInput, RunOutput>
   extends Partial<RunnableBindingArgs<RunInput, RunOutput>> {
-  channels: Record<string, string> | string[];
+  channels: Record<string, string> | string;
   triggers: Array<string>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   mapper?: (args: any) => any;
@@ -98,16 +98,19 @@ export class PregelNode<
 > extends RunnableBinding<RunInput, RunOutput, RunnableConfig> {
   lc_graph_name = "PregelNode";
 
-  channels: Record<string, string> | string[];
+  channels: Record<string, string> | string;
 
   triggers: string[] = [];
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   mapper?: (args: any) => any;
 
   writers: Runnable[] = [];
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   bound: Runnable<any, any> = defaultRunnableBound;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   kwargs: Record<string, any> = {};
 
   constructor(fields: PregelNodeArgs<RunInput, RunOutput>) {

--- a/langgraph/src/pregel/types.ts
+++ b/langgraph/src/pregel/types.ts
@@ -17,10 +17,10 @@ export interface PregelExecutableTask {
 }
 
 export interface StateSnapshot {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   /**
    * Current values of channels
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   values: Record<string, any> | any;
   /**
    * Nodes to execute in the next step, if any

--- a/langgraph/src/pregel/types.ts
+++ b/langgraph/src/pregel/types.ts
@@ -1,0 +1,38 @@
+import { Runnable, RunnableConfig } from "@langchain/core/runnables";
+
+export interface PregelTaskDescription {
+  name: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  input: any;
+}
+
+export interface PregelExecutableTask {
+  name: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  input: any;
+  proc: Runnable;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  writes: Array<[string, any]>; // TODO: Array type may need to be changed
+  config: RunnableConfig | undefined;
+}
+
+export interface StateSnapshot {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  /**
+   * Current values of channels
+   */
+  values: Record<string, any> | any;
+  /**
+   * Nodes to execute in the next step, if any
+   */
+  next: [string];
+  /**
+   * Config used to fetch this snapshot
+   */
+  config: RunnableConfig;
+  /**
+   * Config used to fetch the parent snapshot, if any
+   * @default undefined
+   */
+  parentConfig?: RunnableConfig | undefined;
+}

--- a/langgraph/src/pregel/validate.ts
+++ b/langgraph/src/pregel/validate.ts
@@ -1,6 +1,6 @@
 import { BaseChannel } from "../channels/index.js";
 import { LastValue } from "../channels/last_value.js";
-import { ChannelInvoke } from "./read.js";
+import { PregelNode } from "./read.js";
 import { ReservedChannelsMap } from "./reserved.js";
 
 export function validateGraph({
@@ -11,7 +11,7 @@ export function validateGraph({
   hidden,
   interrupt,
 }: {
-  nodes: Record<string, ChannelInvoke>;
+  nodes: Record<string, PregelNode>;
   channels: { [key: string]: BaseChannel };
   input: string | Array<string>;
   output: string | Array<string>;
@@ -21,7 +21,7 @@ export function validateGraph({
   const newChannels = channels;
   const subscribedChannels = new Set<string>();
   for (const node of Object.values(nodes)) {
-    if (node.lc_graph_name === "ChannelInvoke" && "channels" in node) {
+    if (node.lc_graph_name === "PregelNode" && "channels" in node) {
       if (typeof node.channels === "string") {
         subscribedChannels.add(node.channels);
       } else {

--- a/langgraph/src/pregel/write.ts
+++ b/langgraph/src/pregel/write.ts
@@ -1,6 +1,7 @@
 import {
   Runnable,
   RunnableConfig,
+  RunnableLike,
   RunnablePassthrough,
 } from "@langchain/core/runnables";
 import { ConfigurableFieldSpec } from "../checkpoint/index.js";
@@ -93,7 +94,8 @@ export class ChannelWrite<
     );
   }
 
-  static isWriter(runnable: Runnable): boolean {
+  static isWriter(runnable: RunnableLike): boolean {
+    // eslint-disable-next-line no-instanceof/no-instanceof
     return runnable instanceof ChannelWrite;
   }
 

--- a/langgraph/src/tests/pregel.test.ts
+++ b/langgraph/src/tests/pregel.test.ts
@@ -21,7 +21,7 @@ import { LastValue } from "../channels/last_value.js";
 import { END, Graph, StateGraph } from "../graph/index.js";
 import { ReservedChannelsMap } from "../pregel/reserved.js";
 import { Topic } from "../channels/topic.js";
-import { ChannelInvoke } from "../pregel/read.js";
+import { PregelNode } from "../pregel/read.js";
 import { InvalidUpdateError } from "../channels/base.js";
 import { MemorySaverAssertImmutable } from "../checkpoint/memory.js";
 import { BinaryOperatorAggregate } from "../channels/binop.js";
@@ -293,7 +293,7 @@ it("should batch many processes with input and output", async () => {
   const testSize = 100;
   const addOne = jest.fn((x: number) => x + 1);
 
-  const nodes: Record<string, ChannelInvoke> = {
+  const nodes: Record<string, PregelNode> = {
     "-1": Channel.subscribeTo("input").pipe(addOne).pipe(Channel.writeTo("-1")),
   };
 


### PR DESCRIPTION
### Summary
The following files are updated (as much as possible) to match the corresponding Python implementation: `debug.ts`, `io.ts`, `read.ts`, `types.ts`, `write.ts`. The goal is to update the files without breaking existing tests or adding new functionality that would require significant changes to the `Pregel` class.

The implementation does not match exactly 1:1 with the Python implementation. I'll leave comments directly in the PR to note any differences.

### Implementation
1. `debug.ts`: Small updates.
2. `io.ts`: Moved `readChannel()` function to this file. Added the following unused functions `readChannels()`, `mapOutputValues()`, and `mapOutputUpdates()`.
3. `read.ts`: Renamed `ChannelInvoke` to `PregelNode`. Added more fields to `PregelNode`. Remove `PregelNode.when`. Update `PregelNode.pipe()` to support checking `ChannelWrite`.
4. `types.ts`: New file created to match Python implementation.
5. `write.ts`: Add `ChannelWrite.isWriter()` and `ChannelWrite.registerWriter()`.

### To Do
- [ ] Clean up the code. Improve readability.
- [ ] Add unit tests for new `io.ts.` functions.

### Next Steps
1. Update `pregel/index.ts` (`Pregel` and `Channel` classes).
2. Update `pregel/validate.ts` (I think).