### PR TITLE
Updated dead link in time-travel docs

### DIFF
--- a/examples/how-tos/time-travel.ipynb
+++ b/examples/how-tos/time-travel.ipynb
@@ -597,7 +597,7 @@
         "## Get State\n",
         "\n",
         "You can fetch the latest graph checkpoint using\n",
-        "[`getState(config)`](/langgraphjs/reference/classes/pregel.Pregel.html#getState)."
+        "[`getState(config)`](/langgraphjs/reference/classes/langgraph.Pregel.html#getState)."
       ]
     },
     {


### PR DESCRIPTION
Minor change, fixed a dead link I've found while reading the docs.