### PR TITLE
fix(docs): added missing dependency in tutorial by adding @langchain/langgraph

### DIFF
--- a/examples/rag/langgraph_crag.ipynb
+++ b/examples/rag/langgraph_crag.ipynb
@@ -49,7 +49,7 @@
     "### Install dependencies\n",
     "\n",
     "```bash\n",
-    "npm install cheerio zod langchain @langchain/community @langchain/openai @langchain/core @langchain/textsplitters\n",
+    "npm install cheerio zod langchain @langchain/community @langchain/openai @langchain/core @langchain/textsplitters @langchain/langgraph\n",
     "```"
    ]
   },


### PR DESCRIPTION
While following the LangGraph tutorial, I encountered an issue where the tutorial was missing the @langchain/langgraph dependency. After adding this dependency, the errors were resolved. This PR updates the tutorial documentation to include the missing dependency installation step to help prevent others from encountering the same issue.

My username on X.com is @greyson_codes

