### PR TITLE
langgraph[minor]: Stores

### DIFF
--- a/libs/langgraph/src/constants.ts
+++ b/libs/langgraph/src/constants.ts
@@ -5,6 +5,7 @@ export const CONFIG_KEY_READ = "__pregel_read";
 export const CONFIG_KEY_CHECKPOINTER = "__pregel_checkpointer";
 export const CONFIG_KEY_RESUMING = "__pregel_resuming";
 export const INTERRUPT = "__interrupt__";
+export const CONFIG_KEY_STORE = "__pregel_store";
 
 export const TAG_HIDDEN = "langsmith:hidden";
 

--- a/libs/langgraph/src/graph/state.ts
+++ b/libs/langgraph/src/graph/state.ts
@@ -41,6 +41,7 @@ import {
   UpdateType,
 } from "./annotation.js";
 import type { RetryPolicy } from "../pregel/utils.js";
+import { BaseStore } from "../store/base.js";
 
 const ROOT = "__root__";
 
@@ -338,10 +339,12 @@ export class StateGraph<
 
   compile({
     checkpointer,
+    store,
     interruptBefore,
     interruptAfter,
   }: {
     checkpointer?: BaseCheckpointSaver;
+    store?: BaseStore;
     interruptBefore?: N[] | All;
     interruptAfter?: N[] | All;
   } = {}): CompiledStateGraph<S, U, N, I, O> {
@@ -378,6 +381,7 @@ export class StateGraph<
       outputChannels,
       streamChannels,
       streamMode: "updates",
+      store,
     });
 
     // attach nodes, edges and branches

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -65,6 +65,7 @@ import {
 import { _coerceToDict, getNewChannelVersions, RetryPolicy } from "./utils.js";
 import { PregelLoop } from "./loop.js";
 import { executeTasksWithRetry } from "./retry.js";
+import { BaseStore } from "../store/base.js";
 
 type WriteValue = Runnable | RunnableFunc<unknown, unknown> | unknown;
 
@@ -226,6 +227,8 @@ export class Pregel<
 
   retryPolicy?: RetryPolicy;
 
+  store?: BaseStore;
+
   constructor(fields: PregelParams<Nn, Cc>) {
     super(fields);
 
@@ -247,6 +250,7 @@ export class Pregel<
     this.debug = fields.debug ?? this.debug;
     this.checkpointer = fields.checkpointer;
     this.retryPolicy = fields.retryPolicy;
+    this.store = fields.store;
 
     if (this.autoValidate) {
       this.validate();
@@ -662,6 +666,7 @@ export class Pregel<
         channelSpecs: this.channels,
         outputKeys,
         streamKeys: this.streamChannelsAsIs as string | string[],
+        store: this.store,
       });
       while (
         await loop.tick({

--- a/libs/langgraph/src/pregel/types.ts
+++ b/libs/langgraph/src/pregel/types.ts
@@ -9,6 +9,7 @@ import type { BaseChannel } from "../channels/base.js";
 import type { PregelNode } from "./read.js";
 import { RetryPolicy } from "./utils.js";
 import { Interrupt } from "../constants.js";
+import { BaseStore } from "../store/base.js";
 
 export type StreamMode = "values" | "updates" | "debug";
 
@@ -68,6 +69,11 @@ export interface PregelInterface<
   checkpointer?: BaseCheckpointSaver;
 
   retryPolicy?: RetryPolicy;
+
+  /**
+   * Memory store to use for SharedValues.
+   */
+  store?: BaseStore;
 }
 
 export type PregelParams<

--- a/libs/langgraph/src/store/base.ts
+++ b/libs/langgraph/src/store/base.ts
@@ -1,0 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Values = Record<string, any>;
+
+export abstract class BaseStore {
+  abstract list(
+    prefixes: string[]
+  ): Promise<Record<string, Record<string, Values>>>;
+
+  abstract put(writes: Array<[string, string, Values | null]>): Promise<void>;
+}

--- a/libs/langgraph/src/store/batch.ts
+++ b/libs/langgraph/src/store/batch.ts
@@ -1,0 +1,113 @@
+import { BaseStore, type Values } from "./base.js";
+
+interface ListOp {
+  prefixes: string[];
+}
+
+interface PutOp {
+  writes: Array<[string, string, Values | null]>;
+}
+
+type QueueItem = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  resolve: (value?: any) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reject: (reason?: any) => void;
+  op: ListOp | PutOp;
+};
+
+/**
+ * AsyncBatchedStore extends BaseStore to provide batched operations for list and put methods.
+ * It queues operations and processes them in batches for improved efficiency. This store is
+ * designed to run for the full duration of the process, or until `stop()` is called.
+ */
+export class AsyncBatchedStore extends BaseStore {
+  private store: BaseStore;
+
+  private queue: QueueItem[] = [];
+
+  private running = true;
+
+  constructor(store: BaseStore) {
+    super();
+    this.store = store;
+    void this.runTask();
+  }
+
+  /**
+   * Queues a list operation to be processed in batch.
+   * @param {string[]} prefixes An array of prefixes to list.
+   * @returns {Promise<Record<string, Record<string, Values>>>} A promise that resolves with the list results.
+   */
+  async list(
+    prefixes: string[]
+  ): Promise<Record<string, Record<string, Values>>> {
+    return new Promise((resolve, reject) => {
+      this.queue.push({ resolve, reject, op: { prefixes } });
+    });
+  }
+
+  /**
+   * Queues a put operation to be processed in batch.
+   * @param {Array<[string, string, Values | null]>} writes An array of write operations to be performed.
+   * @returns {Promise<void>} A promise that resolves when the put operation is complete.
+   */
+  async put(writes: Array<[string, string, Values | null]>): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.queue.push({ resolve, reject, op: { writes } });
+    });
+  }
+
+  /**
+   * Stops the batched processing of operations.
+   */
+  stop() {
+    this.running = false;
+  }
+
+  /**
+   * Runs the task that processes queued operations in batches.
+   * This method runs continuously until the store is stopped,
+   * or the process is terminated.
+   * @returns {Promise<void>} A promise that resolves when the task is complete.
+   */
+  private async runTask(): Promise<void> {
+    while (this.running) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+      if (this.queue.length === 0) continue;
+
+      const taken = this.queue.splice(0);
+
+      const lists = taken.filter((item) => "prefixes" in item.op);
+      if (lists.length > 0) {
+        try {
+          const allPrefixes = lists.flatMap(
+            (item) => (item.op as ListOp).prefixes
+          );
+          const results = await this.store.list(allPrefixes);
+          lists.forEach((item) => {
+            const { prefixes } = item.op as ListOp;
+            item.resolve(
+              Object.fromEntries(prefixes.map((p) => [p, results[p] || {}]))
+            );
+          });
+        } catch (e) {
+          lists.forEach((item) => item.reject(e));
+        }
+      }
+
+      const puts = taken.filter((item) => "writes" in item.op);
+      if (puts.length > 0) {
+        try {
+          const allWrites = puts.flatMap((item) => (item.op as PutOp).writes);
+          await this.store.put(allWrites);
+          puts.forEach((item) => item.resolve());
+        } catch (e) {
+          puts.forEach((item) => item.reject(e));
+        }
+      }
+    }
+  }
+}

--- a/libs/langgraph/src/store/memory.ts
+++ b/libs/langgraph/src/store/memory.ts
@@ -1,0 +1,34 @@
+import { BaseStore, type Values } from "./base.js";
+
+export class MemoryStore extends BaseStore {
+  private data: Map<string, Map<string, Values>> = new Map();
+
+  async list(
+    prefixes: string[]
+  ): Promise<Record<string, Record<string, Values>>> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result: Record<string, Record<string, any>> = {};
+    for (const prefix of prefixes) {
+      if (this.data.has(prefix)) {
+        result[prefix] = Object.fromEntries(this.data.get(prefix)!);
+      } else {
+        result[prefix] = {};
+      }
+    }
+    return Promise.resolve(result);
+  }
+
+  async put(writes: Array<[string, string, Values | null]>): Promise<void> {
+    for (const [namespace, key, value] of writes) {
+      if (!this.data.has(namespace)) {
+        this.data.set(namespace, new Map());
+      }
+      const namespaceMap = this.data.get(namespace)!;
+      if (value === null) {
+        namespaceMap.delete(key);
+      } else {
+        namespaceMap.set(key, value);
+      }
+    }
+  }
+}

--- a/libs/langgraph/src/tests/store.test.ts
+++ b/libs/langgraph/src/tests/store.test.ts
@@ -25,6 +25,9 @@ describe("AsyncBatchedStore", () => {
 
     const store = new AsyncBatchedStore(new MockStore());
 
+    // Start the store
+    store.start();
+
     // Concurrent calls are batched
     const results = await Promise.all([
       store.list(["a", "b"]),

--- a/libs/langgraph/src/tests/store.test.ts
+++ b/libs/langgraph/src/tests/store.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, jest } from "@jest/globals";
+import { BaseStore, type Values } from "../store/base.js";
+import { AsyncBatchedStore } from "../store/batch.js";
+
+describe("AsyncBatchedStore", () => {
+  it("should batch concurrent calls", async () => {
+    const listMock = jest.fn();
+
+    class MockStore extends BaseStore {
+      async list(
+        prefixes: string[]
+      ): Promise<Record<string, Record<string, Values>>> {
+        listMock(prefixes);
+        return Object.fromEntries(
+          prefixes.map((prefix) => [prefix, { [prefix]: { value: 1 } }])
+        );
+      }
+
+      async put(
+        _writes: Array<[string, string, Values | null]>
+      ): Promise<void> {
+        // Not used in this test
+      }
+    }
+
+    const store = new AsyncBatchedStore(new MockStore());
+
+    // Concurrent calls are batched
+    const results = await Promise.all([
+      store.list(["a", "b"]),
+      store.list(["c", "d"]),
+    ]);
+
+    expect(results).toEqual([
+      { a: { a: { value: 1 } }, b: { b: { value: 1 } } },
+      { c: { c: { value: 1 } }, d: { d: { value: 1 } } },
+    ]);
+
+    expect(listMock.mock.calls).toEqual([[["a", "b", "c", "d"]]]);
+
+    store.stop();
+  });
+});

--- a/libs/langgraph/src/utils.ts
+++ b/libs/langgraph/src/utils.ts
@@ -143,3 +143,28 @@ export function gatherIteratorSync<T>(i: Iterable<T>): Array<T> {
   }
   return out;
 }
+
+export function patchConfigurable(
+  config: RunnableConfig | undefined,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  patch: Record<string, any>
+): RunnableConfig {
+  if (!config) {
+    return {
+      configurable: patch,
+    };
+  } else if (!("configurable" in config)) {
+    return {
+      ...config,
+      configurable: patch,
+    };
+  } else {
+    return {
+      ...config,
+      configurable: {
+        ...config.configurable,
+        ...patch,
+      },
+    };
+  }
+}


### PR DESCRIPTION
Adds stores:
- `BaseStore`
- `MemoryStore`
- `AsyncBatchStore`


Updates `PregelLoop.initialize` to set the store inside `config.configurable` under the key `__pregel_store` (aliased via `CONFIG_KEY_STORE` constant)

This will be used inside the managed values (memory) implementation to put/list values

@jacoblee93 / @nfcampos 