### PR TITLE
fix(docs): typos

### DIFF
--- a/docs/docs/concepts/agentic_concepts.md
+++ b/docs/docs/concepts/agentic_concepts.md
@@ -66,7 +66,7 @@ The big question in multi-agent systems is how they communicate. This involves b
 
 ## Planning
 
-One of the big things that agentic systems struggle with is long term planning. A common technique to overcome this is to have an explicit planning this. This generally involves calling an LLM to come up with a series of steps to execute. From there, the system then tries to execute the series of tasks (this could use a sub-agent to do so). Optionally, you can revisit the plan after each step and update it if needed.
+One of the big challenges that agentic systems struggle with is long-term planning. A common technique to overcome this is to have an explicit planning phase. This generally involves calling an LLM to come up with a series of steps to execute. From there, the system tries to execute the series of tasks (this could use a sub-agent to do so). Optionally, you can revisit the plan after each step and update it if needed.
 
 ## Reflection
 

--- a/docs/docs/concepts/low_level.md
+++ b/docs/docs/concepts/low_level.md
@@ -269,7 +269,7 @@ graph.addConditionalEdges("nodeA", continueToJokes);
 
 LangGraph has a built-in persistence layer, implemented through [checkpointers](/langgraphjs/reference/classes/checkpoint.BaseCheckpointSaver.html). When you use a checkpointer with a graph, you can interact with the state of that graph. When you use a checkpointer with a graph, you can interact with and manage the graph's state. The checkpointer saves a _checkpoint_ of the graph state at every super-step, enabling several powerful capabilities:
 
-First, checkpointers facilitate [human-in-the-loop workflows](agentic_concepts.md#human-in-the-loop) workflows by allowing humans to inspect, interrupt, and approve steps. Checkpointers are needed for these workflows as the human has to be able to view the state of a graph at any point in time, and the graph has to be to resume execution after the human has made any updates to the state.
+First, checkpointers facilitate [human-in-the-loop](agentic_concepts.md#human-in-the-loop) workflows by allowing humans to inspect, interrupt, and approve steps. Checkpointers are needed for these workflows as the human has to be able to view the state of a graph at any point in time, and the graph has to be able to resume execution after the human has made any updates to the state.
 
 Second, it allows for ["memory"](agentic_concepts.md#memory) between interactions. You can use checkpointers to create threads and save the state of a thread after a graph executes. In the case of repeated human interactions (like conversations) any follow up messages can be sent to that checkpoint, which will retain its memory of previous ones.
 


### PR DESCRIPTION
### **Pull Request Overview**

This PR addresses typos found in three sections of the LangGraph documentation, ensuring clarity and correctness of the text. The following sections were corrected:

---

### **1. Typo in Checkpointer section of "Low Level LangGraph Concepts"**
**Link:** [Checkpointer Section](https://langchain-ai.github.io/langgraphjs/concepts/low_level/#checkpointer:~:text=First%2C%20checkpointers%20facilitate%20human%2Din%2Dthe%2Dloop%20workflows%20workflows%20by%20allowing%20humans%20to%20inspect%2C%20interrupt%2C%20and%20approve%20steps.)

- **Issue:** Duplicated word "workflows."
- **Correction:** Removed the extra "workflows" to improve readability.

### **2. Typo in Checkpointer section of "Low Level LangGraph Concepts"**
**Link:** [Checkpointer Section](https://langchain-ai.github.io/langgraphjs/concepts/low_level/#checkpointer:~:text=Checkpointers%20are%20needed%20for%20these%20workflows%20as%20the%20human%20has%20to%20be%20able%20to%20view%20the%20state%20of%20a%20graph%20at%20any%20point%20in%20time%2C%20and%20the%20graph%20has%20to%20be%20to%20resume%20execution%20after%20the%20human%20has%20made%20any%20updates%20to%20the%20state.)

- **Issue:** "Has to be to resume execution" is incorrect.
- **Correction:** Changed to "has to be able to resume execution" for clarity.

### **3. Typo in Planning section of "Common Agentic Patterns"**
**Link:** [Planning Section](https://langchain-ai.github.io/langgraphjs/concepts/agentic_concepts/#multi-agent:~:text=A%20common%20technique%20to%20overcome%20this%20is%20to%20have%20an%20explicit%20planning%20this)

- **Issue:** Incorrect phrase "explicit planning this."
- **Correction:** Changed to "explicit planning phase" for better accuracy.

---
