### PR TITLE
fix(docs): Add section to demonstrate saving a graph diagram locally

### DIFF
--- a/examples/how-tos/breakpoints.ipynb
+++ b/examples/how-tos/breakpoints.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "!!! tip \"Prerequisites\"\n",
     "\n",
-    "    This guide assumes familiarity with the following concepts:ddd\n",
+    "    This guide assumes familiarity with the following concepts:\n",
     "\n",
     "    * [Breakpoints](/langgraphjs/concepts/breakpoints)\n",
     "    * [LangGraph Glossary](/langgraphjs/concepts/low_level)\n",

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -196,6 +196,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dc7e342f",
+   "metadata": {},
+   "source": [
+    "Alternatively, you can save the graph as a PNG file locally using the following approach:\n",
+    "\n",
+    "```ts\n",
+    "import { writeFileSync } from \"node:fs\";\n",
+    "\n",
+    "const graphStateImage = await drawableGraphGraphState.drawMermaidPng();\n",
+    "const graphStateArrayBuffer = await graphStateImage.arrayBuffer();\n",
+    "\n",
+    "const filePath = \"./graphState.png\";\n",
+    "writeFileSync(filePath, new Uint8Array(graphStateArrayBuffer));\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Customizing agent behavior\n",


### PR DESCRIPTION
Inspired by the below conversation in the LangChain Community Slack, I have added an example to the Quickstart documentation page for how to save the mermaid representation of the graph to a local PNG file.

![image](https://github.com/user-attachments/assets/aec1bfd7-57b2-41ac-b206-486720db78fd)

I also noticed a minor typo in the how-to breakpoints doc which I fixed while I was in the area.

Thanks!