### PR TITLE
feat(pregel): add Zod config schema + langgraph studio meta properties

### DIFF
--- a/libs/langgraph/src/graph/zod/schema.ts
+++ b/libs/langgraph/src/graph/zod/schema.ts
@@ -3,27 +3,74 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import { getMeta } from "./state.js";
 
 const UPDATE_TYPE_CACHE = new WeakMap<z.AnyZodObject, z.AnyZodObject>();
+const DESCRIPTION_PREFIX = "lg:";
 
-export function getUpdateTypeSchema(schema: z.AnyZodObject) {
+export function getUpdateTypeSchema(shape: z.AnyZodObject) {
   const updateSchema = (() => {
-    if (UPDATE_TYPE_CACHE.has(schema)) UPDATE_TYPE_CACHE.get(schema);
+    if (UPDATE_TYPE_CACHE.has(shape)) UPDATE_TYPE_CACHE.get(shape);
 
     const newSchema = z.object({
       ...Object.fromEntries(
-        Object.entries(schema.shape as Record<string, z.ZodTypeAny>).map(
-          ([key, value]): [string, z.ZodTypeAny] => [
-            key,
-            getMeta(value)?.reducer?.schema ?? value,
-          ]
+        Object.entries(shape.shape as Record<string, z.ZodTypeAny>).map(
+          ([key, value]): [string, z.ZodTypeAny] => {
+            const meta = getMeta(value);
+            let finalSchema = meta?.reducer?.schema ?? value;
+
+            finalSchema = finalSchema.describe(
+              `${DESCRIPTION_PREFIX}${JSON.stringify({
+                ...meta?.jsonSchemaExtra,
+                description: finalSchema.description ?? value.description,
+              })}`
+            );
+
+            return [key, finalSchema];
+          }
         )
       ),
     });
 
-    UPDATE_TYPE_CACHE.set(schema, newSchema);
+    UPDATE_TYPE_CACHE.set(shape, newSchema);
     return newSchema;
   })();
 
-  return zodToJsonSchema(updateSchema);
+  const schema = zodToJsonSchema(updateSchema);
+
+  const findAndReplaceSchema = (schema: unknown): unknown => {
+    if (Array.isArray(schema)) {
+      return schema.map(findAndReplaceSchema);
+    }
+
+    if (typeof schema === "object" && schema != null) {
+      const output = Object.fromEntries(
+        Object.entries(schema).map(([key, value]) => [
+          key,
+          findAndReplaceSchema(value),
+        ])
+      );
+
+      if (
+        "description" in output &&
+        typeof output.description === "string" &&
+        output.description.startsWith(DESCRIPTION_PREFIX)
+      ) {
+        Object.assign(
+          output,
+          JSON.parse(output.description.slice(DESCRIPTION_PREFIX.length))
+        );
+
+        if (output.description == null) delete output.description;
+      }
+
+      return output;
+    }
+
+    return schema;
+  };
+  return findAndReplaceSchema(schema);
+}
+
+export function getConfigTypeSchema(schema: z.AnyZodObject) {
+  return getUpdateTypeSchema(schema);
 }
 
 export function getStateTypeSchema(schema: z.AnyZodObject) {

--- a/libs/langgraph/src/graph/zod/state.ts
+++ b/libs/langgraph/src/graph/zod/state.ts
@@ -7,7 +7,12 @@ import { LastValue } from "../../channels/last_value.js";
 const META_MAP = new WeakMap<z.ZodType, Meta<any, any>>();
 
 export interface Meta<ValueType, UpdateType = ValueType> {
-  metadata?: Record<string, unknown>;
+  jsonSchemaExtra?: {
+    langgraph_nodes?: string[];
+    langgraph_type?: "prompt";
+
+    [key: string]: unknown;
+  };
   reducer?: {
     schema?: z.ZodType<UpdateType>;
     fn: (a: ValueType, b: UpdateType) => ValueType;

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -1724,8 +1724,26 @@ export class Pregel<
     };
   }
 
+  /**
+   * Validates the input for the graph.
+   * @param input - The input to validate
+   * @returns The validated input
+   * @internal
+   */
   protected async _validateInput(input: PregelInputType) {
     return input;
+  }
+
+  /**
+   * Validates the configurable options for the graph.
+   * @param config - The configurable options to validate
+   * @returns The validated configurable options
+   * @internal
+   */
+  protected async _validateConfigurable(
+    config: Partial<LangGraphRunnableConfig["configurable"]>
+  ): Promise<LangGraphRunnableConfig["configurable"]> {
+    return config;
   }
 
   /**
@@ -1774,6 +1792,8 @@ export class Pregel<
       store,
       streamModeSingle,
     ] = this._defaults(restConfig);
+
+    config.configurable = await this._validateConfigurable(config.configurable);
 
     const stream = new IterableReadableWritableStream({
       modes: new Set(streamMode),


### PR DESCRIPTION
Rely on parsing and post-processing description, similar to how `jsonDescription` works in `zod-to-json-schema`. Avoiding use of `postprocess` for now: https://github.com/StefanTerdell/zod-to-json-schema?tab=readme-ov-file#using-postprocess-for-including-examples-and-other-meta

Related PRs
- https://github.com/langchain-ai/langgraphjs/pull/1029