### PR TITLE
Define StateGraph State in a single delcaration, from which both reducers and state and update interfaces are inferred

### DIFF
--- a/langgraph/package.json
+++ b/langgraph/package.json
@@ -30,7 +30,7 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "@langchain/core": ">=0.2.18 <0.3.0",
+    "@langchain/core": ">=0.2.20 <0.3.0",
     "uuid": "^10.0.0",
     "zod": "^3.23.8"
   },

--- a/langgraph/src/channels/base.ts
+++ b/langgraph/src/channels/base.ts
@@ -8,6 +8,10 @@ export abstract class BaseChannel<
   UpdateType = unknown,
   CheckpointType = unknown
 > {
+  ValueType: ValueType;
+
+  UpdateType: UpdateType;
+
   /**
    * The name of the channel.
    */

--- a/langgraph/src/graph/message.ts
+++ b/langgraph/src/graph/message.ts
@@ -59,7 +59,11 @@ export function messagesStateReducer(
   return merged.filter((m) => !idsToRemove.has(m.id));
 }
 
-export class MessageGraph extends StateGraph<BaseMessage[], Messages> {
+export class MessageGraph extends StateGraph<
+  BaseMessage[],
+  BaseMessage[],
+  Messages
+> {
   constructor() {
     super({
       channels: {

--- a/langgraph/src/graph/state.ts
+++ b/langgraph/src/graph/state.ts
@@ -430,15 +430,16 @@ export class CompiledStateGraph<
   }
 }
 
+function isBaseChannel(obj: unknown): obj is BaseChannel {
+  return obj != null && typeof (obj as BaseChannel).lc_graph_name === "string";
+}
+
 function isStateDefinition(obj: unknown): obj is StateDefinition {
   return (
     typeof obj === "object" &&
     obj !== null &&
     !Array.isArray(obj) &&
     Object.keys(obj).length > 0 &&
-    Object.values(obj).every(
-      // eslint-disable-next-line no-instanceof/no-instanceof
-      (v) => typeof v === "function" || v instanceof BaseChannel
-    )
+    Object.values(obj).every((v) => typeof v === "function" || isBaseChannel(v))
   );
 }

--- a/langgraph/src/graph/state.ts
+++ b/langgraph/src/graph/state.ts
@@ -25,6 +25,47 @@ import { InvalidUpdateError } from "../errors.js";
 
 const ROOT = "__root__";
 
+export function Annotation<ValueType>(): LastValue<ValueType>;
+
+export function Annotation<ValueType, UpdateType = ValueType>(
+  annotation: SingleReducer<ValueType, UpdateType>
+): BinaryOperatorAggregate<ValueType, UpdateType>;
+
+export function Annotation<ValueType, UpdateType = ValueType>(
+  annotation?: SingleReducer<ValueType, UpdateType>
+): BaseChannel<ValueType, UpdateType> {
+  if (annotation) {
+    return getChannel<ValueType, UpdateType>(annotation);
+  } else {
+    // @ts-expect-error - Annotation without reducer
+    return new LastValue<ValueType>();
+  }
+}
+
+interface StateDefinition {
+  [key: string]: BaseChannel | (() => BaseChannel);
+}
+
+type ExtractValueType<C> = C extends BaseChannel
+  ? C["ValueType"]
+  : C extends () => BaseChannel
+  ? ReturnType<C>["ValueType"]
+  : never;
+
+type ExtractUpdateType<C> = C extends BaseChannel
+  ? C["UpdateType"]
+  : C extends () => BaseChannel
+  ? ReturnType<C>["UpdateType"]
+  : never;
+
+export type StateInterface<S extends StateDefinition> = {
+  [key in keyof S]: ExtractValueType<S[key]>;
+};
+
+export type UpdateInterface<S extends StateDefinition> = {
+  [key in keyof S]?: ExtractUpdateType<S[key]>;
+};
+
 type SingleReducer<ValueType, UpdateType = ValueType> =
   | {
       reducer: BinaryOperator<ValueType, UpdateType>;
@@ -53,19 +94,34 @@ export interface StateGraphArgs<Channels extends object | unknown> {
 }
 
 export class StateGraph<
-  State extends object | unknown,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Update extends object | unknown = Partial<Record<keyof State, any>>,
+  SD extends StateDefinition | unknown,
+  S = SD extends StateDefinition ? StateInterface<SD> : SD,
+  U = SD extends StateDefinition ? UpdateInterface<SD> : Partial<S>,
   N extends string = typeof START
-> extends Graph<N, State, Update> {
+> extends Graph<N, S, U> {
   channels: Record<string, BaseChannel>;
 
   // TODO: this doesn't dedupe edges as in py, so worth fixing at some point
   waitingEdges: Set<[N[], N]> = new Set();
 
-  constructor(fields: StateGraphArgs<State>) {
+  constructor(
+    fields: SD extends StateDefinition
+      ? SD | StateGraphArgs<S>
+      : StateGraphArgs<S>
+  ) {
     super();
-    this.channels = _getChannels(fields.channels);
+    if (isStateDefinition(fields)) {
+      this.channels = {};
+      for (const [key, val] of Object.entries(fields)) {
+        if (typeof val === "function") {
+          this.channels[key] = val();
+        } else {
+          this.channels[key] = val;
+        }
+      }
+    } else {
+      this.channels = _getChannels(fields.channels);
+    }
     for (const c of Object.values(this.channels)) {
       if (c.lc_graph_name === "BinaryOperatorAggregate") {
         this.supportMultipleEdges = true;
@@ -85,14 +141,14 @@ export class StateGraph<
 
   addNode<K extends string>(
     key: K,
-    action: RunnableLike<State, Update>
-  ): StateGraph<State, Update, N | K> {
+    action: RunnableLike<S, U>
+  ): StateGraph<SD, S, U, N | K> {
     if (key in this.channels) {
       throw new Error(
         `${key} is already being used as a state attribute (a.k.a. a channel), cannot also be used as a node name.`
       );
     }
-    return super.addNode(key, action) as StateGraph<State, Update, N | K>;
+    return super.addNode(key, action) as StateGraph<SD, S, U, N | K>;
   }
 
   addEdge(startKey: typeof START | N | N[], endKey: N | typeof END): this {
@@ -135,7 +191,7 @@ export class StateGraph<
     checkpointer?: BaseCheckpointSaver;
     interruptBefore?: N[] | All;
     interruptAfter?: N[] | All;
-  } = {}): CompiledStateGraph<State, Update, N> {
+  } = {}): CompiledStateGraph<S, U, N> {
     // validate the graph
     this.validate([
       ...(Array.isArray(interruptBefore) ? interruptBefore : []),
@@ -156,7 +212,7 @@ export class StateGraph<
       interruptAfter,
       interruptBefore,
       autoValidate: false,
-      nodes: {} as Record<N | typeof START, PregelNode<State, Update>>,
+      nodes: {} as Record<N | typeof START, PregelNode<S, U>>,
       channels: {
         ...this.channels,
         [START]: new EphemeralValue(),
@@ -169,9 +225,7 @@ export class StateGraph<
 
     // attach nodes, edges and branches
     compiled.attachNode(START);
-    for (const [key, node] of Object.entries<Runnable<State, Update>>(
-      this.nodes
-    )) {
+    for (const [key, node] of Object.entries<Runnable<S, U>>(this.nodes)) {
       compiled.attachNode(key as N, node);
     }
     for (const [start, end] of this.edges) {
@@ -207,7 +261,7 @@ function _getChannels<Channels extends Record<string, unknown> | unknown>(
   return channels;
 }
 
-function getChannel<T>(reducer: SingleReducer<T>): BaseChannel<T> {
+function getChannel<V, U = V>(reducer: SingleReducer<V, U>): BaseChannel<V, U> {
   if (
     typeof reducer === "object" &&
     reducer &&
@@ -224,27 +278,28 @@ function getChannel<T>(reducer: SingleReducer<T>): BaseChannel<T> {
   ) {
     return new BinaryOperatorAggregate(reducer.value, reducer.default);
   }
-  return new LastValue<T>();
+  // @ts-expect-error - Annotation without reducer
+  return new LastValue<V>();
 }
 
 export class CompiledStateGraph<
-  State extends object | unknown,
-  Update extends object | unknown = Partial<State>,
+  S,
+  U,
   N extends string = typeof START
-> extends CompiledGraph<N, State, Update> {
-  declare builder: StateGraph<State, Update, N>;
+> extends CompiledGraph<N, S, U> {
+  declare builder: StateGraph<unknown, S, U, N>;
 
   attachNode(key: typeof START, node?: never): void;
 
-  attachNode(key: N, node: Runnable<State, Update, RunnableConfig>): void;
+  attachNode(key: N, node: Runnable<S, U, RunnableConfig>): void;
 
   attachNode(
     key: N | typeof START,
-    node?: Runnable<State, Update, RunnableConfig>
+    node?: Runnable<S, U, RunnableConfig>
   ): void {
     const stateKeys = Object.keys(this.builder.channels);
 
-    function getStateKey(key: keyof Update, input: Update) {
+    function getStateKey(key: keyof U, input: U) {
       if (!input) {
         return SKIP_WRITE;
       } else if (typeof input !== "object" || Array.isArray(input)) {
@@ -262,7 +317,7 @@ export class CompiledStateGraph<
             channel: key,
             value: PASSTHROUGH,
             mapper: new RunnableCallable({
-              func: getStateKey.bind(null, key as keyof Update),
+              func: getStateKey.bind(null, key as keyof U),
               trace: false,
               recurse: false,
             }),
@@ -271,7 +326,7 @@ export class CompiledStateGraph<
 
     // add node and output channel
     if (key === START) {
-      this.nodes[key] = new PregelNode<State, Update>({
+      this.nodes[key] = new PregelNode<S, U>({
         tags: [TAG_HIDDEN],
         triggers: [START],
         channels: [START],
@@ -279,7 +334,7 @@ export class CompiledStateGraph<
       });
     } else {
       this.channels[key] = new EphemeralValue();
-      this.nodes[key] = new PregelNode<State, Update>({
+      this.nodes[key] = new PregelNode<S, U>({
         triggers: [],
         // read state keys
         channels:
@@ -337,7 +392,7 @@ export class CompiledStateGraph<
   attachBranch(
     start: N | typeof START,
     name: string,
-    branch: Branch<State, N>
+    branch: Branch<S, N>
   ): void {
     // attach branch publisher
     this.nodes[start].writers.push(
@@ -355,7 +410,7 @@ export class CompiledStateGraph<
           return new ChannelWrite(writes, [TAG_HIDDEN]);
         },
         // reader
-        (config) => ChannelRead.doRead<State>(config, this.outputs, true)
+        (config) => ChannelRead.doRead<S>(config, this.outputs, true)
       )
     );
 
@@ -373,4 +428,17 @@ export class CompiledStateGraph<
       this.nodes[end as N].triggers.push(channelName);
     }
   }
+}
+
+function isStateDefinition(obj: unknown): obj is StateDefinition {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    !Array.isArray(obj) &&
+    Object.keys(obj).length > 0 &&
+    Object.values(obj).every(
+      // eslint-disable-next-line no-instanceof/no-instanceof
+      (v) => typeof v === "function" || v instanceof BaseChannel
+    )
+  );
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/d3": "^7",
     "@types/semver": "^7",
     "cheerio": "^1.0.0-rc.12",
+    "cheminfo-types": "^1.4.0",
     "d3": "^7.9.0",
     "esm-hook": "^0.1.4",
     "readline": "^1.3.0",
@@ -49,7 +50,7 @@
     "typescript": "^4.9.5 || ^5.4.5"
   },
   "resolutions": {
-    "@langchain/core": "0.2.18",
+    "@langchain/core": "0.2.20",
     "cheerio": "^1.0.0-rc.12",
     "typescript": "4.9.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1404,23 +1404,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@langchain/core@npm:0.2.18":
-  version: 0.2.18
-  resolution: "@langchain/core@npm:0.2.18"
+"@langchain/core@npm:0.2.20":
+  version: 0.2.20
+  resolution: "@langchain/core@npm:0.2.20"
   dependencies:
     ansi-styles: ^5.0.0
     camelcase: 6
     decamelize: 1.2.0
     js-tiktoken: ^1.0.12
     langsmith: ~0.1.39
-    ml-distance: ^4.0.0
     mustache: ^4.2.0
     p-queue: ^6.6.2
     p-retry: 4
     uuid: ^10.0.0
     zod: ^3.22.4
     zod-to-json-schema: ^3.22.3
-  checksum: f1090a300825a8cefdf873a38926f5a3a8f1208ebcdd9f65c4858e851082b8f89b7b7d7dba50c3907de997b0f2fad2856d611adf61096dffcf240e959809e4fc
+  checksum: 0c1c877d9d94d38e32067e1259ca658ca552161ee36b98f9ef6453aa8b1fe37b1b49c321d7789e110c9f515cbb491a6f543f51ba34baff483f073182bcb187e7
   languageName: node
   linkType: hard
 
@@ -1431,7 +1430,7 @@ __metadata:
     "@jest/globals": ^29.5.0
     "@langchain/anthropic": ^0.2.6
     "@langchain/community": ^0.2.19
-    "@langchain/core": ">=0.2.18 <0.3.0"
+    "@langchain/core": ">=0.2.20 <0.3.0"
     "@langchain/openai": ^0.2.4
     "@langchain/scripts": ^0.0.19
     "@swc/core": ^1.3.90
@@ -3736,6 +3735,13 @@ __metadata:
     parse5: ^7.0.0
     parse5-htmlparser2-tree-adapter: ^7.0.0
   checksum: 5d4c1b7a53cf22d3a2eddc0aff70cf23cbb30d01a4c79013e703a012475c02461aa1fcd99127e8d83a02216386ed6942b2c8103845fd0812300dd199e6e7e054
+  languageName: node
+  linkType: hard
+
+"cheminfo-types@npm:^1.4.0":
+  version: 1.7.3
+  resolution: "cheminfo-types@npm:1.7.3"
+  checksum: 52831a45f880f9ed31f6494abae023a3b35bdd4015d40baaa042602ed552effbebad08c09b02a5e3f8a9b0567aa0e14aebed401f0759a3d5059cff4871f4b43e
   languageName: node
   linkType: hard
 
@@ -8078,6 +8084,7 @@ __metadata:
     "@types/d3": ^7
     "@types/semver": ^7
     cheerio: ^1.0.0-rc.12
+    cheminfo-types: ^1.4.0
     d3: ^7.9.0
     esm-hook: ^0.1.4
     readline: ^1.3.0


### PR DESCRIPTION


This more closely matches python, where a single declaration gives you all three

<!--
Thank you for contributing to LangGraph.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langgraphjs/blob/main/CONTRIBUTING.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
