### PR TITLE
chore(langgraph): add tests to validate AbortSignal is passed into nodes

### DIFF
--- a/libs/langgraph/src/tests/pregel.test.ts
+++ b/libs/langgraph/src/tests/pregel.test.ts
@@ -9708,47 +9708,6 @@ graph TD;
     expect(thirdState.tasks).toHaveLength(0);
   });
 
-  it("should cancel when signal is aborted", async () => {
-    let oneCount = 0;
-    let twoCount = 0;
-    const graph = new StateGraph(MessagesAnnotation)
-      .addNode("one", async () => {
-        oneCount += 1;
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        return {};
-      })
-      .addNode("two", () => {
-        twoCount += 1;
-        throw new Error("Should not be called!");
-      })
-      .addEdge(START, "one")
-      .addEdge("one", "two")
-      .addEdge("two", END)
-      .compile();
-
-    const abortController = new AbortController();
-    const config = {
-      signal: abortController.signal,
-    };
-
-    setTimeout(() => abortController.abort(), 10);
-
-    await expect(
-      async () =>
-        await graph.invoke(
-          {
-            messages: [],
-          },
-          config
-        )
-    ).rejects.toThrow("Aborted");
-
-    // Ensure that the `twoCount` has had time to increment before we check it, in case the stream aborted but the graph execution didn't.
-    await new Promise((resolve) => setTimeout(resolve, 300));
-    expect(oneCount).toEqual(1);
-    expect(twoCount).toEqual(0);
-  });
-
   it("should throw when resuming without a checkpointer", async () => {
     const chain = Channel.subscribeTo("input").pipe(
       Channel.writeTo(["output"])

--- a/libs/langgraph/src/tests/pregel/pregel.cancellation.test.ts
+++ b/libs/langgraph/src/tests/pregel/pregel.cancellation.test.ts
@@ -1,0 +1,226 @@
+import {
+  CompiledStateGraph,
+  END,
+  LangGraphRunnableConfig,
+  MessagesAnnotation,
+  START,
+  StateGraph,
+} from "../../index.js";
+
+type TestMode =
+  | "singleLayer"
+  | "subgraphCalledWithinNode"
+  | "subgraphCalledAsNode";
+
+describe("Pregel AbortSignal", () => {
+  let oneCount = 0;
+  let oneResolved = false;
+  let oneRejected = false;
+  let twoCount = 0;
+
+  beforeEach(() => {
+    oneCount = 0;
+    oneResolved = false;
+    oneRejected = false;
+    twoCount = 0;
+  });
+
+  function createGraph({
+    mode,
+    checkSignal,
+  }: {
+    mode: TestMode;
+    checkSignal: boolean;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }): CompiledStateGraph<any, any, any> {
+    const graph = new StateGraph(MessagesAnnotation)
+      .addNode("one", async (_, config: LangGraphRunnableConfig) => {
+        oneCount += 1;
+        if (checkSignal) {
+          const { signal } = config;
+          expect(signal).toBeDefined();
+          return new Promise((resolve, reject) => {
+            signal!.addEventListener("abort", () => {
+              oneRejected = true;
+              reject(new Error("Aborted"));
+            });
+            setTimeout(() => {
+              if (!signal!.aborted) {
+                oneResolved = true;
+                resolve({});
+              }
+            }, 50);
+          });
+        } else {
+          await new Promise((resolve) => {
+            oneResolved = true;
+            setTimeout(resolve, 100);
+          });
+          return {};
+        }
+      })
+      .addNode("two", () => {
+        twoCount += 1;
+        throw new Error("Should not be called!");
+      })
+      .addEdge(START, "one")
+      .addEdge("one", "two")
+      .addEdge("two", END)
+      .compile();
+
+    if (mode === "singleLayer") {
+      return graph;
+    }
+
+    if (mode === "subgraphCalledWithinNode") {
+      return new StateGraph(MessagesAnnotation)
+        .addNode("graph", async () => {
+          await graph.invoke({ messages: [] });
+        })
+        .addEdge(START, "graph")
+        .addEdge("graph", END)
+        .compile();
+    }
+
+    return new StateGraph(MessagesAnnotation)
+      .addNode("graph", graph)
+      .addEdge(START, "graph")
+      .addEdge("graph", END)
+      .compile();
+  }
+
+  it.each([
+    "singleLayerGraph",
+    "subgraphCalledWithinNode",
+    "subgraphCalledAsNode",
+  ] as TestMode[])(
+    "should cancel when external AbortSignal is aborted (%s)",
+    async (mode) => {
+      const abortController = new AbortController();
+      const config = {
+        signal: abortController.signal,
+      };
+
+      setTimeout(() => abortController.abort(), 10);
+
+      await expect(
+        async () =>
+          await createGraph({ mode, checkSignal: false }).invoke(
+            {
+              messages: [],
+            },
+            config
+          )
+      ).rejects.toThrow("Aborted");
+
+      // Ensure that the `twoCount` has had time to increment before we check it, in case the stream aborted but the graph execution didn't.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 300);
+      });
+      expect(oneCount).toEqual(1);
+      expect(twoCount).toEqual(0);
+    }
+  );
+
+  it.each([
+    "singleLayerGraph",
+    "subgraphCalledWithinNode",
+    "subgraphCalledAsNode",
+  ] as TestMode[])(
+    "should pass AbortSignal into nodes via config when timeout is provided but no external signal is given (%s)",
+    async (mode) => {
+      const config = {
+        timeout: 10,
+      };
+
+      await expect(
+        async () =>
+          await createGraph({ mode, checkSignal: true }).invoke(
+            {
+              messages: [],
+            },
+            config
+          )
+      ).rejects.toThrow("Aborted");
+
+      // Ensure that the `twoCount` has had time to increment before we check it, in case the stream aborted but the graph execution didn't.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 300);
+      });
+      expect(oneCount).toEqual(1);
+      expect(oneResolved).toEqual(false);
+      expect(oneRejected).toEqual(true);
+      expect(twoCount).toEqual(0);
+    }
+  );
+
+  it.each([
+    "singleLayerGraph",
+    "subgraphCalledWithinNode",
+    "subgraphCalledAsNode",
+  ] as TestMode[])(
+    "should trigger AbortSignal that is passed to node on timeout when both signal and timeout are set on invocation (%s)",
+    async (mode) => {
+      const abortController = new AbortController();
+      const config = {
+        signal: abortController.signal,
+        timeout: 10,
+      };
+
+      await expect(
+        async () =>
+          await createGraph({ mode, checkSignal: true }).invoke(
+            {
+              messages: [],
+            },
+            config
+          )
+      ).rejects.toThrow("Aborted");
+
+      // Ensure that the `twoCount` has had time to increment before we check it, in case the stream aborted but the graph execution didn't.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 300);
+      });
+      expect(oneCount).toEqual(1);
+      expect(oneResolved).toEqual(false);
+      expect(oneRejected).toEqual(true);
+      expect(twoCount).toEqual(0);
+    }
+  );
+
+  it.each([
+    "singleLayerGraph",
+    "subgraphCalledWithinNode",
+    "subgraphCalledAsNode",
+  ] as TestMode[])(
+    "should trigger AbortSignal that is passed to node when external signal triggered when both signal and timeout are set on invocation (%s)",
+    async (mode) => {
+      const abortController = new AbortController();
+      const config = {
+        signal: abortController.signal,
+        timeout: 100,
+      };
+
+      setTimeout(() => abortController.abort(), 10);
+
+      await expect(
+        async () =>
+          await createGraph({ mode, checkSignal: true }).invoke(
+            {
+              messages: [],
+            },
+            config
+          )
+      ).rejects.toThrow("Aborted");
+
+      // Ensure that the `twoCount` has had time to increment before we check it, in case the stream aborted but the graph execution didn't.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 300);
+      });
+      expect(oneCount).toEqual(1);
+      expect(oneResolved).toEqual(false);
+      expect(oneRejected).toEqual(true);
+      expect(twoCount).toEqual(0);
+    }
+  );
+});


### PR DESCRIPTION
Also validates that

- The signal received by nodes
  - fires in the event of a timeout
  - fires in the event of an external trigger (user code calling `abort` on the associated `AbortController`)
  - propagates correctly from parent graphs into subgraphs
    - when subgraph is called from within a node w/o explicitly passing `config`
    - when subgraph is a node