### PR TITLE
feat(langgraph): add Zod support for state definition / config schema

### DIFF
--- a/libs/langgraph-swarm/src/swarm.ts
+++ b/libs/langgraph-swarm/src/swarm.ts
@@ -130,7 +130,8 @@ const createSwarm = <
     agentNames.add(agent.name);
   }
 
-  const builder = new StateGraph(stateSchema ?? SwarmState);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const builder = new StateGraph<any>(stateSchema ?? SwarmState);
 
   addActiveAgentRouter(builder, {
     routeTo: [...agentNames],

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -37,7 +37,13 @@
     "zod": "^3.23.8"
   },
   "peerDependencies": {
-    "@langchain/core": ">=0.2.36 <0.3.0 || >=0.3.40 < 0.4.0"
+    "@langchain/core": ">=0.2.36 <0.3.0 || >=0.3.40 < 0.4.0",
+    "zod-to-json-schema": "^3.x"
+  },
+  "peerDependenciesMeta": {
+    "zod-to-json-schema": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/libs/langgraph/src/graph/state.ts
+++ b/libs/langgraph/src/graph/state.ts
@@ -57,7 +57,7 @@ import {
   getChannelsFromZod,
   isAnyZodObject,
   ZodToStateDefinition,
-} from "./zod.js";
+} from "./zod/state.js";
 
 const ROOT = "__root__";
 
@@ -195,6 +195,9 @@ export class StateGraph<
   _schemaDefinition: StateDefinition;
 
   /** @internal */
+  _schemaRuntimeDefinition: AnyZodObject | undefined;
+
+  /** @internal */
   _inputDefinition: I;
 
   /** @internal */
@@ -271,6 +274,7 @@ export class StateGraph<
       this._schemaDefinition = spec;
     } else if (isAnyZodObject(fields)) {
       this._schemaDefinition = getChannelsFromZod(fields);
+      this._schemaRuntimeDefinition = fields;
     } else {
       throw new Error("Invalid StateGraph input.");
     }

--- a/libs/langgraph/src/graph/zod.ts
+++ b/libs/langgraph/src/graph/zod.ts
@@ -1,42 +1,26 @@
-import z from "zod";
-
-import { RunnableLike } from "@langchain/core/runnables";
-import { BinaryOperator, BinaryOperatorAggregate } from "../channels/binop.js";
-import { LastValue } from "../channels/last_value.js";
+import * as z from "zod";
 import { BaseChannel } from "../channels/base.js";
-import {
-  Annotation,
-  AnnotationRoot,
-  StateDefinition,
-  StateType,
-  UpdateType,
-} from "./annotation.js";
-import { START } from "../constants.js";
-import {
-  StateGraphAddNodeOptions,
-  StateGraphArgs,
-  StateGraphNodeSpec,
-} from "./state.js";
-import { Graph } from "./graph.js";
-import { LangGraphRunnableConfig } from "../web.js";
-
-export interface Meta<ValueType, UpdateType = ValueType> {
-  metadata?: Record<string, unknown>;
-  reducer?: BinaryOperator<ValueType, UpdateType>;
-  default?: () => ValueType;
-}
+import { BinaryOperatorAggregate } from "../channels/binop.js";
+import { LastValue } from "../channels/last_value.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const META_MAP = new WeakMap<z.ZodType, Meta<any, any>>();
 
-type ExtraType<ValueType, UpdateType = ValueType> = z.ZodType<
-  ValueType | undefined
-> & { "~meta": Meta<ValueType, UpdateType> };
+export interface Meta<ValueType, UpdateType = ValueType> {
+  metadata?: Record<string, unknown>;
+  reducer?: {
+    schema?: z.ZodType<UpdateType>;
+    fn: (a: ValueType, b: UpdateType) => ValueType;
+  };
+  default?: () => ValueType;
+}
+
+export type AnyZodObject = z.ZodObject<z.ZodRawShape>;
 
 export function extra<ValueType, UpdateType = ValueType>(
   schema: z.ZodType<ValueType | undefined>,
   meta: Meta<ValueType, UpdateType>
-): ExtraType<ValueType, UpdateType> {
+): z.ZodType<ValueType, z.ZodTypeDef, UpdateType> {
   if (meta.reducer && !meta.default) {
     const defaultValue =
       // eslint-disable-next-line no-instanceof/no-instanceof
@@ -47,7 +31,7 @@ export function extra<ValueType, UpdateType = ValueType>(
     }
   }
   META_MAP.set(schema, meta);
-  return schema as ExtraType<ValueType, UpdateType>;
+  return schema as z.ZodType<ValueType, z.ZodTypeDef, UpdateType>;
 }
 
 export function getMeta<ValueType, UpdateType = ValueType>(
@@ -56,11 +40,19 @@ export function getMeta<ValueType, UpdateType = ValueType>(
   return META_MAP.get(schema);
 }
 
-type Channels<T extends z.ZodRawShape> = {
-  [key in keyof T]: BaseChannel<z.infer<T[key]>>;
+export type ZodToStateDefinition<T extends AnyZodObject> = {
+  [key in keyof T["shape"]]: T["shape"][key] extends z.ZodType<
+    infer V,
+    z.ZodTypeDef,
+    infer U
+  >
+    ? BaseChannel<V, U>
+    : never;
 };
 
-export function getChannels<T extends z.ZodRawShape>(schema: z.ZodObject<T>) {
+export function getChannelsFromZod<T extends z.ZodRawShape>(
+  schema: z.ZodObject<T>
+): ZodToStateDefinition<z.ZodObject<T>> {
   const channels = {} as Record<string, BaseChannel>;
   for (const key in schema.shape) {
     if (Object.prototype.hasOwnProperty.call(schema.shape, key)) {
@@ -68,7 +60,7 @@ export function getChannels<T extends z.ZodRawShape>(schema: z.ZodObject<T>) {
       const meta = getMeta(keySchema);
       if (meta?.reducer) {
         channels[key] = new BinaryOperatorAggregate<z.infer<T[typeof key]>>(
-          meta.reducer,
+          meta.reducer.fn,
           meta.default
         );
       } else {
@@ -76,81 +68,18 @@ export function getChannels<T extends z.ZodRawShape>(schema: z.ZodObject<T>) {
       }
     }
   }
-  return channels;
+  return channels as ZodToStateDefinition<z.ZodObject<T>>;
 }
 
-type ZodToStateDefinition<T extends z.ZodObject<z.ZodRawShape>> = {
-  [key in keyof T["shape"]]: T["shape"][key] extends ExtraType<infer V, infer U>
-    ? BaseChannel<V, U>
-    : T["shape"][key] extends z.ZodType<infer V>
-    ? BaseChannel<V>
-    : never;
-};
-
-type AnyZodObject = z.ZodObject<z.ZodRawShape>;
-type SDZod = StateDefinition | AnyZodObject;
-
-type ToStateDefinition<T extends SDZod> = T extends z.ZodObject<z.ZodRawShape>
-  ? ZodToStateDefinition<T>
-  : T;
-
-// Demo usage
-class ZodStateGraph<
-  SD extends SDZod,
-  S = SD extends SDZod ? StateType<ToStateDefinition<SD>> : SD,
-  U = SD extends SDZod ? UpdateType<ToStateDefinition<SD>> : Partial<S>,
-  N extends string = typeof START,
-  I extends SDZod = SD extends StateDefinition ? SD : StateDefinition,
-  O extends SDZod = SD extends StateDefinition ? SD : StateDefinition,
-  C extends SDZod = StateDefinition
-> extends Graph<N, S, U, StateGraphNodeSpec<S, U>, ToStateDefinition<C>> {
-  constructor(
-    state: SD extends AnyZodObject
-      ? SD
-      : SD extends StateDefinition
-      ? SD
-      : StateGraphArgs<S>,
-    configSchema?: C | AnnotationRoot<ToStateDefinition<C>>
-  ) {
-    super();
-  }
-
-  override addNode<K extends string, NodeInput = S>(
-    key: K,
-    action: RunnableLike<
-      NodeInput,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      U extends object ? U & Record<string, any> : U,
-      LangGraphRunnableConfig<StateType<ToStateDefinition<C>>>
-    >,
-    options?: StateGraphAddNodeOptions
-  ): ZodStateGraph<SD, S, U, N | K, I, O, C> {
-    return this as ZodStateGraph<SD, S, U, N | K, I, O, C>;
-  }
-}
-
-const oldState = Annotation.Root({
-  name: Annotation<string>,
-});
-
-const zodState = z.object({
-  name: z.string(),
-  messages: extra(z.array(z.string()), {
-    reducer: (left: string[], right: string | string[]) => [
-      ...left,
-      ...(Array.isArray(right) ? right : [right]),
-    ],
+const schema = z.object({
+  a: z.number(),
+  b: extra(z.array(z.number()), {
     default: () => [],
-    metadata: {},
+    reducer: {
+      schema: z.union([z.number(), z.array(z.number())]),
+      fn: (a, b) => [...a, ...(Array.isArray(b) ? b : [b])],
+    },
   }),
 });
 
-const graph = new ZodStateGraph(zodState, z.object({ name: z.string() }))
-  .addNode("text", (state) => {
-    return { messages: ["Hello"] };
-  })
-  .compile();
-
-// TODO
-// - [ ] Config Schema
-// - [ ] Add support for zod schema with default value
+type X = ZodToStateDefinition<typeof schema>;

--- a/libs/langgraph/src/graph/zod.ts
+++ b/libs/langgraph/src/graph/zod.ts
@@ -1,0 +1,156 @@
+import z from "zod";
+
+import { RunnableLike } from "@langchain/core/runnables";
+import { BinaryOperator, BinaryOperatorAggregate } from "../channels/binop.js";
+import { LastValue } from "../channels/last_value.js";
+import { BaseChannel } from "../channels/base.js";
+import {
+  Annotation,
+  AnnotationRoot,
+  StateDefinition,
+  StateType,
+  UpdateType,
+} from "./annotation.js";
+import { START } from "../constants.js";
+import {
+  StateGraphAddNodeOptions,
+  StateGraphArgs,
+  StateGraphNodeSpec,
+} from "./state.js";
+import { Graph } from "./graph.js";
+import { LangGraphRunnableConfig } from "../web.js";
+
+export interface Meta<ValueType, UpdateType = ValueType> {
+  metadata?: Record<string, unknown>;
+  reducer?: BinaryOperator<ValueType, UpdateType>;
+  default?: () => ValueType;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const META_MAP = new WeakMap<z.ZodType, Meta<any, any>>();
+
+type ExtraType<ValueType, UpdateType = ValueType> = z.ZodType<
+  ValueType | undefined
+> & { "~meta": Meta<ValueType, UpdateType> };
+
+export function extra<ValueType, UpdateType = ValueType>(
+  schema: z.ZodType<ValueType | undefined>,
+  meta: Meta<ValueType, UpdateType>
+): ExtraType<ValueType, UpdateType> {
+  if (meta.reducer && !meta.default) {
+    const defaultValue =
+      // eslint-disable-next-line no-instanceof/no-instanceof
+      schema instanceof z.ZodDefault ? schema._def.defaultValue : undefined;
+    if (defaultValue) {
+      // eslint-disable-next-line no-param-reassign
+      meta.default = defaultValue;
+    }
+  }
+  META_MAP.set(schema, meta);
+  return schema as ExtraType<ValueType, UpdateType>;
+}
+
+export function getMeta<ValueType, UpdateType = ValueType>(
+  schema: z.ZodType<ValueType>
+): Meta<ValueType, UpdateType> | undefined {
+  return META_MAP.get(schema);
+}
+
+type Channels<T extends z.ZodRawShape> = {
+  [key in keyof T]: BaseChannel<z.infer<T[key]>>;
+};
+
+export function getChannels<T extends z.ZodRawShape>(schema: z.ZodObject<T>) {
+  const channels = {} as Record<string, BaseChannel>;
+  for (const key in schema.shape) {
+    if (Object.prototype.hasOwnProperty.call(schema.shape, key)) {
+      const keySchema = schema.shape[key];
+      const meta = getMeta(keySchema);
+      if (meta?.reducer) {
+        channels[key] = new BinaryOperatorAggregate<z.infer<T[typeof key]>>(
+          meta.reducer,
+          meta.default
+        );
+      } else {
+        channels[key] = new LastValue();
+      }
+    }
+  }
+  return channels;
+}
+
+type ZodToStateDefinition<T extends z.ZodObject<z.ZodRawShape>> = {
+  [key in keyof T["shape"]]: T["shape"][key] extends ExtraType<infer V, infer U>
+    ? BaseChannel<V, U>
+    : T["shape"][key] extends z.ZodType<infer V>
+    ? BaseChannel<V>
+    : never;
+};
+
+type AnyZodObject = z.ZodObject<z.ZodRawShape>;
+type SDZod = StateDefinition | AnyZodObject;
+
+type ToStateDefinition<T extends SDZod> = T extends z.ZodObject<z.ZodRawShape>
+  ? ZodToStateDefinition<T>
+  : T;
+
+// Demo usage
+class ZodStateGraph<
+  SD extends SDZod,
+  S = SD extends SDZod ? StateType<ToStateDefinition<SD>> : SD,
+  U = SD extends SDZod ? UpdateType<ToStateDefinition<SD>> : Partial<S>,
+  N extends string = typeof START,
+  I extends SDZod = SD extends StateDefinition ? SD : StateDefinition,
+  O extends SDZod = SD extends StateDefinition ? SD : StateDefinition,
+  C extends SDZod = StateDefinition
+> extends Graph<N, S, U, StateGraphNodeSpec<S, U>, ToStateDefinition<C>> {
+  constructor(
+    state: SD extends AnyZodObject
+      ? SD
+      : SD extends StateDefinition
+      ? SD
+      : StateGraphArgs<S>,
+    configSchema?: C | AnnotationRoot<ToStateDefinition<C>>
+  ) {
+    super();
+  }
+
+  override addNode<K extends string, NodeInput = S>(
+    key: K,
+    action: RunnableLike<
+      NodeInput,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      U extends object ? U & Record<string, any> : U,
+      LangGraphRunnableConfig<StateType<ToStateDefinition<C>>>
+    >,
+    options?: StateGraphAddNodeOptions
+  ): ZodStateGraph<SD, S, U, N | K, I, O, C> {
+    return this as ZodStateGraph<SD, S, U, N | K, I, O, C>;
+  }
+}
+
+const oldState = Annotation.Root({
+  name: Annotation<string>,
+});
+
+const zodState = z.object({
+  name: z.string(),
+  messages: extra(z.array(z.string()), {
+    reducer: (left: string[], right: string | string[]) => [
+      ...left,
+      ...(Array.isArray(right) ? right : [right]),
+    ],
+    default: () => [],
+    metadata: {},
+  }),
+});
+
+const graph = new ZodStateGraph(zodState, z.object({ name: z.string() }))
+  .addNode("text", (state) => {
+    return { messages: ["Hello"] };
+  })
+  .compile();
+
+// TODO
+// - [ ] Config Schema
+// - [ ] Add support for zod schema with default value

--- a/libs/langgraph/src/graph/zod.ts
+++ b/libs/langgraph/src/graph/zod.ts
@@ -71,15 +71,7 @@ export function getChannelsFromZod<T extends z.ZodRawShape>(
   return channels as ZodToStateDefinition<z.ZodObject<T>>;
 }
 
-const schema = z.object({
-  a: z.number(),
-  b: extra(z.array(z.number()), {
-    default: () => [],
-    reducer: {
-      schema: z.union([z.number(), z.array(z.number())]),
-      fn: (a, b) => [...a, ...(Array.isArray(b) ? b : [b])],
-    },
-  }),
-});
-
-type X = ZodToStateDefinition<typeof schema>;
+export const isAnyZodObject = (value: unknown): value is AnyZodObject => {
+  // eslint-disable-next-line no-instanceof/no-instanceof
+  return value instanceof z.ZodObject;
+};

--- a/libs/langgraph/src/graph/zod/schema.ts
+++ b/libs/langgraph/src/graph/zod/schema.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { getMeta } from "./state.js";
+
+const UPDATE_TYPE_CACHE = new WeakMap<z.AnyZodObject, z.AnyZodObject>();
+
+export function getUpdateTypeSchema(schema: z.AnyZodObject) {
+  const updateSchema = (() => {
+    if (UPDATE_TYPE_CACHE.has(schema)) UPDATE_TYPE_CACHE.get(schema);
+
+    const newSchema = z.object({
+      ...Object.fromEntries(
+        Object.entries(schema.shape as Record<string, z.ZodTypeAny>).map(
+          ([key, value]): [string, z.ZodTypeAny] => [
+            key,
+            getMeta(value)?.reducer?.schema ?? value,
+          ]
+        )
+      ),
+    });
+
+    UPDATE_TYPE_CACHE.set(schema, newSchema);
+    return newSchema;
+  })();
+
+  return zodToJsonSchema(updateSchema);
+}
+
+export function getStateTypeSchema(schema: z.AnyZodObject) {
+  return zodToJsonSchema(schema);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2027,6 +2027,10 @@ __metadata:
     zod-to-json-schema: ^3.22.4
   peerDependencies:
     "@langchain/core": ">=0.2.36 <0.3.0 || >=0.3.40 < 0.4.0"
+    zod-to-json-schema: ^3.x
+  peerDependenciesMeta:
+    zod-to-json-schema:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This PR adds an alternative method of defining schema of an agent, with the primary goal having the ability to extract the schema of the graph in runtime, rather than relying on `tsc`

Follow-up PRs:
- https://github.com/langchain-ai/langgraphjs/pull/1024
- https://github.com/langchain-ai/langgraphjs/pull/1025
- https://github.com/langchain-ai/langgraphjs/pull/1029