### PR TITLE
fix(debug): interrupts task result double tuple format

### DIFF
--- a/libs/langgraph/src/pregel/debug.ts
+++ b/libs/langgraph/src/pregel/debug.ts
@@ -134,9 +134,7 @@ export function* mapDebugTaskResults<
             ? streamChannels.includes(channel)
             : channel === streamChannels;
         }),
-        interrupts: writes.filter(([channel]) => {
-          return channel === INTERRUPT;
-        }),
+        interrupts: writes.filter((w) => w[0] === INTERRUPT).map((w) => w[1]),
       },
     };
   }


### PR DESCRIPTION
<!--
Thank you for contributing to LangGraph.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langgraphjs/blob/main/CONTRIBUTING.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
