### PR TITLE
improve migration for PostgresSaver and error handling

### DIFF
--- a/libs/checkpoint-postgres/.gitignore
+++ b/libs/checkpoint-postgres/.gitignore
@@ -6,5 +6,4 @@ node_modules
 dist
 .yarn
 .env
-.vscode
 .DS_Store

--- a/libs/checkpoint-postgres/.gitignore
+++ b/libs/checkpoint-postgres/.gitignore
@@ -5,3 +5,6 @@ index.d.cts
 node_modules
 dist
 .yarn
+.env
+.vscode
+.DS_Store

--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -252,7 +252,7 @@ export class PostgresSaver extends BaseCheckpointSaver {
       pending_sends: [],
     };
     if ("channel_values" in serialized) {
-      serialized.channel_values = undefined;
+      delete serialized.channel_values;
     }
     return serialized;
   }

--- a/libs/checkpoint-postgres/src/sql.ts
+++ b/libs/checkpoint-postgres/src/sql.ts
@@ -92,3 +92,12 @@ export const getSQLStatements = (schema: string): SQL_STATEMENTS => {
   `,
   };
 };
+
+export const tableExistsSQL = (schema: string, table: string) => {
+  const tableWithoutSchema = table.split(".")[1];
+  return `SELECT EXISTS (
+  SELECT FROM information_schema.tables 
+  WHERE  table_schema = '${schema}'
+  AND    table_name   = '${tableWithoutSchema}'
+  );`;
+};

--- a/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
+++ b/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
@@ -1,12 +1,13 @@
 /* eslint-disable no-process-env */
 import { describe, it, expect, beforeEach, afterAll } from "@jest/globals";
-import {
+import type {
   Checkpoint,
   CheckpointTuple,
-  uuid6,
 } from "@langchain/langgraph-checkpoint";
+import { uuid6 } from "@langchain/langgraph-checkpoint";
 import pg from "pg";
 import { PostgresSaver } from "../index.js"; // Adjust the import path as needed
+import { getMigrations } from "../migrations.js";
 
 const { Pool } = pg;
 
@@ -61,6 +62,8 @@ describe.each([
 ])("PostgresSaver with $description", ({ schema }) => {
   let postgresSaver: PostgresSaver;
 
+  let currentDbConnectionString: string;
+
   beforeEach(async () => {
     const pool = new Pool({
       connectionString: TEST_POSTGRES_URL,
@@ -79,6 +82,7 @@ describe.each([
       const dbConnectionString = `${TEST_POSTGRES_URL?.split("/")
         .slice(0, -1)
         .join("/")}/${dbName}`;
+      currentDbConnectionString = dbConnectionString;
       postgresSaver = PostgresSaver.fromConnString(dbConnectionString, {
         schema,
       });
@@ -106,10 +110,220 @@ describe.each([
 
       for (const row of result.rows) {
         const dbName = row.datname;
-        await pool.query(`DROP DATABASE ${dbName}`);
+        await pool.query(`DROP DATABASE ${dbName} WITH (FORCE)`);
         console.log(`Dropped database: ${dbName}`);
       }
     } finally {
+      await pool.end();
+    }
+  });
+
+  it("should properly initialize and setup the database", async () => {
+    // Verify that the database is properly initialized
+    const pool = new Pool({
+      connectionString: currentDbConnectionString,
+    });
+    const client = await pool.connect();
+    const currentSchema = schema ?? "public";
+    try {
+      // Check if the schema exists
+      const schemaResult = await client.query(
+        `
+        SELECT schema_name
+        FROM information_schema.schemata
+        WHERE schema_name = $1
+      `,
+        [currentSchema]
+      );
+      expect(schemaResult.rows.length).toBe(1);
+
+      // Check if the required tables exist
+      const tablesQuery = `
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = $1
+        AND table_name IN ('checkpoints', 'checkpoint_blobs', 'checkpoint_writes', 'checkpoint_migrations')
+      `;
+      const tablesResult = await client.query(tablesQuery, [currentSchema]);
+      expect(tablesResult.rows.length).toBe(4);
+
+      // Verify table structures
+      const checkpointsColumns = await client.query(
+        `
+        SELECT column_name, data_type, is_nullable, column_default
+        FROM information_schema.columns
+        WHERE table_schema = $1 AND table_name = 'checkpoints'
+        ORDER BY ordinal_position
+      `,
+        [currentSchema]
+      );
+
+      expect(checkpointsColumns.rows).toEqual([
+        {
+          column_name: "thread_id",
+          data_type: "text",
+          is_nullable: "NO",
+          column_default: null,
+        },
+        {
+          column_name: "checkpoint_ns",
+          data_type: "text",
+          is_nullable: "NO",
+          column_default: "''::text",
+        },
+        {
+          column_name: "checkpoint_id",
+          data_type: "text",
+          is_nullable: "NO",
+          column_default: null,
+        },
+        {
+          column_name: "parent_checkpoint_id",
+          data_type: "text",
+          is_nullable: "YES",
+          column_default: null,
+        },
+        {
+          column_name: "type",
+          data_type: "text",
+          is_nullable: "YES",
+          column_default: null,
+        },
+        {
+          column_name: "checkpoint",
+          data_type: "jsonb",
+          is_nullable: "NO",
+          column_default: null,
+        },
+        {
+          column_name: "metadata",
+          data_type: "jsonb",
+          is_nullable: "NO",
+          column_default: "'{}'::jsonb",
+        },
+      ]);
+
+      const checkpointBlobsColumns = await client.query(
+        `
+        SELECT column_name, data_type, is_nullable, column_default
+        FROM information_schema.columns
+        WHERE table_schema = $1 AND table_name = 'checkpoint_blobs'
+        ORDER BY ordinal_position
+      `,
+        [currentSchema]
+      );
+
+      expect(checkpointBlobsColumns.rows).toEqual([
+        {
+          column_name: "thread_id",
+          data_type: "text",
+          is_nullable: "NO",
+          column_default: null,
+        },
+        {
+          column_name: "checkpoint_ns",
+          data_type: "text",
+          is_nullable: "NO",
+          column_default: "''::text",
+        },
+        {
+          column_name: "channel",
+          data_type: "text",
+          is_nullable: "NO",
+          column_default: null,
+        },
+        {
+          column_name: "version",
+          data_type: "text",
+          is_nullable: "NO",
+          column_default: null,
+        },
+        {
+          column_name: "type",
+          data_type: "text",
+          is_nullable: "NO",
+          column_default: null,
+        },
+        {
+          column_name: "blob",
+          data_type: "bytea",
+          is_nullable: "YES",
+          column_default: null,
+        },
+      ]);
+
+      const checkpointWritesColumns = await client.query(
+        `
+        SELECT column_name, data_type, is_nullable, column_default
+        FROM information_schema.columns
+        WHERE table_schema = $1 AND table_name = 'checkpoint_writes'
+        ORDER BY ordinal_position
+      `,
+        [currentSchema]
+      );
+
+      expect(checkpointWritesColumns.rows).toEqual([
+        {
+          column_name: "thread_id",
+          data_type: "text",
+          is_nullable: "NO",
+          column_default: null,
+        },
+        {
+          column_name: "checkpoint_ns",
+          data_type: "text",
+          is_nullable: "NO",
+          column_default: "''::text",
+        },
+        {
+          column_name: "checkpoint_id",
+          data_type: "text",
+          is_nullable: "NO",
+          column_default: null,
+        },
+        {
+          column_name: "task_id",
+          data_type: "text",
+          is_nullable: "NO",
+          column_default: null,
+        },
+        {
+          column_name: "idx",
+          data_type: "integer",
+          is_nullable: "NO",
+          column_default: null,
+        },
+        {
+          column_name: "channel",
+          data_type: "text",
+          is_nullable: "NO",
+          column_default: null,
+        },
+        {
+          column_name: "type",
+          data_type: "text",
+          is_nullable: "YES",
+          column_default: null,
+        },
+        {
+          column_name: "blob",
+          data_type: "bytea",
+          is_nullable: "NO",
+          column_default: null,
+        },
+      ]);
+
+      // Verify migrations table has correct number of entries
+      const migrationsResult = await client.query(`
+        SELECT COUNT(*) as count
+        FROM ${schema ? `${schema}.` : ""}checkpoint_migrations
+      `);
+      const MIGRATIONS = getMigrations(currentSchema);
+      expect(Number.parseInt(migrationsResult.rows[0].count, 10)).toBe(
+        MIGRATIONS.length - 1
+      );
+    } finally {
+      client.release();
       await pool.end();
     }
   });

--- a/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
+++ b/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
@@ -76,7 +76,7 @@ describe.each([
     try {
       // Create a new database
       await pool.query(`CREATE DATABASE ${dbName}`);
-      console.log(`Created database: ${dbName}`);
+      console.log(`✅ Created database: ${dbName}`);
 
       // Connect to the new database
       const dbConnectionString = `${TEST_POSTGRES_URL?.split("/")
@@ -111,7 +111,7 @@ describe.each([
       for (const row of result.rows) {
         const dbName = row.datname;
         await pool.query(`DROP DATABASE ${dbName} WITH (FORCE)`);
-        console.log(`Dropped database: ${dbName}`);
+        console.log(`🗑️  Dropped database: ${dbName}`);
       }
     } finally {
       await pool.end();
@@ -320,7 +320,7 @@ describe.each([
       `);
       const MIGRATIONS = getMigrations(currentSchema);
       expect(Number.parseInt(migrationsResult.rows[0].count, 10)).toBe(
-        MIGRATIONS.length - 1
+        MIGRATIONS.length
       );
     } finally {
       client.release();

--- a/libs/checkpoint-postgres/tsconfig.json
+++ b/libs/checkpoint-postgres/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "./src",
     "target": "ES2021",
     "lib": ["ES2021", "ES2022.Object", "DOM"],
-    "module": "ES2020",
+    "module": "NodeNext",
     "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "declaration": true,

--- a/libs/checkpoint-postgres/tsconfig.json
+++ b/libs/checkpoint-postgres/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "./src",
     "target": "ES2021",
     "lib": ["ES2021", "ES2022.Object", "DOM"],
-    "module": "NodeNext",
+    "module": "ES2020",
     "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "declaration": true,


### PR DESCRIPTION
Ensure that table `checkpoint_migrations` is created before the `SELECT` query.
This will prevent the error of non-existing table

Also fixed some minor code style errors

Fixes #903
