### PR TITLE
Handle explicit undefined values passed into serde

### DIFF
--- a/libs/checkpoint/src/memory.ts
+++ b/libs/checkpoint/src/memory.ts
@@ -54,17 +54,7 @@ export class MemorySaver extends BaseCheckpointSaver {
             ];
           })
         );
-        const parentConfig =
-          parentCheckpointId !== undefined
-            ? {
-                configurable: {
-                  thread_id,
-                  checkpoint_ns,
-                  checkpoint_id,
-                },
-              }
-            : undefined;
-        return {
+        const checkpointTuple: CheckpointTuple = {
           config,
           checkpoint: (await this.serde.loadsTyped(
             "json",
@@ -75,8 +65,17 @@ export class MemorySaver extends BaseCheckpointSaver {
             metadata
           )) as CheckpointMetadata,
           pendingWrites,
-          parentConfig,
         };
+        if (parentCheckpointId !== undefined) {
+          checkpointTuple.parentConfig = {
+            configurable: {
+              thread_id,
+              checkpoint_ns,
+              checkpoint_id,
+            },
+          };
+        }
+        return checkpointTuple;
       }
     } else {
       const checkpoints = this.storage[thread_id]?.[checkpoint_ns];
@@ -99,17 +98,7 @@ export class MemorySaver extends BaseCheckpointSaver {
             ];
           })
         );
-        const parentConfig =
-          parentCheckpointId !== undefined
-            ? {
-                configurable: {
-                  thread_id,
-                  checkpoint_ns,
-                  checkpoint_id: parentCheckpointId,
-                },
-              }
-            : undefined;
-        return {
+        const checkpointTuple: CheckpointTuple = {
           config: {
             configurable: {
               thread_id,
@@ -126,8 +115,17 @@ export class MemorySaver extends BaseCheckpointSaver {
             metadata
           )) as CheckpointMetadata,
           pendingWrites,
-          parentConfig,
         };
+        if (parentCheckpointId !== undefined) {
+          checkpointTuple.parentConfig = {
+            configurable: {
+              thread_id,
+              checkpoint_ns,
+              checkpoint_id: parentCheckpointId,
+            },
+          };
+        }
+        return checkpointTuple;
       }
     }
 
@@ -191,7 +189,7 @@ export class MemorySaver extends BaseCheckpointSaver {
           })
         );
 
-        yield {
+        const checkpointTuple: CheckpointTuple = {
           config: {
             configurable: {
               thread_id: threadId,
@@ -205,16 +203,17 @@ export class MemorySaver extends BaseCheckpointSaver {
           )) as Checkpoint,
           metadata,
           pendingWrites,
-          parentConfig: parentCheckpointId
-            ? {
-                configurable: {
-                  thread_id: threadId,
-                  checkpoint_ns: checkpointNamespace,
-                  checkpoint_id: parentCheckpointId,
-                },
-              }
-            : undefined,
         };
+        if (parentCheckpointId !== undefined) {
+          checkpointTuple.parentConfig = {
+            configurable: {
+              thread_id: threadId,
+              checkpoint_ns: checkpointNamespace,
+              checkpoint_id: parentCheckpointId,
+            },
+          };
+        }
+        yield checkpointTuple;
       }
     }
   }

--- a/libs/checkpoint/src/serde/jsonplus.ts
+++ b/libs/checkpoint/src/serde/jsonplus.ts
@@ -5,7 +5,9 @@ import { SerializerProtocol } from "./base.js";
 
 async function _reviver(value: any): Promise<any> {
   if (value && typeof value === "object") {
-    if (
+    if (value.lc === 2 && value.type === "undefined") {
+      return undefined;
+    } else if (
       value.lc === 2 &&
       value.type === "constructor" &&
       Array.isArray(value.id)
@@ -72,8 +74,10 @@ function _encodeConstructorArgs(
 
 function _default(_key: string, obj: any): any {
   if (obj === undefined) {
-    console.warn(`Serializer received an explicit "undefined" value. Converting to "null".`);
-    return null;
+    return {
+      lc: 2,
+      type: "undefined",
+    };
   } else if (obj instanceof Set || obj instanceof Map) {
     return _encodeConstructorArgs(obj.constructor, undefined, [
       Array.from(obj),

--- a/libs/checkpoint/src/serde/jsonplus.ts
+++ b/libs/checkpoint/src/serde/jsonplus.ts
@@ -64,14 +64,17 @@ function _encodeConstructorArgs(
     lc: 2,
     type: "constructor",
     id: [constructor.name],
-    method,
+    method: method ?? null,
     args: args ?? [],
     kwargs: kwargs ?? {},
   };
 }
 
 function _default(_key: string, obj: any): any {
-  if (obj instanceof Set || obj instanceof Map) {
+  if (obj === undefined) {
+    console.warn(`Serializer received an explicit "undefined" value. Converting to "null".`);
+    return null;
+  } else if (obj instanceof Set || obj instanceof Map) {
     return _encodeConstructorArgs(obj.constructor, undefined, [
       Array.from(obj),
     ]);

--- a/libs/checkpoint/src/serde/tests/jsonplus.test.ts
+++ b/libs/checkpoint/src/serde/tests/jsonplus.test.ts
@@ -35,6 +35,7 @@ const complexValue = {
 };
 
 const VALUES = [
+  ["undefined", undefined],
   ["null", null],
   ["empty string", ""],
   ["simple string", "foobar"],
@@ -46,11 +47,4 @@ it.each(VALUES)("should serialize and deserialize %s", async (_description, valu
   const [type, serialized] = serde.dumpsTyped(value);
   const deserialized = await serde.loadsTyped(type, serialized);
   expect(deserialized).toEqual(value);
-});
-
-it(`should serialize "undefined" as "null"`, async () => {
-  const serde = new JsonPlusSerializer();
-  const [type, serialized] = serde.dumpsTyped(undefined);
-  const deserialized = await serde.loadsTyped(type, serialized);
-  expect(deserialized).toEqual(null);
 });

--- a/libs/checkpoint/src/serde/tests/jsonplus.test.ts
+++ b/libs/checkpoint/src/serde/tests/jsonplus.test.ts
@@ -3,7 +3,7 @@ import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import { uuid6 } from "../../id.js";
 import { JsonPlusSerializer } from "../jsonplus.js";
 
-const value = {
+const complexValue = {
   number: 1,
   id: uuid6(-1),
   error: new Error("test error"),
@@ -18,6 +18,7 @@ const value = {
     new Error("nestedfoo"),
     5,
     true,
+    null,
     false,
     {
       a: "b",
@@ -26,12 +27,30 @@ const value = {
   ],
   object: {
     messages: [new HumanMessage("hey there"), new AIMessage("hi how are you")],
+    nestedNullVal: null,
+    emptyString: "",
   },
+  emptyString: "",
+  nullVal: null,
 };
 
-it("should serialize and deserialize various data types", async () => {
+const VALUES = [
+  ["null", null],
+  ["empty string", ""],
+  ["simple string", "foobar"],
+  ["various data types", complexValue],
+] satisfies [string, unknown][];
+
+it.each(VALUES)("should serialize and deserialize %s", async (_description, value) => {
   const serde = new JsonPlusSerializer();
   const [type, serialized] = serde.dumpsTyped(value);
   const deserialized = await serde.loadsTyped(type, serialized);
   expect(deserialized).toEqual(value);
+});
+
+it(`should serialize "undefined" as "null"`, async () => {
+  const serde = new JsonPlusSerializer();
+  const [type, serialized] = serde.dumpsTyped(undefined);
+  const deserialized = await serde.loadsTyped(type, serialized);
+  expect(deserialized).toEqual(null);
 });

--- a/libs/checkpoint/src/serde/tests/jsonplus.test.ts
+++ b/libs/checkpoint/src/serde/tests/jsonplus.test.ts
@@ -42,9 +42,12 @@ const VALUES = [
   ["various data types", complexValue],
 ] satisfies [string, unknown][];
 
-it.each(VALUES)("should serialize and deserialize %s", async (_description, value) => {
-  const serde = new JsonPlusSerializer();
-  const [type, serialized] = serde.dumpsTyped(value);
-  const deserialized = await serde.loadsTyped(type, serialized);
-  expect(deserialized).toEqual(value);
-});
+it.each(VALUES)(
+  "should serialize and deserialize %s",
+  async (_description, value) => {
+    const serde = new JsonPlusSerializer();
+    const [type, serialized] = serde.dumpsTyped(value);
+    const deserialized = await serde.loadsTyped(type, serialized);
+    expect(deserialized).toEqual(value);
+  }
+);

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -454,7 +454,6 @@ export class Pregel<
         writers.length > 1 ? RunnableSequence.from(writers as any) : writers[0],
       writes: [],
       triggers: [INTERRUPT],
-      config: undefined,
       id: uuid5(INTERRUPT, checkpoint.id),
     };
 

--- a/libs/langgraph/src/pregel/loop.ts
+++ b/libs/langgraph/src/pregel/loop.ts
@@ -302,7 +302,7 @@ export class PregelLoop {
         : mapOutputValues(outputKeys, writes, this.channels).next().value;
       await this._putCheckpoint({
         source: "loop",
-        writes: metadataWrites,
+        writes: metadataWrites ?? null,
       });
       // after execution, check if we should interrupt
       if (shouldInterrupt(this.checkpoint, interruptAfter, this.tasks)) {
@@ -456,7 +456,10 @@ export class PregelLoop {
         this.checkpointerGetNextVersion
       );
       // save input checkpoint
-      await this._putCheckpoint({ source: "input", writes: this.input });
+      await this._putCheckpoint({
+        source: "input",
+        writes: this.input ?? null,
+      });
     }
     // done with input
     this.input = isResuming ? INPUT_RESUMING : INPUT_DONE;

--- a/libs/langgraph/src/pregel/types.ts
+++ b/libs/langgraph/src/pregel/types.ts
@@ -84,7 +84,7 @@ export interface PregelExecutableTask<
   readonly input: unknown;
   readonly proc: Runnable;
   readonly writes: PendingWrite<C>[];
-  readonly config: RunnableConfig | undefined;
+  readonly config?: RunnableConfig;
   readonly triggers: Array<string>;
   readonly retry_policy?: string;
   readonly id: string;

--- a/libs/langgraph/src/tests/pregel.test.ts
+++ b/libs/langgraph/src/tests/pregel.test.ts
@@ -42,6 +42,7 @@ import {
   Graph,
   START,
   StateGraph,
+  StateGraphArgs,
   StateType,
 } from "../graph/index.js";
 import { Topic } from "../channels/topic.js";
@@ -1340,7 +1341,7 @@ it("should invoke two processes with input/output and interrupt", async () => {
           checkpoint_id: expect.any(String),
         },
       },
-      metadata: { source: "loop", step: 5 },
+      metadata: { source: "loop", step: 5, writes: null },
       createdAt: expect.any(String),
       parentConfig: history[2].config,
     }),
@@ -1370,7 +1371,7 @@ it("should invoke two processes with input/output and interrupt", async () => {
           checkpoint_id: expect.any(String),
         },
       },
-      metadata: { source: "loop", step: 3 },
+      metadata: { source: "loop", step: 3, writes: null },
       createdAt: expect.any(String),
       parentConfig: history[4].config,
     }),
@@ -1415,7 +1416,7 @@ it("should invoke two processes with input/output and interrupt", async () => {
           checkpoint_id: expect.any(String),
         },
       },
-      metadata: { source: "loop", step: 0 },
+      metadata: { source: "loop", step: 0, writes: null },
       createdAt: expect.any(String),
       parentConfig: history[7].config,
     }),
@@ -1657,7 +1658,7 @@ it("pending writes resume", async () => {
       }),
     },
   ]);
-  expect(state.metadata).toEqual({ source: "loop", step: 0 });
+  expect(state.metadata).toEqual({ source: "loop", step: 0, writes: null });
 
   // should contain pending write of "one" and should contain error from "two"
   const checkpoint = await checkpointer.getTuple(thread1);
@@ -2931,6 +2932,197 @@ describe("StateGraph", () => {
       ["values", { value: 6 }],
     ]);
   });
+
+  it("should allow undefined values returned in a node update", async () => {
+    interface GraphState {
+      test?: string;
+      reducerField?: string;
+    }
+
+    const graphState: StateGraphArgs<GraphState>["channels"] = {
+      test: null,
+      reducerField: {
+        default: () => "",
+        reducer: (x, y?: string) => (y ?? x),
+      },
+    };
+
+    const workflow = new StateGraph<GraphState>({ channels: graphState });
+
+    async function updateTest(
+      _state: GraphState
+    ): Promise<Partial<GraphState>> {
+      return {
+        test: "test",
+        reducerField: "should not be wiped",
+      };
+    }
+
+    async function wipeFields(
+      _state: GraphState
+    ): Promise<Partial<GraphState>> {
+      return {
+        test: undefined,
+        reducerField: undefined,
+      };
+    }
+
+    workflow
+      .addNode("updateTest", updateTest)
+      .addNode("wipeFields", wipeFields)
+      .addEdge(START, "updateTest")
+      .addEdge("updateTest", "wipeFields")
+      .addEdge("wipeFields", END);
+
+    const checkpointer = new MemorySaver();
+
+    const app = workflow.compile({ checkpointer });
+    const config: RunnableConfig = {
+      configurable: { thread_id: "102" },
+    };
+    const res = await app.invoke(
+      {
+        messages: ["initial input"],
+      },
+      config
+    );
+    expect(res).toEqual({
+      reducerField: "should not be wiped",
+    });
+    const history = await gatherIterator(app.getStateHistory(config));
+    expect(history).toEqual([
+      {
+        values: {
+          reducerField: "should not be wiped",
+        },
+        next: [],
+        tasks: [],
+        metadata: {
+          source: "loop",
+          writes: {
+            wipeFields: {
+              test: null,
+              reducerField: null,
+            },
+          },
+          step: 2,
+        },
+        config: {
+          configurable: {
+            thread_id: "102",
+            checkpoint_ns: "",
+            checkpoint_id: expect.any(String),
+          },
+        },
+        createdAt: expect.any(String),
+        parentConfig: {
+          configurable: {
+            thread_id: "102",
+            checkpoint_ns: "",
+            checkpoint_id: expect.any(String),
+          },
+        },
+      },
+      {
+        values: {
+          test: "test",
+          reducerField: "should not be wiped",
+        },
+        next: ["wipeFields"],
+        tasks: [
+          {
+            id: expect.any(String),
+            name: "wipeFields",
+          },
+        ],
+        metadata: {
+          source: "loop",
+          writes: {
+            updateTest: {
+              test: "test",
+              reducerField: "should not be wiped",
+            },
+          },
+          step: 1,
+        },
+        config: {
+          configurable: {
+            thread_id: "102",
+            checkpoint_ns: "",
+            checkpoint_id: expect.any(String),
+          },
+        },
+        createdAt: expect.any(String),
+        parentConfig: {
+          configurable: {
+            thread_id: "102",
+            checkpoint_ns: "",
+            checkpoint_id: expect.any(String),
+          },
+        },
+      },
+      {
+        values: {
+          reducerField: "",
+        },
+        next: ["updateTest"],
+        tasks: [
+          {
+            id: expect.any(String),
+            name: "updateTest",
+          },
+        ],
+        metadata: {
+          source: "loop",
+          writes: null,
+          step: 0,
+        },
+        config: {
+          configurable: {
+            thread_id: "102",
+            checkpoint_ns: "",
+            checkpoint_id: expect.any(String),
+          },
+        },
+        createdAt: expect.any(String),
+        parentConfig: {
+          configurable: {
+            thread_id: "102",
+            checkpoint_ns: "",
+            checkpoint_id: expect.any(String),
+          },
+        },
+      },
+      {
+        values: {
+          reducerField: "",
+        },
+        next: ["__start__"],
+        tasks: [
+          {
+            id: expect.any(String),
+            name: "__start__",
+          },
+        ],
+        metadata: {
+          source: "input",
+          writes: {
+            messages: ["initial input"],
+          },
+          step: -1,
+        },
+        config: {
+          configurable: {
+            thread_id: "102",
+            checkpoint_ns: "",
+            checkpoint_id: expect.any(String),
+          },
+        },
+        createdAt: expect.any(String),
+        parentConfig: undefined,
+      },
+    ]);
+  });
 });
 
 describe("PreBuilt", () => {
@@ -3327,7 +3519,7 @@ it("checkpoint events", async () => {
         metadata: {
           source: "loop",
           step: 0,
-          writes: undefined,
+          writes: null,
         },
         next: ["prepare"],
         tasks: [{ id: expect.any(String), name: "prepare" }],
@@ -3580,6 +3772,7 @@ it("StateGraph start branch then end", async () => {
     {
       source: "loop",
       step: 0,
+      writes: null,
     },
     {
       source: "input",
@@ -3595,7 +3788,7 @@ it("StateGraph start branch then end", async () => {
       .config,
     createdAt: (await toolTwoWithCheckpointer.checkpointer!.getTuple(thread1))!
       .checkpoint.ts,
-    metadata: { source: "loop", step: 0 },
+    metadata: { source: "loop", step: 0, writes: null },
     parentConfig: (
       await last(
         toolTwoWithCheckpointer.checkpointer!.list(thread1, { limit: 2 })
@@ -3645,7 +3838,7 @@ it("StateGraph start branch then end", async () => {
       .config,
     createdAt: (await toolTwoWithCheckpointer.checkpointer!.getTuple(thread2))!
       .checkpoint.ts,
-    metadata: { source: "loop", step: 0 },
+    metadata: { source: "loop", step: 0, writes: null },
     parentConfig: (
       await last(
         toolTwoWithCheckpointer.checkpointer!.list(thread2, { limit: 2 })
@@ -3695,7 +3888,7 @@ it("StateGraph start branch then end", async () => {
       .config,
     createdAt: (await toolTwoWithCheckpointer.checkpointer!.getTuple(thread3))!
       .checkpoint.ts,
-    metadata: { source: "loop", step: 0 },
+    metadata: { source: "loop", step: 0, writes: null },
     parentConfig: (
       await last(
         toolTwoWithCheckpointer.checkpointer!.list(thread3, { limit: 2 })

--- a/libs/langgraph/src/tests/pregel.test.ts
+++ b/libs/langgraph/src/tests/pregel.test.ts
@@ -2943,7 +2943,7 @@ describe("StateGraph", () => {
       test: null,
       reducerField: {
         default: () => "",
-        reducer: (x, y?: string) => (y ?? x),
+        reducer: (x, y?: string) => y ?? x,
       },
     };
 
@@ -3001,8 +3001,8 @@ describe("StateGraph", () => {
           source: "loop",
           writes: {
             wipeFields: {
-              test: null,
-              reducerField: null,
+              test: undefined,
+              reducerField: undefined,
             },
           },
           step: 2,


### PR DESCRIPTION
Cleans up instances where we do it internally, can also occur if a user passes an `undefined` value into a node update step.