### PR TITLE
fix(checkpoint): don't throw in MemorySaver.list if thread not found

### DIFF
--- a/libs/checkpoint/src/memory.ts
+++ b/libs/checkpoint/src/memory.ts
@@ -178,7 +178,9 @@ export class MemorySaver extends BaseCheckpointSaver {
     const configCheckpointNamespace = config.configurable?.checkpoint_ns;
 
     for (const threadId of threadIds) {
-      for (const checkpointNamespace of Object.keys(this.storage[threadId])) {
+      for (const checkpointNamespace of Object.keys(
+        this.storage[threadId] ?? {}
+      )) {
         if (
           configCheckpointNamespace !== undefined &&
           checkpointNamespace !== configCheckpointNamespace


### PR DESCRIPTION
Prior to this change, if you passed a `thread_id` to `MemorySaver.list` that wasn't stored, the changed line would throw due to `this.storage[threadId]` evaluating to `undefined`.

Found while working on #541.