### PR TITLE
minor: Allow RunnableToolLike

### DIFF
--- a/langgraph/src/prebuilt/chat_agent_executor.ts
+++ b/langgraph/src/prebuilt/chat_agent_executor.ts
@@ -1,8 +1,12 @@
-import { StructuredTool } from "@langchain/core/tools";
+import { StructuredToolInterface } from "@langchain/core/tools";
 import { convertToOpenAIFunction } from "@langchain/core/utils/function_calling";
 import { AgentAction } from "@langchain/core/agents";
 import { FunctionMessage, BaseMessage } from "@langchain/core/messages";
-import { type RunnableConfig, RunnableLambda } from "@langchain/core/runnables";
+import {
+  type RunnableConfig,
+  RunnableLambda,
+  RunnableToolLike,
+} from "@langchain/core/runnables";
 import { ToolExecutor } from "./tool_executor.js";
 import {
   CompiledStateGraph,
@@ -18,14 +22,14 @@ export function createFunctionCallingExecutor<Model extends object>({
   tools,
 }: {
   model: Model;
-  tools: Array<StructuredTool> | ToolExecutor;
+  tools: Array<StructuredToolInterface | RunnableToolLike> | ToolExecutor;
 }): CompiledStateGraph<
   FunctionCallingExecutorState,
   Partial<FunctionCallingExecutorState>,
   typeof START | "agent" | "action"
 > {
   let toolExecutor: ToolExecutor;
-  let toolClasses: Array<StructuredTool>;
+  let toolClasses: Array<StructuredToolInterface | RunnableToolLike>;
   if (!Array.isArray(tools)) {
     toolExecutor = tools;
     toolClasses = tools.tools;

--- a/langgraph/src/prebuilt/react_agent_executor.ts
+++ b/langgraph/src/prebuilt/react_agent_executor.ts
@@ -10,8 +10,9 @@ import {
   RunnableConfig,
   RunnableInterface,
   RunnableLambda,
+  RunnableToolLike,
 } from "@langchain/core/runnables";
-import { DynamicTool, StructuredTool } from "@langchain/core/tools";
+import { DynamicTool, StructuredToolInterface } from "@langchain/core/tools";
 
 import {
   BaseLanguageModelCallOptions,
@@ -38,7 +39,10 @@ export type N = typeof START | "agent" | "tools";
 
 export type CreateReactAgentParams = {
   llm: BaseChatModel;
-  tools: ToolNode<MessagesState> | StructuredTool[];
+  tools:
+    | ToolNode<MessagesState>
+    | StructuredToolInterface[]
+    | RunnableToolLike[];
   messageModifier?:
     | SystemMessage
     | string
@@ -83,7 +87,7 @@ export function createReactAgent(
     },
   };
 
-  let toolClasses: (StructuredTool | DynamicTool)[];
+  let toolClasses: (StructuredToolInterface | DynamicTool | RunnableToolLike)[];
   if (!Array.isArray(tools)) {
     toolClasses = tools.tools;
   } else {

--- a/langgraph/src/prebuilt/tool_executor.ts
+++ b/langgraph/src/prebuilt/tool_executor.ts
@@ -2,13 +2,14 @@ import {
   RunnableBinding,
   RunnableConfig,
   RunnableLambda,
+  RunnableToolLike,
 } from "@langchain/core/runnables";
-import { StructuredTool } from "@langchain/core/tools";
+import { StructuredToolInterface } from "@langchain/core/tools";
 
 const INVALID_TOOL_MSG_TEMPLATE = `{requestedToolName} is not a valid tool, try one of {availableToolNamesString}.`;
 
 export interface ToolExecutorArgs {
-  tools: Array<StructuredTool>;
+  tools: Array<StructuredToolInterface | RunnableToolLike>;
   /**
    * @default {INVALID_TOOL_MSG_TEMPLATE}
    */
@@ -35,9 +36,9 @@ export class ToolExecutor extends RunnableBinding<
 > {
   lc_graph_name = "ToolExecutor";
 
-  tools: Array<StructuredTool>;
+  tools: Array<StructuredToolInterface | RunnableToolLike>;
 
-  toolMap: Record<string, StructuredTool>;
+  toolMap: Record<string, StructuredToolInterface | RunnableToolLike>;
 
   invalidToolMsgTemplate: string;
 
@@ -59,7 +60,7 @@ export class ToolExecutor extends RunnableBinding<
     this.toolMap = this.tools.reduce((acc, tool) => {
       acc[tool.name] = tool;
       return acc;
-    }, {} as Record<string, StructuredTool>);
+    }, {} as Record<string, StructuredToolInterface | RunnableToolLike>);
   }
 
   /**

--- a/langgraph/src/prebuilt/tool_node.ts
+++ b/langgraph/src/prebuilt/tool_node.ts
@@ -4,8 +4,8 @@ import {
   AIMessage,
   isBaseMessage,
 } from "@langchain/core/messages";
-import { RunnableConfig } from "@langchain/core/runnables";
-import { StructuredTool } from "@langchain/core/tools";
+import { RunnableConfig, RunnableToolLike } from "@langchain/core/runnables";
+import { StructuredToolInterface } from "@langchain/core/tools";
 import { RunnableCallable } from "../utils.js";
 import { END } from "../graph/graph.js";
 import { MessagesState } from "../graph/message.js";
@@ -20,10 +20,10 @@ export class ToolNode<
   a list of ToolMessages, one for each tool call.
   */
 
-  tools: StructuredTool[];
+  tools: (StructuredToolInterface | RunnableToolLike)[];
 
   constructor(
-    tools: StructuredTool[],
+    tools: (StructuredToolInterface | RunnableToolLike)[],
     name: string = "tools",
     tags: string[] = []
   ) {


### PR DESCRIPTION
Updated tool input types to also allow `RunnableToolLike`
Updated all instances of inputs for `StructuredTool` with `StructuredToolInterface`