### PR TITLE
fix(langgraph): make sure the pregel loop aborts on cancellation

### DIFF
--- a/libs/langgraph/src/pregel/retry.ts
+++ b/libs/langgraph/src/pregel/retry.ts
@@ -67,7 +67,8 @@ export async function _runWithRetry<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   pregelTask: PregelExecutableTask<N, C>,
   retryPolicy?: RetryPolicy,
-  configurable?: Record<string, unknown>
+  configurable?: Record<string, unknown>,
+  signal?: AbortSignal
 ): Promise<{
   task: PregelExecutableTask<N, C>;
   result: unknown;
@@ -88,6 +89,11 @@ export async function _runWithRetry<
   }
   // eslint-disable-next-line no-constant-condition
   while (true) {
+    if (signal?.aborted) {
+      // no need to throw here - we'll throw from the runner, instead.
+      // there's just no point in retrying if the user has requested an abort.
+      break;
+    }
     // Clear any writes from previous attempts
     pregelTask.writes.splice(0, pregelTask.writes.length);
     error = undefined;

--- a/libs/langgraph/src/pregel/utils/config.ts
+++ b/libs/langgraph/src/pregel/utils/config.ts
@@ -19,6 +19,7 @@ const CONFIG_KEYS = [
   "writer",
   "interruptBefore",
   "interruptAfter",
+  "signal",
 ];
 
 const DEFAULT_RECURSION_LIMIT = 25;

--- a/libs/langgraph/src/tests/pregel.test.ts
+++ b/libs/langgraph/src/tests/pregel.test.ts
@@ -9464,6 +9464,9 @@ graph TD;
           config
         )
     ).rejects.toThrow("Aborted");
+
+    // Ensure that the `twoCount` has had time to increment before we check it, in case the stream aborted but the graph execution didn't.
+    await new Promise((resolve) => setTimeout(resolve, 300));
     expect(oneCount).toEqual(1);
     expect(twoCount).toEqual(0);
   });


### PR DESCRIPTION
This is a follow-up to #795. The change in #795 caused the stream to abort, but not the pregel loop execution.

This change 
- prevents the `AbortSignal` from being filtered out of the config object that's handed off to the `PregelRunner`
- ensures that the abort error type is consistent
- checks the abort signal in the retry loop so we don't retry tasks after abort