### PR TITLE
Remove StateGraphArgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ import { AIMessage, BaseMessage, HumanMessage } from "@langchain/core/messages";
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 import { ChatAnthropic } from "@langchain/anthropic";
-import { StateGraph, StateGraphArgs } from "@langchain/langgraph";
+import { StateGraph } from "@langchain/langgraph";
 import { MemorySaver, Annotation } from "@langchain/langgraph";
 import { ToolNode } from "@langchain/langgraph/prebuilt";
 

--- a/libs/langgraph/README.md
+++ b/libs/langgraph/README.md
@@ -59,7 +59,7 @@ import { AIMessage, BaseMessage, HumanMessage } from "@langchain/core/messages";
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
 import { ChatAnthropic } from "@langchain/anthropic";
-import { StateGraph, StateGraphArgs } from "@langchain/langgraph";
+import { StateGraph } from "@langchain/langgraph";
 import { MemorySaver, Annotation } from "@langchain/langgraph";
 import { ToolNode } from "@langchain/langgraph/prebuilt";
 


### PR DESCRIPTION
StateGraphArgs is not used in the code

And it anyway throws an error: 

```
import { StateGraph, StateGraphArgs } from "@langchain/langgraph";
                     ^^^^^^^^^^^^^^
SyntaxError: The requested module '@langchain/langgraph' does not provide an export named 'StateGraphArgs'
```
