### PR TITLE
Rewrite StateGraph.compile and and MessageGraph.compile to delegate to new CompiledStateGraph methods

### DIFF
--- a/langgraph/src/graph/graph.ts
+++ b/langgraph/src/graph/graph.ts
@@ -18,7 +18,7 @@ import { RunnableCallable } from "../utils.js";
 export const START = "__start__";
 export const END = "__end__";
 
-class Branch<IO, N extends string> {
+export class Branch<IO, N extends string> {
   condition: (
     input: IO,
     config?: RunnableConfig

--- a/langgraph/src/graph/state.ts
+++ b/langgraph/src/graph/state.ts
@@ -1,20 +1,28 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
 import {
   Runnable,
-  RunnableLambda,
+  RunnableConfig,
   RunnableLike,
 } from "@langchain/core/runnables";
-import { BaseChannel } from "../channels/base.js";
+import { BaseChannel, InvalidUpdateError } from "../channels/base.js";
 import { BinaryOperator, BinaryOperatorAggregate } from "../channels/binop.js";
-import { END, CompiledGraph, Graph, START } from "./graph.js";
+import { END, CompiledGraph, Graph, START, Branch } from "./graph.js";
 import { LastValue } from "../channels/last_value.js";
-import { ChannelWrite, PASSTHROUGH, SKIP_WRITE } from "../pregel/write.js";
+import {
+  ChannelWrite,
+  ChannelWriteEntry,
+  PASSTHROUGH,
+  SKIP_WRITE,
+} from "../pregel/write.js";
 import { BaseCheckpointSaver } from "../checkpoint/base.js";
-import { Pregel, Channel } from "../pregel/index.js";
-import { PregelNode, ChannelRead } from "../pregel/read.js";
+import { ChannelRead, PregelNode } from "../pregel/read.js";
 import { NamedBarrierValue } from "../channels/named_barrier_value.js";
-import { AnyValue } from "../channels/any_value.js";
 import { EphemeralValue } from "../channels/ephemeral_value.js";
 import { RunnableCallable } from "../utils.js";
+import { All } from "../pregel/types.js";
+import { TAG_HIDDEN } from "../constants.js";
+
+const ROOT = "__root__";
 
 type SingleReducer<T> =
   | {
@@ -117,176 +125,61 @@ export class StateGraph<
   }
 
   compile(
-    checkpointer?: BaseCheckpointSaver
+    checkpointer?: BaseCheckpointSaver,
+    interruptBefore?: N[] | All,
+    interruptAfter?: N[] | All
   ): CompiledStateGraph<State, Update, N> {
-    this.validate();
+    // validate the graph
+    this.validate([
+      ...(Array.isArray(interruptBefore) ? interruptBefore : []),
+      ...(Array.isArray(interruptAfter) ? interruptAfter : []),
+    ]);
 
-    if (Object.keys(this.nodes).some((key) => key in this.channels)) {
-      throw new Error("Cannot use channel names as node names");
-    }
-
+    // prepare output channels
     const stateKeys = Object.keys(this.channels);
-    const stateKeysRead =
-      stateKeys.length === 1 && stateKeys[0] === "__root__"
+    const outputs =
+      stateKeys.length === 1 && stateKeys[0] === ROOT
         ? stateKeys[0]
         : stateKeys;
-    let stateChannels: Record<string, string> | string[] = {};
-    if (Array.isArray(stateKeysRead)) {
-      for (const chan of stateKeys) {
-        stateChannels[chan] = chan;
-      }
-    } else {
-      stateChannels = [stateKeysRead];
-    }
 
-    const getInputKey = (key: string, input: unknown) => {
-      if (!input) {
-        return SKIP_WRITE;
-      }
-      if (typeof input !== "object") {
-        throw new Error(`Invalid state update, expected dict and got ${input}`);
-      }
-      if (key in input) {
-        return (input as Record<string, unknown>)[key];
-      }
-      return SKIP_WRITE;
-    };
-
-    const updateChannels = Array.isArray(stateKeysRead)
-      ? stateKeysRead.map((key) => ({
-          channel: key,
-          value: PASSTHROUGH,
-          skipNone: false,
-          mapper: new RunnableCallable({
-            func: (input) => getInputKey(key, input),
-            trace: false,
-            recurse: false,
-          }),
-        }))
-      : [{ channel: "__root__", value: PASSTHROUGH, skipNone: true }];
-
-    const waitingEdges: Set<[string, string[], string]> = new Set();
-    this.waitingEdges.forEach(([starts, end]) => {
-      waitingEdges.add([`${starts}:${end}`, starts, end]);
+    // create empty compiled graph
+    const compiled = new CompiledStateGraph({
+      builder: this,
+      checkpointer,
+      interruptAfter,
+      interruptBefore,
+      autoValidate: false,
+      nodes: {} as Record<N | typeof START, PregelNode<State, Update>>,
+      channels: {
+        ...this.channels,
+        [START]: new EphemeralValue(),
+      } as Record<N | typeof START | typeof END | string, BaseChannel>,
+      inputs: START,
+      outputs,
+      streamChannels: outputs,
+      streamMode: "updates",
     });
 
-    const waitingEdgeChannels: { [key: string]: NamedBarrierValue<string> } =
-      {};
-    waitingEdges.forEach(([key, starts]) => {
-      waitingEdgeChannels[key] = new NamedBarrierValue<string>(new Set(starts));
-    });
-
-    const outgoingEdges: Record<string, string[]> = {};
-    for (const [start, end] of this.edges) {
-      if (!outgoingEdges[start]) {
-        outgoingEdges[start] = [];
-      }
-      outgoingEdges[start].push(end !== END ? `${end}:inbox` : END);
-    }
-    for (const [key, starts] of waitingEdges) {
-      for (const start of starts) {
-        if (!outgoingEdges[start]) {
-          outgoingEdges[start] = [];
-        }
-        outgoingEdges[start].push(key);
-      }
-    }
-
-    const nodes: Record<string, PregelNode> = {};
-
+    // attach nodes, edges and branches
+    compiled.attachNode(START);
     for (const [key, node] of Object.entries<Runnable<State, Update>>(
       this.nodes
     )) {
-      const triggers = [
-        `${key}:inbox`,
-        ...Array.from(waitingEdges)
-          .filter(([, , end]) => end === key)
-          .map(([chan]) => chan),
-      ];
-      nodes[key] = new PregelNode({
-        triggers,
-        channels: stateChannels,
-      })
-        .pipe(node)
-        .pipe(
-          new ChannelWrite([
-            { channel: key, value: PASSTHROUGH, skipNone: false },
-            ...updateChannels,
-          ])
-        );
+      compiled.attachNode(key as N, node);
     }
-
-    const nodeInboxes: Record<string, Channel> = {};
-    const nodeOutboxes: Record<string, Channel> = {};
-    for (const key of [...Object.keys(this.nodes), START]) {
-      nodeInboxes[`${key}:inbox`] = new AnyValue();
-      nodeOutboxes[key] = new EphemeralValue(); // we clear outbox channels after each step
+    for (const [start, end] of this.edges) {
+      compiled.attachEdge(start, end);
     }
-
-    for (const key of Object.keys(this.nodes)) {
-      const outgoing = outgoingEdges[key];
-      const edgesKey = `${key}:edges`;
-      if (outgoing || this.branches[key]) {
-        nodes[edgesKey] = new PregelNode({
-          triggers: [key],
-          tags: ["langsmith:hidden"],
-          channels: stateChannels,
-        }).pipe(new ChannelRead(stateKeysRead));
-      }
-      if (outgoing) {
-        nodes[edgesKey] = nodes[edgesKey].pipe(
-          new ChannelWrite(
-            outgoing.map((dest) => ({
-              channel: dest,
-              value: dest === END ? PASSTHROUGH : key,
-              skipNone: false,
-            }))
-          )
-        );
-      }
-      if (this.branches[key]) {
-        for (const branch of this.branches[key]) {
-          nodes[edgesKey] = nodes[edgesKey].pipe(
-            new RunnableLambda({
-              func: (i, c) => branch.runnable(i, c),
-            })
-          );
-        }
+    for (const [starts, end] of this.waitingEdges) {
+      compiled.attachEdge(starts, end);
+    }
+    for (const [start, branches] of Object.entries(this.branches)) {
+      for (const [name, branch] of Object.entries(branches)) {
+        compiled.attachBranch(start as N, name, branch);
       }
     }
 
-    nodes[START] = Channel.subscribeTo(`${START}:inbox`, {
-      tags: ["langsmith:hidden"],
-    }).pipe(
-      new ChannelWrite([
-        { channel: START, value: PASSTHROUGH, skipNone: false },
-        ...updateChannels,
-      ])
-    );
-
-    nodes[`${START}:edges`] = new PregelNode({
-      triggers: [START],
-      tags: ["langsmith:hidden"],
-      channels: stateChannels,
-    })
-      .pipe(new ChannelRead(stateKeysRead))
-      .pipe(Channel.writeTo([`${this.entryPoint}:inbox`]));
-
-    const channels: Record<string, BaseChannel> = {
-      ...this.channels,
-      ...waitingEdgeChannels,
-      ...nodeInboxes,
-      ...nodeOutboxes,
-      [END]: new LastValue(),
-    };
-
-    return new Pregel({
-      nodes,
-      channels,
-      inputs: `${START}:inbox`,
-      outputs: END,
-      checkpointer,
-    });
+    return compiled.validate();
   }
 }
 
@@ -295,7 +188,7 @@ function _getChannels<Channels extends Record<string, unknown> | unknown>(
 ): Record<string, BaseChannel> {
   const channels: Record<string, BaseChannel> = {};
   for (const [name, val] of Object.entries(schema)) {
-    if (name === "__root__") {
+    if (name === ROOT) {
       channels[name] = getChannel<Channels>(val as SingleReducer<Channels>);
     } else {
       const key = name as keyof Channels;
@@ -317,10 +210,153 @@ function getChannel<T>(reducer: SingleReducer<T>): BaseChannel<T> {
   return new LastValue<T>();
 }
 
-class CompiledStateGraph<
+export class CompiledStateGraph<
   const State extends object | unknown,
-  const Update extends object | unknown,
-  const N extends string
+  const Update extends object | unknown = Partial<State>,
+  const N extends string = typeof START
 > extends CompiledGraph<N, State, Update> {
   declare builder: StateGraph<State, Update, N>;
+
+  attachNode(key: typeof START, node?: never): void;
+
+  attachNode(key: N, node: Runnable<State, Update, RunnableConfig>): void;
+
+  attachNode(
+    key: N | typeof START,
+    node?: Runnable<State, Update, RunnableConfig>
+  ): void {
+    const stateKeys = Object.keys(this.builder.channels);
+
+    function getStateKey(key: keyof Update, input: Update) {
+      if (!input) {
+        return SKIP_WRITE;
+      } else if (typeof input !== "object" || Array.isArray(input)) {
+        throw new InvalidUpdateError(`Expected dict, got ${typeof input}`);
+      } else {
+        return key in input ? input[key] : SKIP_WRITE;
+      }
+    }
+
+    // state updaters
+    const stateWriteEntries: ChannelWriteEntry[] = stateKeys.map((key) =>
+      key === ROOT
+        ? { channel: key, value: PASSTHROUGH, skipNone: true }
+        : {
+            channel: key,
+            value: PASSTHROUGH,
+            mapper: new RunnableCallable({
+              func: getStateKey.bind(null, key as keyof Update),
+              trace: false,
+              recurse: false,
+            }),
+          }
+    );
+
+    // add node and output channel
+    if (key === START) {
+      this.nodes[key] = new PregelNode({
+        tags: [TAG_HIDDEN],
+        triggers: [START],
+        channels: [START],
+        writers: [new ChannelWrite(stateWriteEntries, [TAG_HIDDEN])],
+      });
+    } else {
+      this.channels[key] = new EphemeralValue();
+      this.nodes[key] = new PregelNode({
+        triggers: [],
+        // read state keys
+        channels:
+          stateKeys.length === 1 && stateKeys[0] === ROOT
+            ? stateKeys
+            : stateKeys.reduce((acc, k) => {
+                acc[k] = k;
+                return acc;
+              }, {} as Record<string, string>),
+        // publish to this channel and state keys
+        writers: [
+          new ChannelWrite(
+            stateWriteEntries.concat({ channel: key, value: key }),
+            [TAG_HIDDEN]
+          ),
+        ],
+        bound: node,
+      });
+    }
+  }
+
+  attachEdge(start: N | N[] | "__start__", end: N | "__end__"): void {
+    if (end === END) {
+      return;
+    }
+    if (Array.isArray(start)) {
+      const channelName = `join:${start.join("+")}:${end}`;
+      // register channel
+      (this.channels as Record<string, BaseChannel>)[channelName] =
+        new NamedBarrierValue(new Set(start));
+      // subscribe to channel
+      this.nodes[end].triggers.push(channelName);
+      // publish to channel
+      for (const s of start) {
+        this.nodes[s].writers.push(
+          new ChannelWrite([{ channel: channelName, value: s }], [TAG_HIDDEN])
+        );
+      }
+    } else if (start === START) {
+      const channelName = `start:${end}`;
+      // register channel
+      (this.channels as Record<string, BaseChannel>)[channelName] =
+        new EphemeralValue();
+      // subscribe to channel
+      this.nodes[end].triggers.push(channelName);
+      // publish to channel
+      this.nodes[START].writers.push(
+        new ChannelWrite([{ channel: channelName, value: START }], [TAG_HIDDEN])
+      );
+    } else {
+      this.nodes[end].triggers.push(start);
+    }
+  }
+
+  attachBranch(
+    start: N | typeof START,
+    name: string,
+    branch: Branch<State, N>
+  ): void {
+    // attach branch publisher
+    this.nodes[start].writers.push(
+      branch.compile(
+        // writer
+        (dests) => {
+          const filteredDests = dests.filter((dest) => dest !== END);
+          if (!filteredDests.length) {
+            return;
+          }
+          const writes: ChannelWriteEntry[] = filteredDests.map((dest) => ({
+            channel: `branch:${start}:${name}:${dest}`,
+            value: start,
+          }));
+          // TODO implement branch.then
+          return new ChannelWrite(writes, [TAG_HIDDEN]);
+        },
+        // reader
+        (config) => ChannelRead.doRead<State>(config, this.outputs, true)
+      )
+    );
+
+    // attach branch subscribers
+    const ends = branch.ends
+      ? Object.values(branch.ends)
+      : Object.keys(this.builder.nodes);
+    for (const end of ends) {
+      if (end === END) {
+        continue;
+      }
+      const channelName = `branch:${start}:${name}:${end}`;
+      (this.channels as Record<string, BaseChannel>)[channelName] =
+        new EphemeralValue();
+      this.nodes[end as N].triggers.push(channelName);
+    }
+
+    // TODO: implement branch.then
+  }
 }

--- a/langgraph/src/prebuilt/chat_agent_executor.ts
+++ b/langgraph/src/prebuilt/chat_agent_executor.ts
@@ -4,8 +4,12 @@ import { AgentAction } from "@langchain/core/agents";
 import { FunctionMessage, BaseMessage } from "@langchain/core/messages";
 import { type RunnableConfig, RunnableLambda } from "@langchain/core/runnables";
 import { ToolExecutor } from "./tool_executor.js";
-import { StateGraph, StateGraphArgs } from "../graph/state.js";
-import { END } from "../index.js";
+import {
+  CompiledStateGraph,
+  StateGraph,
+  StateGraphArgs,
+} from "../graph/state.js";
+import { END, START } from "../index.js";
 
 export type FunctionCallingExecutorState = { messages: Array<BaseMessage> };
 
@@ -15,7 +19,11 @@ export function createFunctionCallingExecutor<Model extends object>({
 }: {
   model: Model;
   tools: Array<StructuredTool> | ToolExecutor;
-}) {
+}): CompiledStateGraph<
+  FunctionCallingExecutorState,
+  Partial<FunctionCallingExecutorState>,
+  typeof START | "agent" | "action"
+> {
   let toolExecutor: ToolExecutor;
   let toolClasses: Array<StructuredTool>;
   if (!Array.isArray(tools)) {


### PR DESCRIPTION


- enables more dynamic graphs in future
- implement stream_mode=updates
- fix extra options keys being passed to nodes
- fix stream_mode for invoke
- fix issue where writes array for each task wasn't used

<!--
Thank you for contributing to LangGraph.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langgraphjs/blob/main/CONTRIBUTING.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
