### PR TITLE
Fix: broken link in agent_supervisor.ipynb

### DIFF
--- a/examples/multi_agent/agent_supervisor.ipynb
+++ b/examples/multi_agent/agent_supervisor.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Agent Supervisor\n",
     "\n",
-    "The [previous example](multi-agent-collaboration.ipynb) routed messages\n",
+    "The [previous example](./multi-agent-collaboration.ipynb) routed messages\n",
     "automatically based on the output of the initial researcher agent.\n",
     "\n",
     "We can also choose to use an LLM to orchestrate the different agents.\n",


### PR DESCRIPTION
The purpose of this small PR is to fix a broken link (i.e. the one titled "The previous example") in the `agent_supervisor.ipynb` example docs.

**BEFORE** (clicking the link takes to `404`):

<img width="1269" alt="Screenshot 2024-07-02 at 11 54 09" src="https://github.com/langchain-ai/langgraphjs/assets/21361479/b4e726c9-a370-4c70-8bb2-f27805af4975">

**AFTER** (clicking the link takes to the actual page):

<img width="858" alt="Screenshot 2024-07-02 at 11 55 12" src="https://github.com/langchain-ai/langgraphjs/assets/21361479/a6bfb4dc-8f7f-4034-a531-faab8a121d2a">
