### PR TITLE
fix: return correct checkpointId in parentConfig in MemorySaver.getTuple

### DIFF
--- a/libs/checkpoint/src/memory.ts
+++ b/libs/checkpoint/src/memory.ts
@@ -99,7 +99,7 @@ export class MemorySaver extends BaseCheckpointSaver {
             configurable: {
               thread_id,
               checkpoint_ns,
-              checkpoint_id,
+              checkpoint_id: parentCheckpointId,
             },
           };
         }


### PR DESCRIPTION
Found while working on #541.

Prior to this fix, when `MemorySaver.getTuple` was called to fetch a specific `checkpoint_id` that was a child of some other checkpoint, the value of `parentConfig.configurable.checkpoint_id` in the returned `CheckpointTuple` would be assigned to the child's `checkpoint_id` rather than the parent's.