### PR TITLE
fix(checkpoint-mongodb): fix filter support, store state deltas, populate pendingWrites

### DIFF
--- a/libs/checkpoint-mongodb/package.json
+++ b/libs/checkpoint-mongodb/package.json
@@ -43,6 +43,7 @@
     "@langchain/scripts": ">=0.1.3 <0.2.0",
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
+    "@testcontainers/mongodb": "^10.13.2",
     "@tsconfig/recommended": "^1.0.3",
     "@types/better-sqlite3": "^7.6.9",
     "@types/uuid": "^10",
@@ -62,6 +63,7 @@
     "prettier": "^2.8.3",
     "release-it": "^17.6.0",
     "rollup": "^4.23.0",
+    "testcontainers": "^10.13.2",
     "ts-jest": "^29.1.0",
     "tsx": "^4.7.0",
     "typescript": "^4.9.5 || ^5.4.5"

--- a/libs/checkpoint-mongodb/src/migrations/1_object_metadata.ts
+++ b/libs/checkpoint-mongodb/src/migrations/1_object_metadata.ts
@@ -1,0 +1,110 @@
+import { Binary, ObjectId, Collection, Document, WithId } from "mongodb";
+import { CheckpointMetadata } from "@langchain/langgraph-checkpoint";
+import { Migration, MigrationParams } from "./base.js";
+
+const BULK_WRITE_SIZE = 100;
+
+interface OldCheckpointDocument {
+  parent_checkpoint_id: string | undefined;
+  type: string;
+  checkpoint: Binary;
+  metadata: Binary;
+  thread_id: string;
+  checkpoint_ns: string | undefined;
+  checkpoint_id: string;
+}
+
+interface NewCheckpointDocument {
+  parent_checkpoint_id: string | undefined;
+  type: string;
+  checkpoint: Binary;
+  metadata: CheckpointMetadata;
+  thread_id: string;
+  checkpoint_ns: string | undefined;
+  checkpoint_id: string;
+}
+
+export class Migration1ObjectMetadata extends Migration {
+  version = 1;
+
+  constructor(params: MigrationParams) {
+    super(params);
+  }
+
+  override async apply() {
+    const db = this.client.db(this.dbName);
+    const checkpointCollection = db.collection(this.checkpointCollectionName);
+    const schemaVersionCollection = db.collection(
+      this.schemaVersionCollectionName
+    );
+
+    // Fetch all documents from the checkpoints collection
+    const cursor = checkpointCollection.find({});
+
+    let updateBatch: {
+      id: string;
+      newDoc: NewCheckpointDocument;
+    }[] = [];
+
+    for await (const doc of cursor) {
+      // already migrated
+      if (!(doc.metadata._bsontype && doc.metadata._bsontype === "Binary")) {
+        continue;
+      }
+
+      const oldDoc = doc as WithId<OldCheckpointDocument>;
+
+      const metadata: CheckpointMetadata = await this.serializer.loadsTyped(
+        oldDoc.type,
+        oldDoc.metadata.value()
+      );
+
+      const newDoc: NewCheckpointDocument = {
+        ...oldDoc,
+        metadata,
+      };
+
+      updateBatch.push({
+        id: doc._id.toString(),
+        newDoc,
+      });
+
+      if (updateBatch.length >= BULK_WRITE_SIZE) {
+        await this.flushBatch(updateBatch, checkpointCollection);
+        updateBatch = [];
+      }
+    }
+
+    if (updateBatch.length > 0) {
+      await this.flushBatch(updateBatch, checkpointCollection);
+    }
+
+    // Update schema version to 1
+    await schemaVersionCollection.updateOne(
+      {},
+      { $set: { version: 1 } },
+      { upsert: true }
+    );
+  }
+
+  private async flushBatch(
+    updateBatch: {
+      id: string;
+      newDoc: NewCheckpointDocument;
+    }[],
+    checkpointCollection: Collection<Document>
+  ) {
+    if (updateBatch.length === 0) {
+      throw new Error("No updates to apply");
+    }
+
+    const bulkOps = updateBatch.map(({ id, newDoc: newCheckpoint }) => ({
+      updateOne: {
+        filter: { _id: new ObjectId(id) },
+        update: { $set: newCheckpoint },
+      },
+    }));
+
+    await checkpointCollection.bulkWrite(bulkOps);
+  }
+}

--- a/libs/checkpoint-mongodb/src/migrations/base.ts
+++ b/libs/checkpoint-mongodb/src/migrations/base.ts
@@ -1,0 +1,73 @@
+import { SerializerProtocol } from "@langchain/langgraph-checkpoint";
+import { Db, MongoClient } from "mongodb";
+
+export interface MigrationParams {
+  client: MongoClient;
+  dbName: string;
+  checkpointCollectionName: string;
+  checkpointWritesCollectionName: string;
+  schemaVersionCollectionName: string;
+  serializer: SerializerProtocol;
+  currentSchemaVersion: number;
+}
+
+export abstract class Migration {
+  abstract version: number;
+
+  protected client: MongoClient;
+
+  protected dbName: string;
+
+  protected checkpointCollectionName: string;
+
+  protected checkpointWritesCollectionName: string;
+
+  protected schemaVersionCollectionName: string;
+
+  protected serializer: SerializerProtocol;
+
+  protected currentSchemaVersion: number;
+
+  private db: Db;
+
+  constructor({
+    client,
+    dbName,
+    checkpointCollectionName,
+    checkpointWritesCollectionName,
+    schemaVersionCollectionName,
+    serializer,
+    currentSchemaVersion,
+  }: MigrationParams) {
+    this.client = client;
+    this.dbName = dbName;
+    this.checkpointCollectionName = checkpointCollectionName;
+    this.checkpointWritesCollectionName = checkpointWritesCollectionName;
+    this.schemaVersionCollectionName = schemaVersionCollectionName;
+    this.serializer = serializer;
+    this.currentSchemaVersion = currentSchemaVersion;
+    this.db = this.client.db(this.dbName);
+  }
+
+  abstract apply(): Promise<void>;
+
+  async isApplicable(): Promise<boolean> {
+    const versionDoc = await this.db
+      .collection(this.schemaVersionCollectionName)
+      .findOne({});
+
+    if (!versionDoc || versionDoc.version === undefined) {
+      return true;
+    }
+
+    const version = versionDoc.version as number;
+
+    if (version < this.version) {
+      return true;
+    }
+
+    return false;
+  }
+}
+
+export class MigrationError extends Error {}

--- a/libs/checkpoint-mongodb/src/migrations/index.ts
+++ b/libs/checkpoint-mongodb/src/migrations/index.ts
@@ -1,0 +1,21 @@
+import { Migration1ObjectMetadata } from "./1_object_metadata.js";
+import { MigrationParams } from "./base.js";
+
+function _getMigrations(params: MigrationParams) {
+  const migrations = [Migration1ObjectMetadata];
+  return migrations.map((MigrationClass) => new MigrationClass(params));
+}
+
+export async function needsMigration(params: MigrationParams) {
+  const migrations = _getMigrations(params);
+  return migrations.some((migration) => migration.isApplicable());
+}
+
+export async function applyMigrations(params: MigrationParams) {
+  const migrations = _getMigrations(params);
+  for (const migration of migrations) {
+    if (await migration.isApplicable()) {
+      await migration.apply();
+    }
+  }
+}

--- a/libs/checkpoint-mongodb/src/tests/checkpoints.int.test.ts
+++ b/libs/checkpoint-mongodb/src/tests/checkpoints.int.test.ts
@@ -68,7 +68,8 @@ describe("MongoDBSaver", () => {
     const runnableConfig = await saver.put(
       { configurable: { thread_id: "1" } },
       checkpoint1,
-      { source: "update", step: -1, writes: null, parents: {} }
+      { source: "update", step: -1, writes: null, parents: {} },
+      checkpoint1.channel_versions
     );
     expect(runnableConfig).toEqual({
       configurable: {
@@ -117,7 +118,8 @@ describe("MongoDBSaver", () => {
         },
       },
       checkpoint2,
-      { source: "update", step: -1, writes: null, parents: {} }
+      { source: "update", step: -1, writes: null, parents: {} },
+      checkpoint2.channel_versions
     );
 
     // verify that parentTs is set and retrieved correctly for second checkpoint

--- a/libs/checkpoint-mongodb/src/tests/migrations/1_object_metadata.test.ts
+++ b/libs/checkpoint-mongodb/src/tests/migrations/1_object_metadata.test.ts
@@ -1,0 +1,176 @@
+import {
+  beforeAll,
+  describe,
+  it,
+  expect,
+  afterAll,
+  beforeEach,
+} from "@jest/globals";
+import {
+  MongoDBContainer,
+  StartedMongoDBContainer,
+} from "@testcontainers/mongodb";
+import { Binary, MongoClient } from "mongodb";
+import {
+  Checkpoint,
+  CheckpointMetadata,
+  JsonPlusSerializer,
+  uuid6,
+} from "@langchain/langgraph-checkpoint";
+import { Migration1ObjectMetadata } from "../../migrations/1_object_metadata.js";
+
+describe("1_object_metadata", () => {
+  const dbName = "test_db";
+  let container: StartedMongoDBContainer;
+  let client: MongoClient;
+
+  beforeAll(async () => {
+    container = await new MongoDBContainer("mongo:6.0.1").start();
+    const connectionString = `mongodb://127.0.0.1:${container.getMappedPort(
+      27017
+    )}/${dbName}?directConnection=true`;
+    client = new MongoClient(connectionString);
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await container.stop();
+  });
+
+  describe("isApplicable", () => {
+    // MongoDBSaver handles this automatically in initializeSchemaVersion
+    it("should want to apply on empty database", async () => {
+      // ensure database is empty
+      const db = client.db(dbName);
+      await db.dropDatabase();
+
+      const migration = new Migration1ObjectMetadata({
+        client,
+        dbName,
+        checkpointCollectionName: "checkpoints",
+        checkpointWritesCollectionName: "checkpoint_writes",
+        schemaVersionCollectionName: "schema_version",
+        serializer: new JsonPlusSerializer(),
+        currentSchemaVersion: 1,
+      });
+      expect(await migration.isApplicable()).toBe(true);
+    });
+
+    it("should not want to apply on database with schema version of 1", async () => {
+      const db = client.db(dbName);
+      await db.dropDatabase();
+      await db.createCollection("schema_version");
+      await db.collection("schema_version").insertOne({ version: 1 });
+
+      const migration = new Migration1ObjectMetadata({
+        client,
+        dbName,
+        checkpointCollectionName: "checkpoints",
+        checkpointWritesCollectionName: "checkpoint_writes",
+        schemaVersionCollectionName: "schema_version",
+        serializer: new JsonPlusSerializer(),
+        currentSchemaVersion: 1,
+      });
+      expect(await migration.isApplicable()).toBe(false);
+    });
+  });
+
+  describe("apply", () => {
+    const expectedCheckpoints: Record<
+      string,
+      {
+        parent_checkpoint_id?: string;
+        checkpoint: Binary;
+        type: string;
+        metadata: CheckpointMetadata;
+        thread_id: string;
+        checkpoint_ns: string;
+        checkpoint_id: string;
+      }
+    > = {};
+
+    beforeEach(async () => {
+      const serde = new JsonPlusSerializer();
+      const dropDb = client.db(dbName);
+      await dropDb.dropDatabase();
+      const db = client.db(dbName);
+      await db.createCollection("checkpoints");
+      await db.createCollection("schema_version");
+
+      for (let i = 0; i < 10; i += 1) {
+        const checkpoint_id = uuid6(-3);
+        const thread_id = uuid6(-3);
+        const checkpoint_ns = "";
+
+        const checkpoint: Checkpoint = {
+          v: 1,
+          id: checkpoint_id,
+          ts: new Date().toISOString(),
+          channel_values: {},
+          channel_versions: {},
+          versions_seen: {},
+          pending_sends: [],
+        };
+
+        const metadata: CheckpointMetadata = {
+          source: "update",
+          step: -1,
+          writes: {},
+          parents: {},
+        };
+
+        const [checkpointType, serializedCheckpoint] =
+          serde.dumpsTyped(checkpoint);
+        const serializedMetadata = serde.dumpsTyped(metadata)[1];
+
+        await db.collection("checkpoints").insertOne({
+          type: checkpointType,
+          checkpoint: serializedCheckpoint,
+          metadata: serializedMetadata,
+          thread_id,
+          checkpoint_ns,
+          checkpoint_id,
+        });
+
+        expectedCheckpoints[checkpoint_id] = {
+          checkpoint: new Binary(serializedCheckpoint),
+          type: checkpointType,
+          metadata,
+          thread_id,
+          checkpoint_ns,
+          checkpoint_id,
+        };
+      }
+    });
+
+    it("should migrate all checkpoints", async () => {
+      const migration = new Migration1ObjectMetadata({
+        client,
+        dbName,
+        checkpointCollectionName: "checkpoints",
+        checkpointWritesCollectionName: "checkpoint_writes",
+        schemaVersionCollectionName: "schema_version",
+        serializer: new JsonPlusSerializer(),
+        currentSchemaVersion: 1,
+      });
+      await migration.apply();
+
+      const db = client.db(dbName);
+      const cursor = await db.collection("checkpoints").find({});
+
+      let docCount = 0;
+      for await (const actual of cursor) {
+        docCount += 1;
+        const expected = expectedCheckpoints[actual.checkpoint_id];
+        expect(actual.parent_checkpoint_id).toBe(expected.parent_checkpoint_id);
+        expect(actual.type).toBe(expected.type);
+        expect(actual.checkpoint).toEqual(expected.checkpoint);
+        expect(actual.metadata).toEqual(expected.metadata);
+        expect(actual.thread_id).toBe(expected.thread_id);
+        expect(actual.checkpoint_ns).toBe(expected.checkpoint_ns);
+        expect(actual.checkpoint_id).toBe(expected.checkpoint_id);
+      }
+      expect(docCount).toBe(10);
+    });
+  });
+});

--- a/libs/checkpoint-mongodb/src/tests/migrations/1_object_metadata.test.ts
+++ b/libs/checkpoint-mongodb/src/tests/migrations/1_object_metadata.test.ts
@@ -18,159 +18,166 @@ import {
   uuid6,
 } from "@langchain/langgraph-checkpoint";
 import { Migration1ObjectMetadata } from "../../migrations/1_object_metadata.js";
+import { isSkippedCIEnvironment } from "../utils.js";
 
 describe("1_object_metadata", () => {
-  const dbName = "test_db";
-  let container: StartedMongoDBContainer;
-  let client: MongoClient;
+  if (!isSkippedCIEnvironment()) {
+    const dbName = "test_db";
+    let container: StartedMongoDBContainer;
+    let client: MongoClient;
 
-  beforeAll(async () => {
-    container = await new MongoDBContainer("mongo:6.0.1").start();
-    const connectionString = `mongodb://127.0.0.1:${container.getMappedPort(
-      27017
-    )}/${dbName}?directConnection=true`;
-    client = new MongoClient(connectionString);
-  });
-
-  afterAll(async () => {
-    await client.close();
-    await container.stop();
-  });
-
-  describe("isApplicable", () => {
-    // MongoDBSaver handles this automatically in initializeSchemaVersion
-    it("should want to apply on empty database", async () => {
-      // ensure database is empty
-      const db = client.db(dbName);
-      await db.dropDatabase();
-
-      const migration = new Migration1ObjectMetadata({
-        client,
-        dbName,
-        checkpointCollectionName: "checkpoints",
-        checkpointWritesCollectionName: "checkpoint_writes",
-        schemaVersionCollectionName: "schema_version",
-        serializer: new JsonPlusSerializer(),
-        currentSchemaVersion: 1,
-      });
-      expect(await migration.isApplicable()).toBe(true);
+    beforeAll(async () => {
+      container = await new MongoDBContainer("mongo:6.0.1").start();
+      const connectionString = `mongodb://127.0.0.1:${container.getMappedPort(
+        27017
+      )}/${dbName}?directConnection=true`;
+      client = new MongoClient(connectionString);
     });
 
-    it("should not want to apply on database with schema version of 1", async () => {
-      const db = client.db(dbName);
-      await db.dropDatabase();
-      await db.createCollection("schema_version");
-      await db.collection("schema_version").insertOne({ version: 1 });
-
-      const migration = new Migration1ObjectMetadata({
-        client,
-        dbName,
-        checkpointCollectionName: "checkpoints",
-        checkpointWritesCollectionName: "checkpoint_writes",
-        schemaVersionCollectionName: "schema_version",
-        serializer: new JsonPlusSerializer(),
-        currentSchemaVersion: 1,
-      });
-      expect(await migration.isApplicable()).toBe(false);
+    afterAll(async () => {
+      await client.close();
+      await container.stop();
     });
-  });
 
-  describe("apply", () => {
-    const expectedCheckpoints: Record<
-      string,
-      {
-        parent_checkpoint_id?: string;
-        checkpoint: Binary;
-        type: string;
-        metadata: CheckpointMetadata;
-        thread_id: string;
-        checkpoint_ns: string;
-        checkpoint_id: string;
-      }
-    > = {};
+    describe("isApplicable", () => {
+      // MongoDBSaver handles this automatically in initializeSchemaVersion
+      it("should want to apply on empty database", async () => {
+        // ensure database is empty
+        const db = client.db(dbName);
+        await db.dropDatabase();
 
-    beforeEach(async () => {
-      const serde = new JsonPlusSerializer();
-      const dropDb = client.db(dbName);
-      await dropDb.dropDatabase();
-      const db = client.db(dbName);
-      await db.createCollection("checkpoints");
-      await db.createCollection("schema_version");
-
-      for (let i = 0; i < 10; i += 1) {
-        const checkpoint_id = uuid6(-3);
-        const thread_id = uuid6(-3);
-        const checkpoint_ns = "";
-
-        const checkpoint: Checkpoint = {
-          v: 1,
-          id: checkpoint_id,
-          ts: new Date().toISOString(),
-          channel_values: {},
-          channel_versions: {},
-          versions_seen: {},
-          pending_sends: [],
-        };
-
-        const metadata: CheckpointMetadata = {
-          source: "update",
-          step: -1,
-          writes: {},
-          parents: {},
-        };
-
-        const [checkpointType, serializedCheckpoint] =
-          serde.dumpsTyped(checkpoint);
-        const serializedMetadata = serde.dumpsTyped(metadata)[1];
-
-        await db.collection("checkpoints").insertOne({
-          type: checkpointType,
-          checkpoint: serializedCheckpoint,
-          metadata: serializedMetadata,
-          thread_id,
-          checkpoint_ns,
-          checkpoint_id,
+        const migration = new Migration1ObjectMetadata({
+          client,
+          dbName,
+          checkpointCollectionName: "checkpoints",
+          checkpointWritesCollectionName: "checkpoint_writes",
+          schemaVersionCollectionName: "schema_version",
+          serializer: new JsonPlusSerializer(),
+          currentSchemaVersion: 1,
         });
-
-        expectedCheckpoints[checkpoint_id] = {
-          checkpoint: new Binary(serializedCheckpoint),
-          type: checkpointType,
-          metadata,
-          thread_id,
-          checkpoint_ns,
-          checkpoint_id,
-        };
-      }
-    });
-
-    it("should migrate all checkpoints", async () => {
-      const migration = new Migration1ObjectMetadata({
-        client,
-        dbName,
-        checkpointCollectionName: "checkpoints",
-        checkpointWritesCollectionName: "checkpoint_writes",
-        schemaVersionCollectionName: "schema_version",
-        serializer: new JsonPlusSerializer(),
-        currentSchemaVersion: 1,
+        expect(await migration.isApplicable()).toBe(true);
       });
-      await migration.apply();
 
-      const db = client.db(dbName);
-      const cursor = await db.collection("checkpoints").find({});
+      it("should not want to apply on database with schema version of 1", async () => {
+        const db = client.db(dbName);
+        await db.dropDatabase();
+        await db.createCollection("schema_version");
+        await db.collection("schema_version").insertOne({ version: 1 });
 
-      let docCount = 0;
-      for await (const actual of cursor) {
-        docCount += 1;
-        const expected = expectedCheckpoints[actual.checkpoint_id];
-        expect(actual.parent_checkpoint_id).toBe(expected.parent_checkpoint_id);
-        expect(actual.type).toBe(expected.type);
-        expect(actual.checkpoint).toEqual(expected.checkpoint);
-        expect(actual.metadata).toEqual(expected.metadata);
-        expect(actual.thread_id).toBe(expected.thread_id);
-        expect(actual.checkpoint_ns).toBe(expected.checkpoint_ns);
-        expect(actual.checkpoint_id).toBe(expected.checkpoint_id);
-      }
-      expect(docCount).toBe(10);
+        const migration = new Migration1ObjectMetadata({
+          client,
+          dbName,
+          checkpointCollectionName: "checkpoints",
+          checkpointWritesCollectionName: "checkpoint_writes",
+          schemaVersionCollectionName: "schema_version",
+          serializer: new JsonPlusSerializer(),
+          currentSchemaVersion: 1,
+        });
+        expect(await migration.isApplicable()).toBe(false);
+      });
     });
-  });
+
+    describe("apply", () => {
+      const expectedCheckpoints: Record<
+        string,
+        {
+          parent_checkpoint_id?: string;
+          checkpoint: Binary;
+          type: string;
+          metadata: CheckpointMetadata;
+          thread_id: string;
+          checkpoint_ns: string;
+          checkpoint_id: string;
+        }
+      > = {};
+
+      beforeEach(async () => {
+        const serde = new JsonPlusSerializer();
+        const dropDb = client.db(dbName);
+        await dropDb.dropDatabase();
+        const db = client.db(dbName);
+        await db.createCollection("checkpoints");
+        await db.createCollection("schema_version");
+
+        for (let i = 0; i < 10; i += 1) {
+          const checkpoint_id = uuid6(-3);
+          const thread_id = uuid6(-3);
+          const checkpoint_ns = "";
+
+          const checkpoint: Checkpoint = {
+            v: 1,
+            id: checkpoint_id,
+            ts: new Date().toISOString(),
+            channel_values: {},
+            channel_versions: {},
+            versions_seen: {},
+            pending_sends: [],
+          };
+
+          const metadata: CheckpointMetadata = {
+            source: "update",
+            step: -1,
+            writes: {},
+            parents: {},
+          };
+
+          const [checkpointType, serializedCheckpoint] =
+            serde.dumpsTyped(checkpoint);
+          const serializedMetadata = serde.dumpsTyped(metadata)[1];
+
+          await db.collection("checkpoints").insertOne({
+            type: checkpointType,
+            checkpoint: serializedCheckpoint,
+            metadata: serializedMetadata,
+            thread_id,
+            checkpoint_ns,
+            checkpoint_id,
+          });
+
+          expectedCheckpoints[checkpoint_id] = {
+            checkpoint: new Binary(serializedCheckpoint),
+            type: checkpointType,
+            metadata,
+            thread_id,
+            checkpoint_ns,
+            checkpoint_id,
+          };
+        }
+      });
+
+      it("should migrate all checkpoints", async () => {
+        const migration = new Migration1ObjectMetadata({
+          client,
+          dbName,
+          checkpointCollectionName: "checkpoints",
+          checkpointWritesCollectionName: "checkpoint_writes",
+          schemaVersionCollectionName: "schema_version",
+          serializer: new JsonPlusSerializer(),
+          currentSchemaVersion: 1,
+        });
+        await migration.apply();
+
+        const db = client.db(dbName);
+        const cursor = await db.collection("checkpoints").find({});
+
+        let docCount = 0;
+        for await (const actual of cursor) {
+          docCount += 1;
+          const expected = expectedCheckpoints[actual.checkpoint_id];
+          expect(actual.parent_checkpoint_id).toBe(
+            expected.parent_checkpoint_id
+          );
+          expect(actual.type).toBe(expected.type);
+          expect(actual.checkpoint).toEqual(expected.checkpoint);
+          expect(actual.metadata).toEqual(expected.metadata);
+          expect(actual.thread_id).toBe(expected.thread_id);
+          expect(actual.checkpoint_ns).toBe(expected.checkpoint_ns);
+          expect(actual.checkpoint_id).toBe(expected.checkpoint_id);
+        }
+        expect(docCount).toBe(10);
+      });
+    });
+  } else {
+    it.skip("GitHub can't run containers on M-Series macOS runners due to lack of support for nested virtualization.", () => {});
+  }
 });

--- a/libs/checkpoint-mongodb/src/tests/utils.ts
+++ b/libs/checkpoint-mongodb/src/tests/utils.ts
@@ -1,0 +1,33 @@
+import { platform, arch } from "node:os";
+
+function isMSeriesMac() {
+  return platform() === "darwin" && arch() === "arm64";
+}
+
+function isWindows() {
+  return platform() === "win32";
+}
+
+function isCI() {
+  // eslint-disable-next-line no-process-env
+  return (process.env.CI ?? "").toLowerCase() === "true";
+}
+
+/**
+ * GitHub Actions doesn't support containers on m-series macOS due to a lack of hypervisor support for nested
+ * virtualization.
+ *
+ * For details, see https://github.com/actions/runner-images/issues/9460#issuecomment-1981203045
+ *
+ * GitHub actions also doesn't support Linux containers on Windows, and may never do so. This is in part due to Docker
+ * Desktop licensing restrictions, and the complexity of setting up Moby or similar without Docker Desktop.
+ * Unfortunately, TestContainers doesn't support windows containers, so we can't run the tests on Windows either.
+ *
+ * For details, see https://github.com/actions/runner/issues/904 and
+ * https://java.testcontainers.org/supported_docker_environment/windows/#windows-container-on-windows-wcow
+ *
+ *
+ */
+export function isSkippedCIEnvironment() {
+  return isCI() && (isWindows() || isMSeriesMac());
+}

--- a/libs/checkpoint-sqlite/src/index.ts
+++ b/libs/checkpoint-sqlite/src/index.ts
@@ -10,6 +10,7 @@ import {
   type CheckpointMetadata,
   TASKS,
   copyCheckpoint,
+  validCheckpointMetadataKeys,
 } from "@langchain/langgraph-checkpoint";
 
 interface CheckpointRow {
@@ -35,33 +36,6 @@ interface PendingSendColumn {
   type: string;
   value: string;
 }
-
-// In the `SqliteSaver.list` method, we need to sanitize the `options.filter` argument to ensure it only contains keys
-// that are part of the `CheckpointMetadata` type. The lines below ensure that we get compile-time errors if the list
-// of keys that we use is out of sync with the `CheckpointMetadata` type.
-const checkpointMetadataKeys = ["source", "step", "writes", "parents"] as const;
-
-type CheckKeys<T, K extends readonly (keyof T)[]> = [K[number]] extends [
-  keyof T
-]
-  ? [keyof T] extends [K[number]]
-    ? K
-    : never
-  : never;
-
-function validateKeys<T, K extends readonly (keyof T)[]>(
-  keys: CheckKeys<T, K>
-): K {
-  return keys;
-}
-
-// If this line fails to compile, the list of keys that we use in the `SqliteSaver.list` method is out of sync with the
-// `CheckpointMetadata` type. In that case, just update `checkpointMetadataKeys` to contain all the keys in
-// `CheckpointMetadata`
-const validCheckpointMetadataKeys = validateKeys<
-  CheckpointMetadata,
-  typeof checkpointMetadataKeys
->(checkpointMetadataKeys);
 
 export class SqliteSaver extends BaseCheckpointSaver {
   db: DatabaseType;

--- a/libs/checkpoint-validation/package.json
+++ b/libs/checkpoint-validation/package.json
@@ -39,8 +39,7 @@
     "jest-environment-node": "^29.6.4",
     "ts-jest": "^29.1.0",
     "uuid": "^10.0.0",
-    "yargs": "^17.7.2",
-    "zod": "^3.23.8"
+    "yargs": "^17.7.2"
   },
   "peerDependencies": {
     "@langchain/core": ">=0.2.31 <0.4.0",

--- a/libs/checkpoint-validation/src/spec/list.ts
+++ b/libs/checkpoint-validation/src/spec/list.ts
@@ -116,17 +116,7 @@ export function listTests<T extends BaseCheckpointSaver>(
         } else {
           expect(actualTuplesMap.size).toEqual(expectedTuplesMap.size);
           for (const [key, value] of actualTuplesMap.entries()) {
-            // TODO: MongoDBSaver doesn't return pendingWrites on list, so we need to special case them
-            // see: https://github.com/langchain-ai/langgraphjs/issues/589
-            const checkpointerIncludesPendingWritesOnList =
-              initializer.checkpointerName !==
-              "@langchain/langgraph-checkpoint-mongodb";
-
             const expectedTuple = expectedTuplesMap.get(key);
-            if (!checkpointerIncludesPendingWritesOnList) {
-              delete expectedTuple?.pendingWrites;
-            }
-
             expect(value).toEqual(expectedTuple);
           }
         }

--- a/libs/checkpoint-validation/src/spec/list.ts
+++ b/libs/checkpoint-validation/src/spec/list.ts
@@ -165,13 +165,7 @@ export function listTests<T extends BaseCheckpointSaver>(
         parentTupleInDefaultNamespace.config,
         childTupleInDefaultNamespace.config,
       ],
-      filter:
-        // TODO: MongoDBSaver support for filter is broken and can't be fixed without a breaking change
-        // see: https://github.com/langchain-ai/langgraphjs/issues/581
-        initializer.checkpointerName ===
-        "@langchain/langgraph-checkpoint-mongodb"
-          ? [undefined]
-          : [undefined, {}, { source: "input" }, { source: "loop" }],
+      filter: [undefined, {}, { source: "input" }, { source: "loop" }],
     };
   }
 

--- a/libs/checkpoint-validation/src/spec/put.ts
+++ b/libs/checkpoint-validation/src/spec/put.ts
@@ -205,10 +205,7 @@ export function putTests<T extends BaseCheckpointSaver>(
       // TODO: all of the checkpointers below store full channel_values on every put, rather than storing deltas
       // see: https://github.com/langchain-ai/langgraphjs/issues/593
       // see: https://github.com/langchain-ai/langgraphjs/issues/594
-      // see: https://github.com/langchain-ai/langgraphjs/issues/595
       MemorySaver: "TODO: MemorySaver doesn't store channel deltas",
-      "@langchain/langgraph-checkpoint-mongodb":
-        "TODO: MongoDBSaver doesn't store channel deltas",
       "@langchain/langgraph-checkpoint-sqlite":
         "TODO: SQLiteSaver doesn't store channel deltas",
     })(

--- a/libs/checkpoint/src/index.ts
+++ b/libs/checkpoint/src/index.ts
@@ -4,4 +4,5 @@ export * from "./id.js";
 export * from "./types.js";
 export * from "./serde/base.js";
 export * from "./serde/types.js";
+export * from "./serde/jsonplus.js";
 export * from "./store/index.js";

--- a/libs/checkpoint/src/types.ts
+++ b/libs/checkpoint/src/types.ts
@@ -36,3 +36,26 @@ export interface CheckpointMetadata {
    */
   parents: Record<string, string>;
 }
+
+const checkpointMetadataKeys = ["source", "step", "writes", "parents"] as const;
+
+type CheckKeys<T, K extends readonly (keyof T)[]> = [K[number]] extends [
+  keyof T
+]
+  ? [keyof T] extends [K[number]]
+    ? K
+    : never
+  : never;
+
+function validateKeys<T, K extends readonly (keyof T)[]>(
+  keys: CheckKeys<T, K>
+): K {
+  return keys;
+}
+
+// Used by checkpoint list methods to sanitize the `options.filter` argument. If this line fails to compile, update
+// `checkpointMetadataKeys` to contain all the keys in `CheckpointMetadata`.
+export const validCheckpointMetadataKeys = validateKeys<
+  CheckpointMetadata,
+  typeof checkpointMetadataKeys
+>(checkpointMetadataKeys);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1634,6 +1634,7 @@ __metadata:
     "@langchain/scripts": ">=0.1.3 <0.2.0"
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
+    "@testcontainers/mongodb": ^10.13.2
     "@tsconfig/recommended": ^1.0.3
     "@types/better-sqlite3": ^7.6.9
     "@types/uuid": ^10
@@ -1654,6 +1655,7 @@ __metadata:
     prettier: ^2.8.3
     release-it: ^17.6.0
     rollup: ^4.23.0
+    testcontainers: ^10.13.2
     ts-jest: ^29.1.0
     tsx: ^4.7.0
     typescript: ^4.9.5 || ^5.4.5
@@ -1780,7 +1782,6 @@ __metadata:
     typescript: ^4.9.5 || ^5.4.5
     uuid: ^10.0.0
     yargs: ^17.7.2
-    zod: ^3.23.8
   peerDependencies:
     "@langchain/core": ">=0.2.31 <0.4.0"
     "@langchain/langgraph-checkpoint": ~0.0.6
@@ -9482,11 +9483,11 @@ __metadata:
   linkType: hard
 
 "nan@npm:^2.19.0, nan@npm:^2.20.0":
-  version: 2.20.0
-  resolution: "nan@npm:2.20.0"
+  version: 2.22.0
+  resolution: "nan@npm:2.22.0"
   dependencies:
     node-gyp: latest
-  checksum: eb09286e6c238a3582db4d88c875db73e9b5ab35f60306090acd2f3acae21696c9b653368b4a0e32abcef64ee304a923d6223acaddd16169e5eaaf5c508fb533
+  checksum: 222e3a090e326c72f6782d948f44ee9b81cfb2161d5fe53216f04426a273fd094deee9dcc6813096dd2397689a2b10c1a92d3885d2e73fd2488a51547beb2929
   languageName: node
   linkType: hard
 
@@ -12792,11 +12793,11 @@ __metadata:
   linkType: hard
 
 "yaml@npm:^2.2.2":
-  version: 2.5.1
-  resolution: "yaml@npm:2.5.1"
+  version: 2.6.0
+  resolution: "yaml@npm:2.6.0"
   bin:
     yaml: bin.mjs
-  checksum: 31275223863fbd0b47ba9d2b248fbdf085db8d899e4ca43fff8a3a009497c5741084da6871d11f40e555d61360951c4c910b98216c1325d2c94753c0036d8172
+  checksum: e5e74fd75e01bde2c09333d529af9fbb5928c5f7f01bfdefdcb2bf753d4ef489a45cab4deac01c9448f55ca27e691612b81fe3c3a59bb8cb5b0069da0f92cf0b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Breaking changes:
- Changes the format of stored documents in mongo, requiring existing databases to be migrated by calling the `MongoDBSaver.migrate` method.

Non-breaking changes:
- Adds filter logic to the `list` method to support the `options.filter` argument, fixes #581
  - Adds basic document format version tagging and migration support
  - Migrates existing stored metadata to stored as BSON objects rather than binary data.
  - Includes a change to `checkpoint-sqlite` and `checkpoint` libraries to centralize an array that I'm using in multiple packages to sanitize filter inputs.
- Stores `channel_values` by version on change, respecting the `newVersions` argument to `put`, fixes #595 
- Populates `pendingWrites` and `pending_sends` correctly, fixes #589
- Updates `checkpoint-validation` to no longer skip tests that exercise the above fixes