### PR TITLE
Fix handoff tool name for multiple whitespaces

### DIFF
--- a/libs/langgraph-swarm/src/handoff.ts
+++ b/libs/langgraph-swarm/src/handoff.ts
@@ -15,7 +15,7 @@ import {
 } from "@langchain/langgraph";
 import { ToolNode } from "@langchain/langgraph/prebuilt";
 
-const WHITESPACE_RE = /\s+/;
+const WHITESPACE_RE = /\s+/g;
 const METADATA_KEY_HANDOFF_DESTINATION = "__handoff_destination";
 
 function _normalizeAgentName(agentName: string): string {


### PR DESCRIPTION
Fix: Handoff Tool function name to replace all whitespace characters
Before: Bob The Builder -> bob_the builder
After: Bob The Builder -> bob_the_builder