### PR TITLE
fix(checkpoint-sqlite): list method bug fixes

### DIFF
--- a/libs/checkpoint-sqlite/src/index.ts
+++ b/libs/checkpoint-sqlite/src/index.ts
@@ -168,6 +168,7 @@ CREATE TABLE IF NOT EXISTS writes (
     const { limit, before } = options ?? {};
     this.setup();
     const thread_id = config.configurable?.thread_id;
+    const checkpoint_ns = config.configurable?.checkpoint_ns;
 
     let sql =
       "SELECT thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, type, checkpoint, metadata FROM checkpoints";
@@ -176,6 +177,10 @@ CREATE TABLE IF NOT EXISTS writes (
 
     if (thread_id) {
       whereClause.push("thread_id = ?");
+    }
+
+    if (checkpoint_ns !== undefined && checkpoint_ns !== null) {
+      whereClause.push("checkpoint_ns = ?");
     }
 
     if (before?.configurable?.checkpoint_id !== undefined) {

--- a/libs/checkpoint-sqlite/src/index.ts
+++ b/libs/checkpoint-sqlite/src/index.ts
@@ -194,7 +194,8 @@ CREATE TABLE IF NOT EXISTS writes (
     sql += ` ORDER BY checkpoint_id DESC`;
 
     if (limit) {
-      sql += ` LIMIT ${limit}`;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      sql += ` LIMIT ${parseInt(limit as any, 10)}`; // parseInt here (with cast to make TS happy) to sanitize input, as limit may be user-provided
     }
 
     const args = [thread_id, before?.configurable?.checkpoint_id].filter(

--- a/libs/checkpoint-sqlite/src/tests/checkpoints.test.ts
+++ b/libs/checkpoint-sqlite/src/tests/checkpoints.test.ts
@@ -103,7 +103,12 @@ describe("SqliteSaver", () => {
         },
       },
       checkpoint2,
-      { source: "update", step: -1, writes: null, parents: {} }
+      {
+        source: "update",
+        step: -1,
+        writes: null,
+        parents: { "": checkpoint1.id },
+      }
     );
 
     // verify that parentTs is set and retrieved correctly for second checkpoint
@@ -119,18 +124,25 @@ describe("SqliteSaver", () => {
     });
 
     // list checkpoints
-    const checkpointTupleGenerator = await sqliteSaver.list({
-      configurable: { thread_id: "1" },
-    });
+    const checkpointTupleGenerator = await sqliteSaver.list(
+      {
+        configurable: { thread_id: "1" },
+      },
+      {
+        filter: {
+          source: "update",
+          step: -1,
+          parents: { "": checkpoint1.id },
+        },
+      }
+    );
     const checkpointTuples: CheckpointTuple[] = [];
     for await (const checkpoint of checkpointTupleGenerator) {
       checkpointTuples.push(checkpoint);
     }
-    expect(checkpointTuples.length).toBe(2);
+    expect(checkpointTuples.length).toBe(1);
 
     const checkpointTuple1 = checkpointTuples[0];
-    const checkpointTuple2 = checkpointTuples[1];
     expect(checkpointTuple1.checkpoint.ts).toBe("2024-04-20T17:19:07.952Z");
-    expect(checkpointTuple2.checkpoint.ts).toBe("2024-04-19T17:19:07.952Z");
   });
 });


### PR DESCRIPTION
This PR fixes a few issues in the `list` method of `SqliteSaver` that were found while working on #541.

- Fixes a SQL syntax error resulting from an empty `WHERE` clause when none of the filtering options are specified
- Adds missing support for filtering on `config.configurable.checkpoint_ns`
- Sanitizes `limit` field prior to concatenating
- Adds support for the `filter` field in the `options` argument by parsing the stored metadata in a CTE

Submitting these together because they're all somewhat intertwined.