### PR TITLE
fix(checkpoint-postgres): store channel_values correctly

### DIFF
--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -298,7 +298,9 @@ export class PostgresSaver extends BaseCheckpointSaver {
    * @param config The config to use for retrieving the checkpoint.
    * @returns The retrieved checkpoint tuple, or undefined.
    */
-  async getTuple(config: RunnableConfig): Promise<CheckpointTuple | undefined> {
+  async getTuple(
+    config: RunnableConfig
+  ): Promise<CheckpointTuple | undefined> {
     const {
       thread_id,
       checkpoint_ns = "",
@@ -416,8 +418,7 @@ export class PostgresSaver extends BaseCheckpointSaver {
   async put(
     config: RunnableConfig,
     checkpoint: Checkpoint,
-    metadata: CheckpointMetadata,
-    newVersions: ChannelVersions
+    metadata: CheckpointMetadata
   ): Promise<RunnableConfig> {
     if (config.configurable === undefined) {
       throw new Error(`Missing "configurable" field in "config" param`);
@@ -443,7 +444,7 @@ export class PostgresSaver extends BaseCheckpointSaver {
         thread_id,
         checkpoint_ns,
         checkpoint.channel_values,
-        newVersions
+        checkpoint.channel_versions
       );
       for (const serializedBlob of serializedBlobs) {
         await client.query(UPSERT_CHECKPOINT_BLOBS_SQL, serializedBlob);

--- a/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
+++ b/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
@@ -112,8 +112,7 @@ describe("PostgresSaver", () => {
     const runnableConfig = await postgresSaver.put(
       { configurable: { thread_id: "1" } },
       checkpoint1,
-      { source: "update", step: -1, writes: null, parents: {} },
-      checkpoint1.channel_versions
+      { source: "update", step: -1, writes: null, parents: {} }
     );
     expect(runnableConfig).toEqual({
       configurable: {
@@ -168,8 +167,7 @@ describe("PostgresSaver", () => {
         },
       },
       checkpoint2,
-      { source: "update", step: -1, writes: null, parents: {} },
-      checkpoint2.channel_versions
+      { source: "update", step: -1, writes: null, parents: {} }
     );
 
     // verify that parentTs is set and retrieved correctly for second checkpoint


### PR DESCRIPTION
Prior to this change, `PostgresSaver` wouldn't store `channel_values` if `newVersions` wasn't passed to the `put` method. This is due to a [filter check in `_dumpBlobs`](https://github.com/langchain-ai/langgraphjs/blob/45e59e64175a89a7cf782015b011b7d348ef835f/libs/checkpoint-postgres/src/index.ts#L186) that checks each channel name to ensure it appears in the channel versions object prior to serializing it for storage.

Upon inspecting the other `CheckpointSaver` types, I noticed that [`MemorySaver`](https://github.com/langchain-ai/langgraphjs/blob/45e59e64175a89a7cf782015b011b7d348ef835f/libs/checkpoint/src/memory.ts#L270-L274), [`MongoDBSaver`](https://github.com/langchain-ai/langgraphjs/blob/45e59e64175a89a7cf782015b011b7d348ef835f/libs/checkpoint-mongodb/src/index.ts#L204-L208), and [`SqliteSaver`](https://github.com/langchain-ai/langgraphjs/blob/45e59e64175a89a7cf782015b011b7d348ef835f/libs/checkpoint-sqlite/src/index.ts#L217-L221)) all ignore [the `newVersions` argument to the `BaseCheckpointSaver.put` method](https://github.com/langchain-ai/langgraphjs/blob/45e59e64175a89a7cf782015b011b7d348ef835f/libs/checkpoint/src/base.ts#L148), so I _think_ this is the correct fix. From what I can see by searching references, no test code (apart from the tests this PR changes) passes the `newVersions` argument.

That said, the **one** reference to `BaseCheckpointSaver.put` that I found in actual shipped code is in [`PregelLoop._putCheckpoint`](https://github.com/langchain-ai/langgraphjs/blob/45e59e64175a89a7cf782015b011b7d348ef835f/libs/langgraph/src/pregel/loop.ts#L780-L785) (via [`_checkpointerPutAfterPrevious`](https://github.com/langchain-ai/langgraphjs/blob/45e59e64175a89a7cf782015b011b7d348ef835f/libs/langgraph/src/pregel/loop.ts#L368)), and this _does_ pass the `newVersions` argument.

So I have to ask, **are all of the other `CheckpointSaver` implementations, and all of the existing tests implemented incorrectly, or is this the correct fix?**

Found this while working on #541, thanks to [the `getTuple` tests](https://github.com/benjamincburns/langgraphjs/blob/d95f4aafac23d2f39c12a7c1c0a2f2ede0815ba8/libs/checkpoint-validation/src/tests/spec/getTuple.ts) (all of them failed when I [wired them up to `PostgresSaver`](https://github.com/benjamincburns/langgraphjs/blob/d95f4aafac23d2f39c12a7c1c0a2f2ede0815ba8/libs/checkpoint-validation/src/tests/postgres.spec.ts#L64)).