### PR TITLE
chore(checkpoint-validation): fix eslint extraneous-import error

### DIFF
--- a/libs/checkpoint-validation/.eslintrc.cjs
+++ b/libs/checkpoint-validation/.eslintrc.cjs
@@ -39,7 +39,7 @@ module.exports = {
     "import/extensions": [2, "ignorePackages"],
     "import/no-extraneous-dependencies": [
       "error",
-      { devDependencies: ["**/*.test.ts"] },
+      { devDependencies: ["src/tests/**/*.ts"] },
     ],
     "import/no-unresolved": 0,
     "import/prefer-default-export": 0,

--- a/libs/checkpoint-validation/src/tests/mongodb_initializer.ts
+++ b/libs/checkpoint-validation/src/tests/mongodb_initializer.ts
@@ -1,12 +1,9 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { MongoDBSaver } from "@langchain/langgraph-checkpoint-mongodb";
-// eslint-disable-next-line import/no-extraneous-dependencies
 import {
   MongoDBContainer,
   type StartedMongoDBContainer,
 } from "@testcontainers/mongodb";
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { MongoClient } from "mongodb";
 import type { CheckpointerTestInitializer } from "../types.js";
 

--- a/libs/checkpoint-validation/src/tests/postgres_initializer.ts
+++ b/libs/checkpoint-validation/src/tests/postgres_initializer.ts
@@ -1,13 +1,10 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { PostgresSaver } from "@langchain/langgraph-checkpoint-postgres";
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import {
   PostgreSqlContainer,
   type StartedPostgreSqlContainer,
 } from "@testcontainers/postgresql";
 
-// eslint-disable-next-line import/no-extraneous-dependencies
 import pg from "pg";
 
 import type { CheckpointerTestInitializer } from "../types.js";

--- a/libs/checkpoint-validation/src/tests/sqlite.spec.ts
+++ b/libs/checkpoint-validation/src/tests/sqlite.spec.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { specTest } from "../spec/index.js";
 import { initializer } from "./sqlite_initializer.js";
 

--- a/libs/checkpoint-validation/src/tests/sqlite_initializer.ts
+++ b/libs/checkpoint-validation/src/tests/sqlite_initializer.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { SqliteSaver } from "@langchain/langgraph-checkpoint-sqlite";
 import { CheckpointerTestInitializer } from "../types.js";
 


### PR DESCRIPTION
No idea why ESLint falsely triggered on the `zod` import in `checkpoint-validation`, but this appears to fix it.

[CI run of this commit on my fork](https://github.com/benjamincburns/langgraphjs/actions/runs/11513705853) is ✅ . 