### PR TITLE
fix(langgraph): Re-throw NodeInterrupt errors from ToolNode for HITL.

### DIFF
--- a/libs/langgraph/src/prebuilt/tool_node.ts
+++ b/libs/langgraph/src/prebuilt/tool_node.ts
@@ -9,7 +9,7 @@ import { StructuredToolInterface } from "@langchain/core/tools";
 import { RunnableCallable } from "../utils.js";
 import { END } from "../graph/graph.js";
 import { MessagesAnnotation } from "../graph/messages_annotation.js";
-import { NodeInterrupt } from "../errors.js";
+import { isGraphInterrupt } from "../errors.js";
 
 export type ToolNodeOptions = {
   name?: string;
@@ -188,10 +188,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           if (!this.handleToolErrors) {
             throw e;
           }
-          if (e.name === NodeInterrupt.unminifiable_name) {
+          if (isGraphInterrupt(e.name)) {
             // `NodeInterrupt` errors are a breakpoint to bring a human into the loop.
             // As such, they are not recoverable by the agent and shouldn't be fed
-            // back.  Instead, re-throw these errors even when `handleToolErrors = true`.
+            // back. Instead, re-throw these errors even when `handleToolErrors = true`.
             throw e;
           }
           return new ToolMessage({


### PR DESCRIPTION
This changes `ToolNode` to always re-throw `NodeInterrupt` errors, rather than feeding errors back into the agent.

As documented [here](https://langchain-ai.github.io/langgraphjs/how-tos/dynamic_breakpoints/), the intent of `NodeInterrupt` is to act as a breakpoint for when a human needs to be brought into the loop.  This works as intended when thrown from a step function.  However, when wrapped in a `ToolNode`, the default behavior traps `NodeInterrupt` and feeds it back to the agent.   This is unexpected, since if a human is necessary the agent can't recover on its own.

Furthermore, setting `handleToolErrors` to `false` is a way to workaround this, but that then requires the developer to feed all other non-NodeInterrupt errors back manually (which is also unexpected).

The best default behavior seems to be feeding all errors _except_ NodeInterrupt back, and re-throwing NodeInterrupt so the application can handle it appropriately.

I discussed this with @jacoblee93 on an internal Slack channel.

Twitter: [@jaredhanson](https://x.com/jaredhanson)

