### PR TITLE
feat(pregel): add ability to bulk update as input

### DIFF
--- a/libs/langgraph/src/constants.ts
+++ b/libs/langgraph/src/constants.ts
@@ -3,6 +3,7 @@ export const START = "__start__";
 /** Special reserved node name denoting the end of a graph. */
 export const END = "__end__";
 export const INPUT = "__input__";
+export const COPY = "__copy__";
 export const ERROR = "__error__";
 export const CONFIG_KEY_SEND = "__pregel_send";
 /** config key containing function used to call a node (push task) */

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -891,6 +891,8 @@ export class Pregel<
    * from a list of updates, especially if a checkpoint
    * is created as a result of multiple tasks.
    *
+   * @internal The API might change in the future.
+   *
    * @param startConfig - Configuration for the update
    * @param updates - The list of updates to apply to graph state
    * @returns Updated configuration

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -1129,7 +1129,6 @@ export class Pregel<
         }
 
         // apply to checkpoint
-        // TODO: Why does keyof StrRecord allow number and symbol?
         _applyWrites(
           checkpoint,
           channels,
@@ -1141,12 +1140,6 @@ export class Pregel<
             },
           ],
           checkpointer.getNextVersion.bind(this.checkpointer)
-        );
-
-        await checkpointer.putWrites(
-          checkpointConfig,
-          inputWrites as PendingWrite[],
-          uuid5(INPUT, checkpoint.id)
         );
 
         // apply input write to channels
@@ -1163,6 +1156,13 @@ export class Pregel<
             checkpointPreviousVersions,
             checkpoint.channel_versions
           )
+        );
+
+        // Store the writes
+        await checkpointer.putWrites(
+          nextConfig,
+          inputWrites as PendingWrite[],
+          uuid5(INPUT, checkpoint.id)
         );
 
         return patchCheckpointMap(

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -1147,12 +1147,14 @@ export class Pregel<
         );
 
         // apply input write to channels
+        const nextStep =
+          saved?.metadata?.step != null ? saved.metadata.step + 1 : -1;
         const nextConfig = await checkpointer.put(
           checkpointConfig,
-          createCheckpoint(checkpoint, channels, step),
+          createCheckpoint(checkpoint, channels, nextStep),
           {
             source: "input",
-            step,
+            step: nextStep,
             writes: Object.fromEntries(inputWrites),
             parents: saved?.metadata?.parents ?? {},
           },

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -1147,12 +1147,14 @@ export class Pregel<
         );
 
         // apply input write to channels
+        const nextStep =
+          saved?.metadata?.step != null ? saved.metadata.step + 1 : -1;
         const nextConfig = await checkpointer.put(
           checkpointConfig,
-          createCheckpoint(checkpoint, channels, step),
+          createCheckpoint(checkpoint, channels, nextStep),
           {
             source: "input",
-            step: saved?.metadata?.step != null ? saved.metadata.step + 1 : -1,
+            step: nextStep,
             writes: Object.fromEntries(inputWrites),
             parents: saved?.metadata?.parents ?? {},
           },

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -1147,14 +1147,12 @@ export class Pregel<
         );
 
         // apply input write to channels
-        const nextStep =
-          saved?.metadata?.step != null ? saved.metadata.step + 1 : -1;
         const nextConfig = await checkpointer.put(
           checkpointConfig,
-          createCheckpoint(checkpoint, channels, nextStep),
+          createCheckpoint(checkpoint, channels, step),
           {
             source: "input",
-            step: nextStep,
+            step: saved?.metadata?.step != null ? saved.metadata.step + 1 : -1,
             writes: Object.fromEntries(inputWrites),
             parents: saved?.metadata?.parents ?? {},
           },

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -53,6 +53,8 @@ import {
   Command,
   NULL_TASK_ID,
   INPUT,
+  COPY,
+  END,
   PUSH,
 } from "../constants.js";
 import {
@@ -1012,7 +1014,7 @@ export class Pregel<
         skipManaged: true,
       });
 
-      if (values === null && asNode === "__end__") {
+      if (values === null && asNode === END) {
         if (updates.length > 1) {
           throw new InvalidUpdateError(
             `Cannot apply multiple updates when clearing state`
@@ -1084,7 +1086,7 @@ export class Pregel<
           saved ? saved.metadata : undefined
         );
       }
-      if (values == null && asNode === "__copy__") {
+      if (values == null && asNode === COPY) {
         if (updates.length > 1) {
           throw new InvalidUpdateError(
             `Cannot copy checkpoint with multiple updates`
@@ -1108,7 +1110,7 @@ export class Pregel<
         );
       }
 
-      if (asNode === "__input__") {
+      if (asNode === INPUT) {
         if (updates.length > 1) {
           throw new InvalidUpdateError(
             `Cannot apply multiple updates when clearing state`

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -1152,7 +1152,7 @@ export class Pregel<
           createCheckpoint(checkpoint, channels, step),
           {
             source: "input",
-            step: saved?.metadata?.step != null ? saved.metadata.step + 1 : -1,
+            step,
             writes: Object.fromEntries(inputWrites),
             parents: saved?.metadata?.parents ?? {},
           },

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -1115,7 +1115,7 @@ export class Pregel<
       if (asNode === INPUT) {
         if (updates.length > 1) {
           throw new InvalidUpdateError(
-            `Cannot apply multiple updates when clearing state`
+            `Cannot apply multiple updates when updating as input`
           );
         }
 

--- a/libs/langgraph/src/tests/pregel.test.ts
+++ b/libs/langgraph/src/tests/pregel.test.ts
@@ -10035,7 +10035,7 @@ graph TD;
     ).rejects.toThrow();
   });
 
-  it.only("update as input", async () => {
+  it("update as input", async () => {
     const checkpointer = await createCheckpointer();
     const graph = new StateGraph(Annotation.Root({ foo: Annotation<string> }))
       .addNode("agent", () => ({ foo: "agent" }))
@@ -10087,7 +10087,7 @@ graph TD;
     expect(newHistory.map(mapSnapshot)).toMatchObject(history.map(mapSnapshot));
   });
 
-  it.skip("batch update as input (map-reduce)", async () => {
+  it("batch update as input (map-reduce)", async () => {
     const checkpointer = await createCheckpointer();
     const graph = new StateGraph(
       Annotation.Root({
@@ -10147,7 +10147,7 @@ graph TD;
       {
         updates: [
           {
-            command: new Command({
+            values: new Command({
               goto: [
                 new Send("task", { index: 0 }),
                 new Send("task", { index: 1 }),

--- a/libs/langgraph/src/tests/pregel.test.ts
+++ b/libs/langgraph/src/tests/pregel.test.ts
@@ -10035,7 +10035,7 @@ graph TD;
     ).rejects.toThrow();
   });
 
-  it("update as input", async () => {
+  it.only("update as input", async () => {
     const checkpointer = await createCheckpointer();
     const graph = new StateGraph(Annotation.Root({ foo: Annotation<string> }))
       .addNode("agent", () => ({ foo: "agent" }))
@@ -10044,11 +10044,13 @@ graph TD;
       .addEdge("agent", "tool")
       .compile({ checkpointer });
 
-    const res = await graph.invoke(
-      { foo: "input" },
-      { configurable: { thread_id: "1" } }
-    );
-    expect(res).toEqual({ foo: "tool" });
+    expect(
+      await graph.invoke({ foo: "input" }, { configurable: { thread_id: "1" } })
+    ).toEqual({ foo: "tool" });
+
+    expect(
+      await graph.invoke({ foo: "input" }, { configurable: { thread_id: "1" } })
+    ).toEqual({ foo: "tool" });
 
     const history = await gatherIterator(
       graph.getStateHistory({ configurable: { thread_id: "1" } })
@@ -10056,6 +10058,13 @@ graph TD;
 
     // now clone the thread
     await graph.bulkUpdateState({ configurable: { thread_id: "2" } }, [
+      // first turn
+      { updates: [{ values: { foo: "input" }, asNode: "__input__" }] },
+      { updates: [{ values: { foo: "input" }, asNode: "__start__" }] },
+      { updates: [{ values: { foo: "agent" }, asNode: "agent" }] },
+      { updates: [{ values: { foo: "tool" }, asNode: "tool" }] },
+
+      // second turn
       { updates: [{ values: { foo: "input" }, asNode: "__input__" }] },
       { updates: [{ values: { foo: "input" }, asNode: "__start__" }] },
       { updates: [{ values: { foo: "agent" }, asNode: "agent" }] },
@@ -10069,9 +10078,104 @@ graph TD;
       graph.getStateHistory({ configurable: { thread_id: "2" } })
     );
 
+    const mapSnapshot = (i: StateSnapshot) => ({
+      values: i.values,
+      next: i.next,
+      step: i.metadata?.step,
+    });
+
+    expect(newHistory.map(mapSnapshot)).toMatchObject(history.map(mapSnapshot));
+  });
+
+  it.skip("batch update as input (map-reduce)", async () => {
+    const checkpointer = await createCheckpointer();
+    const graph = new StateGraph(
+      Annotation.Root({
+        foo: Annotation<string>,
+        tasks: Annotation<number[]>({
+          default: () => [],
+          reducer: (acc, task: number | number[]) => [
+            ...acc,
+            ...(Array.isArray(task) ? task : [task]),
+          ],
+        }),
+      })
+    )
+      .addNode("agent", () => ({ foo: "agent" }))
+      .addNode(
+        "map",
+        () => {
+          return new Command({
+            goto: [
+              new Send("task", { index: 0 }),
+              new Send("task", { index: 1 }),
+              new Send("task", { index: 2 }),
+            ],
+            update: { foo: "map" },
+          });
+        },
+        { ends: ["task"] }
+      )
+      .addNode("task", (task: { index: number }) => ({
+        tasks: [task.index],
+      }))
+      .addEdge(START, "agent")
+      .addEdge("agent", "map")
+      .compile({ checkpointer });
+
     expect(
-      newHistory.map((i) => ({ values: i.values, next: i.next }))
-    ).toMatchObject(history.map((i) => ({ values: i.values, next: i.next })));
+      await graph.invoke({ foo: "input" }, { configurable: { thread_id: "1" } })
+    ).toEqual({ foo: "map", tasks: [0, 1, 2] });
+
+    const mapSnapshot = (i: StateSnapshot) => ({
+      values: i.values,
+      next: i.next,
+      step: i.metadata?.step,
+      tasks: i.tasks.map((t) => t.name),
+    });
+
+    const history = await gatherIterator(
+      graph.getStateHistory({ configurable: { thread_id: "1" } })
+    );
+
+    // now clone the thread
+    await graph.bulkUpdateState({ configurable: { thread_id: "2" } }, [
+      // first turn
+      { updates: [{ values: { foo: "input" }, asNode: "__input__" }] },
+      { updates: [{ values: { foo: "input" }, asNode: "__start__" }] },
+      { updates: [{ values: { foo: "agent", tasks: [] }, asNode: "agent" }] },
+      {
+        updates: [
+          {
+            command: new Command({
+              goto: [
+                new Send("task", { index: 0 }),
+                new Send("task", { index: 1 }),
+                new Send("task", { index: 2 }),
+              ],
+              update: { foo: "map" },
+            }),
+            asNode: "map",
+          },
+        ],
+      },
+      {
+        updates: [
+          { values: { tasks: [0] }, asNode: "task" },
+          { values: { tasks: [1] }, asNode: "task" },
+          { values: { tasks: [2] }, asNode: "task" },
+        ],
+      },
+    ]);
+
+    const state = await graph.getState({ configurable: { thread_id: "2" } });
+    expect(state.values).toEqual({ foo: "map", tasks: [0, 1, 2] });
+
+    const newHistory = await gatherIterator(
+      graph.getStateHistory({ configurable: { thread_id: "2" } })
+    );
+
+    expect(newHistory.map(mapSnapshot)).toMatchObject(history.map(mapSnapshot));
   });
 }
 


### PR DESCRIPTION
- Add option to submit an update as input, creates a `source: input` checkpoint that will contain `__start__` task, which can be populated with a second update
- Also adds a test for expected usage + map reduce patterns