### PR TITLE
chore(docs): proper use of GA consent mode

### DIFF
--- a/docs/overrides/partials/integrations/analytics.html
+++ b/docs/overrides/partials/integrations/analytics.html
@@ -1,0 +1,36 @@
+<!--
+  Copyright (c) 2016-2025 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Determine analytics provider -->
+{% if config.extra.analytics %}
+  {% set provider = config.extra.analytics.provider %}
+{% endif %}
+
+<!-- Set up analytics provider -->
+{% if provider %}
+  {% include "partials/integrations/analytics/" ~ provider ~ ".html" %}
+    <script>
+      if (typeof __md_analytics !== "undefined") {
+        __md_analytics() // using GA consent mode, so we load with restrictive defaults first
+      }
+    </script>
+{% endif %}

--- a/docs/overrides/partials/integrations/analytics/google.html
+++ b/docs/overrides/partials/integrations/analytics/google.html
@@ -1,0 +1,122 @@
+<!--
+  Copyright (c) 2016-2025 Martin Donath <martin.donath@squidfunk.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Determine analytics property -->
+{% if config.extra.analytics %}
+  {% set property = config.extra.analytics.property | d("", true) %}
+{% endif %}
+
+<!-- Integrate with Google Analytics 4 -->
+<script id="__analytics">
+  function __md_analytics() {
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+
+    /* Set default consent */
+    gtag("consent", "default", {
+      ad_storage: "denied",
+      ad_user_data: "denied",
+      ad_personalization: "denied",
+      analytics_storage: "denied",
+      functionality_storage: "denied",
+      personalization_storage: "denied",
+      security_storage: "granted",
+      wait_for_update: 300, // give the page time to load the consent preferences before sending data
+    });
+
+    /* Initialize GA */
+    gtag("js", new Date());
+    gtag("config", "{{ property }}");
+
+    /* Register event handlers after document is loaded */
+    document.addEventListener("DOMContentLoaded", function() {
+      const userConsentSetting = __md_get("__consent");
+      const userAnalyticsPreference = !!userConsentSetting?.analytics;
+
+      const consentValue = userAnalyticsPreference ? "granted" : "denied";
+      gtag("consent", "update", {
+        analytics_storage: consentValue,
+      });
+      gtag("consent", "update", {
+        functionality_storage: consentValue,
+      });
+      gtag("consent", "update", {
+        personalization_storage: consentValue,
+      });
+
+      /* Set up search tracking */
+      if (document.forms.search) {
+        var query = document.forms.search.query;
+        query.addEventListener("blur", function() {
+          if (this.value)
+            gtag("event", "search", { search_term: this.value });
+        });
+      }
+
+      /* Set up feedback, i.e., "Was this page helpful?" */
+      document$.subscribe(function() {
+        var feedback = document.forms.feedback;
+        if (typeof feedback === "undefined")
+          return;
+
+        /* Send feedback to Google Analytics */
+        for (var button of feedback.querySelectorAll("[type=submit]")) {
+          button.addEventListener("click", function(ev) {
+            ev.preventDefault();
+
+            /* Retrieve and send data */
+            var page = document.location.pathname;
+            var data = this.getAttribute("data-md-value");
+            gtag("event", "feedback", { page, data });
+
+            /* Disable form and show note, if given */
+            feedback.firstElementChild.disabled = true;
+            var note = feedback.querySelector(
+              ".md-feedback__note [data-md-value='" + data + "']"
+            );
+            if (note)
+              note.hidden = false;
+          });
+
+          /* Show feedback */
+          feedback.hidden = false;
+        }
+      });
+
+      /* Send page view on location change */
+      location$.subscribe(function(url) {
+        gtag("config", "{{ property }}", {
+          page_path: url.pathname
+        });
+      });
+    });
+  }
+</script>
+
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','{{ property }}');</script>
+  <!-- End Google Tag Manager -->
+


### PR DESCRIPTION
Communicates cookie consent preferences back to Google and uses cookieless mode when users decline cookies.