### PR TITLE
fix(checkpoint): don't throw on MemorySaver.put if no checkpoint_ns

### DIFF
--- a/libs/checkpoint-validation/src/spec/put.ts
+++ b/libs/checkpoint-validation/src/spec/put.ts
@@ -178,9 +178,6 @@ export function putTests<T extends BaseCheckpointSaver>(
     });
 
     it_skipForSomeModules(initializer.checkpointerName, {
-      // TODO: MemorySaver throws instead of defaulting to empty namespace
-      // see: https://github.com/langchain-ai/langgraphjs/issues/591
-      MemorySaver: "TODO: throws instead of defaulting to empty namespace",
       // TODO: SqliteSaver stores with undefined namespace instead of empty namespace
       // see: https://github.com/langchain-ai/langgraphjs/issues/592
       "@langchain/langgraph-checkpoint-sqlite":

--- a/libs/checkpoint/src/memory.ts
+++ b/libs/checkpoint/src/memory.ts
@@ -287,15 +287,10 @@ export class MemorySaver extends BaseCheckpointSaver {
     const preparedCheckpoint: Partial<Checkpoint> = copyCheckpoint(checkpoint);
     delete preparedCheckpoint.pending_sends;
     const threadId = config.configurable?.thread_id;
-    const checkpointNamespace = config.configurable?.checkpoint_ns;
+    const checkpointNamespace = config.configurable?.checkpoint_ns ?? "";
     if (threadId === undefined) {
       throw new Error(
         `Failed to put checkpoint. The passed RunnableConfig is missing a required "thread_id" field in its "configurable" property.`
-      );
-    }
-    if (checkpointNamespace === undefined) {
-      throw new Error(
-        `Failed to put checkpoint. The passed RunnableConfig is missing a required "checkpoint_ns" field in its "configurable" property.`
       );
     }
 


### PR DESCRIPTION
For consistency with the other checkpointers, this change makes `MemorySaver.put` use the default namespace when `config.configurable.checkpoint_ns` is undefined.

Also unignores relevant tests in `checkpoint-validation` for `MemorySaver` runs.

Fixes #591
