### PR TITLE
feat(checkpoint-postgres): Add support for providing a custom schema during initialization

### DIFF
--- a/libs/checkpoint-postgres/README.md
+++ b/libs/checkpoint-postgres/README.md
@@ -19,8 +19,10 @@ const readConfig = {
   }
 };
 
-// you can optionally provide a schema name as the second argument, otherwise it will default to "public"
-const checkpointer = PostgresSaver.fromConnString("postgresql://...", "schema_name");
+// you can optionally pass a configuration object as the second parameter
+const checkpointer = PostgresSaver.fromConnString("postgresql://...", {
+  schema: "schema_name" // defaults to "public"
+});
 
 // You must call .setup() the first time you use the checkpointer:
 await checkpointer.setup();

--- a/libs/checkpoint-postgres/README.md
+++ b/libs/checkpoint-postgres/README.md
@@ -19,7 +19,8 @@ const readConfig = {
   }
 };
 
-const checkpointer = PostgresSaver.fromConnString("postgresql://...");
+// you can optionally provide a schema name as the second argument, otherwise it will default to "public"
+const checkpointer = PostgresSaver.fromConnString("postgresql://...", "schema_name");
 
 // You must call .setup() the first time you use the checkpointer:
 await checkpointer.setup();

--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -13,7 +13,7 @@ import {
 import pg from "pg";
 
 import { getMigrations } from "./migrations.js";
-import { type SQL_STATEMENTS, getSQLStatements, getTables } from "./sql.js";
+import { type SQL_STATEMENTS, getSQLStatements, getTablesWithSchema } from "./sql.js";
 
 const { Pool } = pg;
 
@@ -93,7 +93,7 @@ export class PostgresSaver extends BaseCheckpointSaver {
    */
   async setup(): Promise<void> {
     const client = await this.pool.connect();
-    const SCHEMA_TABLES = getTables(this.schema);
+    const SCHEMA_TABLES = getTablesWithSchema(this.schema);
     try {
       await client.query(`CREATE SCHEMA IF NOT EXISTS ${this.schema}`);
       let version = -1;

--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -88,17 +88,20 @@ export class PostgresSaver extends BaseCheckpointSaver {
    * Creates a new instance of PostgresSaver from a connection string.
    *
    * @param {string} connString - The connection string to connect to the Postgres database.
-   * @param {string} [schema] - The schema name to use. Defaults to 'public' if not provided.
+   * @param {PostgresSaverOptions} [options] - Optional configuration object.
    * @returns {PostgresSaver} A new instance of PostgresSaver.
    *
    * @example
    * const connString = "postgresql://user:password@localhost:5432/db";
-   * const checkpointer = PostgresSaver.fromConnString(connString, "custom_schema");
+   * const checkpointer = PostgresSaver.fromConnString(connString, );
    * await checkpointer.setup();
    */
-  static fromConnString(connString: string, config: PostgresSaverOptions = {}): PostgresSaver {
+  static fromConnString(
+    connString: string,
+    options: PostgresSaverOptions = {}
+  ): PostgresSaver {
     const pool = new Pool({ connectionString: connString });
-    return new PostgresSaver(pool, undefined, config);
+    return new PostgresSaver(pool, undefined, options);
   }
 
   /**

--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -101,7 +101,9 @@ export class PostgresSaver extends BaseCheckpointSaver {
    *
    * @example
    * const connString = "postgresql://user:password@localhost:5432/db";
-   * const checkpointer = PostgresSaver.fromConnString(connString, );
+   * const checkpointer = PostgresSaver.fromConnString(connString, {
+   *  schema: "custom_schema" // defaults to "public"
+   * });
    * await checkpointer.setup();
    */
   static fromConnString(

--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -70,6 +70,18 @@ export class PostgresSaver extends BaseCheckpointSaver {
     this.SQL_STATEMENTS = getSQLStatements(this.schema);
   }
 
+  /**
+ * Creates a new instance of PostgresSaver from a connection string.
+ *
+ * @param {string} connString - The connection string to connect to the Postgres database.
+ * @param {string} [schema] - The schema name to use. Defaults to 'public' if not provided.
+ * @returns {PostgresSaver} A new instance of PostgresSaver.
+ *
+ * @example
+ * const connString = "postgresql://user:password@localhost:5432/db";
+  * const checkpointer = PostgresSaver.fromConnString(connString, "custom_schema");
+  * await checkpointer.setup();
+  */
   static fromConnString(connString: string, schema?: string): PostgresSaver {
     const pool = new Pool({ connectionString: connString });
     return new PostgresSaver(pool, undefined, schema);

--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -13,7 +13,11 @@ import {
 import pg from "pg";
 
 import { getMigrations } from "./migrations.js";
-import { type SQL_STATEMENTS, getSQLStatements, getTablesWithSchema } from "./sql.js";
+import {
+  type SQL_STATEMENTS,
+  getSQLStatements,
+  getTablesWithSchema,
+} from "./sql.js";
 
 const { Pool } = pg;
 

--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -33,7 +33,8 @@ const { Pool } = pg;
  * import { createReactAgent } from "@langchain/langgraph/prebuilt";
  *
  * const checkpointer = PostgresSaver.fromConnString(
- *   "postgresql://user:password@localhost:5432/db"
+ *   "postgresql://user:password@localhost:5432/db",
+ *   "custom_schema" // optional schema name, defaults to 'public'
  * );
  *
  * // NOTE: you need to call .setup() the first time you're using your checkpointer

--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -79,8 +79,11 @@ const { Pool } = pg;
  */
 export class PostgresSaver extends BaseCheckpointSaver {
   private pool: pg.Pool;
+
   private readonly options: PostgresSaverOptions;
+
   private readonly SQL_STATEMENTS: SQL_STATEMENTS;
+
   protected isSetup: boolean;
 
   constructor(

--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -27,7 +27,7 @@ const _defaultOptions: PostgresSaverOptions = {
   schema: "public",
 };
 
-const ensureCompleteOptions = (
+const _ensureCompleteOptions = (
   options?: Partial<PostgresSaverOptions>
 ): PostgresSaverOptions => {
   return {
@@ -91,7 +91,7 @@ export class PostgresSaver extends BaseCheckpointSaver {
     super(serde);
     this.pool = pool;
     this.isSetup = false;
-    this.options = ensureCompleteOptions(options);
+    this.options = _ensureCompleteOptions(options);
     this.SQL_STATEMENTS = getSQLStatements(this.options.schema);
   }
 

--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -45,7 +45,7 @@ const { Pool } = pg;
  *   // optional configuration object
  *   {
  *     schema: "custom_schema" // defaults to "public"
- *   },
+ *   }
  * );
  *
  * // NOTE: you need to call .setup() the first time you're using your checkpointer

--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -23,6 +23,10 @@ export interface PostgresSaverOptions {
   schema?: string;
 }
 
+interface DefaultPostgresSaverOptions extends PostgresSaverOptions {
+  schema: "public" | string;
+}
+
 const { Pool } = pg;
 
 /**
@@ -66,7 +70,7 @@ const { Pool } = pg;
  */
 export class PostgresSaver extends BaseCheckpointSaver {
   private pool: pg.Pool;
-  private readonly options: Required<PostgresSaverOptions> = {
+  private readonly options: DefaultPostgresSaverOptions = {
     schema: "public",
   };
   private readonly SQL_STATEMENTS: SQL_STATEMENTS;

--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -70,9 +70,11 @@ const { Pool } = pg;
  */
 export class PostgresSaver extends BaseCheckpointSaver {
   private pool: pg.Pool;
+
   private readonly options: DefaultPostgresSaverOptions = {
     schema: "public",
   };
+
   private readonly SQL_STATEMENTS: SQL_STATEMENTS;
 
   protected isSetup: boolean;

--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -13,10 +13,7 @@ import {
 import pg from "pg";
 
 import { getMigrations } from "./migrations.js";
-import {
-  type SQL_STATEMENTS,
-  getSQLStatements,
-} from "./sql.js";
+import { type SQL_STATEMENTS, getSQLStatements } from "./sql.js";
 
 const { Pool } = pg;
 
@@ -71,17 +68,17 @@ export class PostgresSaver extends BaseCheckpointSaver {
   }
 
   /**
- * Creates a new instance of PostgresSaver from a connection string.
- *
- * @param {string} connString - The connection string to connect to the Postgres database.
- * @param {string} [schema] - The schema name to use. Defaults to 'public' if not provided.
- * @returns {PostgresSaver} A new instance of PostgresSaver.
- *
- * @example
- * const connString = "postgresql://user:password@localhost:5432/db";
-  * const checkpointer = PostgresSaver.fromConnString(connString, "custom_schema");
-  * await checkpointer.setup();
-  */
+   * Creates a new instance of PostgresSaver from a connection string.
+   *
+   * @param {string} connString - The connection string to connect to the Postgres database.
+   * @param {string} [schema] - The schema name to use. Defaults to 'public' if not provided.
+   * @returns {PostgresSaver} A new instance of PostgresSaver.
+   *
+   * @example
+   * const connString = "postgresql://user:password@localhost:5432/db";
+   * const checkpointer = PostgresSaver.fromConnString(connString, "custom_schema");
+   * await checkpointer.setup();
+   */
   static fromConnString(connString: string, schema?: string): PostgresSaver {
     const pool = new Pool({ connectionString: connString });
     return new PostgresSaver(pool, undefined, schema);
@@ -332,7 +329,10 @@ export class PostgresSaver extends BaseCheckpointSaver {
       args = [thread_id, checkpoint_ns];
     }
 
-    const result = await this.pool.query(this.SQL_STATEMENTS.SELECT_SQL + where, args);
+    const result = await this.pool.query(
+      this.SQL_STATEMENTS.SELECT_SQL + where,
+      args
+    );
 
     const [row] = result.rows;
 
@@ -464,7 +464,10 @@ export class PostgresSaver extends BaseCheckpointSaver {
         newVersions
       );
       for (const serializedBlob of serializedBlobs) {
-        await client.query(this.SQL_STATEMENTS.UPSERT_CHECKPOINT_BLOBS_SQL, serializedBlob);
+        await client.query(
+          this.SQL_STATEMENTS.UPSERT_CHECKPOINT_BLOBS_SQL,
+          serializedBlob
+        );
       }
       await client.query(this.SQL_STATEMENTS.UPSERT_CHECKPOINTS_SQL, [
         thread_id,

--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -73,7 +73,11 @@ export class PostgresSaver extends BaseCheckpointSaver {
 
   protected isSetup: boolean;
 
-  constructor(pool: pg.Pool, serde?: SerializerProtocol, options?: PostgresSaverOptions) {
+  constructor(
+    pool: pg.Pool,
+    serde?: SerializerProtocol,
+    options?: PostgresSaverOptions
+  ) {
     super(serde);
     this.pool = pool;
     this.isSetup = false;

--- a/libs/checkpoint-postgres/src/migrations.ts
+++ b/libs/checkpoint-postgres/src/migrations.ts
@@ -1,11 +1,11 @@
-import { getTables } from './sql.js';
+import { getTablesWithSchema } from './sql.js';
 
 /**
  * To add a new migration, add a new string to the list returned by the getMigrations function.
  * The position of the migration in the list is the version number.
  */
 export const getMigrations = (schema: string) => {
-  const SCHEMA_TABLES = getTables(schema);
+  const SCHEMA_TABLES = getTablesWithSchema(schema);
   return [
     `CREATE TABLE IF NOT EXISTS ${SCHEMA_TABLES.checkpoint_migrations} (
     v INTEGER PRIMARY KEY

--- a/libs/checkpoint-postgres/src/migrations.ts
+++ b/libs/checkpoint-postgres/src/migrations.ts
@@ -1,4 +1,4 @@
-import { getTablesWithSchema } from './sql.js';
+import { getTablesWithSchema } from "./sql.js";
 
 /**
  * To add a new migration, add a new string to the list returned by the getMigrations function.
@@ -42,4 +42,4 @@ export const getMigrations = (schema: string) => {
   );`,
     `ALTER TABLE ${SCHEMA_TABLES.checkpoint_blobs} ALTER COLUMN blob DROP not null;`,
   ];
-}
+};

--- a/libs/checkpoint-postgres/src/migrations.ts
+++ b/libs/checkpoint-postgres/src/migrations.ts
@@ -1,40 +1,45 @@
+import { getTables } from './sql.js';
+
 /**
  * To add a new migration, add a new string to the list returned by the getMigrations function.
  * The position of the migration in the list is the version number.
  */
-export const getMigrations = (schema: string) => [
-  `CREATE TABLE IF NOT EXISTS ${schema}.checkpoint_migrations (
-  v INTEGER PRIMARY KEY
-);`,
-  `CREATE TABLE IF NOT EXISTS ${schema}.checkpoints (
-  thread_id TEXT NOT NULL,
-  checkpoint_ns TEXT NOT NULL DEFAULT '',
-  checkpoint_id TEXT NOT NULL,
-  parent_checkpoint_id TEXT,
-  type TEXT,
-  checkpoint JSONB NOT NULL,
-  metadata JSONB NOT NULL DEFAULT '{}',
-  PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id)
-);`,
-  `CREATE TABLE IF NOT EXISTS ${schema}.checkpoint_blobs (
-  thread_id TEXT NOT NULL,
-  checkpoint_ns TEXT NOT NULL DEFAULT '',
-  channel TEXT NOT NULL,
-  version TEXT NOT NULL,
-  type TEXT NOT NULL,
-  blob BYTEA,
-  PRIMARY KEY (thread_id, checkpoint_ns, channel, version)
-);`,
-  `CREATE TABLE IF NOT EXISTS ${schema}.checkpoint_writes (
-  thread_id TEXT NOT NULL,
-  checkpoint_ns TEXT NOT NULL DEFAULT '',
-  checkpoint_id TEXT NOT NULL,
-  task_id TEXT NOT NULL,
-  idx INTEGER NOT NULL,
-  channel TEXT NOT NULL,
-  type TEXT,
-  blob BYTEA NOT NULL,
-  PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id, task_id, idx)
-);`,
-  `ALTER TABLE ${schema}.checkpoint_blobs ALTER COLUMN blob DROP not null;`,
-];
+export const getMigrations = (schema: string) => {
+  const SCHEMA_TABLES = getTables(schema);
+  return [
+    `CREATE TABLE IF NOT EXISTS ${SCHEMA_TABLES.checkpoint_migrations} (
+    v INTEGER PRIMARY KEY
+  );`,
+    `CREATE TABLE IF NOT EXISTS ${SCHEMA_TABLES.checkpoints} (
+    thread_id TEXT NOT NULL,
+    checkpoint_ns TEXT NOT NULL DEFAULT '',
+    checkpoint_id TEXT NOT NULL,
+    parent_checkpoint_id TEXT,
+    type TEXT,
+    checkpoint JSONB NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}',
+    PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id)
+  );`,
+    `CREATE TABLE IF NOT EXISTS ${SCHEMA_TABLES.checkpoint_blobs} (
+    thread_id TEXT NOT NULL,
+    checkpoint_ns TEXT NOT NULL DEFAULT '',
+    channel TEXT NOT NULL,
+    version TEXT NOT NULL,
+    type TEXT NOT NULL,
+    blob BYTEA,
+    PRIMARY KEY (thread_id, checkpoint_ns, channel, version)
+  );`,
+    `CREATE TABLE IF NOT EXISTS ${SCHEMA_TABLES.checkpoint_writes} (
+    thread_id TEXT NOT NULL,
+    checkpoint_ns TEXT NOT NULL DEFAULT '',
+    checkpoint_id TEXT NOT NULL,
+    task_id TEXT NOT NULL,
+    idx INTEGER NOT NULL,
+    channel TEXT NOT NULL,
+    type TEXT,
+    blob BYTEA NOT NULL,
+    PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id, task_id, idx)
+  );`,
+    `ALTER TABLE ${SCHEMA_TABLES.checkpoint_blobs} ALTER COLUMN blob DROP not null;`,
+  ];
+}

--- a/libs/checkpoint-postgres/src/migrations.ts
+++ b/libs/checkpoint-postgres/src/migrations.ts
@@ -1,12 +1,12 @@
 /**
- * To add a new migration, add a new string to the MIGRATIONS list.
+ * To add a new migration, add a new string to the list returned by the getMigrations function.
  * The position of the migration in the list is the version number.
  */
-export const MIGRATIONS = [
-  `CREATE TABLE IF NOT EXISTS checkpoint_migrations (
+export const getMigrations = (schema: string) => [
+  `CREATE TABLE IF NOT EXISTS ${schema}.checkpoint_migrations (
   v INTEGER PRIMARY KEY
 );`,
-  `CREATE TABLE IF NOT EXISTS checkpoints (
+  `CREATE TABLE IF NOT EXISTS ${schema}.checkpoints (
   thread_id TEXT NOT NULL,
   checkpoint_ns TEXT NOT NULL DEFAULT '',
   checkpoint_id TEXT NOT NULL,
@@ -16,7 +16,7 @@ export const MIGRATIONS = [
   metadata JSONB NOT NULL DEFAULT '{}',
   PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id)
 );`,
-  `CREATE TABLE IF NOT EXISTS checkpoint_blobs (
+  `CREATE TABLE IF NOT EXISTS ${schema}.checkpoint_blobs (
   thread_id TEXT NOT NULL,
   checkpoint_ns TEXT NOT NULL DEFAULT '',
   channel TEXT NOT NULL,
@@ -25,7 +25,7 @@ export const MIGRATIONS = [
   blob BYTEA,
   PRIMARY KEY (thread_id, checkpoint_ns, channel, version)
 );`,
-  `CREATE TABLE IF NOT EXISTS checkpoint_writes (
+  `CREATE TABLE IF NOT EXISTS ${schema}.checkpoint_writes (
   thread_id TEXT NOT NULL,
   checkpoint_ns TEXT NOT NULL DEFAULT '',
   checkpoint_id TEXT NOT NULL,
@@ -36,5 +36,5 @@ export const MIGRATIONS = [
   blob BYTEA NOT NULL,
   PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id, task_id, idx)
 );`,
-  "ALTER TABLE checkpoint_blobs ALTER COLUMN blob DROP not null;",
+  `ALTER TABLE ${schema}.checkpoint_blobs ALTER COLUMN blob DROP not null;`,
 ];

--- a/libs/checkpoint-postgres/src/sql.ts
+++ b/libs/checkpoint-postgres/src/sql.ts
@@ -42,7 +42,7 @@ export const getSQLStatements = (schema: string): SQL_STATEMENTS => ({
       and cw.checkpoint_id = cp.parent_checkpoint_id
       and cw.channel = '${TASKS}'
   ) as pending_sends
-from ${schema}.checkpoints cp `,
+from ${schema}.checkpoints cp `, // <-- the trailing space is necessary for combining with WHERE clauses
 
   UPSERT_CHECKPOINT_BLOBS_SQL: 
 `INSERT INTO ${schema}.checkpoint_blobs (thread_id, checkpoint_ns, channel, version, type, blob)

--- a/libs/checkpoint-postgres/src/sql.ts
+++ b/libs/checkpoint-postgres/src/sql.ts
@@ -15,7 +15,7 @@ interface TABLES {
   checkpoint_migrations: string;
 }
 
-export const getTables = (schema: string): TABLES => {
+export const getTablesWithSchema = (schema: string): TABLES => {
   const tables = ["checkpoints", "checkpoint_blobs", "checkpoint_writes", "checkpoint_migrations"];
   return tables.reduce((acc, table) => {
     acc[table as keyof TABLES] = `${schema}.${table}`;
@@ -24,7 +24,7 @@ export const getTables = (schema: string): TABLES => {
 };
 
 export const getSQLStatements = (schema: string): SQL_STATEMENTS => {
-  const SCHEMA_TABLES = getTables(schema);
+  const SCHEMA_TABLES = getTablesWithSchema(schema);
   return {
     SELECT_SQL: `select
     thread_id,

--- a/libs/checkpoint-postgres/src/sql.ts
+++ b/libs/checkpoint-postgres/src/sql.ts
@@ -16,7 +16,12 @@ interface TABLES {
 }
 
 export const getTablesWithSchema = (schema: string): TABLES => {
-  const tables = ["checkpoints", "checkpoint_blobs", "checkpoint_writes", "checkpoint_migrations"];
+  const tables = [
+    "checkpoints",
+    "checkpoint_blobs",
+    "checkpoint_migrations",
+    "checkpoint_writes",
+  ];
   return tables.reduce((acc, table) => {
     acc[table as keyof TABLES] = `${schema}.${table}`;
     return acc;
@@ -59,12 +64,12 @@ export const getSQLStatements = (schema: string): SQL_STATEMENTS => {
         and cw.channel = '${TASKS}'
     ) as pending_sends
   from ${SCHEMA_TABLES.checkpoints} cp `, // <-- the trailing space is necessary for combining with WHERE clauses
-  
+
     UPSERT_CHECKPOINT_BLOBS_SQL: `INSERT INTO ${SCHEMA_TABLES.checkpoint_blobs} (thread_id, checkpoint_ns, channel, version, type, blob)
   VALUES ($1, $2, $3, $4, $5, $6)
   ON CONFLICT (thread_id, checkpoint_ns, channel, version) DO NOTHING
   `,
-  
+
     UPSERT_CHECKPOINTS_SQL: `INSERT INTO ${SCHEMA_TABLES.checkpoints} (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, checkpoint, metadata)
   VALUES ($1, $2, $3, $4, $5, $6)
   ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id)
@@ -72,7 +77,7 @@ export const getSQLStatements = (schema: string): SQL_STATEMENTS => {
     checkpoint = EXCLUDED.checkpoint,
     metadata = EXCLUDED.metadata;
   `,
-  
+
     UPSERT_CHECKPOINT_WRITES_SQL: `INSERT INTO ${SCHEMA_TABLES.checkpoint_writes} (thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, blob)
   VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
   ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id, task_id, idx) DO UPDATE SET
@@ -80,7 +85,7 @@ export const getSQLStatements = (schema: string): SQL_STATEMENTS => {
     type = EXCLUDED.type,
     blob = EXCLUDED.blob;
   `,
-  
+
     INSERT_CHECKPOINT_WRITES_SQL: `INSERT INTO ${SCHEMA_TABLES.checkpoint_writes} (thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, blob)
   VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
   ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id, task_id, idx) DO NOTHING

--- a/libs/checkpoint-postgres/src/sql.ts
+++ b/libs/checkpoint-postgres/src/sql.ts
@@ -1,66 +1,76 @@
 import { TASKS } from "@langchain/langgraph-checkpoint";
 
-export const SELECT_SQL = `
-select
-    thread_id,
-    checkpoint,
-    checkpoint_ns,
-    checkpoint_id,
-    parent_checkpoint_id,
-    metadata,
-    (
-        select array_agg(array[bl.channel::bytea, bl.type::bytea, bl.blob])
-        from jsonb_each_text(checkpoint -> 'channel_versions')
-        inner join checkpoint_blobs bl
-            on bl.thread_id = checkpoints.thread_id
-            and bl.checkpoint_ns = checkpoints.checkpoint_ns
-            and bl.channel = jsonb_each_text.key
-            and bl.version = jsonb_each_text.value
-    ) as channel_values,
-    (
-        select
-        array_agg(array[cw.task_id::text::bytea, cw.channel::bytea, cw.type::bytea, cw.blob] order by cw.task_id, cw.idx)
-        from checkpoint_writes cw
-        where cw.thread_id = checkpoints.thread_id
-            and cw.checkpoint_ns = checkpoints.checkpoint_ns
-            and cw.checkpoint_id = checkpoints.checkpoint_id
-    ) as pending_writes,
-    (
-        select array_agg(array[cw.type::bytea, cw.blob] order by cw.idx)
-        from checkpoint_writes cw
-        where cw.thread_id = checkpoints.thread_id
-            and cw.checkpoint_ns = checkpoints.checkpoint_ns
-            and cw.checkpoint_id = checkpoints.parent_checkpoint_id
-            and cw.channel = '${TASKS}'
-    ) as pending_sends
-from checkpoints `;
+export interface SQL_STATEMENTS {
+  SELECT_SQL: string;
+  UPSERT_CHECKPOINT_BLOBS_SQL: string;
+  UPSERT_CHECKPOINTS_SQL: string;
+  UPSERT_CHECKPOINT_WRITES_SQL: string;
+  INSERT_CHECKPOINT_WRITES_SQL: string;
+}
 
-export const UPSERT_CHECKPOINT_BLOBS_SQL = `
-    INSERT INTO checkpoint_blobs (thread_id, checkpoint_ns, channel, version, type, blob)
-    VALUES ($1, $2, $3, $4, $5, $6)
-    ON CONFLICT (thread_id, checkpoint_ns, channel, version) DO NOTHING
-`;
+export const getSQLStatements = (schema: string): SQL_STATEMENTS => ({
+  SELECT_SQL: 
+`select
+  thread_id,
+  checkpoint,
+  checkpoint_ns,
+  checkpoint_id,
+  parent_checkpoint_id,
+  metadata,
+  (
+    select array_agg(array[bl.channel::bytea, bl.type::bytea, bl.blob])
+    from jsonb_each_text(checkpoint -> 'channel_versions')
+    inner join ${schema}.checkpoint_blobs bl
+      on bl.thread_id = cp.thread_id
+      and bl.checkpoint_ns = cp.checkpoint_ns
+      and bl.channel = jsonb_each_text.key
+      and bl.version = jsonb_each_text.value
+  ) as channel_values,
+  (
+    select
+    array_agg(array[cw.task_id::text::bytea, cw.channel::bytea, cw.type::bytea, cw.blob] order by cw.task_id, cw.idx)
+    from ${schema}.checkpoint_writes cw
+    where cw.thread_id = cp.thread_id
+      and cw.checkpoint_ns = cp.checkpoint_ns
+      and cw.checkpoint_id = cp.checkpoint_id
+  ) as pending_writes,
+  (
+    select array_agg(array[cw.type::bytea, cw.blob] order by cw.idx)
+    from ${schema}.checkpoint_writes cw
+    where cw.thread_id = cp.thread_id
+      and cw.checkpoint_ns = cp.checkpoint_ns
+      and cw.checkpoint_id = cp.parent_checkpoint_id
+      and cw.channel = '${TASKS}'
+  ) as pending_sends
+from ${schema}.checkpoints cp `,
 
-export const UPSERT_CHECKPOINTS_SQL = `
-    INSERT INTO checkpoints (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, checkpoint, metadata)
-    VALUES ($1, $2, $3, $4, $5, $6)
-    ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id)
-    DO UPDATE SET
-        checkpoint = EXCLUDED.checkpoint,
-        metadata = EXCLUDED.metadata;
-`;
+  UPSERT_CHECKPOINT_BLOBS_SQL: 
+`INSERT INTO ${schema}.checkpoint_blobs (thread_id, checkpoint_ns, channel, version, type, blob)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (thread_id, checkpoint_ns, channel, version) DO NOTHING
+`,
 
-export const UPSERT_CHECKPOINT_WRITES_SQL = `
-    INSERT INTO checkpoint_writes (thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, blob)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-    ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id, task_id, idx) DO UPDATE SET
-        channel = EXCLUDED.channel,
-        type = EXCLUDED.type,
-        blob = EXCLUDED.blob;
-`;
+  UPSERT_CHECKPOINTS_SQL: 
+`INSERT INTO ${schema}.checkpoints (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, checkpoint, metadata)
+VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id)
+DO UPDATE SET
+  checkpoint = EXCLUDED.checkpoint,
+  metadata = EXCLUDED.metadata;
+`,
 
-export const INSERT_CHECKPOINT_WRITES_SQL = `
-    INSERT INTO checkpoint_writes (thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, blob)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-    ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id, task_id, idx) DO NOTHING
-`;
+  UPSERT_CHECKPOINT_WRITES_SQL: 
+`INSERT INTO ${schema}.checkpoint_writes (thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, blob)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id, task_id, idx) DO UPDATE SET
+  channel = EXCLUDED.channel,
+  type = EXCLUDED.type,
+  blob = EXCLUDED.blob;
+`,
+
+  INSERT_CHECKPOINT_WRITES_SQL: 
+`INSERT INTO ${schema}.checkpoint_writes (thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, blob)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id, task_id, idx) DO NOTHING
+`,
+});

--- a/libs/checkpoint-postgres/src/sql.ts
+++ b/libs/checkpoint-postgres/src/sql.ts
@@ -9,8 +9,7 @@ export interface SQL_STATEMENTS {
 }
 
 export const getSQLStatements = (schema: string): SQL_STATEMENTS => ({
-  SELECT_SQL: 
-`select
+  SELECT_SQL: `select
   thread_id,
   checkpoint,
   checkpoint_ns,
@@ -44,14 +43,12 @@ export const getSQLStatements = (schema: string): SQL_STATEMENTS => ({
   ) as pending_sends
 from ${schema}.checkpoints cp `, // <-- the trailing space is necessary for combining with WHERE clauses
 
-  UPSERT_CHECKPOINT_BLOBS_SQL: 
-`INSERT INTO ${schema}.checkpoint_blobs (thread_id, checkpoint_ns, channel, version, type, blob)
+  UPSERT_CHECKPOINT_BLOBS_SQL: `INSERT INTO ${schema}.checkpoint_blobs (thread_id, checkpoint_ns, channel, version, type, blob)
 VALUES ($1, $2, $3, $4, $5, $6)
 ON CONFLICT (thread_id, checkpoint_ns, channel, version) DO NOTHING
 `,
 
-  UPSERT_CHECKPOINTS_SQL: 
-`INSERT INTO ${schema}.checkpoints (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, checkpoint, metadata)
+  UPSERT_CHECKPOINTS_SQL: `INSERT INTO ${schema}.checkpoints (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, checkpoint, metadata)
 VALUES ($1, $2, $3, $4, $5, $6)
 ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id)
 DO UPDATE SET
@@ -59,8 +56,7 @@ DO UPDATE SET
   metadata = EXCLUDED.metadata;
 `,
 
-  UPSERT_CHECKPOINT_WRITES_SQL: 
-`INSERT INTO ${schema}.checkpoint_writes (thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, blob)
+  UPSERT_CHECKPOINT_WRITES_SQL: `INSERT INTO ${schema}.checkpoint_writes (thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, blob)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id, task_id, idx) DO UPDATE SET
   channel = EXCLUDED.channel,
@@ -68,8 +64,7 @@ ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id, task_id, idx) DO UPDATE SE
   blob = EXCLUDED.blob;
 `,
 
-  INSERT_CHECKPOINT_WRITES_SQL: 
-`INSERT INTO ${schema}.checkpoint_writes (thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, blob)
+  INSERT_CHECKPOINT_WRITES_SQL: `INSERT INTO ${schema}.checkpoint_writes (thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, blob)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id, task_id, idx) DO NOTHING
 `,

--- a/libs/checkpoint-postgres/src/sql.ts
+++ b/libs/checkpoint-postgres/src/sql.ts
@@ -8,64 +8,82 @@ export interface SQL_STATEMENTS {
   INSERT_CHECKPOINT_WRITES_SQL: string;
 }
 
-export const getSQLStatements = (schema: string): SQL_STATEMENTS => ({
-  SELECT_SQL: `select
-  thread_id,
-  checkpoint,
-  checkpoint_ns,
-  checkpoint_id,
-  parent_checkpoint_id,
-  metadata,
-  (
-    select array_agg(array[bl.channel::bytea, bl.type::bytea, bl.blob])
-    from jsonb_each_text(checkpoint -> 'channel_versions')
-    inner join ${schema}.checkpoint_blobs bl
-      on bl.thread_id = cp.thread_id
-      and bl.checkpoint_ns = cp.checkpoint_ns
-      and bl.channel = jsonb_each_text.key
-      and bl.version = jsonb_each_text.value
-  ) as channel_values,
-  (
-    select
-    array_agg(array[cw.task_id::text::bytea, cw.channel::bytea, cw.type::bytea, cw.blob] order by cw.task_id, cw.idx)
-    from ${schema}.checkpoint_writes cw
-    where cw.thread_id = cp.thread_id
-      and cw.checkpoint_ns = cp.checkpoint_ns
-      and cw.checkpoint_id = cp.checkpoint_id
-  ) as pending_writes,
-  (
-    select array_agg(array[cw.type::bytea, cw.blob] order by cw.idx)
-    from ${schema}.checkpoint_writes cw
-    where cw.thread_id = cp.thread_id
-      and cw.checkpoint_ns = cp.checkpoint_ns
-      and cw.checkpoint_id = cp.parent_checkpoint_id
-      and cw.channel = '${TASKS}'
-  ) as pending_sends
-from ${schema}.checkpoints cp `, // <-- the trailing space is necessary for combining with WHERE clauses
+interface TABLES {
+  checkpoints: string;
+  checkpoint_blobs: string;
+  checkpoint_writes: string;
+  checkpoint_migrations: string;
+}
 
-  UPSERT_CHECKPOINT_BLOBS_SQL: `INSERT INTO ${schema}.checkpoint_blobs (thread_id, checkpoint_ns, channel, version, type, blob)
-VALUES ($1, $2, $3, $4, $5, $6)
-ON CONFLICT (thread_id, checkpoint_ns, channel, version) DO NOTHING
-`,
+export const getTables = (schema: string): TABLES => {
+  const tables = ["checkpoints", "checkpoint_blobs", "checkpoint_writes", "checkpoint_migrations"];
+  return tables.reduce((acc, table) => {
+    acc[table as keyof TABLES] = `${schema}.${table}`;
+    return acc;
+  }, {} as TABLES);
+};
 
-  UPSERT_CHECKPOINTS_SQL: `INSERT INTO ${schema}.checkpoints (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, checkpoint, metadata)
-VALUES ($1, $2, $3, $4, $5, $6)
-ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id)
-DO UPDATE SET
-  checkpoint = EXCLUDED.checkpoint,
-  metadata = EXCLUDED.metadata;
-`,
-
-  UPSERT_CHECKPOINT_WRITES_SQL: `INSERT INTO ${schema}.checkpoint_writes (thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, blob)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id, task_id, idx) DO UPDATE SET
-  channel = EXCLUDED.channel,
-  type = EXCLUDED.type,
-  blob = EXCLUDED.blob;
-`,
-
-  INSERT_CHECKPOINT_WRITES_SQL: `INSERT INTO ${schema}.checkpoint_writes (thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, blob)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id, task_id, idx) DO NOTHING
-`,
-});
+export const getSQLStatements = (schema: string): SQL_STATEMENTS => {
+  const SCHEMA_TABLES = getTables(schema);
+  return {
+    SELECT_SQL: `select
+    thread_id,
+    checkpoint,
+    checkpoint_ns,
+    checkpoint_id,
+    parent_checkpoint_id,
+    metadata,
+    (
+      select array_agg(array[bl.channel::bytea, bl.type::bytea, bl.blob])
+      from jsonb_each_text(checkpoint -> 'channel_versions')
+      inner join ${SCHEMA_TABLES.checkpoint_blobs} bl
+        on bl.thread_id = cp.thread_id
+        and bl.checkpoint_ns = cp.checkpoint_ns
+        and bl.channel = jsonb_each_text.key
+        and bl.version = jsonb_each_text.value
+    ) as channel_values,
+    (
+      select
+      array_agg(array[cw.task_id::text::bytea, cw.channel::bytea, cw.type::bytea, cw.blob] order by cw.task_id, cw.idx)
+      from ${SCHEMA_TABLES.checkpoint_writes} cw
+      where cw.thread_id = cp.thread_id
+        and cw.checkpoint_ns = cp.checkpoint_ns
+        and cw.checkpoint_id = cp.checkpoint_id
+    ) as pending_writes,
+    (
+      select array_agg(array[cw.type::bytea, cw.blob] order by cw.idx)
+      from ${SCHEMA_TABLES.checkpoint_writes} cw
+      where cw.thread_id = cp.thread_id
+        and cw.checkpoint_ns = cp.checkpoint_ns
+        and cw.checkpoint_id = cp.parent_checkpoint_id
+        and cw.channel = '${TASKS}'
+    ) as pending_sends
+  from ${SCHEMA_TABLES.checkpoints} cp `, // <-- the trailing space is necessary for combining with WHERE clauses
+  
+    UPSERT_CHECKPOINT_BLOBS_SQL: `INSERT INTO ${SCHEMA_TABLES.checkpoint_blobs} (thread_id, checkpoint_ns, channel, version, type, blob)
+  VALUES ($1, $2, $3, $4, $5, $6)
+  ON CONFLICT (thread_id, checkpoint_ns, channel, version) DO NOTHING
+  `,
+  
+    UPSERT_CHECKPOINTS_SQL: `INSERT INTO ${SCHEMA_TABLES.checkpoints} (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, checkpoint, metadata)
+  VALUES ($1, $2, $3, $4, $5, $6)
+  ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id)
+  DO UPDATE SET
+    checkpoint = EXCLUDED.checkpoint,
+    metadata = EXCLUDED.metadata;
+  `,
+  
+    UPSERT_CHECKPOINT_WRITES_SQL: `INSERT INTO ${SCHEMA_TABLES.checkpoint_writes} (thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, blob)
+  VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+  ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id, task_id, idx) DO UPDATE SET
+    channel = EXCLUDED.channel,
+    type = EXCLUDED.type,
+    blob = EXCLUDED.blob;
+  `,
+  
+    INSERT_CHECKPOINT_WRITES_SQL: `INSERT INTO ${SCHEMA_TABLES.checkpoint_writes} (thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, blob)
+  VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+  ON CONFLICT (thread_id, checkpoint_ns, checkpoint_id, task_id, idx) DO NOTHING
+  `,
+  };
+};

--- a/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
+++ b/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
@@ -79,7 +79,9 @@ describe.each([
       const dbConnectionString = `${TEST_POSTGRES_URL?.split("/")
         .slice(0, -1)
         .join("/")}/${dbName}`;
-      postgresSaver = PostgresSaver.fromConnString(dbConnectionString, { schema });
+      postgresSaver = PostgresSaver.fromConnString(dbConnectionString, {
+        schema,
+      });
       postgresSavers.push(postgresSaver);
       await postgresSaver.setup();
     } finally {

--- a/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
+++ b/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
@@ -56,8 +56,8 @@ if (!TEST_POSTGRES_URL) {
 let postgresSavers: PostgresSaver[] = [];
 
 describe.each([
-  { schema: undefined, description: 'default schema' },
-  { schema: 'custom_schema', description: 'custom schema' }
+  { schema: undefined, description: 'the default schema' },
+  { schema: 'custom_schema', description: 'a custom schema' }
 ])("PostgresSaver with $description", ({ schema }) => {
   let postgresSaver: PostgresSaver;
 

--- a/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
+++ b/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
@@ -48,6 +48,11 @@ const checkpoint2: Checkpoint = {
   pending_sends: [],
 };
 
+const TEST_POSTGRES_URL = process.env.TEST_POSTGRES_URL;
+if (!TEST_POSTGRES_URL) {
+  throw new Error("TEST_POSTGRES_URL environment variable is required");
+}
+
 let postgresSavers: PostgresSaver[] = [];
 
 describe.each([
@@ -58,7 +63,7 @@ describe.each([
 
   beforeEach(async () => {
     const pool = new Pool({
-      connectionString: process.env.TEST_POSTGRES_URL,
+      connectionString: TEST_POSTGRES_URL,
     });
     // Generate a unique database name
     const dbName = `lg_test_db_${Date.now()}_${Math.floor(
@@ -71,7 +76,7 @@ describe.each([
       console.log(`Created database: ${dbName}`);
 
       // Connect to the new database
-      const dbConnectionString = `${process.env.TEST_POSTGRES_URL?.split("/")
+      const dbConnectionString = `${TEST_POSTGRES_URL?.split("/")
         .slice(0, -1)
         .join("/")}/${dbName}`;
       postgresSaver = PostgresSaver.fromConnString(dbConnectionString, schema);
@@ -88,7 +93,7 @@ describe.each([
     postgresSavers = [];
     // Drop all test databases
     const pool = new Pool({
-      connectionString: process.env.TEST_POSTGRES_URL,
+      connectionString: TEST_POSTGRES_URL,
     });
 
     try {

--- a/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
+++ b/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
@@ -48,7 +48,7 @@ const checkpoint2: Checkpoint = {
   pending_sends: [],
 };
 
-const TEST_POSTGRES_URL = process.env.TEST_POSTGRES_URL;
+const { TEST_POSTGRES_URL } = process.env;
 if (!TEST_POSTGRES_URL) {
   throw new Error("TEST_POSTGRES_URL environment variable is required");
 }

--- a/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
+++ b/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
@@ -65,6 +65,7 @@ describe("PostgresSaver", () => {
     try {
       // Create a new database
       await pool.query(`CREATE DATABASE ${dbName}`);
+      console.log(`Created database: ${dbName}`);
 
       // Connect to the new database
       const dbConnectionString = `${process.env.TEST_POSTGRES_URL?.split("/")

--- a/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
+++ b/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
@@ -56,8 +56,8 @@ if (!TEST_POSTGRES_URL) {
 let postgresSavers: PostgresSaver[] = [];
 
 describe.each([
-  { schema: undefined, description: 'the default schema' },
-  { schema: 'custom_schema', description: 'a custom schema' }
+  { schema: undefined, description: "the default schema" },
+  { schema: "custom_schema", description: "a custom schema" },
 ])("PostgresSaver with $description", ({ schema }) => {
   let postgresSaver: PostgresSaver;
 

--- a/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
+++ b/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
@@ -79,7 +79,7 @@ describe.each([
       const dbConnectionString = `${TEST_POSTGRES_URL?.split("/")
         .slice(0, -1)
         .join("/")}/${dbName}`;
-      postgresSaver = PostgresSaver.fromConnString(dbConnectionString, schema);
+      postgresSaver = PostgresSaver.fromConnString(dbConnectionString, { schema });
       postgresSavers.push(postgresSaver);
       await postgresSaver.setup();
     } finally {

--- a/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
+++ b/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
@@ -71,7 +71,7 @@ describe("PostgresSaver", () => {
       const dbConnectionString = `${process.env.TEST_POSTGRES_URL?.split("/")
         .slice(0, -1)
         .join("/")}/${dbName}`;
-      postgresSaver = PostgresSaver.fromConnString(dbConnectionString);
+      postgresSaver = PostgresSaver.fromConnString(dbConnectionString, 'custom_schema');
       postgresSavers.push(postgresSaver);
       await postgresSaver.setup();
     } finally {


### PR DESCRIPTION
This PR adds support for specifying a custom schema in the `checkpoint-postgres` module during initialization. Instead of relying on the default `public` schema used by Postgres or modifying the connection string’s search path (which can be unreliable at best), SQL queries now explicitly reference the provided schema, ensuring compatibility across all PostgreSQL versions and configurations, while still allowing the original module to stay backward compatible with previous versions since `public` was already the default schema.

```ts
// you can optionally pass a configuration object as the second parameter
const checkpointer = PostgresSaver.fromConnString("postgresql://...", {
  schema: "schema_name" // defaults to "public"
});
```

### Key Changes
- **Custom Schema Support**
  - Added an extendable `options` parameter to specify a schema when creating a `PostgresSaver` instance via the `fromConnString` method
  - Consolidated SQL queries and migration scripts into reusable functions that accept a schema name
- **Documentation & Testing**
  - Improved JSDoc comments for `fromConnString` with usage example
  - Enhanced integration tests to validate behavior with both the default and a custom schema