### PR TITLE
fix(langgraph): allow setting edges from START on Graph

### DIFF
--- a/libs/langgraph/src/graph/graph.ts
+++ b/libs/langgraph/src/graph/graph.ts
@@ -169,7 +169,7 @@ export type AddNodeOptions = {
 };
 
 export class Graph<
-  N extends string = typeof END,
+  N extends string = typeof START | typeof END,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   RunInput = any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Fixes type checks when adding edges on `Graph`