### PR TITLE
fix(langgraph): abort graph execution when config.signal is aborted

### DIFF
--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -1398,6 +1398,7 @@ export class Pregel<
               );
             }
           },
+          signal: config.signal,
         });
       }
       if (loop.status === "out_of_steps") {


### PR DESCRIPTION
Passes through signal to `PregelRunner` and adds test to guard against this regression in the future.