### PR TITLE
Implement new `Pregel._defaults()` method to match Python implementation

### DIFF
--- a/langgraph/src/pregel/types.ts
+++ b/langgraph/src/pregel/types.ts
@@ -36,3 +36,5 @@ export interface StateSnapshot {
    */
   parentConfig?: RunnableConfig | undefined;
 }
+
+export type All = "*";


### PR DESCRIPTION
### Summary
`_defaults()` is a new method in the `Pregel` class (Python implementation) that the updated `invoke()` and `stream()` methods depend on.

Reference: https://github.com/langchain-ai/langgraph/blob/main/langgraph/pregel/__init__.py#L558

### Implementation
1. Create new `_defaults()` method.
2. Create new `streamChannelsAsIs` getter. `_defaults()` depends on this.
3. Create new `All` (`*`) string literal type. `_defaults()` depends on this. However, this feature was added as part of another feature unrelated to `_defaults()`. See this PR: https://github.com/langchain-ai/langgraph/pull/367.

### Next Steps
1. Update `Pregel` `invoke()` and `stream()` methods.
2. Update Graph APIs and remaining Pregel state APIs.