### PR TITLE
fix: export checkpointer interfaces

### DIFF
--- a/langgraph/src/checkpoint/index.ts
+++ b/langgraph/src/checkpoint/index.ts
@@ -5,5 +5,4 @@ export {
   copyCheckpoint,
   emptyCheckpoint,
   BaseCheckpointSaver,
-  type CheckpointTuple,
 } from "./base.js";

--- a/langgraph/src/checkpoint/index.ts
+++ b/langgraph/src/checkpoint/index.ts
@@ -5,4 +5,5 @@ export {
   copyCheckpoint,
   emptyCheckpoint,
   BaseCheckpointSaver,
+  CheckpointTuple,
 } from "./base.js";

--- a/langgraph/src/checkpoint/index.ts
+++ b/langgraph/src/checkpoint/index.ts
@@ -5,5 +5,5 @@ export {
   copyCheckpoint,
   emptyCheckpoint,
   BaseCheckpointSaver,
-  CheckpointTuple,
+  type CheckpointTuple,
 } from "./base.js";

--- a/langgraph/src/web.ts
+++ b/langgraph/src/web.ts
@@ -11,6 +11,7 @@ export { MemorySaver } from "./checkpoint/memory.js";
 export {
   type Checkpoint,
   type CheckpointMetadata,
+  type CheckpointTuple,
   copyCheckpoint,
   emptyCheckpoint,
   BaseCheckpointSaver,
@@ -21,3 +22,4 @@ export {
   InvalidUpdateError,
   EmptyChannelError,
 } from "./errors.js";
+export { type SerializerProtocol } from "./serde/base.js";


### PR DESCRIPTION
This PR exports `CheckpointTuple` and `SerializerProtocol` interfaces to allow checkpointer contributions from 3rd party pkgs. @jacoblee93 
