### PR TITLE
feat(langgraph): Adds RemoteGraph

### DIFF
--- a/libs/langgraph/.gitignore
+++ b/libs/langgraph/.gitignore
@@ -14,6 +14,10 @@ prebuilt.cjs
 prebuilt.js
 prebuilt.d.ts
 prebuilt.d.cts
+remote.cjs
+remote.js
+remote.d.ts
+remote.d.cts
 node_modules
 dist
 .yarn

--- a/libs/langgraph/langchain.config.js
+++ b/libs/langgraph/langchain.config.js
@@ -15,7 +15,8 @@ export const config = {
     index: "index",
     web: "web",
     pregel: "pregel/index",
-    prebuilt: "prebuilt/index"
+    prebuilt: "prebuilt/index",
+    remote: "remote"
   },
   tsConfigPath: resolve("./tsconfig.json"),
   cjsSource: "./dist-cjs",

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -32,13 +32,13 @@
   "license": "MIT",
   "dependencies": {
     "@langchain/langgraph-checkpoint": "~0.0.10",
+    "@langchain/langgraph-sdk": "~0.0.20",
     "double-ended-queue": "^2.1.0-0",
     "uuid": "^10.0.0",
     "zod": "^3.23.8"
   },
   "peerDependencies": {
-    "@langchain/core": ">=0.2.36 <0.3.0 || >=0.3.9 < 0.4.0",
-    "@langchain/langgraph-sdk": "*"
+    "@langchain/core": ">=0.2.36 <0.3.0 || >=0.3.9 < 0.4.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
@@ -47,7 +47,6 @@
     "@langchain/core": "^0.3.15",
     "@langchain/langgraph-checkpoint-postgres": "workspace:*",
     "@langchain/langgraph-checkpoint-sqlite": "workspace:*",
-    "@langchain/langgraph-sdk": "^0.0.18",
     "@langchain/openai": "^0.3.11",
     "@langchain/scripts": ">=0.1.3 <0.2.0",
     "@swc/core": "^1.3.90",
@@ -80,11 +79,6 @@
     "tsx": "^4.7.0",
     "typescript": "^4.9.5 || ^5.4.5",
     "zod-to-json-schema": "^3.22.4"
-  },
-  "peerDependenciesMeta": {
-    "@langchain/langgraph-sdk": {
-      "optional": true
-    }
   },
   "publishConfig": {
     "access": "public",

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -37,7 +37,8 @@
     "zod": "^3.23.8"
   },
   "peerDependencies": {
-    "@langchain/core": ">=0.2.36 <0.3.0 || >=0.3.9 < 0.4.0"
+    "@langchain/core": ">=0.2.36 <0.3.0 || >=0.3.9 < 0.4.0",
+    "@langchain/langgraph-sdk": "*"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",
@@ -46,6 +47,7 @@
     "@langchain/core": "^0.3.15",
     "@langchain/langgraph-checkpoint-postgres": "workspace:*",
     "@langchain/langgraph-checkpoint-sqlite": "workspace:*",
+    "@langchain/langgraph-sdk": "^0.0.18",
     "@langchain/openai": "^0.3.11",
     "@langchain/scripts": ">=0.1.3 <0.2.0",
     "@swc/core": "^1.3.90",
@@ -78,6 +80,11 @@
     "tsx": "^4.7.0",
     "typescript": "^4.9.5 || ^5.4.5",
     "zod-to-json-schema": "^3.22.4"
+  },
+  "peerDependenciesMeta": {
+    "@langchain/langgraph-sdk": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -121,6 +121,15 @@
       "import": "./prebuilt.js",
       "require": "./prebuilt.cjs"
     },
+    "./remote": {
+      "types": {
+        "import": "./remote.d.ts",
+        "require": "./remote.d.cts",
+        "default": "./remote.d.ts"
+      },
+      "import": "./remote.js",
+      "require": "./remote.cjs"
+    },
     "./package.json": "./package.json"
   },
   "files": [
@@ -140,6 +149,10 @@
     "prebuilt.cjs",
     "prebuilt.js",
     "prebuilt.d.ts",
-    "prebuilt.d.cts"
+    "prebuilt.d.cts",
+    "remote.cjs",
+    "remote.js",
+    "remote.d.ts",
+    "remote.d.cts"
   ]
 }

--- a/libs/langgraph/src/errors.ts
+++ b/libs/langgraph/src/errors.ts
@@ -131,6 +131,20 @@ export class MultipleSubgraphsError extends BaseLangGraphError {
 }
 
 /**
+ * Exception raised when an error occurs in the remote graph.
+ */
+export class RemoteException extends BaseLangGraphError {
+  constructor(message?: string, fields?: BaseLangGraphErrorFields) {
+    super(message, fields);
+    this.name = "RemoteException";
+  }
+
+  static get unminifiable_name() {
+    return "RemoteException";
+  }
+}
+
+/**
  * Used for subgraph detection.
  */
 export const getSubgraphsSeenSet = () => {

--- a/libs/langgraph/src/graph/graph.ts
+++ b/libs/langgraph/src/graph/graph.ts
@@ -27,7 +27,11 @@ import {
   Send,
   TAG_HIDDEN,
 } from "../constants.js";
-import { gatherIteratorSync, RunnableCallable } from "../utils.js";
+import {
+  gatherIterator,
+  gatherIteratorSync,
+  RunnableCallable,
+} from "../utils.js";
 import { InvalidUpdateError, NodeInterrupt } from "../errors.js";
 import { StateDefinition, StateType } from "./annotation.js";
 import type { LangGraphRunnableConfig } from "../pregel/runnable_types.js";
@@ -539,6 +543,187 @@ export class CompiledGraph<
 
   /**
    * Returns a drawable representation of the computation graph.
+   */
+  override async getGraphAsync(
+    config?: RunnableConfig & { xray?: boolean | number }
+  ): Promise<DrawableGraph> {
+    const xray = config?.xray;
+    const graph = new DrawableGraph();
+    const startNodes: Record<string, DrawableGraphNode> = {
+      [START]: graph.addNode(
+        {
+          schema: z.any(),
+        },
+        START
+      ),
+    };
+    const endNodes: Record<string, DrawableGraphNode> = {};
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let subgraphs: Record<string, CompiledGraph<any>> = {};
+    if (xray) {
+      subgraphs = Object.fromEntries(
+        (await gatherIterator(this.getSubgraphsAsync())).filter(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (x): x is [string, CompiledGraph<any>] => isCompiledGraph(x[1])
+        )
+      );
+    }
+
+    function addEdge(
+      start: string,
+      end: string,
+      label?: string,
+      conditional = false
+    ) {
+      if (end === END && endNodes[END] === undefined) {
+        endNodes[END] = graph.addNode({ schema: z.any() }, END);
+      }
+      return graph.addEdge(
+        startNodes[start],
+        endNodes[end],
+        label !== end ? label : undefined,
+        conditional
+      );
+    }
+
+    for (const [key, nodeSpec] of Object.entries(this.builder.nodes) as [
+      N,
+      NodeSpec<RunInput, RunOutput>
+    ][]) {
+      const displayKey = _escapeMermaidKeywords(key);
+      const node = nodeSpec.runnable;
+      const metadata = nodeSpec.metadata ?? {};
+      if (
+        this.interruptBefore?.includes(key) &&
+        this.interruptAfter?.includes(key)
+      ) {
+        metadata.__interrupt = "before,after";
+      } else if (this.interruptBefore?.includes(key)) {
+        metadata.__interrupt = "before";
+      } else if (this.interruptAfter?.includes(key)) {
+        metadata.__interrupt = "after";
+      }
+      if (xray) {
+        const newXrayValue = typeof xray === "number" ? xray - 1 : xray;
+        const drawableSubgraph =
+          subgraphs[key] !== undefined
+            ? await subgraphs[key].getGraphAsync({
+                ...config,
+                xray: newXrayValue,
+              })
+            : node.getGraph(config);
+        drawableSubgraph.trimFirstNode();
+        drawableSubgraph.trimLastNode();
+        if (Object.keys(drawableSubgraph.nodes).length > 1) {
+          const [e, s] = graph.extend(drawableSubgraph, displayKey);
+          if (e === undefined) {
+            throw new Error(
+              `Could not extend subgraph "${key}" due to missing entrypoint.`
+            );
+          }
+
+          // TODO: Remove default name once we stop supporting core 0.2.0
+          // eslint-disable-next-line no-inner-declarations
+          function _isRunnableInterface(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            thing: any
+          ): thing is RunnableInterface {
+            return thing ? thing.lc_runnable : false;
+          }
+          // eslint-disable-next-line no-inner-declarations
+          function _nodeDataStr(
+            id: string | undefined,
+            data: RunnableInterface | RunnableIOSchema
+          ): string {
+            if (id !== undefined && !isUuid(id)) {
+              return id;
+            } else if (_isRunnableInterface(data)) {
+              try {
+                let dataStr = data.getName();
+                dataStr = dataStr.startsWith("Runnable")
+                  ? dataStr.slice("Runnable".length)
+                  : dataStr;
+                return dataStr;
+              } catch (error) {
+                return data.getName();
+              }
+            } else {
+              return data.name ?? "UnknownSchema";
+            }
+          }
+          // TODO: Remove casts when we stop supporting core 0.2.0
+          if (s !== undefined) {
+            startNodes[displayKey] = {
+              name: _nodeDataStr(s.id, s.data),
+              ...s,
+            } as DrawableGraphNode;
+          }
+          endNodes[displayKey] = {
+            name: _nodeDataStr(e.id, e.data),
+            ...e,
+          } as DrawableGraphNode;
+        } else {
+          // TODO: Remove when we stop supporting core 0.2.0
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          const newNode = graph.addNode(node, displayKey, metadata);
+          startNodes[displayKey] = newNode;
+          endNodes[displayKey] = newNode;
+        }
+      } else {
+        // TODO: Remove when we stop supporting core 0.2.0
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        const newNode = graph.addNode(node, displayKey, metadata);
+        startNodes[displayKey] = newNode;
+        endNodes[displayKey] = newNode;
+      }
+    }
+    const sortedEdges = [...this.builder.allEdges].sort(([a], [b]) => {
+      if (a < b) {
+        return -1;
+      } else if (b > a) {
+        return 1;
+      } else {
+        return 0;
+      }
+    });
+    for (const [start, end] of sortedEdges) {
+      addEdge(_escapeMermaidKeywords(start), _escapeMermaidKeywords(end));
+    }
+    for (const [start, branches] of Object.entries(this.builder.branches)) {
+      const defaultEnds: Record<string, string> = {
+        ...Object.fromEntries(
+          Object.keys(this.builder.nodes)
+            .filter((k) => k !== start)
+            .map((k) => [_escapeMermaidKeywords(k), _escapeMermaidKeywords(k)])
+        ),
+        [END]: END,
+      };
+      for (const branch of Object.values(branches)) {
+        let ends;
+        if (branch.ends !== undefined) {
+          ends = branch.ends;
+        } else {
+          ends = defaultEnds;
+        }
+        for (const [label, end] of Object.entries(ends)) {
+          addEdge(
+            _escapeMermaidKeywords(start),
+            _escapeMermaidKeywords(end),
+            label,
+            true
+          );
+        }
+      }
+    }
+    return graph;
+  }
+
+  /**
+   * Returns a drawable representation of the computation graph.
+   *
+   * @deprecated Use getGraphAsync instead. The async method will be the default in the next minor core release.
    */
   override getGraph(
     config?: RunnableConfig & { xray?: boolean | number }

--- a/libs/langgraph/src/pregel/remote.ts
+++ b/libs/langgraph/src/pregel/remote.ts
@@ -1,0 +1,325 @@
+import type { Client, Checkpoint, ThreadState } from "@langchain/langgraph-sdk";
+import {
+  Graph as DrawableGraph,
+  Node as DrawableNode,
+  Edge as DrawableEdge,
+} from "@langchain/core/runnables/graph";
+import { mergeConfigs, RunnableConfig } from "@langchain/core/runnables";
+import {
+  CheckpointListOptions,
+  CheckpointMetadata,
+} from "@langchain/langgraph-checkpoint";
+
+import {
+  BaseChannel,
+  LangGraphRunnableConfig,
+  ManagedValueSpec,
+} from "../web.js";
+import { StrRecord } from "./algo.js";
+import {
+  Pregel,
+  PregelInputType,
+  PregelOptions,
+  PregelOutputType,
+} from "./index.js";
+import { PregelNode } from "./read.js";
+import { PregelParams, PregelTaskDescription, StateSnapshot } from "./types.js";
+import { Interrupt } from "../constants.js";
+
+export type RemoteGraphParams<
+  Nn extends StrRecord<string, PregelNode>,
+  Cc extends StrRecord<string, BaseChannel | ManagedValueSpec>
+> = PregelParams<Nn, Cc> & {
+  graphId: string;
+  client: Client;
+};
+
+export class RemoteGraph<
+  Nn extends StrRecord<string, PregelNode>,
+  Cc extends StrRecord<string, BaseChannel | ManagedValueSpec>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ConfigurableFieldType extends Record<string, any> = StrRecord<string, any>
+> extends Pregel<Nn, Cc, ConfigurableFieldType> {
+  protected graphId: string;
+
+  client: Client;
+
+  constructor(params: RemoteGraphParams<Nn, Cc>) {
+    super(params);
+
+    this.graphId = params.graphId;
+    this.client = params.client;
+  }
+
+  protected _sanitizeConfig(config: RunnableConfig) {
+    const reservedConfigurableKeys = new Set([
+      "callbacks",
+      "checkpoint_map",
+      "checkpoint_id",
+      "checkpoint_ns",
+    ]);
+
+    const sanitizeObj = (obj: any): any => {
+      // Remove non-JSON serializable fields from the given object
+      if (obj && typeof obj === "object") {
+        if (Array.isArray(obj)) {
+          return obj.map((v) => sanitizeObj(v));
+        } else {
+          return Object.fromEntries(
+            Object.entries(obj).map(([k, v]) => [k, sanitizeObj(v)])
+          );
+        }
+      }
+
+      try {
+        JSON.stringify(obj);
+        return obj;
+      } catch {
+        return null;
+      }
+    };
+
+    // Remove non-JSON serializable fields from the config
+    config = sanitizeObj(config);
+
+    // Only include configurable keys that are not reserved and
+    // not starting with "__pregel_" prefix
+    const newConfigurable = Object.fromEntries(
+      Object.entries(config.configurable ?? {}).filter(
+        ([k]) => !reservedConfigurableKeys.has(k) && !k.startsWith("__pregel_")
+      )
+    );
+
+    return { configurable: newConfigurable };
+  }
+
+  protected _getConfig(checkpoint: Record<string, unknown>): RunnableConfig {
+    return {
+      configurable: {
+        thread_id: checkpoint.thread_id,
+        checkpoint_ns: checkpoint.checkpoint_ns,
+        checkpoint_id: checkpoint.checkpoint_id,
+        checkpoint_map: checkpoint.checkpoint_map ?? {},
+      },
+    };
+  }
+
+  protected _getCheckpoint(config?: RunnableConfig): Checkpoint | undefined {
+    if (config?.configurable === undefined) {
+      return undefined;
+    }
+
+    const checkpointKeys = [
+      "thread_id",
+      "checkpoint_ns",
+      "checkpoint_id",
+      "checkpoint_map",
+    ] as const;
+
+    const checkpoint = Object.fromEntries(
+      checkpointKeys
+        .map((key) => [key, config.configurable![key]])
+        .filter(([_, value]) => value !== undefined)
+    );
+
+    return Object.keys(checkpoint).length > 0 ? checkpoint : undefined;
+  }
+
+  protected _createStateSnapshot(state: ThreadState): StateSnapshot {
+    const tasks: PregelTaskDescription[] = state.tasks.map((task) => {
+      return {
+        id: task.id,
+        name: task.name,
+        error: task.error ? { message: task.error } : undefined,
+        interrupts: task.interrupts as Interrupt[],
+        state: task.state
+          ? this._createStateSnapshot(task.state)
+          : task.checkpoint
+          ? { configurable: task.checkpoint }
+          : undefined,
+        result: (task as any).result,
+      };
+    });
+
+    return {
+      values: state.values,
+      next: state.next ? [...state.next] : [],
+      config: {
+        configurable: {
+          thread_id: state.checkpoint.thread_id,
+          checkpoint_ns: state.checkpoint.checkpoint_ns,
+          checkpoint_id: state.checkpoint.checkpoint_id,
+          checkpoint_map: state.checkpoint.checkpoint_map ?? {},
+        },
+      },
+      metadata: state.metadata
+        ? (state.metadata as unknown as CheckpointMetadata)
+        : undefined,
+      createdAt: state.created_at ?? undefined,
+      parentConfig: state.parent_checkpoint
+        ? {
+            configurable: {
+              thread_id: state.parent_checkpoint.thread_id,
+              checkpoint_ns: state.parent_checkpoint.checkpoint_ns,
+              checkpoint_id: state.parent_checkpoint.checkpoint_id,
+              checkpoint_map: state.parent_checkpoint.checkpoint_map ?? {},
+            },
+          }
+        : undefined,
+      tasks,
+    };
+  }
+
+  override async invoke(
+    input: PregelInputType,
+    options?: Partial<PregelOptions<Nn, Cc, ConfigurableFieldType>>
+  ): Promise<PregelOutputType> {
+    const mergedConfig = mergeConfigs(this.config, options);
+    const sanitizedConfig = this._sanitizeConfig(mergedConfig);
+
+    const interruptBefore = this.interruptBefore ?? options?.interruptBefore;
+    const interruptAfter = this.interruptAfter ?? options?.interruptAfter;
+
+    return this.client.runs.wait(
+      sanitizedConfig.configurable?.thread_id,
+      this.graphId,
+      {
+        input,
+        config: sanitizedConfig,
+        interruptBefore: interruptBefore as string[],
+        interruptAfter: interruptAfter as string[],
+      }
+    );
+  }
+
+  override async *_streamIterator(
+    input: PregelInputType,
+    options?: Partial<PregelOptions<Nn, Cc, ConfigurableFieldType>>
+  ): AsyncGenerator<PregelOutputType> {
+    const mergedConfig = mergeConfigs(this.config, options);
+    const sanitizedConfig = this._sanitizeConfig(mergedConfig);
+
+    const interruptBefore = this.interruptBefore ?? options?.interruptBefore;
+    const interruptAfter = this.interruptAfter ?? options?.interruptAfter;
+
+    yield* this.client.runs.stream(
+      sanitizedConfig.configurable.thread_id,
+      this.graphId,
+      {
+        input,
+        config: sanitizedConfig,
+        streamMode:
+          options?.streamMode !== undefined ? options.streamMode : "values",
+        interruptBefore: interruptBefore as string[],
+        interruptAfter: interruptAfter as string[],
+        streamSubgraphs: options?.subgraphs,
+      }
+    );
+  }
+
+  override async updateState(
+    inputConfig: LangGraphRunnableConfig,
+    values: Record<string, unknown>,
+    asNode?: string
+  ): Promise<RunnableConfig> {
+    const mergedConfig = mergeConfigs(this.config, inputConfig);
+    const response = await this.client.threads.updateState(
+      mergedConfig.configurable?.thread_id,
+      { values, asNode, checkpoint: this._getCheckpoint(mergedConfig) }
+    );
+    return this._getConfig((response as any).checkpoint);
+  }
+
+  override async *getStateHistory(
+    config: RunnableConfig,
+    options?: CheckpointListOptions
+  ): AsyncIterableIterator<StateSnapshot> {
+    const mergedConfig = mergeConfigs(this.config, config);
+    const states = await this.client.threads.getHistory(
+      mergedConfig.configurable?.thread_id,
+      {
+        limit: options?.limit ?? 10,
+        before: this._getCheckpoint(options?.before) as any,
+        metadata: options?.filter,
+        checkpoint: this._getCheckpoint(mergedConfig),
+      }
+    );
+    for (const state of states) {
+      yield this._createStateSnapshot(state);
+    }
+  }
+
+  protected _getDrawableNodes(
+    nodes: Array<{
+      id: string | number;
+      name?: string;
+      data?: Record<string, unknown>;
+      metadata?: unknown;
+    }>
+  ): Record<string, DrawableNode> {
+    const nodesMap: Record<string, DrawableNode> = {};
+    for (const node of nodes) {
+      const nodeId = node.id;
+      nodesMap[nodeId] = {
+        id: nodeId.toString(),
+        name: node.name ?? "",
+        data: (node.data as any) ?? {},
+        metadata: node.metadata as any,
+      };
+    }
+    return nodesMap;
+  }
+
+  override async getState(
+    config: RunnableConfig,
+    options?: { subgraphs?: boolean }
+  ): Promise<StateSnapshot> {
+    const mergedConfig = mergeConfigs(this.config, config);
+
+    const state = await this.client.threads.getState(
+      mergedConfig.configurable?.thread_id,
+      {
+        checkpoint: this._getCheckpoint(mergedConfig),
+        subgraphs: options?.subgraphs,
+      } as any
+    );
+    return this._createStateSnapshot(state);
+  }
+
+  /**
+   * Returns a drawable representation of the computation graph.
+   */
+  // @ts-expect-error Fix in core 0.4
+  override async getGraph(
+    config?: RunnableConfig & { xray?: boolean | number }
+  ): Promise<DrawableGraph> {
+    const graph = await this.client.assistants.getGraph(this.graphId, {
+      xray: config?.xray,
+    });
+    return new DrawableGraph({
+      nodes: this._getDrawableNodes(graph.nodes as any),
+      edges: graph.edges as unknown as DrawableEdge[],
+    });
+  }
+
+  // @ts-expect-error Fix in next minor release
+  override async *getSubgraphs(
+    namespace?: string,
+    recurse = false
+  ): AsyncIterableIterator<
+    [string, RemoteGraph<Nn, Cc, ConfigurableFieldType>]
+  > {
+    const subgraphs = await this.client.assistants.getSubgraphs(this.graphId, {
+      namespace,
+      recurse,
+    });
+
+    for (const [ns, graphSchema] of Object.entries(subgraphs)) {
+      const remoteSubgraph = new (this.constructor as any)({
+        ...this,
+        graphId: graphSchema.graph_id,
+      });
+      yield [ns, remoteSubgraph];
+    }
+  }
+}

--- a/libs/langgraph/src/pregel/remote.ts
+++ b/libs/langgraph/src/pregel/remote.ts
@@ -142,6 +142,7 @@ const getStreamModes = (
  * ```ts
  * import { RemoteGraph } from "@langchain/langgraph/remote";
  *
+ * // Can also pass a LangGraph SDK client instance directly
  * const remotePregel = new RemoteGraph({
  *   graphId: process.env.LANGGRAPH_REMOTE_GRAPH_ID!,
  *   apiKey: process.env.LANGGRAPH_REMOTE_GRAPH_API_KEY,

--- a/libs/langgraph/src/pregel/remote.ts
+++ b/libs/langgraph/src/pregel/remote.ts
@@ -286,13 +286,21 @@ export class RemoteGraph<
     return this._createStateSnapshot(state);
   }
 
+  /** @deprecated Use getGraphAsync instead. The async method will become the default in the next minor release. */
+  override getGraph(
+    _?: RunnableConfig & { xray?: boolean | number }
+  ): DrawableGraph {
+    throw new Error(
+      `The synchronous "getGraph" is not supported for this graph. Call "getGraphAsync" instead.`
+    );
+  }
+
   /**
    * Returns a drawable representation of the computation graph.
    */
-  // @ts-expect-error Fix in core 0.4
-  override async getGraph(
+  override async getGraphAsync(
     config?: RunnableConfig & { xray?: boolean | number }
-  ): Promise<DrawableGraph> {
+  ) {
     const graph = await this.client.assistants.getGraph(this.graphId, {
       xray: config?.xray,
     });
@@ -302,13 +310,17 @@ export class RemoteGraph<
     });
   }
 
-  // @ts-expect-error Fix in next minor release
-  override async *getSubgraphs(
+  /** @deprecated Use getSubgraphsAsync instead. The async method will become the default in the next minor release. */
+  override getSubgraphs(): Generator<[string, Pregel<any, any>]> {
+    throw new Error(
+      `The synchronous "getSubgraphs" method is not supported for this graph. Call "getSubgraphsAsync" instead.`
+    );
+  }
+
+  override async *getSubgraphsAsync(
     namespace?: string,
     recurse = false
-  ): AsyncIterableIterator<
-    [string, RemoteGraph<Nn, Cc, ConfigurableFieldType>]
-  > {
+  ): AsyncGenerator<[string, RemoteGraph<Nn, Cc, ConfigurableFieldType>]> {
     const subgraphs = await this.client.assistants.getSubgraphs(this.graphId, {
       namespace,
       recurse,

--- a/libs/langgraph/src/pregel/remote.ts
+++ b/libs/langgraph/src/pregel/remote.ts
@@ -322,7 +322,7 @@ export class RemoteGraph<
     for await (const chunk of stream) {
       lastValue = chunk;
     }
-    return lastValue?.data;
+    return lastValue;
   }
 
   override streamEvents(
@@ -503,7 +503,8 @@ export class RemoteGraph<
         name: typeof node.data === "string" ? node.data : node.data?.name ?? "",
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         data: (node.data as any) ?? {},
-        metadata: (typeof node.data !== "string" && node.data?.metadata) ?? {},
+        metadata:
+          typeof node.data !== "string" ? node.data?.metadata ?? {} : {},
       };
     }
     return nodesMap;

--- a/libs/langgraph/src/pregel/remote.ts
+++ b/libs/langgraph/src/pregel/remote.ts
@@ -377,7 +377,7 @@ export class RemoteGraph<
     ];
 
     for await (const chunk of this.client.runs.stream(
-      sanitizedConfig.configurable.thread_id,
+      sanitizedConfig.configurable.thread_id as string,
       this.graphId,
       {
         input: _serializeInputs(input),

--- a/libs/langgraph/src/pregel/types.ts
+++ b/libs/langgraph/src/pregel/types.ts
@@ -8,13 +8,13 @@ import type {
   CheckpointListOptions,
 } from "@langchain/langgraph-checkpoint";
 import { Graph as DrawableGraph } from "@langchain/core/runnables/graph";
+import { IterableReadableStream } from "@langchain/core/utils/stream";
 import type { BaseChannel } from "../channels/base.js";
 import type { PregelNode } from "./read.js";
 import { RetryPolicy } from "./utils/index.js";
 import { Interrupt } from "../constants.js";
 import { type ManagedValueSpec } from "../managed/base.js";
 import { LangGraphRunnableConfig } from "./runnable_types.js";
-import { IterableReadableStream } from "@langchain/core/utils/stream";
 
 export type StreamMode = "values" | "updates" | "debug";
 

--- a/libs/langgraph/src/pregel/types.ts
+++ b/libs/langgraph/src/pregel/types.ts
@@ -5,15 +5,50 @@ import type {
   CheckpointMetadata,
   BaseCheckpointSaver,
   BaseStore,
+  CheckpointListOptions,
 } from "@langchain/langgraph-checkpoint";
+import { Graph as DrawableGraph } from "@langchain/core/runnables/graph";
 import type { BaseChannel } from "../channels/base.js";
 import type { PregelNode } from "./read.js";
 import { RetryPolicy } from "./utils/index.js";
 import { Interrupt } from "../constants.js";
 import { type ManagedValueSpec } from "../managed/base.js";
 import { LangGraphRunnableConfig } from "./runnable_types.js";
+import { IterableReadableStream } from "@langchain/core/utils/stream";
 
 export type StreamMode = "values" | "updates" | "debug";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PregelInputType = any;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PregelOutputType = any;
+
+/**
+ * Config for executing the graph.
+ */
+export interface PregelOptions<
+  Nn extends StrRecord<string, PregelNode>,
+  Cc extends StrRecord<string, BaseChannel | ManagedValueSpec>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ConfigurableFieldType extends Record<string, any> = Record<string, any>
+> extends RunnableConfig<ConfigurableFieldType> {
+  /** The stream mode for the graph run. Default is ["values"]. */
+  streamMode?: StreamMode | StreamMode[];
+  inputKeys?: keyof Cc | Array<keyof Cc>;
+  /** The output keys to retrieve from the graph run. */
+  outputKeys?: keyof Cc | Array<keyof Cc>;
+  /** The nodes to interrupt the graph run before. */
+  interruptBefore?: All | Array<keyof Nn>;
+  /** The nodes to interrupt the graph run after. */
+  interruptAfter?: All | Array<keyof Nn>;
+  /** Enable debug mode for the graph run. */
+  debug?: boolean;
+  /** Whether to stream subgraphs. */
+  subgraphs?: boolean;
+  /** The shared value store */
+  store?: BaseStore;
+}
 
 /**
  * Construct a type with a set of properties K of type T
@@ -24,8 +59,62 @@ type StrRecord<K extends string, T> = {
 
 export interface PregelInterface<
   Nn extends StrRecord<string, PregelNode>,
-  Cc extends StrRecord<string, BaseChannel | ManagedValueSpec>
+  Cc extends StrRecord<string, BaseChannel | ManagedValueSpec>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ConfigurableFieldType extends Record<string, any> = StrRecord<string, any>
 > {
+  lg_is_pregel: boolean;
+
+  withConfig(config: RunnableConfig): PregelInterface<Nn, Cc>;
+
+  getGraphAsync(
+    config: RunnableConfig & { xray?: boolean | number }
+  ): Promise<DrawableGraph>;
+
+  /** @deprecated Use getSubgraphsAsync instead. The async method will become the default in the next minor release. */
+  getSubgraphs(
+    namespace?: string,
+    recurse?: boolean
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): Generator<[string, PregelInterface<any, any>]>;
+
+  getSubgraphsAsync(
+    namespace?: string,
+    recurse?: boolean
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): AsyncGenerator<[string, PregelInterface<any, any>]>;
+
+  getState(
+    config: RunnableConfig,
+    options?: { subgraphs?: boolean }
+  ): Promise<StateSnapshot>;
+
+  getStateHistory(
+    config: RunnableConfig,
+    options?: CheckpointListOptions
+  ): AsyncIterableIterator<StateSnapshot>;
+
+  updateState(
+    inputConfig: LangGraphRunnableConfig,
+    values: Record<string, unknown> | unknown,
+    asNode?: keyof Nn | string
+  ): Promise<RunnableConfig>;
+
+  stream(
+    input: PregelInputType,
+    options?: Partial<PregelOptions<Nn, Cc, ConfigurableFieldType>>
+  ): Promise<IterableReadableStream<PregelOutputType>>;
+
+  invoke(
+    input: PregelInputType,
+    options?: Partial<PregelOptions<Nn, Cc, ConfigurableFieldType>>
+  ): Promise<PregelOutputType>;
+}
+
+export type PregelParams<
+  Nn extends StrRecord<string, PregelNode>,
+  Cc extends StrRecord<string, BaseChannel | ManagedValueSpec>
+> = {
   nodes: Nn;
 
   channels: Cc;
@@ -56,8 +145,6 @@ export interface PregelInterface<
 
   streamChannels?: keyof Cc | Array<keyof Cc>;
 
-  get streamChannelsAsIs(): keyof Cc | Array<keyof Cc>;
-
   /**
    * @default undefined
    */
@@ -78,12 +165,7 @@ export interface PregelInterface<
    * Memory store to use for SharedValues.
    */
   store?: BaseStore;
-}
-
-export type PregelParams<
-  Nn extends StrRecord<string, PregelNode>,
-  Cc extends StrRecord<string, BaseChannel | ManagedValueSpec>
-> = Omit<PregelInterface<Nn, Cc>, "streamChannelsAsIs">;
+};
 
 export interface PregelTaskDescription {
   readonly id: string;

--- a/libs/langgraph/src/pregel/utils/subgraph.ts
+++ b/libs/langgraph/src/pregel/utils/subgraph.ts
@@ -17,12 +17,7 @@ export function isPregelLike(
   x: PregelInterface<any, any> | RunnableLike<any, any, any>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): x is PregelInterface<any, any> {
-  return (
-    "inputChannels" in x &&
-    x.inputChannels !== undefined &&
-    "outputChannels" &&
-    x.outputChannels !== undefined
-  );
+  return "lg_is_pregel" in x && x.lg_is_pregel === true;
 }
 
 export function findSubgraphPregel(

--- a/libs/langgraph/src/remote.ts
+++ b/libs/langgraph/src/remote.ts
@@ -1,0 +1,1 @@
+export { RemoteGraph, type RemoteGraphParams } from "./pregel/remote.js";

--- a/libs/langgraph/src/tests/remote.int.test.ts
+++ b/libs/langgraph/src/tests/remote.int.test.ts
@@ -1,0 +1,98 @@
+import { Client } from "@langchain/langgraph-sdk";
+import { v4 } from "uuid";
+import { RemoteGraph } from "../pregel/remote.js";
+import { MemorySaver, MessagesAnnotation, StateGraph } from "../web.js";
+
+describe("RemoteGraph", () => {
+  const client = new Client({
+    apiKey: process.env.LANGGRAPH_REMOTE_GRAPH_API_KEY,
+    apiUrl: process.env.LANGGRAPH_REMOTE_GRAPH_API_URL,
+  });
+  const remotePregel = new RemoteGraph({
+    graphId: process.env.LANGGRAPH_REMOTE_GRAPH_ID!,
+    client,
+  });
+
+  const builder = new StateGraph(MessagesAnnotation)
+    .addNode("agent", remotePregel)
+    .addEdge("__start__", "agent")
+    .addEdge("agent", "__end__");
+  const input = {
+    messages: [
+      {
+        role: "human",
+        content: "Hello world!",
+      },
+    ],
+  };
+
+  const config = {
+    configurable: { thread_id: v4() },
+  };
+
+  test("invoke", async () => {
+    const checkpointer = new MemorySaver();
+    const app = builder.compile({ checkpointer });
+
+    const response = await app.invoke(input, config);
+
+    console.log("response:", response);
+  });
+
+  test("stream", async () => {
+    const checkpointer = new MemorySaver();
+    const app = builder.compile({ checkpointer });
+    const stream = await app.stream(input, {
+      ...config,
+      subgraphs: true,
+      streamMode: ["debug", "values"],
+    });
+
+    for await (const chunk of stream) {
+      console.log("chunk:", chunk);
+    }
+  });
+
+  test.only("get and update state", async () => {
+    const checkpointer = new MemorySaver();
+    const app = builder.compile({ checkpointer });
+
+    await app.invoke(input, config);
+    // test get state
+    const stateSnapshot = await remotePregel.getState(config, {
+      subgraphs: true,
+    });
+    console.log("state snapshot: ", stateSnapshot);
+
+    // test update state
+    const updateStateResponse = await remotePregel.updateState(config, {
+      messages: [
+        {
+          role: "ai",
+          content: "Hello world again!",
+        },
+      ],
+    });
+    console.log("update state response:", updateStateResponse);
+
+    // test get history
+    for await (const state of remotePregel.getStateHistory(config)) {
+      console.log("state history snapshot:", state);
+    }
+
+    // test get graph
+    const remotePregel2 = new RemoteGraph({
+      graphId: "fe096781-5601-53d2-b2f6-0d3403f7e9ca",
+      client,
+    });
+
+    const graph = await remotePregel2.getGraphAsync({ xray: true });
+    console.log("graph:", graph);
+
+    // test get subgraphs
+    for await (const [name, pregel] of remotePregel2.getSubgraphsAsync()) {
+      console.log("name:", name);
+      console.log("pregel:", pregel);
+    }
+  });
+});

--- a/libs/langgraph/src/tests/remote.int.test.ts
+++ b/libs/langgraph/src/tests/remote.int.test.ts
@@ -1,17 +1,13 @@
 /* eslint-disable no-process-env */
-import { Client } from "@langchain/langgraph-sdk";
 import { v4 } from "uuid";
 import { RemoteGraph } from "../pregel/remote.js";
 import { MemorySaver, MessagesAnnotation, StateGraph } from "../web.js";
 
 describe("RemoteGraph", () => {
-  const client = new Client({
-    apiKey: process.env.LANGGRAPH_REMOTE_GRAPH_API_KEY,
-    apiUrl: process.env.LANGGRAPH_REMOTE_GRAPH_API_URL,
-  });
   const remotePregel = new RemoteGraph({
     graphId: process.env.LANGGRAPH_REMOTE_GRAPH_ID!,
-    client,
+    apiKey: process.env.LANGGRAPH_REMOTE_GRAPH_API_KEY,
+    url: process.env.LANGGRAPH_REMOTE_GRAPH_API_URL,
   });
 
   const builder = new StateGraph(MessagesAnnotation)
@@ -84,7 +80,8 @@ describe("RemoteGraph", () => {
     // test get graph
     const remotePregel2 = new RemoteGraph({
       graphId: "fe096781-5601-53d2-b2f6-0d3403f7e9ca",
-      client,
+      apiKey: process.env.LANGGRAPH_REMOTE_GRAPH_API_KEY,
+      url: process.env.LANGGRAPH_REMOTE_GRAPH_API_URL,
     });
 
     const graph = await remotePregel2.getGraphAsync({ xray: true });

--- a/libs/langgraph/src/tests/remote.int.test.ts
+++ b/libs/langgraph/src/tests/remote.int.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-process-env */
 import { Client } from "@langchain/langgraph-sdk";
 import { v4 } from "uuid";
 import { RemoteGraph } from "../pregel/remote.js";
@@ -53,7 +54,7 @@ describe("RemoteGraph", () => {
     }
   });
 
-  test.only("get and update state", async () => {
+  test("get and update state", async () => {
     const checkpointer = new MemorySaver();
     const app = builder.compile({ checkpointer });
 

--- a/libs/langgraph/src/tests/remote.test.ts
+++ b/libs/langgraph/src/tests/remote.test.ts
@@ -64,21 +64,24 @@ describe("RemoteGraph", () => {
     expect(drawableGraph.nodes).toEqual({
       __start__: {
         id: "__start__",
-        name: "",
+        name: "__start__",
         data: "__start__",
+        metadata: {},
       },
       __end__: {
         id: "__end__",
-        name: "",
+        name: "__end__",
         data: "__end__",
+        metadata: {},
       },
       agent: {
         id: "agent",
-        name: "",
+        name: "agent",
         data: {
           id: ["langgraph", "utils", "RunnableCallable"],
           name: "agent",
         },
+        metadata: {},
       },
     });
     expect(drawableGraph.edges).toEqual([
@@ -447,9 +450,12 @@ describe("RemoteGraph", () => {
       .spyOn((client as any).runs, "stream")
       .mockImplementation(async function* () {
         const chunks = [
-          { chunk: "data1" },
-          { chunk: "data2" },
-          { chunk: "data3" },
+          { event: "values", data: { chunk: "data1" } },
+          { event: "values", data: { chunk: "data2" } },
+          {
+            event: "values",
+            data: { messages: [{ type: "human", content: "world" }] },
+          },
         ];
         for (const chunk of chunks) {
           yield chunk;
@@ -463,11 +469,9 @@ describe("RemoteGraph", () => {
 
     const config = { configurable: { thread_id: "thread_1" } };
     const result = await remotePregel.invoke(
-      { input: { messages: [{ type: "human", content: "hello" }] } },
+      { messages: [{ type: "human", content: "hello" }] },
       config
     );
-    expect(result).toEqual({
-      values: { messages: [{ type: "human", content: "world" }] },
-    });
+    expect(result).toEqual({ messages: [{ type: "human", content: "world" }] });
   });
 });

--- a/libs/langgraph/src/tests/remote.test.ts
+++ b/libs/langgraph/src/tests/remote.test.ts
@@ -1,8 +1,10 @@
+import { jest } from "@jest/globals";
 import { Client } from "@langchain/langgraph-sdk";
 import { RemoteGraph } from "../pregel/remote.js";
+import { gatherIterator } from "../utils.js";
 
 describe("RemoteGraph", () => {
-  test("with_config", () => {
+  test("withConfig", () => {
     // set up test
     const remotePregel = new RemoteGraph({
       graphId: "test_graph_id",
@@ -28,6 +30,270 @@ describe("RemoteGraph", () => {
         threadId: "thread_id_1",
         hello: "world",
       },
+    });
+  });
+
+  test("getGraph", async () => {
+    const client = new Client({});
+    jest.spyOn((client as any).assistants, "getGraph").mockResolvedValue({
+      nodes: [
+        { id: "__start__", type: "schema", data: "__start__" },
+        { id: "__end__", type: "schema", data: "__end__" },
+        {
+          id: "agent",
+          type: "runnable",
+          data: {
+            id: ["langgraph", "utils", "RunnableCallable"],
+            name: "agent",
+          },
+        },
+      ],
+      edges: [
+        { source: "__start__", target: "agent" },
+        { source: "agent", target: "__end__" },
+      ],
+    });
+    const remotePregel = new RemoteGraph({
+      client,
+      graphId: "test_graph_id",
+    });
+    const drawableGraph = await remotePregel.getGraphAsync();
+    expect(drawableGraph.nodes).toEqual({
+      __start__: {
+        id: "__start__",
+        name: "",
+        data: "__start__",
+      },
+      __end__: {
+        id: "__end__",
+        name: "",
+        data: "__end__",
+      },
+      agent: {
+        id: "agent",
+        name: "",
+        data: {
+          id: ["langgraph", "utils", "RunnableCallable"],
+          name: "agent",
+        },
+      },
+    });
+    expect(drawableGraph.edges).toEqual([
+      { source: "__start__", target: "agent" },
+      { source: "agent", target: "__end__" },
+    ]);
+  });
+
+  test("getSubgraphs", async () => {
+    const client = new Client({});
+    jest.spyOn((client as any).assistants, "getSubgraphs").mockResolvedValue({
+      namespace_1: {
+        graph_id: "test_graph_id_2",
+        input_schema: {},
+        output_schema: {},
+        state_schema: {},
+        config_schema: {},
+      },
+      namespace_2: {
+        graph_id: "test_graph_id_3",
+        input_schema: {},
+        output_schema: {},
+        state_schema: {},
+        config_schema: {},
+      },
+    });
+    const remotePregel = new RemoteGraph({
+      client,
+      graphId: "test_graph_id",
+    });
+    const subgraphs = await gatherIterator(remotePregel.getSubgraphsAsync());
+    expect(subgraphs.length).toEqual(2);
+
+    const subgraph1 = subgraphs[0];
+    const namespace1 = subgraph1[0];
+    const remotePregel1 = subgraph1[1] as RemoteGraph;
+    expect(namespace1).toEqual("namespace_1");
+    expect(remotePregel1.graphId).toEqual("test_graph_id_2");
+
+    const subgraph2 = subgraphs[1];
+    const namespace2 = subgraph2[0];
+    const remotePregel2 = subgraph2[1] as RemoteGraph;
+    expect(namespace2).toEqual("namespace_2");
+    expect(remotePregel2.graphId).toEqual("test_graph_id_3");
+  });
+
+  test("getState", async () => {
+    const client = new Client({});
+    jest.spyOn((client as any).threads, "getState").mockResolvedValue({
+      values: { messages: [{ type: "human", content: "hello" }] },
+      next: undefined,
+      checkpoint: {
+        thread_id: "thread_1",
+        checkpoint_ns: "ns",
+        checkpoint_id: "checkpoint_1",
+        checkpoint_map: {},
+      },
+      metadata: {},
+      created_at: "timestamp",
+      parent_checkpoint: undefined,
+      tasks: [],
+    });
+
+    const remotePregel = new RemoteGraph({
+      client,
+      graphId: "test_graph_id",
+    });
+
+    const config = { configurable: { thread_id: "thread1" } };
+
+    const stateSnapshot = await remotePregel.getState(config);
+
+    expect(stateSnapshot).toEqual({
+      values: { messages: [{ type: "human", content: "hello" }] },
+      next: [],
+      config: {
+        configurable: {
+          thread_id: "thread_1",
+          checkpoint_ns: "ns",
+          checkpoint_id: "checkpoint_1",
+          checkpoint_map: {},
+        },
+      },
+      metadata: {},
+      createdAt: "timestamp",
+      parentConfig: undefined,
+      tasks: [],
+    });
+  });
+
+  test("getStateHistory", async () => {
+    const client = new Client({});
+    jest.spyOn((client as any).threads, "getHistory").mockResolvedValue([
+      {
+        values: { messages: [{ type: "human", content: "hello" }] },
+        next: undefined,
+        checkpoint: {
+          thread_id: "thread_1",
+          checkpoint_ns: "ns",
+          checkpoint_id: "checkpoint_1",
+          checkpoint_map: {},
+        },
+        metadata: {},
+        created_at: "timestamp",
+        parent_checkpoint: undefined,
+        tasks: [],
+      },
+    ]);
+
+    const remotePregel = new RemoteGraph({
+      client,
+      graphId: "test_graph_id",
+    });
+    const config = { configurable: { thread_id: "thread1" } };
+    const stateHistorySnapshots = await gatherIterator(
+      remotePregel.getStateHistory(config)
+    );
+
+    expect(stateHistorySnapshots.length).toEqual(1);
+
+    expect(stateHistorySnapshots[0]).toEqual({
+      values: { messages: [{ type: "human", content: "hello" }] },
+      next: [],
+      config: {
+        configurable: {
+          thread_id: "thread_1",
+          checkpoint_ns: "ns",
+          checkpoint_id: "checkpoint_1",
+          checkpoint_map: {},
+        },
+      },
+      metadata: {},
+      createdAt: "timestamp",
+      parentConfig: undefined,
+      tasks: [],
+    });
+  });
+
+  test("updateState", async () => {
+    const client = new Client({});
+    jest.spyOn((client as any).threads, "updateState").mockResolvedValue({
+      checkpoint: {
+        thread_id: "thread_1",
+        checkpoint_ns: "ns",
+        checkpoint_id: "checkpoint_1",
+        checkpoint_map: {},
+      },
+    });
+
+    const remotePregel = new RemoteGraph({
+      client,
+      graphId: "test_graph_id",
+    });
+
+    const config = { configurable: { thread_id: "thread1" } };
+
+    const response = await remotePregel.updateState(config, { key: "value" });
+
+    expect(response).toEqual({
+      configurable: {
+        thread_id: "thread_1",
+        checkpoint_ns: "ns",
+        checkpoint_id: "checkpoint_1",
+        checkpoint_map: {},
+      },
+    });
+  });
+
+  test("stream", async () => {
+    const client = new Client({});
+    jest
+      .spyOn((client as any).runs, "stream")
+      .mockImplementation(async function* () {
+        const chunks = [
+          { chunk: "data1" },
+          { chunk: "data2" },
+          { chunk: "data3" },
+        ];
+        for (const chunk of chunks) {
+          yield chunk;
+        }
+      });
+
+    const remotePregel = new RemoteGraph({
+      client,
+      graphId: "test_graph_id",
+    });
+
+    const config = { configurable: { thread_id: "thread_1" } };
+
+    const result = await gatherIterator(
+      remotePregel.stream({ input: "data" }, config)
+    );
+    expect(result).toEqual([
+      { chunk: "data1" },
+      { chunk: "data2" },
+      { chunk: "data3" },
+    ]);
+  });
+
+  test("invoke", async () => {
+    const client = new Client({});
+    jest.spyOn((client as any).runs, "wait").mockResolvedValue({
+      values: { messages: [{ type: "human", content: "world" }] },
+    });
+
+    const remotePregel = new RemoteGraph({
+      client,
+      graphId: "test_graph_id",
+    });
+
+    const config = { configurable: { thread_id: "thread_1" } };
+    const result = await remotePregel.invoke(
+      { input: { messages: [{ type: "human", content: "hello" }] } },
+      config
+    );
+    expect(result).toEqual({
+      values: { messages: [{ type: "human", content: "world" }] },
     });
   });
 });

--- a/libs/langgraph/src/tests/remote.test.ts
+++ b/libs/langgraph/src/tests/remote.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { jest } from "@jest/globals";
 import { Client } from "@langchain/langgraph-sdk";
 import { RemoteGraph } from "../pregel/remote.js";

--- a/libs/langgraph/src/tests/remote.test.ts
+++ b/libs/langgraph/src/tests/remote.test.ts
@@ -1,0 +1,33 @@
+import { Client } from "@langchain/langgraph-sdk";
+import { RemoteGraph } from "../pregel/remote.js";
+
+describe("RemoteGraph", () => {
+  test("with_config", () => {
+    // set up test
+    const remotePregel = new RemoteGraph({
+      graphId: "test_graph_id",
+      config: {
+        configurable: {
+          foo: "bar",
+          threadId: "thread_id_1",
+        },
+      },
+      client: new Client(),
+    });
+
+    // call method / assertions
+    const config = { configurable: { hello: "world" } };
+    const remotePregelCopy = remotePregel.withConfig(config);
+
+    // assert that a copy was returned
+    expect(remotePregelCopy).not.toBe(remotePregel);
+    // assert that configs were merged
+    expect(remotePregelCopy.config).toEqual({
+      configurable: {
+        foo: "bar",
+        threadId: "thread_id_1",
+        hello: "world",
+      },
+    });
+  });
+});

--- a/libs/langgraph/src/web.ts
+++ b/libs/langgraph/src/web.ts
@@ -32,6 +32,7 @@ export {
 export { type AnnotationRoot as _INTERNAL_ANNOTATION_ROOT } from "./graph/index.js";
 export { type RetryPolicy } from "./pregel/utils/index.js";
 export { Send } from "./constants.js";
+export { RemoteGraph, type RemoteGraphParams } from "./pregel/remote.js";
 
 export {
   MemorySaver,

--- a/libs/langgraph/src/web.ts
+++ b/libs/langgraph/src/web.ts
@@ -32,7 +32,6 @@ export {
 export { type AnnotationRoot as _INTERNAL_ANNOTATION_ROOT } from "./graph/index.js";
 export { type RetryPolicy } from "./pregel/utils/index.js";
 export { Send } from "./constants.js";
-export { RemoteGraph, type RemoteGraphParams } from "./pregel/remote.js";
 
 export {
   MemorySaver,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1824,15 +1824,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@langchain/langgraph-sdk@npm:^0.0.18":
-  version: 0.0.18
-  resolution: "@langchain/langgraph-sdk@npm:0.0.18"
+"@langchain/langgraph-sdk@npm:~0.0.20":
+  version: 0.0.20
+  resolution: "@langchain/langgraph-sdk@npm:0.0.20"
   dependencies:
     "@types/json-schema": ^7.0.15
     p-queue: ^6.6.2
     p-retry: 4
     uuid: ^9.0.0
-  checksum: ac9b0e0aa05170965ea632cc46ea54219180e1e0b65ca140578ba72ea9e65cbeee85f2ae33e2a4660a657859c174ee5f745c521348191126bafbfda0dcc70877
+  checksum: 0d3f1f887719bdaa3c75adb1409b734b0d3e240e92284ba90bfcf34443d2826f732ab7aab3db10f11b3e809d070566cc53d6cf1fa9660eacb2c2744da5b57cf3
   languageName: node
   linkType: hard
 
@@ -1847,7 +1847,7 @@ __metadata:
     "@langchain/langgraph-checkpoint": ~0.0.10
     "@langchain/langgraph-checkpoint-postgres": "workspace:*"
     "@langchain/langgraph-checkpoint-sqlite": "workspace:*"
-    "@langchain/langgraph-sdk": ^0.0.18
+    "@langchain/langgraph-sdk": ~0.0.20
     "@langchain/openai": ^0.3.11
     "@langchain/scripts": ">=0.1.3 <0.2.0"
     "@swc/core": ^1.3.90
@@ -1885,10 +1885,6 @@ __metadata:
     zod-to-json-schema: ^3.22.4
   peerDependencies:
     "@langchain/core": ">=0.2.36 <0.3.0 || >=0.3.9 < 0.4.0"
-    "@langchain/langgraph-sdk": "*"
-  peerDependenciesMeta:
-    "@langchain/langgraph-sdk":
-      optional: true
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1824,6 +1824,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@langchain/langgraph-sdk@npm:^0.0.18":
+  version: 0.0.18
+  resolution: "@langchain/langgraph-sdk@npm:0.0.18"
+  dependencies:
+    "@types/json-schema": ^7.0.15
+    p-queue: ^6.6.2
+    p-retry: 4
+    uuid: ^9.0.0
+  checksum: ac9b0e0aa05170965ea632cc46ea54219180e1e0b65ca140578ba72ea9e65cbeee85f2ae33e2a4660a657859c174ee5f745c521348191126bafbfda0dcc70877
+  languageName: node
+  linkType: hard
+
 "@langchain/langgraph@workspace:*, @langchain/langgraph@workspace:libs/langgraph":
   version: 0.0.0-use.local
   resolution: "@langchain/langgraph@workspace:libs/langgraph"
@@ -1835,6 +1847,7 @@ __metadata:
     "@langchain/langgraph-checkpoint": ~0.0.10
     "@langchain/langgraph-checkpoint-postgres": "workspace:*"
     "@langchain/langgraph-checkpoint-sqlite": "workspace:*"
+    "@langchain/langgraph-sdk": ^0.0.18
     "@langchain/openai": ^0.3.11
     "@langchain/scripts": ">=0.1.3 <0.2.0"
     "@swc/core": ^1.3.90
@@ -1872,6 +1885,10 @@ __metadata:
     zod-to-json-schema: ^3.22.4
   peerDependencies:
     "@langchain/core": ">=0.2.36 <0.3.0 || >=0.3.9 < 0.4.0"
+    "@langchain/langgraph-sdk": "*"
+  peerDependenciesMeta:
+    "@langchain/langgraph-sdk":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -3351,7 +3368,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:^7.0.12":
+"@types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.15":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 97ed0cb44d4070aecea772b7b2e2ed971e10c81ec87dd4ecc160322ffa55ff330dace1793489540e3e318d90942064bb697cc0f8989391797792d919737b3b98
@@ -12511,6 +12528,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 4b81611ade2885d2313ddd8dc865d93d8dccc13ddf901745edca8f86d99bc46d7a330d678e7532e7ebf93ce616679fb19b2e3568873ac0c14c999032acb25869
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.0":
+  version: 9.0.1
+  resolution: "uuid@npm:9.0.1"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Tests to follow - `getGraph()` and `getSubgraphs()` are unfortunately sync right now, so made new, bespoke async methods for now.

SDK typing also seems to be off in a few cases, will dig in further once tests are finished.