### PR TITLE
fix: make MemorySaver.put throw if thread_id not passed

### DIFF
--- a/libs/checkpoint/src/memory.ts
+++ b/libs/checkpoint/src/memory.ts
@@ -60,6 +60,12 @@ export class MemorySaver extends BaseCheckpointSaver {
     const checkpoint_ns = config.configurable?.checkpoint_ns ?? "";
     let checkpoint_id = config.configurable?.checkpoint_id;
 
+    if (thread_id === undefined) {
+      throw new Error(
+        `Failed to get checkpoint tuple. The passed RunnableConfig is missing a required "thread_id" field in its "configurable" property.`
+      );
+    }
+
     if (checkpoint_id) {
       const saved = this.storage[thread_id]?.[checkpoint_ns]?.[checkpoint_id];
       if (saved !== undefined) {


### PR DESCRIPTION
Found while working on #541.

Prior to this change, the value of `config.configurable.thread_id` was unchecked in `MemorySaver.getTuple`. Admittedly this is a minor problem, without this change it returns `undefined` rather than throwing, but throwing seems more appropriate here, as it better informs the caller that they forgot to supply a `thread_id`.

I also see that this value is unchecked in `checkpoint-sqlite` and `checkpoint-mongodb`, and it looks like they may behave similarly (return `undefined` rather than throwing), although I haven't run them against my tests to check just yet. Happy to submit a PR for those (or include them in this one) if you want this behaviour change everywhere).