### PR TITLE
fix(docs): Replace "Python" with "JavaScript" in swarm README

### DIFF
--- a/libs/langgraph-swarm/README.md
+++ b/libs/langgraph-swarm/README.md
@@ -1,6 +1,6 @@
 # 🤖 LangGraph Multi-Agent Swarm 
 
-A Python library for creating swarm-style multi-agent systems using [LangGraph](https://github.com/langchain-ai/langgraphjs). A swarm is a type of [multi-agent](https://langchain-ai.github.io/langgraphjs/concepts/multi_agent) architecture where agents dynamically hand off control to one another based on their specializations. The system remembers which agent was last active, ensuring that on subsequent interactions, the conversation resumes with that agent.
+A JavaScript library for creating swarm-style multi-agent systems using [LangGraph](https://github.com/langchain-ai/langgraphjs). A swarm is a type of [multi-agent](https://langchain-ai.github.io/langgraphjs/concepts/multi_agent) architecture where agents dynamically hand off control to one another based on their specializations. The system remembers which agent was last active, ensuring that on subsequent interactions, the conversation resumes with that agent.
 
 ![Swarm](static/img/swarm.png)
 


### PR DESCRIPTION
Now that `langgraph-swarm` has been ported to LangGraphJS, I thought I'd take a quick look at it and noticed a minor typo likely due to a find and replace missing it due to the casing.

Thought I'd fix it up real quick.

Thanks!