### PR TITLE
fix(checkpoint-sqlite): upgrade better-sqlite3 to 11.7.0

### DIFF
--- a/libs/checkpoint-mongodb/package.json
+++ b/libs/checkpoint-mongodb/package.json
@@ -44,7 +44,7 @@
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",
-    "@types/better-sqlite3": "^7.6.9",
+    "@types/better-sqlite3": "^7.6.12",
     "@types/uuid": "^10",
     "@typescript-eslint/eslint-plugin": "^6.12.0",
     "@typescript-eslint/parser": "^6.12.0",

--- a/libs/checkpoint-sqlite/package.json
+++ b/libs/checkpoint-sqlite/package.json
@@ -31,7 +31,7 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "better-sqlite3": "^9.5.0"
+    "better-sqlite3": "^11.7.0"
   },
   "peerDependencies": {
     "@langchain/core": ">=0.2.31 <0.4.0",
@@ -44,11 +44,11 @@
     "@swc/core": "^1.3.90",
     "@swc/jest": "^0.2.29",
     "@tsconfig/recommended": "^1.0.3",
-    "@types/better-sqlite3": "^7.6.9",
+    "@types/better-sqlite3": "^7.6.12",
     "@types/uuid": "^10",
     "@typescript-eslint/eslint-plugin": "^6.12.0",
     "@typescript-eslint/parser": "^6.12.0",
-    "better-sqlite3": "^9.5.0",
+    "better-sqlite3": "^11.7.0",
     "dotenv": "^16.3.1",
     "dpdm": "^3.12.0",
     "eslint": "^8.33.0",

--- a/libs/checkpoint-validation/package.json
+++ b/libs/checkpoint-validation/package.json
@@ -59,7 +59,7 @@
     "@types/uuid": "^10",
     "@typescript-eslint/eslint-plugin": "^6.12.0",
     "@typescript-eslint/parser": "^6.12.0",
-    "better-sqlite3": "^9.5.0",
+    "better-sqlite3": "^11.7.0",
     "dotenv": "^16.3.1",
     "dpdm": "^3.12.0",
     "eslint": "^8.33.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1648,7 +1648,7 @@ __metadata:
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
-    "@types/better-sqlite3": ^7.6.9
+    "@types/better-sqlite3": ^7.6.12
     "@types/uuid": ^10
     "@typescript-eslint/eslint-plugin": ^6.12.0
     "@typescript-eslint/parser": ^6.12.0
@@ -1724,11 +1724,11 @@ __metadata:
     "@swc/core": ^1.3.90
     "@swc/jest": ^0.2.29
     "@tsconfig/recommended": ^1.0.3
-    "@types/better-sqlite3": ^7.6.9
+    "@types/better-sqlite3": ^7.6.12
     "@types/uuid": ^10
     "@typescript-eslint/eslint-plugin": ^6.12.0
     "@typescript-eslint/parser": ^6.12.0
-    better-sqlite3: ^9.5.0
+    better-sqlite3: ^11.7.0
     dotenv: ^16.3.1
     dpdm: ^3.12.0
     eslint: ^8.33.0
@@ -1772,7 +1772,7 @@ __metadata:
     "@types/uuid": ^10
     "@typescript-eslint/eslint-plugin": ^6.12.0
     "@typescript-eslint/parser": ^6.12.0
-    better-sqlite3: ^9.5.0
+    better-sqlite3: ^11.7.0
     dotenv: ^16.3.1
     dpdm: ^3.12.0
     eslint: ^8.33.0
@@ -3120,12 +3120,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/better-sqlite3@npm:^7.6.9":
-  version: 7.6.9
-  resolution: "@types/better-sqlite3@npm:7.6.9"
+"@types/better-sqlite3@npm:^7.6.12":
+  version: 7.6.12
+  resolution: "@types/better-sqlite3@npm:7.6.12"
   dependencies:
     "@types/node": "*"
-  checksum: 6572076639dde1e65ad8fe0e319e797fa40793ca805ec39aa1d072d3f145f218775eafd27d7266fb4e42a6291d8b8b836278e7880b15ef728c750dfcbba2ee52
+  checksum: 1b6d8499cdc489cfd920ca96ae86c8f2f06fb5b41ca50830ba335aced8d3f040575c89d7d08ace33610eddf5fc310e5efd52ad9bef7aeb8b531ae483e0351725
   languageName: node
   linkType: hard
 
@@ -4423,14 +4423,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-sqlite3@npm:^9.5.0":
-  version: 9.6.0
-  resolution: "better-sqlite3@npm:9.6.0"
+"better-sqlite3@npm:^11.7.0":
+  version: 11.8.1
+  resolution: "better-sqlite3@npm:11.8.1"
   dependencies:
     bindings: ^1.5.0
     node-gyp: latest
     prebuild-install: ^7.1.1
-  checksum: be3a1d2a3f6f9b5141be6607a38c0a51fa5849495b071955e507bc0c2a2fb08430852c1bf03796eec1a53344b25645807db48dcb51c71b0662b74c5a70420bb0
+  checksum: e71522678a4b54fedbcefa70184856721cb4027675e5820ea135ad9c7f7e7b4110e938a42bb000c83deadb2ca0f574354a8dba0a998b0e89df4b9de1bdd4dc03
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes gyp compilation errors on Node.js >= 23.4.0 (LTS):

```
prebuild-install warn install No prebuilt binaries found (target=23.7.0 runtime=node arch=arm64 libc= platform=darwin)
gyp info it worked if it ends with ok
gyp info using node-gyp@11.1.0
gyp info using node@23.7.0 | darwin | arm64
gyp info find Python using Python version 3.13.2 found at "/opt/homebrew/opt/python@3.13/bin/python3.13"

gyp info spawn /opt/homebrew/opt/python@3.13/bin/python3.13
gyp info spawn args [
gyp info spawn args '/Users/divy/gh/langgraphjs/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args 'binding.gyp',
gyp info spawn args '-f',
gyp info spawn args 'make',
gyp info spawn args '-I',
gyp info spawn args '/Users/divy/gh/langgraphjs/node_modules/better-sqlite3/build/config.gypi',
gyp info spawn args '-I',
gyp info spawn args '/Users/divy/gh/langgraphjs/node_modules/node-gyp/addon.gypi',
gyp info spawn args '-I',
gyp info spawn args '/Users/divy/Library/Caches/node-gyp/23.7.0/include/node/common.gypi',
gyp info spawn args '-Dlibrary=shared_library',
gyp info spawn args '-Dvisibility=default',
gyp info spawn args '-Dnode_root_dir=/Users/divy/Library/Caches/node-gyp/23.7.0',
gyp info spawn args '-Dnode_gyp_dir=/Users/divy/gh/langgraphjs/node_modules/node-gyp',
gyp info spawn args '-Dnode_lib_file=/Users/divy/Library/Caches/node-gyp/23.7.0/<(target_arch)/node.lib',
gyp info spawn args '-Dmodule_root_dir=/Users/divy/gh/langgraphjs/node_modules/better-sqlite3',
gyp info spawn args '-Dnode_engine=v8',
gyp info spawn args '--depth=.',
gyp info spawn args '--no-parallel',
gyp info spawn args '--generator-output',
gyp info spawn args 'build',
gyp info spawn args '-Goutput_dir=.'
gyp info spawn args ]
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
  TOUCH ba23eeee118cd63e16015df367567cb043fed872.intermediate
  ACTION deps_sqlite3_gyp_locate_sqlite3_target_copy_builtin_sqlite3 ba23eeee118cd63e16015df367567cb043fed872.intermediate
  TOUCH Release/obj.target/deps/locate_sqlite3.stamp
  CC(target) Release/obj.target/sqlite3/gen/sqlite3/sqlite3.o
  LIBTOOL-STATIC Release/sqlite3.a
  CXX(target) Release/obj.target/better_sqlite3/src/better_sqlite3.o
In file included from ../src/better_sqlite3.cpp:4:
In file included from ./src/better_sqlite3.lzz:11:
In file included from /Users/divy/Library/Caches/node-gyp/23.7.0/include/node/node.h:73:
In file included from /Users/divy/Library/Caches/node-gyp/23.7.0/include/node/v8.h:23:
In file included from /Users/divy/Library/Caches/node-gyp/23.7.0/include/node/cppgc/common.h:8:
/Users/divy/Library/Caches/node-gyp/23.7.0/include/node/v8config.h:13:2: error: "C++20 or later required."
   13 | #error "C++20 or later required."
      |  ^
In file included from ../src/better_sqlite3.cpp:4:
./src/util/macros.lzz:31:69: error: no template named 'CopyablePersistentTraits' in namespace 'v8'; did you mean 'NonCopyablePersistentTraits'?
   31 | template <class T> using CopyablePersistent = v8::Persistent<T, v8::CopyablePersistentTraits<T>>;
      |                                                                 ~~~~^~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                     NonCopyablePersistentTraits
/Users/divy/Library/Caches/node-gyp/23.7.0/include/node/v8-persistent-handle.h:223:7: note: 'NonCopyablePersistentTraits' declared here
  223 | class NonCopyablePersistentTraits {
      |       ^
In file included from ../src/better_sqlite3.cpp:4:
./src/util/macros.lzz:149:6: error: no type named 'AccessorGetterCallback' in namespace 'v8'; did you mean 'AccessorNameGetterCallback'?
  149 |         v8::AccessorGetterCallback func
      |         ~~~~^~~~~~~~~~~~~~~~~~~~~~
      |             AccessorNameGetterCallback
/Users/divy/Library/Caches/node-gyp/23.7.0/include/node/v8-object.h:155:7: note: 'AccessorNameGetterCallback' declared here
  155 | using AccessorNameGetterCallback =
      |       ^
./src/util/macros.lzz:158:6: error: no type named 'AccessorGetterCallback' in namespace 'v8'; did you mean 'AccessorNameGetterCallback'?
  158 |         v8::AccessorGetterCallback func
      |         ~~~~^~~~~~~~~~~~~~~~~~~~~~
      |             AccessorNameGetterCallback
/Users/divy/Library/Caches/node-gyp/23.7.0/include/node/v8-object.h:155:7: note: 'AccessorNameGetterCallback' declared here
  155 | using AccessorNameGetterCallback =
      |       ^
```