### PR TITLE
docs: Fix typo

### DIFF
--- a/examples/chatbots/customer_support_small_model.ipynb
+++ b/examples/chatbots/customer_support_small_model.ipynb
@@ -660,7 +660,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "But this will again hit the interrupt becuase `refundAuthorized` is not set. If we update the state to set `refundAuthorized` to true, then resume the graph by running it with the same `thread_id` and passing `null` as the input, execution will continue and the refund will process:"
+    "But this will again hit the interrupt because `refundAuthorized` is not set. If we update the state to set `refundAuthorized` to true, then resume the graph by running it with the same `thread_id` and passing `null` as the input, execution will continue and the refund will process:"
    ]
   },
   {


### PR DESCRIPTION
Fixes type: `becuase` => `because`
