### PR TITLE
fix(langgraph): Dedupe input (right-side) messages in messageStateReducer

### DIFF
--- a/libs/langgraph/src/graph/message.ts
+++ b/libs/langgraph/src/graph/message.ts
@@ -26,7 +26,7 @@ export function messagesStateReducer(
   const leftMessages = (leftArray as BaseMessageLike[]).map(
     coerceMessageLikeToMessage
   );
-  const rightMessages = (rightArray as BaseMessageLike[]).map(
+  let rightMessages = (rightArray as BaseMessageLike[]).map(
     coerceMessageLikeToMessage
   );
   // assign missing ids
@@ -36,12 +36,15 @@ export function messagesStateReducer(
       m.lc_kwargs.id = m.id;
     }
   }
+  const dedupeMap = new Map();
   for (const m of rightMessages) {
     if (m.id === null || m.id === undefined) {
       m.id = v4();
       m.lc_kwargs.id = m.id;
     }
+    dedupeMap.set(m.id, m);
   }
+  rightMessages = Array.from(dedupeMap.values());
   // merge
   const leftIdxById = new Map(leftMessages.map((m, i) => [m.id, i]));
   const merged = [...leftMessages];

--- a/libs/langgraph/src/tests/prebuilt.test.ts
+++ b/libs/langgraph/src/tests/prebuilt.test.ts
@@ -791,3 +791,24 @@ describe("MessagesAnnotation", () => {
     expect(res2.messages.length).toEqual(1);
   });
 });
+
+describe("messagesStateReducer", () => {
+  it("should dedupe messages", () => {
+    const deduped = messagesStateReducer(
+      [new HumanMessage({ id: "foo", content: "bar" })],
+      [new HumanMessage({ id: "foo", content: "bar2" })]
+    );
+    expect(deduped.length).toEqual(1);
+    expect(deduped[0].content).toEqual("bar2");
+  });
+
+  it("should dedupe messages if there are dupes on the right", () => {
+    const messages = [
+      new HumanMessage({ id: "foo", content: "bar" }),
+      new HumanMessage({ id: "foo", content: "bar2" }),
+    ];
+    const deduped = messagesStateReducer([], messages);
+    expect(deduped.length).toEqual(1);
+    expect(deduped[0].content).toEqual("bar2");
+  });
+});


### PR DESCRIPTION
There are some cases where duplicate messages (with the same id) can accumulate in a result in before they are returned by a node and passed into a reducer

This change dedupes in new messages

FYI @benjamincburns @nfcampos