### PR TITLE
Add support for TS 4.9.5

### DIFF
--- a/langgraph/package.json
+++ b/langgraph/package.json
@@ -70,7 +70,7 @@
     "rollup": "^4.5.2",
     "ts-jest": "^29.1.0",
     "tsx": "^4.7.0",
-    "typescript": "^5.4.5",
+    "typescript": "^4.9.5 || ^5.4.5",
     "zod": "^3.22.4",
     "zod-to-json-schema": "^3.22.4"
   },

--- a/langgraph/src/graph/graph.ts
+++ b/langgraph/src/graph/graph.ts
@@ -79,7 +79,7 @@ export class Branch<IO, N extends string> {
 }
 
 export class Graph<
-  const N extends string = typeof END,
+  N extends string = typeof END,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   RunInput = any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -113,7 +113,10 @@ export class Graph<
     return this.edges;
   }
 
-  addNode<K extends string>(key: K, action: RunnableLike<RunInput, RunOutput>) {
+  addNode<K extends string>(
+    key: K,
+    action: RunnableLike<RunInput, RunOutput>
+  ): Graph<N | K, RunInput, RunOutput> {
     this.warnIfCompiled(
       `Adding a node to a graph that has already been compiled. This will not be reflected in the compiled graph.`
     );

--- a/langgraph/src/graph/state.ts
+++ b/langgraph/src/graph/state.ts
@@ -52,9 +52,9 @@ export interface StateGraphArgs<Channels extends object | unknown> {
 }
 
 export class StateGraph<
-  const State extends object | unknown,
-  const Update extends object | unknown = Partial<State>,
-  const N extends string = typeof START
+  State extends object | unknown,
+  Update extends object | unknown = Partial<State>,
+  N extends string = typeof START
 > extends Graph<N, State, Update> {
   channels: Record<string, BaseChannel>;
 
@@ -226,9 +226,9 @@ function getChannel<T>(reducer: SingleReducer<T>): BaseChannel<T> {
 }
 
 export class CompiledStateGraph<
-  const State extends object | unknown,
-  const Update extends object | unknown = Partial<State>,
-  const N extends string = typeof START
+  State extends object | unknown,
+  Update extends object | unknown = Partial<State>,
+  N extends string = typeof START
 > extends CompiledGraph<N, State, Update> {
   declare builder: StateGraph<State, Update, N>;
 

--- a/langgraph/src/pregel/index.ts
+++ b/langgraph/src/pregel/index.ts
@@ -221,8 +221,8 @@ export type PregelInputType = any;
 export type PregelOutputType = any;
 
 export class Pregel<
-    const Nn extends StrRecord<string, PregelNode>,
-    const Cc extends StrRecord<string, BaseChannel>
+    Nn extends StrRecord<string, PregelNode>,
+    Cc extends StrRecord<string, BaseChannel>
   >
   extends Runnable<PregelInputType, PregelOutputType, PregelOptions<Nn, Cc>>
   implements PregelInterface<Nn, Cc>

--- a/package.json
+++ b/package.json
@@ -45,11 +45,12 @@
     "tsx": "^4.7.0",
     "turbo": "latest",
     "typedoc": "^0.25.13",
-    "typescript": "^5.4.5"
+    "typescript": "^4.9.5 || ^5.4.5"
   },
   "resolutions": {
     "@langchain/core": "0.2.3",
-    "cheerio": "^1.0.0-rc.12"
+    "cheerio": "^1.0.0-rc.12",
+    "typescript": "4.9.5"
   },
   "publishConfig": {
     "access": "public",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1439,7 +1439,7 @@ __metadata:
     rollup: ^4.5.2
     ts-jest: ^29.1.0
     tsx: ^4.7.0
-    typescript: ^5.4.5
+    typescript: ^4.9.5 || ^5.4.5
     uuid: ^9.0.1
     zod: ^3.22.4
     zod-to-json-schema: ^3.22.4
@@ -7625,7 +7625,7 @@ __metadata:
     tsx: ^4.7.0
     turbo: latest
     typedoc: ^0.25.13
-    typescript: ^5.4.5
+    typescript: ^4.9.5 || ^5.4.5
   languageName: unknown
   linkType: soft
 
@@ -10382,23 +10382,23 @@ turbo@latest:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.2.2, typescript@npm:^5.4.5":
-  version: 5.4.5
-  resolution: "typescript@npm:5.4.5"
+"typescript@npm:4.9.5":
+  version: 4.9.5
+  resolution: "typescript@npm:4.9.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 53c879c6fa1e3bcb194b274d4501ba1985894b2c2692fa079db03c5a5a7140587a1e04e1ba03184605d35f439b40192d9e138eb3279ca8eee313c081c8bcd9b0
+  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>, typescript@patch:typescript@^5.4.5#~builtin<compat/typescript>":
-  version: 5.4.5
-  resolution: "typescript@patch:typescript@npm%3A5.4.5#~builtin<compat/typescript>::version=5.4.5&hash=1f5320"
+"typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>":
+  version: 4.9.5
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=23ec76"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 2373c693f3b328f3b2387c3efafe6d257b057a142f9a79291854b14ff4d5367d3d730810aee981726b677ae0fd8329b23309da3b6aaab8263dbdccf1da07a3ba
+  checksum: ab417a2f398380c90a6cf5a5f74badd17866adf57f1165617d6a551f059c3ba0a3e4da0d147b3ac5681db9ac76a303c5876394b13b3de75fdd5b1eaa06181c9d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Needed to remove the `const` in generic types, as it's only available in TS 5. Not sure exactly what the consequences of removing this feature are but code changes seemed small?

Sets `resolutions` to `typescript@4.9.5` to test, might not be a bad thing going forwards to resolve to the minimum allowable version.

CC @nfcampos @andrewnguonly 