### PR TITLE
Allow value of NodeInterrupt to be any (JSON-serializable) type.

### DIFF
--- a/libs/langgraph/src/errors.ts
+++ b/libs/langgraph/src/errors.ts
@@ -62,7 +62,7 @@ export class GraphInterrupt extends GraphBubbleUp {
 
 /** Raised by a node to interrupt execution. */
 export class NodeInterrupt extends GraphInterrupt {
-  constructor(message: string, fields?: BaseLangGraphErrorFields) {
+  constructor(message: any, fields?: BaseLangGraphErrorFields) {
     super(
       [
         {

--- a/libs/langgraph/src/errors.ts
+++ b/libs/langgraph/src/errors.ts
@@ -62,6 +62,7 @@ export class GraphInterrupt extends GraphBubbleUp {
 
 /** Raised by a node to interrupt execution. */
 export class NodeInterrupt extends GraphInterrupt {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(message: any, fields?: BaseLangGraphErrorFields) {
     super(
       [


### PR DESCRIPTION
This changes `NodeInterrupt`'s `message` to allow `any` type, rather than just a string.  This allows steps and tools to bubble up structured objects as interrupts, where they can be handled by the application.

My specific use case is the ability to make an API call and receive a 401 Unauthorized response that contains challenge parameters (such as `scope` or `max_age`) that indicate what authorization context is needed.  The step/tool throws a structured `NodeInterrupt` including the parameters from the challenge.   Then application then uses these parameters to bring the human in the loop with an OAuth 2.0 authorization request.

I discussed this with @jacoblee93 on an internal Slack channel.

Twitter: [@jaredhanson](https://x.com/jaredhanson)