### PR TITLE
feat(langgraph): add subgraph add node option to explicitly specify subgraphs

### DIFF
--- a/libs/langgraph/src/pregel/algo.ts
+++ b/libs/langgraph/src/pregel/algo.ts
@@ -541,6 +541,7 @@ export function _prepareSingleTask<
           name: packet.node,
           input: packet.args,
           proc: node,
+          subgraphs: proc.subgraphs,
           writes,
           config: patchConfig(
             mergeConfigs(config, {
@@ -665,6 +666,7 @@ export function _prepareSingleTask<
             name,
             input: val,
             proc: node,
+            subgraphs: proc.subgraphs,
             writes,
             config: patchConfig(
               mergeConfigs(config, {

--- a/libs/langgraph/src/pregel/debug.ts
+++ b/libs/langgraph/src/pregel/debug.ts
@@ -192,7 +192,8 @@ export function* mapDebugCheckpoint<
   const taskStates: Record<string, RunnableConfig | StateSnapshot> = {};
 
   for (const task of tasks) {
-    if (!findSubgraphPregel(task.proc)) continue;
+    const candidates = task.subgraphs?.length ? task.subgraphs : [task.proc];
+    if (!candidates.find(findSubgraphPregel)) continue;
 
     let taskNs = `${task.name as string}:${task.id}`;
     if (parentNs) taskNs = `${parentNs}|${taskNs}`;

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -350,29 +350,36 @@ export class Pregel<
       // find the subgraph if any
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       type SubgraphPregelType = Pregel<any, any> | undefined;
-      const graph = findSubgraphPregel(node.bound) as SubgraphPregelType;
-      // if found, yield recursively
-      if (graph !== undefined) {
-        if (name === namespace) {
-          yield [name, graph];
-          return;
-        }
-        if (namespace === undefined) {
-          yield [name, graph];
-        }
-        if (recurse) {
-          let newNamespace = namespace;
-          if (namespace !== undefined) {
-            newNamespace = namespace.slice(name.length + 1);
+
+      const candidates = node.subgraphs?.length ? node.subgraphs : [node.bound];
+
+      for (const candidate of candidates) {
+        const graph = findSubgraphPregel(candidate) as SubgraphPregelType;
+
+        if (graph !== undefined) {
+          if (name === namespace) {
+            yield [name, graph];
+            return;
           }
-          for (const [subgraphName, subgraph] of graph.getSubgraphs(
-            newNamespace,
-            recurse
-          )) {
-            yield [
-              `${name}${CHECKPOINT_NAMESPACE_SEPARATOR}${subgraphName}`,
-              subgraph,
-            ];
+
+          if (namespace === undefined) {
+            yield [name, graph];
+          }
+
+          if (recurse) {
+            let newNamespace = namespace;
+            if (namespace !== undefined) {
+              newNamespace = namespace.slice(name.length + 1);
+            }
+            for (const [subgraphName, subgraph] of graph.getSubgraphs(
+              newNamespace,
+              recurse
+            )) {
+              yield [
+                `${name}${CHECKPOINT_NAMESPACE_SEPARATOR}${subgraphName}`,
+                subgraph,
+              ];
+            }
           }
         }
       }

--- a/libs/langgraph/src/pregel/read.ts
+++ b/libs/langgraph/src/pregel/read.ts
@@ -83,6 +83,7 @@ interface PregelNodeArgs<RunInput, RunOutput>
   config?: RunnableConfig;
   metadata?: Record<string, unknown>;
   retryPolicy?: RetryPolicy;
+  subgraphs?: Runnable[];
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -117,6 +118,8 @@ export class PregelNode<
 
   retryPolicy?: RetryPolicy;
 
+  subgraphs?: Runnable[];
+
   constructor(fields: PregelNodeArgs<RunInput, RunOutput>) {
     const {
       channels,
@@ -128,6 +131,7 @@ export class PregelNode<
       metadata,
       retryPolicy,
       tags,
+      subgraphs,
     } = fields;
     const mergedTags = [
       ...(fields.config?.tags ? fields.config.tags : []),
@@ -154,6 +158,7 @@ export class PregelNode<
     this.metadata = metadata ?? this.metadata;
     this.tags = mergedTags;
     this.retryPolicy = retryPolicy;
+    this.subgraphs = subgraphs;
   }
 
   getWriters(): Array<Runnable> {

--- a/libs/langgraph/src/pregel/types.ts
+++ b/libs/langgraph/src/pregel/types.ts
@@ -107,6 +107,7 @@ export interface PregelExecutableTask<
   readonly retry_policy?: RetryPolicy;
   readonly id: string;
   readonly path?: [string, ...(string | number)[]];
+  readonly subgraphs?: Runnable[];
 }
 
 export interface StateSnapshot {

--- a/libs/langgraph/src/pregel/utils/subgraph.ts
+++ b/libs/langgraph/src/pregel/utils/subgraph.ts
@@ -1,4 +1,8 @@
-import { RunnableSequence, Runnable } from "@langchain/core/runnables";
+import {
+  RunnableSequence,
+  Runnable,
+  RunnableLike,
+} from "@langchain/core/runnables";
 import type { PregelInterface } from "../types.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -7,9 +11,10 @@ function isRunnableSequence(
 ): x is RunnableSequence {
   return "steps" in x && Array.isArray(x.steps);
 }
-function isPregelLike(
+
+export function isPregelLike(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  x: PregelInterface<any, any> | Runnable
+  x: PregelInterface<any, any> | RunnableLike<any, any, any>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): x is PregelInterface<any, any> {
   return (


### PR DESCRIPTION
Unlike in Python, we need to specify the subgraphs beforehand when adding nodes with lambdas that invoke the subgraph. 

This is necessary to ensure that:
1. Nested interrupts are properly handled
2. Debug stream events include checkpoint metadata
3. Both the graph and the subgraph are introspectable