### PR TITLE
feat(graph): passthrough input types to invoke/stream

### DIFF
--- a/libs/langgraph/src/graph/graph.ts
+++ b/libs/langgraph/src/graph/graph.ts
@@ -456,6 +456,7 @@ export class CompiledGraph<
 > {
   declare NodeType: N;
 
+  // TODO: deprecate these values after updating the API
   declare RunInput: State;
 
   declare RunOutput: Update;

--- a/libs/langgraph/src/graph/graph.ts
+++ b/libs/langgraph/src/graph/graph.ts
@@ -450,7 +450,9 @@ export class CompiledGraph<
   Record<N | typeof START, PregelNode<RunInput, RunOutput>>,
   Record<N | typeof START | typeof END | string, BaseChannel>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ConfigurableFieldType & Record<string, any>
+  ConfigurableFieldType & Record<string, any>,
+  RunInput,
+  RunOutput
 > {
   declare NodeType: N;
 

--- a/libs/langgraph/src/graph/graph.ts
+++ b/libs/langgraph/src/graph/graph.ts
@@ -456,7 +456,6 @@ export class CompiledGraph<
 > {
   declare NodeType: N;
 
-  // TODO: deprecate these values after updating the API
   declare RunInput: State;
 
   declare RunOutput: Update;

--- a/libs/langgraph/src/graph/graph.ts
+++ b/libs/langgraph/src/graph/graph.ts
@@ -441,39 +441,39 @@ export class Graph<
 export class CompiledGraph<
   N extends string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  RunInput = any,
+  State = any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  RunOutput = any,
+  Update = any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ConfigurableFieldType extends Record<string, any> = Record<string, any>
 > extends Pregel<
-  Record<N | typeof START, PregelNode<RunInput, RunOutput>>,
+  Record<N | typeof START, PregelNode<State, Update>>,
   Record<N | typeof START | typeof END | string, BaseChannel>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ConfigurableFieldType & Record<string, any>,
-  RunInput,
-  RunOutput
+  Update,
+  State
 > {
   declare NodeType: N;
 
-  declare RunInput: RunInput;
+  declare RunInput: State;
 
-  declare RunOutput: RunOutput;
+  declare RunOutput: Update;
 
-  builder: Graph<N, RunInput, RunOutput>;
+  builder: Graph<N, State, Update>;
 
   constructor({
     builder,
     ...rest
-  }: { builder: Graph<N, RunInput, RunOutput> } & PregelParams<
-    Record<N | typeof START, PregelNode<RunInput, RunOutput>>,
+  }: { builder: Graph<N, State, Update> } & PregelParams<
+    Record<N | typeof START, PregelNode<State, Update>>,
     Record<N | typeof START | typeof END | string, BaseChannel>
   >) {
     super(rest);
     this.builder = builder;
   }
 
-  attachNode(key: N, node: NodeSpec<RunInput, RunOutput>): void {
+  attachNode(key: N, node: NodeSpec<State, Update>): void {
     this.channels[key] = new EphemeralValue();
     this.nodes[key] = new PregelNode({
       channels: [],
@@ -505,7 +505,7 @@ export class CompiledGraph<
   attachBranch(
     start: N | typeof START,
     name: string,
-    branch: Branch<RunInput, N>
+    branch: Branch<State, N>
   ) {
     // add hidden start node
     if (start === START && this.nodes[START]) {
@@ -590,7 +590,7 @@ export class CompiledGraph<
 
     for (const [key, nodeSpec] of Object.entries(this.builder.nodes) as [
       N,
-      NodeSpec<RunInput, RunOutput>
+      NodeSpec<State, Update>
     ][]) {
       const displayKey = _escapeMermaidKeywords(key);
       const node = nodeSpec.runnable;
@@ -771,7 +771,7 @@ export class CompiledGraph<
 
     for (const [key, nodeSpec] of Object.entries(this.builder.nodes) as [
       N,
-      NodeSpec<RunInput, RunOutput>
+      NodeSpec<State, Update>
     ][]) {
       const displayKey = _escapeMermaidKeywords(key);
       const node = nodeSpec.runnable;

--- a/libs/langgraph/src/graph/state.ts
+++ b/libs/langgraph/src/graph/state.ts
@@ -49,7 +49,6 @@ import type { RetryPolicy } from "../pregel/utils/index.js";
 import { isConfiguredManagedValue, ManagedValueSpec } from "../managed/base.js";
 import type { LangGraphRunnableConfig } from "../pregel/runnable_types.js";
 import { isPregelLike } from "../pregel/utils/subgraph.js";
-import { MessagesAnnotation } from "./messages_annotation.js";
 
 const ROOT = "__root__";
 

--- a/libs/langgraph/src/graph/state.ts
+++ b/libs/langgraph/src/graph/state.ts
@@ -49,6 +49,7 @@ import type { RetryPolicy } from "../pregel/utils/index.js";
 import { isConfiguredManagedValue, ManagedValueSpec } from "../managed/base.js";
 import type { LangGraphRunnableConfig } from "../pregel/runnable_types.js";
 import { isPregelLike } from "../pregel/utils/subgraph.js";
+import { MessagesAnnotation } from "./messages_annotation.js";
 
 const ROOT = "__root__";
 

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -201,7 +201,7 @@ export class Pregel<
     OutputType = PregelOutputType
   >
   extends Runnable<
-    InputType,
+    InputType | null,
     OutputType,
     PregelOptions<Nn, Cc, ConfigurableFieldType>
   >
@@ -920,7 +920,7 @@ export class Pregel<
    * @param options.debug Whether to print debug information during execution.
    */
   override async stream(
-    input: InputType | Command,
+    input: InputType | null | Command,
     options?: Partial<PregelOptions<Nn, Cc, ConfigurableFieldType>>
   ): Promise<IterableReadableStream<OutputType>> {
     // The ensureConfig method called internally defaults recursionLimit to 25 if not
@@ -1247,7 +1247,7 @@ export class Pregel<
    * @param options.debug Whether to print debug information during execution.
    */
   override async invoke(
-    input: InputType | Command,
+    input: InputType | null | Command,
     options?: Partial<PregelOptions<Nn, Cc, ConfigurableFieldType>>
   ): Promise<OutputType> {
     const streamMode = options?.streamMode ?? "values";

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -201,7 +201,7 @@ export class Pregel<
     OutputType = PregelOutputType
   >
   extends Runnable<
-    InputType | null,
+    InputType | Command | null,
     OutputType,
     PregelOptions<Nn, Cc, ConfigurableFieldType>
   >
@@ -920,7 +920,7 @@ export class Pregel<
    * @param options.debug Whether to print debug information during execution.
    */
   override async stream(
-    input: InputType | null | Command,
+    input: InputType | Command | null,
     options?: Partial<PregelOptions<Nn, Cc, ConfigurableFieldType>>
   ): Promise<IterableReadableStream<PregelOutputType>> {
     // The ensureConfig method called internally defaults recursionLimit to 25 if not
@@ -1247,7 +1247,7 @@ export class Pregel<
    * @param options.debug Whether to print debug information during execution.
    */
   override async invoke(
-    input: InputType | null | Command,
+    input: InputType | Command | null,
     options?: Partial<PregelOptions<Nn, Cc, ConfigurableFieldType>>
   ): Promise<OutputType> {
     const streamMode = options?.streamMode ?? "values";

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -922,7 +922,7 @@ export class Pregel<
   override async stream(
     input: InputType | null | Command,
     options?: Partial<PregelOptions<Nn, Cc, ConfigurableFieldType>>
-  ): Promise<IterableReadableStream<OutputType>> {
+  ): Promise<IterableReadableStream<PregelOutputType>> {
     // The ensureConfig method called internally defaults recursionLimit to 25 if not
     // passed directly in `options`.
     // There is currently no way in _streamIterator to determine whether this was

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -196,11 +196,13 @@ export class Pregel<
     Nn extends StrRecord<string, PregelNode>,
     Cc extends StrRecord<string, BaseChannel | ManagedValueSpec>,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ConfigurableFieldType extends Record<string, any> = StrRecord<string, any>
+    ConfigurableFieldType extends Record<string, any> = StrRecord<string, any>,
+    InputType = PregelInputType,
+    OutputType = PregelOutputType
   >
   extends Runnable<
-    PregelInputType,
-    PregelOutputType,
+    InputType,
+    OutputType,
     PregelOptions<Nn, Cc, ConfigurableFieldType>
   >
   implements
@@ -918,9 +920,9 @@ export class Pregel<
    * @param options.debug Whether to print debug information during execution.
    */
   override async stream(
-    input: PregelInputType | Command,
+    input: InputType | Command,
     options?: Partial<PregelOptions<Nn, Cc, ConfigurableFieldType>>
-  ): Promise<IterableReadableStream<PregelOutputType>> {
+  ): Promise<IterableReadableStream<OutputType>> {
     // The ensureConfig method called internally defaults recursionLimit to 25 if not
     // passed directly in `options`.
     // There is currently no way in _streamIterator to determine whether this was
@@ -1245,9 +1247,9 @@ export class Pregel<
    * @param options.debug Whether to print debug information during execution.
    */
   override async invoke(
-    input: PregelInputType | Command,
+    input: InputType | Command,
     options?: Partial<PregelOptions<Nn, Cc, ConfigurableFieldType>>
-  ): Promise<PregelOutputType> {
+  ): Promise<OutputType> {
     const streamMode = options?.streamMode ?? "values";
     const config = {
       ...options,
@@ -1262,6 +1264,6 @@ export class Pregel<
     if (streamMode === "values") {
       return chunks[chunks.length - 1];
     }
-    return chunks;
+    return chunks as OutputType;
   }
 }

--- a/libs/langgraph/src/tests/prebuilt.int.test.ts
+++ b/libs/langgraph/src/tests/prebuilt.int.test.ts
@@ -63,7 +63,9 @@ describe("createReactAgent", () => {
     expect(response.messages.length > 1).toBe(true);
     const lastMessage = response.messages[response.messages.length - 1];
     expect(lastMessage._getType()).toBe("ai");
-    expect(lastMessage.content.toLowerCase()).toContain("not too cold");
+    expect((lastMessage.content as string).toLowerCase()).toContain(
+      "not too cold"
+    );
   });
 
   it("can stream a tool call with a checkpointer", async () => {

--- a/libs/langgraph/src/tests/pregel.test.ts
+++ b/libs/langgraph/src/tests/pregel.test.ts
@@ -3566,6 +3566,7 @@ export function runPregelTests(
           hello: "there",
           bye: "world",
           messages: ["hello"],
+          // @ts-expect-error This should emit a TS error
           now: 345, // ignored because not in input schema
         })
       ).toEqual({
@@ -3578,6 +3579,7 @@ export function runPregelTests(
             hello: "there",
             bye: "world",
             messages: ["hello"],
+            // @ts-expect-error This should emit a TS error
             now: 345, // ignored because not in input schema
           })
         )
@@ -3737,6 +3739,7 @@ export function runPregelTests(
       };
       const res = await app.invoke(
         {
+          // @ts-expect-error Messages is not in schema
           messages: ["initial input"],
         },
         config

--- a/libs/langgraph/src/tests/tracing.int.test.ts
+++ b/libs/langgraph/src/tests/tracing.int.test.ts
@@ -470,10 +470,16 @@ Only add steps to the plan that still NEED to be done. Do not return previously 
     state: PlanExecuteState
   ): Promise<Partial<PlanExecuteState>> {
     const task = state.input;
-    const agentResponse = await agentExecutor.invoke({ input: task });
-    return {
-      pastSteps: [task, agentResponse.agentOutcome.returnValues.output],
-    };
+    const agentResponse = await agentExecutor.invoke({
+      input: task ?? undefined,
+    });
+
+    const outcome = agentResponse.agentOutcome;
+    if (!outcome || !("returnValues" in outcome)) {
+      throw new Error("Agent did not return a valid outcome.");
+    }
+
+    return { pastSteps: [task, outcome.returnValues.output] };
   }
 
   async function planStep(


### PR DESCRIPTION
Opting to fix output types in a different PR due to the complexity of `streamMode` 

Closes #628 