### PR TITLE
fix(docs/etc): Fix miscellaneous typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,7 +288,7 @@ In the example below, the graph has one node. The `checkpointer` parameter in Pr
 Invocation 1:
 
 1. When the graph is invoked with `2`, `input` channels value becomes `2`
-2. Node `one` runs because it is subscribed to `input`. The node tranforms `2` to `2` by running `inputPlusTotal`.
+2. Node `one` runs because it is subscribed to `input`. The node transforms `2` to `2` by running `inputPlusTotal`.
 3. The value of channels `output` and `total` get set to `2` because node `one` writes to both channels
 4. Because `memory` is passed into the graph, `total` at thread_id of `1` is saved as a value of `2`
 5. The graph ends with `output`'s value which is `2`

--- a/docs/docs/concepts/double_texting.md
+++ b/docs/docs/concepts/double_texting.md
@@ -40,7 +40,7 @@ See the [how-to guide](/langgraphjs/cloud/how-tos/interrupt_concurrent) for conf
 This option rolls back all work done up until that point.
 It then sends the user input in, basically as if it just followed the original run input.
 
-This may create some weird states - for example, you may have two `User` messages in a row, with no `Asssitant` message in between them.
+This may create some weird states - for example, you may have two `User` messages in a row, with no `Assistant` message in between them.
 
 You will need to make sure the LLM you are calling can handle that, or combine those into a single `User` message.
 

--- a/docs/docs/tutorials/workflows/index.md
+++ b/docs/docs/tutorials/workflows/index.md
@@ -68,7 +68,7 @@ const multiply = tool(
   },
   {
     name: "multiply",
-    description: "mutiplies two numbers together",
+    description: "multiplies two numbers together",
     schema: z.object({
       a: z.number("the first number"),
       b: z.number("the second number"),

--- a/libs/checkpoint-mongodb/README.md
+++ b/libs/checkpoint-mongodb/README.md
@@ -35,7 +35,7 @@ const checkpoint = {
   channel_versions: {
     __start__: 2,
     my_key: 3,
-    start:node: 3,
+    "start:node": 3,
     node: 3
   },
   versions_seen: {
@@ -44,7 +44,7 @@ const checkpoint = {
       __start__: 1
     },
     node: {
-      start:node: 2
+      "start:node": 2
     }
   },
   pending_sends: [],

--- a/libs/checkpoint-postgres/README.md
+++ b/libs/checkpoint-postgres/README.md
@@ -35,7 +35,7 @@ const checkpoint = {
   channel_versions: {
     __start__: 2,
     my_key: 3,
-    start:node: 3,
+    "start:node": 3,
     node: 3
   },
   versions_seen: {
@@ -44,7 +44,7 @@ const checkpoint = {
       __start__: 1
     },
     node: {
-      start:node: 2
+      "start:node": 2
     }
   },
   pending_sends: [],

--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -237,10 +237,10 @@ export class PostgresSaver extends BaseCheckpointSaver {
   }
 
   /**
-   * Return WHERE clause predicates for alist() given config, filter, cursor.
+   * Return WHERE clause predicates for a given list() config, filter, cursor.
    *
    * This method returns a tuple of a string and a tuple of values. The string
-   * is the parametered WHERE clause predicate (including the WHERE keyword):
+   * is the parameterized WHERE clause predicate (including the WHERE keyword):
    * "WHERE column1 = $1 AND column2 IS $2". The list of values contains the
    * values for each of the corresponding parameters.
    */

--- a/libs/checkpoint-sqlite/README.md
+++ b/libs/checkpoint-sqlite/README.md
@@ -31,7 +31,7 @@ const checkpoint = {
   channel_versions: {
     __start__: 2,
     my_key: 3,
-    start:node: 3,
+    "start:node": 3,
     node: 3
   },
   versions_seen: {
@@ -40,7 +40,7 @@ const checkpoint = {
       __start__: 1
     },
     node: {
-      start:node: 2
+      "start:node": 2
     }
   },
   pending_sends: [],

--- a/libs/checkpoint/README.md
+++ b/libs/checkpoint/README.md
@@ -68,7 +68,7 @@ const checkpoint = {
   channel_versions: {
     __start__: 2,
     my_key: 3,
-    start:node: 3,
+    "start:node": 3,
     node: 3
   },
   versions_seen: {
@@ -77,7 +77,7 @@ const checkpoint = {
       __start__: 1
     },
     node: {
-      start:node: 2
+      "start:node": 2
     }
   },
   pending_sends: [],

--- a/libs/langgraph/src/tests/channels.test.ts
+++ b/libs/langgraph/src/tests/channels.test.ts
@@ -195,7 +195,7 @@ describe("AnyValue", () => {
   });
 });
 
-describe("EphemeralValue with gaurd: false", () => {
+describe("EphemeralValue with guard: false", () => {
   it("should handle ephemeral value correctly", () => {
     const channel = new EphemeralValue<number>(false);
 

--- a/libs/langgraph/src/tests/func.test.ts
+++ b/libs/langgraph/src/tests/func.test.ts
@@ -357,7 +357,7 @@ export function runFuncTests(
             expect(() =>
               entrypoint(
                 { name: "graph", checkpointer },
-                // we need ts-expect-error here because the type system also gaurds against this
+                // we need ts-expect-error here because the type system also guards against this
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-expect-error
                 function* () {
@@ -374,7 +374,7 @@ export function runFuncTests(
             expect(() =>
               entrypoint(
                 { name: "graph", checkpointer },
-                // we need ts-expect-error here because the type system also gaurds against this
+                // we need ts-expect-error here because the type system also guards against this
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-expect-error
                 async function* () {
@@ -392,7 +392,7 @@ export function runFuncTests(
             expect(() =>
               task(
                 "task",
-                // we need ts-expect-error here because the type system also gaurds against this
+                // we need ts-expect-error here because the type system also guards against this
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-expect-error
                 function* () {
@@ -409,7 +409,7 @@ export function runFuncTests(
             expect(() =>
               task(
                 "task",
-                // we need ts-expect-error here because the type system also gaurds against this
+                // we need ts-expect-error here because the type system also guards against this
                 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
                 // @ts-expect-error
                 async function* () {

--- a/libs/langgraph/src/tests/pregel.read.test.ts
+++ b/libs/langgraph/src/tests/pregel.read.test.ts
@@ -34,7 +34,7 @@ describe("PregelNode", () => {
   });
 
   describe("getNode", () => {
-    it("should return undefined if bound is default andthere are no writers", () => {
+    it("should return undefined if bound is default and there are no writers", () => {
       // set up test
       const pregelNode = new PregelNode({
         channels: ["foo"],

--- a/libs/langgraph/src/tests/pregel.test.ts
+++ b/libs/langgraph/src/tests/pregel.test.ts
@@ -6240,7 +6240,7 @@ graph TD;
         const { store } = config;
         expect(store).toBeDefined();
         if (!store) {
-          throw new Error("No store foubd");
+          throw new Error("No store found");
         }
 
         expect(config.configurable?.assistant_id).toEqual("a");
@@ -6260,7 +6260,7 @@ graph TD;
         const { store } = config;
         expect(store).toBeDefined();
         if (!store) {
-          throw new Error("No store foubd");
+          throw new Error("No store found");
         }
 
         expect(config.configurable?.assistant_id).toEqual("a");
@@ -6414,7 +6414,7 @@ graph TD;
 
       // below combo of assertions is asserting two things
       // - outer_1 finishes before inner interrupts (because we see its output in stream, which only happens after node finishes)
-      // - the writes of outer are persisted in 1st call and used in 2nd call, ie outer isn't called again (because we dont see outer_1 output again in 2nd stream)
+      // - the writes of outer are persisted in 1st call and used in 2nd call, ie outer isn't called again (because we don't see outer_1 output again in 2nd stream)
       // test stream updates w/ nested interrupt
       const config2 = { configurable: { thread_id: "2" } };
 


### PR DESCRIPTION
I noticed a handful of typos/invalid JSON properties while reading through the documentation and code for some of the checkpointer integrations. 

Thought I'd submit a quick PR to fix them up.

Thanks!
