### PR TITLE
Allowing checkpointers' serializers to be asynchronous

### DIFF
--- a/libs/checkpoint-mongodb/src/index.ts
+++ b/libs/checkpoint-mongodb/src/index.ts
@@ -214,9 +214,12 @@ export class MongoDBSaver extends BaseCheckpointSaver {
         `The provided config must contain a configurable field with a "thread_id" field.`
       );
     }
-    const [checkpointType, serializedCheckpoint] =
-      this.serde.dumpsTyped(checkpoint);
-    const [metadataType, serializedMetadata] = this.serde.dumpsTyped(metadata);
+    const [checkpointType, serializedCheckpoint] = await this.serde.dumpsTyped(
+      checkpoint
+    );
+    const [metadataType, serializedMetadata] = await this.serde.dumpsTyped(
+      metadata
+    );
     if (checkpointType !== metadataType) {
       throw new Error("Mismatched checkpoint and metadata types.");
     }
@@ -268,31 +271,33 @@ export class MongoDBSaver extends BaseCheckpointSaver {
       );
     }
 
-    const operations = writes.map(([channel, value], idx) => {
-      const upsertQuery = {
-        thread_id,
-        checkpoint_ns,
-        checkpoint_id,
-        task_id: taskId,
-        idx,
-      };
+    const operations = await Promise.all(
+      writes.map(async ([channel, value], idx) => {
+        const upsertQuery = {
+          thread_id,
+          checkpoint_ns,
+          checkpoint_id,
+          task_id: taskId,
+          idx,
+        };
 
-      const [type, serializedValue] = this.serde.dumpsTyped(value);
+        const [type, serializedValue] = await this.serde.dumpsTyped(value);
 
-      return {
-        updateOne: {
-          filter: upsertQuery,
-          update: {
-            $set: {
-              channel,
-              type,
-              value: serializedValue,
+        return {
+          updateOne: {
+            filter: upsertQuery,
+            update: {
+              $set: {
+                channel,
+                type,
+                value: serializedValue,
+              },
             },
+            upsert: true,
           },
-          upsert: true,
-        },
-      };
-    });
+        };
+      })
+    );
 
     await this.db
       .collection(this.checkpointWritesCollectionName)

--- a/libs/checkpoint/src/serde/base.ts
+++ b/libs/checkpoint/src/serde/base.ts
@@ -1,6 +1,6 @@
 export interface SerializerProtocol {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  dumpsTyped(data: any): [string, Uint8Array];
+  dumpsTyped(data: any): Promise<[string, Uint8Array]> | [string, Uint8Array];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  loadsTyped(type: string, data: Uint8Array | string): any;
+  loadsTyped(type: string, data: Uint8Array | string): Promise<any> | any;
 }

--- a/libs/langgraph/src/tests/utils.ts
+++ b/libs/langgraph/src/tests/utils.ts
@@ -175,7 +175,7 @@ export class MemorySaverAssertImmutable extends MemorySaver {
         );
       }
     }
-    const [, serializedCheckpoint] = this.serde.dumpsTyped(checkpoint);
+    const [, serializedCheckpoint] = await this.serde.dumpsTyped(checkpoint);
     // save a copy of the checkpoint
     this.storageForCopies[thread_id][checkpoint.id] = new TextDecoder().decode(
       serializedCheckpoint


### PR DESCRIPTION
Updated the SerializationProtocol interface to allow `dumpsTyped` and `loadsTyped` to be run synchronously or asynchronously.
Applied `await` to calls of each function throughout the existing checkpoint savers and tests.

This should allow future users to provide asynchronous serialization and deserialization for their savers, without breaking any current implementations.
