### PR TITLE
Update static functions in `pregel/index.ts` to match corresponding Python implementation

### DIFF
--- a/langgraph/package.json
+++ b/langgraph/package.json
@@ -37,7 +37,7 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "@langchain/core": "^0.1.51",
+    "@langchain/core": "^0.1.61",
     "better-sqlite3": "^9.5.0"
   },
   "devDependencies": {

--- a/langgraph/src/channels/base.ts
+++ b/langgraph/src/channels/base.ts
@@ -77,15 +77,15 @@ export function emptyChannels(
   return newChannels;
 }
 
-export async function createCheckpoint<ValueType>(
+export function createCheckpoint<ValueType>(
   checkpoint: Checkpoint,
   channels: Record<string, BaseChannel<ValueType>>
-): Promise<Checkpoint> {
+): Checkpoint {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const values: Record<string, any> = {};
   for (const k of Object.keys(channels)) {
     try {
-      values[k] = await channels[k].checkpoint();
+      values[k] = channels[k].checkpoint();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       if (error.name === EmptyChannelError.name) {

--- a/langgraph/src/pregel/index.ts
+++ b/langgraph/src/pregel/index.ts
@@ -386,10 +386,6 @@ export class Pregel
 
       if (stepOutput) {
         yield stepOutput;
-
-        if (typeof outputKeys !== "string") {
-          _applyWritesFromView(checkpoint, channels, stepOutput);
-        }
       }
 
       // save end of step checkpoint
@@ -556,24 +552,6 @@ export function _applyWrites(
       // side effect: update channels
       channels[chan].update([]);
     }
-  }
-}
-
-function _applyWritesFromView(
-  checkpoint: Checkpoint,
-  channels: Record<string, BaseChannel>,
-  values: Record<string, unknown>
-) {
-  for (const [chan, val] of Object.entries(values)) {
-    if (val === readChannel(channels, chan)) {
-      continue;
-    }
-
-    if (channels[chan].lc_graph_name === "LastValue") {
-      throw new Error(`Can't modify channel ${chan} with LastValue`);
-    }
-    checkpoint.channelVersions[chan] += 1;
-    channels[chan].update([values[chan]]);
   }
 }
 

--- a/langgraph/src/pregel/index.ts
+++ b/langgraph/src/pregel/index.ts
@@ -288,6 +288,18 @@ export class Pregel
     return this;
   }
 
+  get streamChannelsList(): Array<string> {
+    if (typeof this.streamChannels === "string") {
+      return [this.streamChannels];
+    } else {
+      if (this.streamChannels && this.streamChannels.length > 0) {
+        return this.streamChannels;
+      } else {
+        return Object.keys(this.channels);
+      }
+    }
+  }
+
   async *_transform(
     input: AsyncGenerator<PregelInputType>,
     runManager?: CallbackManagerForChainRun,

--- a/langgraph/src/pregel/index.ts
+++ b/langgraph/src/pregel/index.ts
@@ -669,13 +669,16 @@ export function _prepareNextTasks(
           }
         });
 
-        tasks.push({
-          name,
-          input: val,
-          proc,
-          writes: [],
-          config: undefined,
-        });
+        const node = proc.getNode();
+        if (node !== undefined) {
+          tasks.push({
+            name,
+            input: val,
+            proc: node,
+            writes: [],
+            config: proc.config,
+          });
+        }
       } else {
         taskDescriptions.push({
           name,

--- a/langgraph/src/pregel/read.ts
+++ b/langgraph/src/pregel/read.ts
@@ -3,7 +3,6 @@ import {
   RunnableBinding,
   RunnableBindingArgs,
   RunnableConfig,
-  RunnableLambda,
   RunnableLike,
   RunnablePassthrough,
   RunnableSequence,
@@ -12,13 +11,12 @@ import {
 import { ConfigurableFieldSpec } from "../checkpoint/index.js";
 import { CONFIG_KEY_READ } from "../constants.js";
 import { ChannelWrite } from "./write.js";
+import { RunnableCallable } from "../utils.js";
 
 export class ChannelRead<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  RunInput = any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  RunOutput = any
-> extends RunnableLambda<RunInput, RunOutput> {
+  RunInput = any
+> extends RunnableCallable {
   lc_graph_name = "ChannelRead";
 
   channel: string | Array<string>;

--- a/langgraph/src/pregel/read.ts
+++ b/langgraph/src/pregel/read.ts
@@ -232,7 +232,10 @@ export class PregelNode<
         triggers: this.triggers,
         mapper: this.mapper,
         writers: [...this.writers, coerceable as ChannelWrite],
-        bound: this.bound.pipe(coerceable),
+        bound: this.bound as unknown as PregelNode<
+          RunInput,
+          Exclude<NewRunOutput, Error>
+        >,
         config: this.config,
         kwargs: this.kwargs,
       });

--- a/langgraph/src/pregel/write.ts
+++ b/langgraph/src/pregel/write.ts
@@ -2,10 +2,10 @@ import {
   Runnable,
   RunnableConfig,
   RunnableLike,
-  RunnablePassthrough,
 } from "@langchain/core/runnables";
 import { ConfigurableFieldSpec } from "../checkpoint/index.js";
 import { CONFIG_KEY_SEND } from "../constants.js";
+import { RunnableCallable } from "../utils.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type TYPE_SEND = (values: Array<[string, any]>) => void;
@@ -20,7 +20,7 @@ export const PASSTHROUGH = {};
 export class ChannelWrite<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   RunInput = any
-> extends RunnablePassthrough<RunInput> {
+> extends RunnableCallable {
   writes: Array<ChannelWriteEntry>;
 
   constructor(writes: Array<ChannelWriteEntry>) {

--- a/langgraph/src/tests/pregel.test.ts
+++ b/langgraph/src/tests/pregel.test.ts
@@ -109,6 +109,38 @@ describe("Pregel", () => {
       }).toThrowError();
     });
   });
+
+  describe("streamChannelsList", () => {
+    it("should return the expected list of stream channels", () => {
+      // set up test
+      const chain = Channel.subscribeTo("input").pipe(
+        Channel.writeTo(["output"])
+      );
+
+      const pregel1 = new Pregel({
+        nodes: { one: chain },
+        streamChannels: "channel",
+      });
+      const pregel2 = new Pregel({
+        nodes: { one: chain },
+        streamChannels: ["channel1", "channel2"],
+      });
+      const pregel3 = new Pregel({
+        nodes: { one: chain },
+        channels: { channel3: new LastValue() },
+        streamChannels: [],
+      });
+
+      // call method / assertions
+      expect(pregel1.streamChannelsList).toEqual(["channel"]);
+      expect(pregel2.streamChannelsList).toEqual(["channel1", "channel2"]);
+      expect(pregel3.streamChannelsList).toEqual([
+        "channel3",
+        "input",
+        "output",
+      ]);
+    });
+  });
 });
 
 describe("_shouldInterrupt", () => {

--- a/langgraph/src/tests/pregel.test.ts
+++ b/langgraph/src/tests/pregel.test.ts
@@ -405,10 +405,12 @@ describe("_prepareNextTasks", () => {
       node1: new PregelNode({
         channels: ["channel1"],
         triggers: ["channel1"],
+        writers: [new RunnablePassthrough()],
       }),
       node2: new PregelNode({
         channels: ["channel2"],
         triggers: ["channel1", "channel2"],
+        writers: [new RunnablePassthrough()],
         mapper: () => 100, // return 100 no matter what
       }),
       node3: new PregelNode({
@@ -461,23 +463,17 @@ describe("_prepareNextTasks", () => {
     expect(tasks[0]).toEqual({
       name: "node1",
       input: 1,
-      proc: new PregelNode({ channels: ["channel1"], triggers: ["channel1"] }),
+      proc: new RunnablePassthrough(),
       writes: [],
-      config: undefined,
+      config: { tags: [] },
     });
-    expect(JSON.stringify(tasks[1])).toEqual(
-      JSON.stringify({
-        name: "node2",
-        input: 100,
-        proc: new PregelNode({
-          channels: ["channel2"],
-          triggers: ["channel1", "channel2"],
-          mapper: () => 100,
-        }),
-        writes: [],
-        config: undefined,
-      })
-    );
+    expect(tasks[1]).toEqual({
+      name: "node2",
+      input: 100,
+      proc: new RunnablePassthrough(),
+      writes: [],
+      config: { tags: [] },
+    });
 
     expect(newCheckpoint.versionsSeen.node1.channel1).toBe(2);
     expect(newCheckpoint.versionsSeen.node2.channel1).toBe(2);

--- a/langgraph/src/utils.ts
+++ b/langgraph/src/utils.ts
@@ -50,7 +50,6 @@ export class RunnableCallable extends Runnable {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let returnValue: any;
 
-    // TODO: mergeConfigs() from @langchain/core is not exported
     if (this.trace) {
       returnValue = await this._callWithConfig(
         this.func,

--- a/langgraph/src/utils.ts
+++ b/langgraph/src/utils.ts
@@ -1,4 +1,8 @@
-import { Runnable, RunnableConfig } from "@langchain/core/runnables";
+import {
+  mergeConfigs,
+  Runnable,
+  RunnableConfig,
+} from "@langchain/core/runnables";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface RunnableCallableArgs extends Partial<any> {
@@ -48,9 +52,13 @@ export class RunnableCallable extends Runnable {
 
     // TODO: mergeConfigs() from @langchain/core is not exported
     if (this.trace) {
-      returnValue = await this._callWithConfig(this.func, input, options);
+      returnValue = await this._callWithConfig(
+        this.func,
+        input,
+        mergeConfigs(this.config, options)
+      );
     } else {
-      returnValue = await this.func(input, options);
+      returnValue = await this.func(input, mergeConfigs(this.config, options));
     }
 
     // eslint-disable-next-line no-instanceof/no-instanceof

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "author": "LangChain",
   "license": "MIT",
   "resolutions": {
-    "@langchain/core": "0.1.51"
+    "@langchain/core": "0.1.61"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,9 +1561,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@langchain/core@npm:0.1.51":
-  version: 0.1.51
-  resolution: "@langchain/core@npm:0.1.51"
+"@langchain/core@npm:0.1.61":
+  version: 0.1.61
+  resolution: "@langchain/core@npm:0.1.61"
   dependencies:
     ansi-styles: ^5.0.0
     camelcase: 6
@@ -1571,12 +1571,13 @@ __metadata:
     js-tiktoken: ^1.0.8
     langsmith: ~0.1.7
     ml-distance: ^4.0.0
+    mustache: ^4.2.0
     p-queue: ^6.6.2
     p-retry: 4
     uuid: ^9.0.0
     zod: ^3.22.4
     zod-to-json-schema: ^3.22.3
-  checksum: 5ff5851888a6dde4e51368667908406af3c65307f9934da3933b1223f36cfd389ab80dc1ec7aa4706573c5df30a1437cac5f6845214c48d84d05a11387b3db06
+  checksum: f3eadae482f05e2b48c9cbac063460b0282c19ed42939d82736615e8ad1163a498916513261ea49efa2bfbe7c6b716071e437ac76586bd7a4864ed2c869e7cfd
   languageName: node
   linkType: hard
 
@@ -1586,7 +1587,7 @@ __metadata:
   dependencies:
     "@jest/globals": ^29.5.0
     "@langchain/community": ^0.0.43
-    "@langchain/core": ^0.1.51
+    "@langchain/core": ^0.1.61
     "@langchain/openai": ^0.0.23
     "@langchain/scripts": ~0.0
     "@swc/core": ^1.3.90
@@ -7219,6 +7220,15 @@ __metadata:
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
+  languageName: node
+  linkType: hard
+
+"mustache@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "mustache@npm:4.2.0"
+  bin:
+    mustache: bin/mustache
+  checksum: 928fcb63e3aa44a562bfe9b59ba202cccbe40a46da50be6f0dd831b495be1dd7e38ca4657f0ecab2c1a89dc7bccba0885eab7ee7c1b215830da765758c7e0506
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary
This PR updates static functions in `pregel/index.ts` to the match the corresponding Python implementation. These functions are used in the core `stream()` and `invoke()` methods of the `Pregel` class.

### Implementation
1. Implement `_shouldInterrupt()` (currently unused).
2. Update `_applyWrites()` to match Python implementation.
3. Remove `_applyWritesFromView()`. Removing the function did not break any tests. Not sure if this needs to be migrated.
4. Update `_prepareNextTasks()` to match Python implementation. Note: The side effect from this function is removed and the calling code is updated to ensure that all existing tests pass.
5. Implement `_localRead()` (replaced old implementation of `read`).
6. Update `ChannelRead` and `ChannelWrite` to extend from `RunnableCallable` (this was a regression).
7. Update `@langchain/core` and update `RunnableCallable.invoke()` to call `mergeConfigs()` (this was a regression).
8. Implement `streamChannelsList` getter.

### Next Steps
1. Update `_default()`, `stream()`, and `invoke()` in `Pregel` class.