### PR TITLE
fix(checkpoint-mongodb): fix utf8 encoding support

### DIFF
--- a/libs/checkpoint-mongodb/src/index.ts
+++ b/libs/checkpoint-mongodb/src/index.ts
@@ -87,7 +87,7 @@ export class MongoDBSaver extends BaseCheckpointSaver {
     };
     const checkpoint = (await this.serde.loadsTyped(
       doc.type,
-      doc.checkpoint.value()
+      doc.checkpoint.value("utf8")
     )) as Checkpoint;
     const serializedWrites = await this.db
       .collection(this.checkpointWritesCollectionName)
@@ -100,7 +100,7 @@ export class MongoDBSaver extends BaseCheckpointSaver {
           serializedWrite.channel,
           await this.serde.loadsTyped(
             serializedWrite.type,
-            serializedWrite.value.value()
+            serializedWrite.value.value("utf8")
           ),
         ] as CheckpointPendingWrite;
       })
@@ -111,7 +111,7 @@ export class MongoDBSaver extends BaseCheckpointSaver {
       pendingWrites,
       metadata: (await this.serde.loadsTyped(
         doc.type,
-        doc.metadata.value()
+        doc.metadata.value("utf8")
       )) as CheckpointMetadata,
       parentConfig:
         doc.parent_checkpoint_id != null
@@ -171,11 +171,11 @@ export class MongoDBSaver extends BaseCheckpointSaver {
     for await (const doc of result) {
       const checkpoint = (await this.serde.loadsTyped(
         doc.type,
-        doc.checkpoint.value()
+        doc.checkpoint.value("utf8")
       )) as Checkpoint;
       const metadata = (await this.serde.loadsTyped(
         doc.type,
-        doc.metadata.value()
+        doc.metadata.value("utf8")
       )) as CheckpointMetadata;
 
       yield {


### PR DESCRIPTION
Issue
The MongoDB checkpoint storage implementation currently does not properly handle UTF-8 encoded input (such as Chinese characters). When retrieving checkpoints via getTuple, message contents containing non-ASCII characters are corrupted and displayed as garbled text.
Changes

Added proper UTF-8 encoding support for MongoDB checkpoint storage
Ensures correct storage and retrieval of non-ASCII characters in checkpoint messages
Maintains data integrity for international character sets

Impact
This fix enables LangGraphJS to properly handle international text in conversations and workflows when using MongoDB as the checkpoint storage backend. Users working with non-English languages will now see their content preserved correctly throughout the graph execution process.