### PR TITLE
Adds shorthand for array state properties

### DIFF
--- a/langgraph/src/graph/message.ts
+++ b/langgraph/src/graph/message.ts
@@ -3,20 +3,11 @@ import { StateGraph } from "./state.js";
 
 type Messages = Array<BaseMessage> | BaseMessage;
 
-function addMessages(left: Messages, right: Messages): BaseMessage[] {
-  const leftArray = Array.isArray(left) ? left : [left];
-  const rightArray = Array.isArray(right) ? right : [right];
-  return [...leftArray, ...rightArray];
-}
-
 export class MessageGraph extends StateGraph<BaseMessage[], Messages> {
   constructor() {
     super({
       channels: {
-        __root__: {
-          reducer: addMessages,
-          default: () => [],
-        },
+        __root__: [],
       },
     });
   }

--- a/langgraph/src/graph/state.ts
+++ b/langgraph/src/graph/state.ts
@@ -37,6 +37,7 @@ type SingleReducer<ValueType, UpdateType = ValueType> =
       value: BinaryOperator<ValueType, UpdateType>;
       default?: () => ValueType;
     }
+  | []
   | null;
 
 export type ChannelReducers<Channels extends object> = {
@@ -50,6 +51,12 @@ export interface StateGraphArgs<Channels extends object | unknown> {
       ? ChannelReducers<{ __root__: Channels }>
       : ChannelReducers<Channels>
     : ChannelReducers<{ __root__: Channels }>;
+}
+
+export function mergeArrays<T>(left: T | T[], right: T | T[]): T[] {
+  const leftArray: T[] = Array.isArray(left) ? left : [left];
+  const rightArray: T[] = Array.isArray(right) ? right : [right];
+  return [...leftArray, ...rightArray];
 }
 
 export class StateGraph<
@@ -208,6 +215,12 @@ function _getChannels<Channels extends Record<string, unknown> | unknown>(
 }
 
 function getChannel<T>(reducer: SingleReducer<T>): BaseChannel<T> {
+  if (Array.isArray(reducer)) {
+    return new BinaryOperatorAggregate(
+      mergeArrays as BinaryOperator<T, T>,
+      () => [] as T
+    );
+  }
   if (
     typeof reducer === "object" &&
     reducer &&


### PR DESCRIPTION
Allows for slightly easier initialization and passing of states like this:

```ts
interface AdaptiveRAGGraphState {
  question: string;
  generation: string;
  documents: Document[];
}

const graphState = {
  question: null,
  generation: null,
  documents: [],
};

const graph = new StateGraph<AdaptiveRAGGraphState>({ channels: graphState });
```

Can also see how it could be confusing though too