### PR TITLE
feat(pregel): add bulk update state method

### DIFF
--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -992,7 +992,7 @@ export class Pregel<
     if (values === null && asNode === "__end__") {
       if (updates.length > 1) {
         throw new InvalidUpdateError(
-          "Cannot update as __end__ in bulk with multiple updates"
+          `Cannot update as "__end__" when applying multiple updates`
         );
       }
 
@@ -1061,7 +1061,7 @@ export class Pregel<
     if (values == null && asNode === "__copy__") {
       if (updates.length > 1) {
         throw new InvalidUpdateError(
-          "Cannot update as __copy__ in bulk with multiple updates"
+          `Cannot update as "__copy__" when applying multiple updates`
         );
       }
 
@@ -1145,10 +1145,6 @@ export class Pregel<
     if (updates.length === 1) {
       // eslint-disable-next-line prefer-const
       let { values, asNode } = updates[0];
-      if (values === null && asNode === "__end__") {
-        throw new Error("Cannot update as __end__ in bulk");
-      }
-
       if (asNode === undefined && nonNullVersion === undefined) {
         if (
           typeof this.inputChannels === "string" &&
@@ -1191,7 +1187,7 @@ export class Pregel<
       for (const { asNode, values } of updates) {
         if (asNode == null) {
           throw new InvalidUpdateError(
-            "asNode is required when applying multiple updates"
+            `"asNode" is required when applying multiple updates`
           );
         }
 

--- a/libs/langgraph/src/tests/pregel.test.ts
+++ b/libs/langgraph/src/tests/pregel.test.ts
@@ -9959,6 +9959,77 @@ graph TD;
     );
     expect(chunks2[0][1][1].langgraph_node).toEqual("callModel");
   });
+
+  it("should handle bulk state updates", async () => {
+    const State = Annotation.Root({
+      foo: Annotation<string>,
+      baz: Annotation<string>,
+    });
+
+    const checkpointer = new MemorySaverAssertImmutable();
+
+    const nodeA = (_state: typeof State.State) => ({ foo: "bar" });
+    const nodeB = (_state: typeof State.State) => ({ baz: "qux" });
+
+    const graph = new StateGraph(State)
+      .addNode("nodeA", nodeA)
+      .addNode("nodeB", nodeB)
+      .addEdge(START, "nodeA")
+      .addEdge("nodeA", "nodeB")
+      .compile({ checkpointer });
+
+    const config = { configurable: { thread_id: "1" } };
+
+    // First update with nodeA
+    await graph.bulkUpdateState(config, [
+      { values: { foo: "bar" }, asNode: "nodeA" },
+    ]);
+
+    // Then bulk update with both nodes
+    await graph.bulkUpdateState(config, [
+      { values: { foo: "updated" }, asNode: "nodeA" },
+      { values: { baz: "new" }, asNode: "nodeB" },
+    ]);
+
+    const state = await graph.getState(config);
+    expect(state.values).toEqual({ foo: "updated", baz: "new" });
+
+    // check if there are only two checkpoints
+    const checkpoints = await gatherIterator(
+      checkpointer.list({ configurable: { thread_id: "1" } })
+    );
+
+    expect(checkpoints.length).toBe(2);
+    expect(checkpoints).toMatchObject([
+      {
+        metadata: {
+          writes: { nodeA: { foo: "updated" }, nodeB: { baz: "new" } },
+        },
+      },
+      { metadata: { writes: { nodeA: { foo: "bar" } } } },
+    ]);
+
+    // throw error if updating without `asNode`
+    await expect(
+      graph.bulkUpdateState(config, [
+        { values: { foo: "error" } },
+        { values: { bar: "error" } },
+      ])
+    ).rejects.toThrow(`"asNode" is required`);
+
+    // throw if no updates are provided
+    await expect(graph.bulkUpdateState(config, [])).rejects.toThrow(
+      "No updates provided"
+    );
+
+    // throw if __end__ or __copy__ update is applied in bulk
+    await expect(
+      graph.bulkUpdateState(config, [
+        { values: null, asNode: "__end__" },
+        { values: null, asNode: "__copy__" },
+      ])
+    ).rejects.toThrow(`when applying multiple updates`);
+  });
 }
 
 runPregelTests(() => new MemorySaverAssertImmutable());

--- a/libs/langgraph/src/tests/pregel.test.ts
+++ b/libs/langgraph/src/tests/pregel.test.ts
@@ -10015,7 +10015,7 @@ graph TD;
         { values: { foo: "error" } },
         { values: { bar: "error" } },
       ])
-    ).rejects.toThrow(`"asNode" is required`);
+    ).rejects.toThrow();
 
     // throw if no updates are provided
     await expect(graph.bulkUpdateState(config, [])).rejects.toThrow(
@@ -10028,7 +10028,7 @@ graph TD;
         { values: null, asNode: "__end__" },
         { values: null, asNode: "__copy__" },
       ])
-    ).rejects.toThrow(`when applying multiple updates`);
+    ).rejects.toThrow();
   });
 }
 


### PR DESCRIPTION
This method is useful for recreating a thread from a list of checkpoint writes. A new method is needed to clone a checkpoint that has been created from multiple writes (functional API, map-reduce)

<!--
Thank you for contributing to LangGraph.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langgraphjs/blob/main/CONTRIBUTING.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
