### PR TITLE
Update ToolNode link to correct documentation link

### DIFF
--- a/examples/how-tos/persistence.ipynb
+++ b/examples/how-tos/persistence.ipynb
@@ -157,7 +157,7 @@
       "metadata": {},
       "source": [
         "We can now wrap these tools in a simple\n",
-        "[ToolNode](/langgraphjs/reference/classes/prebuilt.ToolNode.html).\n",
+        "[ToolNode](/langgraphjs/reference/classes/langgraph_prebuilt.ToolNode.html).\n",
         "This object will actually run the tools (functions) whenever they are invoked by\n",
         "our LLM."
       ]


### PR DESCRIPTION
Currently this 404's

