### PR TITLE
fix(checkpoint): add support for options.filter in MemorySaver.list

### DIFF
--- a/libs/checkpoint/src/memory.ts
+++ b/libs/checkpoint/src/memory.ts
@@ -171,7 +171,7 @@ export class MemorySaver extends BaseCheckpointSaver {
     options?: CheckpointListOptions
   ): AsyncGenerator<CheckpointTuple> {
     // eslint-disable-next-line prefer-const
-    let { before, limit } = options ?? {};
+    let { before, limit, filter } = options ?? {};
     const threadIds = config.configurable?.thread_id
       ? [config.configurable?.thread_id]
       : Object.keys(this.storage);
@@ -208,6 +208,16 @@ export class MemorySaver extends BaseCheckpointSaver {
             "json",
             metadataStr
           )) as CheckpointMetadata;
+
+          if (
+            filter &&
+            !Object.entries(filter).every(
+              ([key, value]) =>
+                (metadata as unknown as Record<string, unknown>)[key] === value
+            )
+          ) {
+            continue;
+          }
 
           // Limit search results
           if (limit !== undefined) {


### PR DESCRIPTION
Per the title, adds support for the `options.filter` argument to `MemorySaver`.list (another one from #541).

I suppose this could be a `feat` instead of a `fix`, but I opted to call it the latter as it's a part of the core checkpoint interface that was never implemented in `MemorySaver`.