### PR TITLE
fix(docs): crag wrong tool invocation

### DIFF
--- a/examples/rag/langgraph_crag.ipynb
+++ b/examples/rag/langgraph_crag.ipynb
@@ -379,7 +379,7 @@
     "  console.log(\"---WEB SEARCH---\");\n",
     "\n",
     "  const tool = new TavilySearchResults();\n",
-    "  const docs = await tool.invoke({ query: state.question });\n",
+    "  const docs = await tool.invoke({ input: state.question });\n",
     "  const webResults = new Document({ pageContent: docs });\n",
     "  const newDocuments = state.documents.concat(webResults);\n",
     "\n",


### PR DESCRIPTION
Fix CRAG tutorial tool invocation issue
Resolved an issue where the tool invocation in the CRAG tutorial was not working.

Origin: query
Fixed: input