### PR TITLE
Loosen types to allow reducers with different update types

### DIFF
--- a/docs/docs/concepts/index.md
+++ b/docs/docs/concepts/index.md
@@ -142,7 +142,7 @@ interface StateA {
 const builderA = new StateGraph<StateA>({
   channels: {
     myField: {
-      // "Overrirde" is the default behavior:
+      // "Override" is the default behavior:
       value: (_x: number, y: number) => y,
       default: () => 0,
     },

--- a/langgraph/src/tests/graph.test.ts
+++ b/langgraph/src/tests/graph.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "@jest/globals";
 import { StateGraph } from "../graph/state.js";
+import { END, START } from "../web.js";
 
 describe("State", () => {
   it("should validate a new node key correctly ", () => {
@@ -15,5 +16,27 @@ describe("State", () => {
     expect(() => {
       stateGraph.addNode("newNodeKey", (_) => ({}));
     }).not.toThrow();
+  });
+
+  it("should allow reducers with different argument types", async () => {
+    const stateGraph = new StateGraph<{
+      testval: string[];
+    }>({
+      channels: {
+        testval: {
+          reducer: (left: string[], right?: string) =>
+            right ? left.concat([right.toString()]) : left,
+        },
+      },
+    });
+
+    const graph = stateGraph
+      .addNode("testnode", (_) => ({ testval: "hi!" }))
+      .addEdge(START, "testnode")
+      .addEdge("testnode", END)
+      .compile();
+    expect(await graph.invoke({ testval: ["hello"] })).toEqual({
+      testval: ["hello", "hi!"],
+    });
   });
 });


### PR DESCRIPTION
Types are tricky and could use a refactor in general, but this unblocks an immediate issue

Supports

```
def update_dialog_stack(left: list[str], right: Optional[str]) -> list[str]:
    """Push or pop the state."""
    if right is None:
        return left
    if right == "pop":
        return left[:-1]
    return left + [right]
```

CC @nfcampos @hinthornw @andrewnguonly 