### PR TITLE
ci[minor]: Add script & GH action to validate deno and node deps in sync

### DIFF
--- a/.github/workflows/validate-new-notebooks.yml
+++ b/.github/workflows/validate-new-notebooks.yml
@@ -22,6 +22,25 @@ on:
       - 'examples/**'
   workflow_dispatch:
 
+env:
+  NODE_VERSION: "22.4.1"
+
+jobs:
+  validate-dep-files:
+    name: Validate Deno and Node dependencies in sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Validate
+        run: yarn tsx --experimental-wasm-modules ./scripts/validate_deps_sync.ts 
+
 jobs:
   validate-new-notebooks:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-new-notebooks.yml
+++ b/.github/workflows/validate-new-notebooks.yml
@@ -20,6 +20,7 @@ on:
     paths:
       - 'docs/docs/**'
       - 'examples/**'
+      - 'deno.json'
   workflow_dispatch:
 
 env:

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "esm-hook": "^0.1.4",
     "readline": "^1.3.0",
     "release-it": "^17.6.0",
-    "semver": "^7.5.4",
+    "semver": "^7.6.3",
     "tslab": "^1.0.21",
     "tsx": "^4.7.0",
     "turbo": "canary",

--- a/scripts/validate_deps_sync.ts
+++ b/scripts/validate_deps_sync.ts
@@ -61,6 +61,4 @@ function main() {
   });
 }
 
-if (import.meta.url === import.meta.resolve("./validate-deps-sync.ts")) {
-  main();
-}
+main();

--- a/scripts/validate_deps_sync.ts
+++ b/scripts/validate_deps_sync.ts
@@ -1,0 +1,66 @@
+import fs from "fs";
+import semver from "semver";
+
+type DenoJson = {
+  imports: Record<string, string>;
+};
+
+type PackageJson = {
+  // Only adding the fields we care about
+  devDependencies: Record<string, string>;
+};
+
+function main() {
+  const denoJson: DenoJson = JSON.parse(fs.readFileSync("deno.json", "utf-8"));
+  const packageJson: PackageJson = JSON.parse(
+    fs.readFileSync("examples/package.json", "utf-8")
+  );
+
+  // Parse the dependency names and versions from the deno.json file
+  const denoDeps = Object.entries(denoJson.imports).map(([name, version]) => {
+    let depName = name.endsWith("/") ? name.slice(0, -1) : name;
+    let depVersion = version
+      .replace(/^npm:\/?(.*)/g, "$1")
+      .replace(depName, "");
+    depVersion = depVersion.replace(/@.*$/, "").replace(/\/$/, "");
+    if (!depVersion || depVersion === "") {
+      depVersion = "latest";
+    }
+
+    // `latest` is not a valid semver, do not validate it
+    if (depVersion !== "latest" && !semver.valid(depVersion)) {
+      throw new Error(`Invalid version for ${depName}: ${depVersion}`);
+    }
+    return { name: depName, version: depVersion };
+  });
+
+  // Match the dependencies to those in the `package.json` file, and
+  // use the `semver` package to verify the versions are compatible
+  denoDeps.forEach((denoDep) => {
+    if (!(denoDep.name in packageJson.devDependencies)) {
+      throw new Error(
+        `Dependency ${denoDep.name} is not in the package.json file`
+      );
+    }
+
+    const packageVersion = packageJson.devDependencies[denoDep.name];
+    if (denoDep.version === "latest") {
+      // If the deno version is latest, we can not validate it. Assume it is correct
+      return;
+    }
+    const cleanedPackageJsonVersion =
+      semver.clean(packageVersion) ?? packageVersion;
+    if (
+      cleanedPackageJsonVersion !== denoDep.version &&
+      !semver.gte(cleanedPackageJsonVersion, denoDep.version)
+    ) {
+      throw new Error(
+        `Version mismatch for ${denoDep.name}: package.json version ${cleanedPackageJsonVersion} is less than deno.json version ${denoDep.version}`
+      );
+    }
+  });
+}
+
+if (import.meta.url === import.meta.resolve("./validate-deps-sync.ts")) {
+  main();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8779,7 +8779,7 @@ __metadata:
     esm-hook: ^0.1.4
     readline: ^1.3.0
     release-it: ^17.6.0
-    semver: ^7.5.4
+    semver: ^7.6.3
     tslab: ^1.0.21
     tsx: ^4.7.0
     turbo: canary


### PR DESCRIPTION
The validate new notebook gh action requires the notebook dependencies to be installed w/ npm, but notebooks do not require deps to be listed in a package.json (`deno.json`)

This script & gh action verifies that all dependencies listed in the `deno.json` file are also present in the `examples/package.json` file, and the version is greater than or equal to that in `deno.json`