### PR TITLE
Update langgraph_agentic_rag.ipynb

### DIFF
--- a/examples/rag/langgraph_agentic_rag.ipynb
+++ b/examples/rag/langgraph_agentic_rag.ipynb
@@ -116,7 +116,7 @@
     "\n",
     "const GraphState = Annotation.Root({\n",
     "  messages: Annotation<BaseMessage[]>({\n",
-    "    value: (x, y) => x.concat(y),\n",
+    "    reducer: (x, y) => x.concat(y),\n",
     "    default: () => [],\n",
     "  })\n",
     "})"


### PR DESCRIPTION
Replaced "value" with "reducer" when defining the Annotation channels. "value" was deprecated and replaced with reducer.

<!--
Thank you for contributing to LangGraph.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langgraphjs/blob/main/CONTRIBUTING.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
