### PR TITLE
fix(checkpoint-mongodb): fix query filtering logic in list method

### DIFF
--- a/libs/checkpoint-mongodb/src/index.ts
+++ b/libs/checkpoint-mongodb/src/index.ts
@@ -136,13 +136,17 @@ export class MongoDBSaver extends BaseCheckpointSaver {
     options?: CheckpointListOptions
   ): AsyncGenerator<CheckpointTuple> {
     const { limit, before, filter } = options ?? {};
-    let query: Record<string, unknown> = {};
+    const query: Record<string, unknown> = {};
 
-    if (config?.configurable) {
-      query = {
-        thread_id: config.configurable.thread_id,
-        checkpoint_ns: config.configurable.checkpoint_ns ?? "",
-      };
+    if (config?.configurable?.thread_id) {
+      query.thread_id = config.configurable.thread_id;
+    }
+
+    if (
+      config?.configurable?.checkpoint_ns !== undefined &&
+      config?.configurable?.checkpoint_ns !== null
+    ) {
+      query.checkpoint_ns = config.configurable.checkpoint_ns;
     }
 
     if (filter) {


### PR DESCRIPTION
Found while working on #541. Much like in #578, prior to this change the way that the `MongoDBSaver` constructed its query filter arguments caused it to return no results if you passed `{ configurable: {} }` as the config argument. This change fixes that, and makes it so that `MongoDBSaver` treats each property of the `config` object as an independent filter criteria. This offers a bit more flexibility when querying for persisted checkpoints via the `list` method.