### PR TITLE
infra[patch]: Use non rc of langchain/scripts 0.0.19

### DIFF
--- a/langgraph/package.json
+++ b/langgraph/package.json
@@ -39,7 +39,7 @@
     "@langchain/anthropic": "^0.2.6",
     "@langchain/community": "^0.2.19",
     "@langchain/openai": "^0.2.4",
-    "@langchain/scripts": "0.0.19-rc.0",
+    "@langchain/scripts": "^0.0.19",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1433,7 +1433,7 @@ __metadata:
     "@langchain/community": ^0.2.19
     "@langchain/core": ">=0.2.18 <0.3.0"
     "@langchain/openai": ^0.2.4
-    "@langchain/scripts": 0.0.19-rc.0
+    "@langchain/scripts": ^0.0.19
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
@@ -1511,9 +1511,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@langchain/scripts@npm:0.0.19-rc.0":
-  version: 0.0.19-rc.0
-  resolution: "@langchain/scripts@npm:0.0.19-rc.0"
+"@langchain/scripts@npm:^0.0.19":
+  version: 0.0.19
+  resolution: "@langchain/scripts@npm:0.0.19"
   dependencies:
     "@rollup/wasm-node": ^4.19.0
     axios: ^1.6.7
@@ -1526,7 +1526,7 @@ __metadata:
   bin:
     lc-build: bin/build.js
     lc_build_v2: bin/build_v2.js
-  checksum: 68051c555e4039cd268c1b8a75b65483536592f67f2eda96b7742e8a525859acf1cd48b28ec7571b0e74ce992b024af79e28a41e339d3c7a2c10ae359c395549
+  checksum: ef58af8139ee701475bc602353ae132655ee00f0c3366a7d54dafad52195026de8ee2c378a66a6ab5b2c4e83494b553c6ab5f98353d3bd48502bf6e50b097729
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I released an actual release of `@langchain/scripts` on v`0.0.19` so no need to use the rc anymore.