### PR TITLE
docs: Add @langchain/core to quickstart

### DIFF
--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -41,7 +41,7 @@
     "You can install these dependencies using by running following npm command in your terminal:\n",
     "\n",
     "```bash\n",
-    "npm install @langchain/langgraph @langchain/openai @langchain/community\n",
+    "npm install @langchain/core @langchain/langgraph @langchain/openai @langchain/community\n",
     "```\n",
     "\n",
     "## LangSmith\n",


### PR DESCRIPTION
Adds a missing dependency needed to run the quickstart
