### PR TITLE
fix(checkpointers): Avoid storing Sends twice in memory checkpointer

### DIFF
--- a/libs/checkpoint/src/serde/jsonplus.ts
+++ b/libs/checkpoint/src/serde/jsonplus.ts
@@ -140,6 +140,12 @@ function _default(_key: string, obj: any): any {
     return _encodeConstructorArgs(RegExp, undefined, [obj.source, obj.flags]);
   } else if (obj instanceof Error) {
     return _encodeConstructorArgs(obj.constructor, undefined, [obj.message]);
+    // TODO: Remove special case
+  } else if (obj?.lg_name === "Send") {
+    return {
+      node: obj.node,
+      args: obj.args,
+    };
   } else {
     return obj;
   }

--- a/libs/checkpoint/src/serde/types.ts
+++ b/libs/checkpoint/src/serde/types.ts
@@ -1,3 +1,5 @@
+export const TASKS = "__pregel_tasks";
+
 // Mirrors BaseChannel in "@langchain/langgraph"
 export interface ChannelProtocol<
   ValueType = unknown,

--- a/libs/langgraph/src/graph/graph.ts
+++ b/libs/langgraph/src/graph/graph.ts
@@ -84,7 +84,6 @@ export class Branch<IO, N extends string> {
 
     let destinations: (string | Send)[];
     if (this.ends) {
-      // destinations = [r if isinstance(r, Send) else self.ends[r] for r in result]
       destinations = result.map((r) => (_isSend(r) ? r : this.ends![r]));
     } else {
       destinations = result;

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -18,6 +18,7 @@ import {
   compareChannelVersions,
   copyCheckpoint,
   emptyCheckpoint,
+  PendingWrite,
   uuid5,
 } from "@langchain/langgraph-checkpoint";
 import {
@@ -479,7 +480,15 @@ export class Pregel<
       })
     );
 
-    // apply to checkpoint and save
+    if (saved !== undefined) {
+      await this.checkpointer.putWrites(
+        checkpointConfig,
+        task.writes as PendingWrite[],
+        task.id
+      );
+    }
+
+    // apply to checkpoint
     // TODO: Why does keyof StrRecord allow number and symbol?
     _applyWrites(
       checkpoint,


### PR DESCRIPTION
Will probably want to do the same for the other implementations