### PR TITLE
fix(checkpoint-validation): fix broken initial release

### DIFF
--- a/libs/checkpoint-validation/bin/cli.js
+++ b/libs/checkpoint-validation/bin/cli.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
-
+import { register } from "node:module";
 import { main } from "../dist/cli.js";
+
+register("@swc-node/register/esm", import.meta.url);
 
 await main();

--- a/libs/checkpoint-validation/src/cli.ts
+++ b/libs/checkpoint-validation/src/cli.ts
@@ -2,8 +2,6 @@ import { dirname, resolve as pathResolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runCLI } from "@jest/core";
 
-// make it so we can import/require .ts files
-import "@swc-node/register/esm-register";
 import { parseArgs } from "./parse_args.js";
 
 export async function main() {
@@ -18,6 +16,6 @@ export async function main() {
       $0: "",
       runInBand: true,
     },
-    [pathResolve(moduleDirname, "..", "bin", "jest.config.js")]
+    [pathResolve(moduleDirname, "runtime_jest_config.js")]
   );
 }

--- a/libs/checkpoint-validation/src/runtime_jest_config.ts
+++ b/libs/checkpoint-validation/src/runtime_jest_config.ts
@@ -2,21 +2,27 @@
 // For the Jest config for the tests in this project, see the `jest.config.cjs` in the root of the package workspace.
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { parseArgs } from "../dist/parse_args.js";
+import type { JestConfigWithTsJest } from "ts-jest";
+import { parseArgs } from "./parse_args.js";
 
 const args = await parseArgs(process.argv.slice(2));
 
-/** @type {import('ts-jest').JestConfigWithTsJest} */
-export default {
+const config: JestConfigWithTsJest = {
   preset: "ts-jest/presets/default-esm",
-  rootDir: path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "dist"),
+  rootDir: path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "dist"
+  ),
   testEnvironment: "node",
   testMatch: ["<rootDir>/runner.js"],
   transform: {
-    "^.+\\.[jt]sx?$": ["@swc/jest"],
+    "^.+\\.[jt]sx?$": "@swc/jest",
   },
   moduleNameMapper: {
     "^(\\.{1,2}/.*)\\.[jt]sx?$": "$1",
   },
   globals: args,
 };
+
+export default config;

--- a/libs/checkpoint-validation/tsconfig.cjs.json
+++ b/libs/checkpoint-validation/tsconfig.cjs.json
@@ -13,6 +13,7 @@
     "src/cli.ts",
     "src/import_utils.ts",
     "src/runner.ts",
-    "src/parse_args.ts"
+    "src/parse_args.ts",
+    "src/runtime_jest_config.ts"
   ]
 }

--- a/libs/checkpoint-validation/tsconfig.json
+++ b/libs/checkpoint-validation/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "ES2021",
     "lib": ["ES2021", "ES2022.Object", "DOM"],
     "types": ["node", "jest"],
-    "module": "ES2020",
+    "module": "ES2022",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "declaration": true,


### PR DESCRIPTION
Unfortunately the initial release of `@langchain/langgraph-checkpoint-validator` is broken for two reasons.

1. A bug in `@swc-node/register` attempts to resolve SWC packages from the CWD rather than the installed package's `node_modules` directory.
2. The jest config used by the CLI wasn't included in the release because I forgot to add it to the `files` array in `package.json`.

I fixed the first issue by applying the workaround mentioned here: https://github.com/swc-project/swc-node/pull/805#issuecomment-2257146304.

I fixed the second issue by moving the runtime jest config into the `src` dir and making it a TS file.

I tested this locally using `npm link` and it seems to fix both issues.

Sorry for the hiccup!
