### PR TITLE
feat(cua): add hyperbrowser provider for cua agent

### DIFF
--- a/libs/langgraph-cua/package.json
+++ b/libs/langgraph-cua/package.json
@@ -32,6 +32,8 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
+    "@hyperbrowser/sdk": "^0.40.0",
+    "playwright-core": "^1.51.1",
     "scrapybara": "^2.4.4",
     "zod": "^3.23.8"
   },

--- a/libs/langgraph-cua/src/index.ts
+++ b/libs/langgraph-cua/src/index.ts
@@ -15,6 +15,7 @@ import {
   CUAAnnotation,
   CUAConfigurable,
   CUAUpdate,
+  Provider,
 } from "./types.js";
 import { getToolOutputs, isComputerCallToolMessage } from "./utils.js";
 
@@ -64,11 +65,31 @@ interface CreateCuaParams<
   StateModifier extends AnnotationRoot<any> = typeof CUAAnnotation
 > {
   /**
+   * The provider to use for the browser instance.
+   * @default "scrapybara"
+   */
+  provider?: Provider;
+
+  /**
    * The API key to use for Scrapybara.
    * This can be provided in the configuration, or set as an environment variable (SCRAPYBARA_API_KEY).
    * @default process.env.SCRAPYBARA_API_KEY
    */
   scrapybaraApiKey?: string;
+
+  /**
+   * The API key to use for Hyperbrowser.
+   * This can be provided in the configuration, or set as an environment variable (HYPERBROWSER_API_KEY).
+   * @default process.env.HYPERBROWSER_API_KEY
+   */
+  hyperbrowserApiKey?: string;
+
+  /**
+   * Parameters to use for configuring the Hyperbrowser session, such as proxy usage, screen dimensions, etc.
+   * For more information on the available parameters, see the [Hyperbrowser API documentation](https://docs.hyperbrowser.ai/sessions/overview/session-parameters).
+   * @default undefined
+   */
+  sessionParams?: Record<string, unknown>;
 
   /**
    * The number of hours to keep the virtual machine running before it times out.
@@ -145,7 +166,10 @@ export function createCua<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   StateModifier extends AnnotationRoot<any> = typeof CUAAnnotation
 >({
+  provider = "scrapybara",
   scrapybaraApiKey,
+  hyperbrowserApiKey,
+  sessionParams,
   timeoutHours = 1.0,
   zdrEnabled = false,
   recursionLimit = 100,
@@ -195,7 +219,10 @@ export function createCua<
   // Configure the graph with the provided parameters
   const configuredGraph = cuaGraph.withConfig({
     configurable: {
+      provider,
       scrapybaraApiKey,
+      hyperbrowserApiKey,
+      sessionParams,
       timeoutHours,
       zdrEnabled,
       authStateId,

--- a/libs/langgraph-cua/src/nodes/call-model.ts
+++ b/libs/langgraph-cua/src/nodes/call-model.ts
@@ -33,6 +33,32 @@ const _promptToSysMessage = (prompt: string | SystemMessage | undefined) => {
   return prompt;
 };
 
+const getAvailableTools = (config: LangGraphRunnableConfig) => {
+  const { provider, environment, sessionParams } =
+    getConfigurationWithDefaults(config);
+  if (provider === "scrapybara") {
+    return [
+      {
+        type: "computer_use_preview",
+        display_width: DEFAULT_DISPLAY_WIDTH,
+        display_height: DEFAULT_DISPLAY_HEIGHT,
+        environment: _getOpenAIEnvFromStateEnv(environment),
+      },
+    ];
+  } else if (provider === "hyperbrowser") {
+    return [
+      {
+        type: "computer_use_preview",
+        display_width: sessionParams?.screen?.width ?? DEFAULT_DISPLAY_WIDTH,
+        display_height: sessionParams?.screen?.height ?? DEFAULT_DISPLAY_HEIGHT,
+        environment: "browser",
+      },
+    ];
+  } else {
+    throw new Error(`Invalid provider: ${provider}`);
+  }
+};
+
 /**
  * Invokes the computer preview model with the given messages.
  *
@@ -60,14 +86,7 @@ export async function callModel(
     model: "computer-use-preview",
     useResponsesApi: true,
   })
-    .bindTools([
-      {
-        type: "computer_use_preview",
-        display_width: DEFAULT_DISPLAY_WIDTH,
-        display_height: DEFAULT_DISPLAY_HEIGHT,
-        environment: _getOpenAIEnvFromStateEnv(configuration.environment),
-      },
-    ])
+    .bindTools(getAvailableTools(config))
     .bind({
       truncation: "auto",
       previous_response_id: previousResponseId,

--- a/libs/langgraph-cua/src/nodes/create-vm-instance.ts
+++ b/libs/langgraph-cua/src/nodes/create-vm-instance.ts
@@ -1,18 +1,62 @@
 import { LangGraphRunnableConfig } from "@langchain/langgraph";
+import { chromium } from "playwright-core";
 import { UbuntuInstance, BrowserInstance, WindowsInstance } from "scrapybara";
+import { SessionDetail } from "@hyperbrowser/sdk/types";
 import { CUAState, CUAUpdate, getConfigurationWithDefaults } from "../types.js";
-import { getScrapybaraClient } from "../utils.js";
+import { getHyperbrowserClient, getScrapybaraClient } from "../utils.js";
 
-export async function createVMInstance(
+async function createHyperbrowserInstance(
   state: CUAState,
   config: LangGraphRunnableConfig
 ): Promise<CUAUpdate> {
-  const { instanceId } = state;
-  if (instanceId) {
-    // Instance already exists, no need to initialize
-    return {};
+  const { hyperbrowserApiKey, sessionParams } =
+    getConfigurationWithDefaults(config);
+  let { browserState } = state;
+
+  if (!hyperbrowserApiKey) {
+    throw new Error(
+      "Hyperbrowser API key not provided. Please provide one in the configurable fields, or set it as an environment variable (HYPERBROWSER_API_KEY)"
+    );
   }
 
+  const client = getHyperbrowserClient(hyperbrowserApiKey);
+  const session: SessionDetail = await client.sessions.create(sessionParams);
+
+  if (!browserState && session.wsEndpoint) {
+    const browser = await chromium.connectOverCDP(
+      `${session.wsEndpoint}&keepAlive=true`
+    );
+    const currPage = browser.contexts()[0].pages()[0];
+    if (currPage.url() === "about:blank") {
+      await currPage.goto("https://www.google.com");
+    }
+    browserState = {
+      browser,
+      currentPage: currPage,
+    };
+  }
+
+  if (!state.streamUrl) {
+    // If the streamUrl is not yet defined in state, fetch it, then write to the custom stream
+    // so that it's made accessible to the client (or whatever is reading the stream) before any actions are taken.
+    const streamUrl = session.liveUrl;
+    return {
+      instanceId: session.id,
+      streamUrl,
+      browserState,
+    };
+  }
+
+  return {
+    instanceId: session.id,
+    browserState,
+  };
+}
+
+async function createScrapybaraInstance(
+  state: CUAState,
+  config: LangGraphRunnableConfig
+): Promise<CUAUpdate> {
   const { scrapybaraApiKey, timeoutHours, environment, blockedDomains } =
     getConfigurationWithDefaults(config);
   if (!scrapybaraApiKey) {
@@ -55,4 +99,23 @@ export async function createVMInstance(
   return {
     instanceId: instance.id,
   };
+}
+
+export async function createVMInstance(
+  state: CUAState,
+  config: LangGraphRunnableConfig
+): Promise<CUAUpdate> {
+  const { instanceId } = state;
+  if (instanceId) {
+    // Instance already exists, no need to initialize
+    return {};
+  }
+  const { provider } = getConfigurationWithDefaults(config);
+  if (provider === "scrapybara") {
+    return createScrapybaraInstance(state, config);
+  } else if (provider === "hyperbrowser") {
+    return createHyperbrowserInstance(state, config);
+  } else {
+    throw new Error(`Unsupported provider: ${provider}`);
+  }
 }

--- a/libs/langgraph-cua/src/nodes/take-browser-action.ts
+++ b/libs/langgraph-cua/src/nodes/take-browser-action.ts
@@ -1,0 +1,240 @@
+import { LangGraphRunnableConfig } from "@langchain/langgraph";
+import { BaseMessageLike } from "@langchain/core/messages";
+import { Page } from "playwright-core";
+import { CUAState, CUAUpdate } from "../types.js";
+import { getHyperbrowserInstance, getToolOutputs } from "../utils.js";
+
+const sleep = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+export const CUA_KEY_TO_PLAYWRIGHT_KEY = {
+  "/": "Divide",
+  "\\": "Backslash",
+  alt: "Alt",
+  arrowdown: "ArrowDown",
+  arrowleft: "ArrowLeft",
+  arrowright: "ArrowRight",
+  arrowup: "ArrowUp",
+  backspace: "Backspace",
+  capslock: "CapsLock",
+  cmd: "Meta",
+  ctrl: "Control",
+  delete: "Delete",
+  end: "End",
+  enter: "Enter",
+  esc: "Escape",
+  home: "Home",
+  insert: "Insert",
+  option: "Alt",
+  pagedown: "PageDown",
+  pageup: "PageUp",
+  shift: "Shift",
+  space: " ",
+  super: "Meta",
+  tab: "Tab",
+  win: "Meta",
+};
+
+const DUMMY_SCREENSHOT =
+  "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8AKp//2Q==";
+
+const translateKey = (key: string): string => {
+  const lowerKey = key.toLowerCase();
+  return lowerKey in CUA_KEY_TO_PLAYWRIGHT_KEY
+    ? CUA_KEY_TO_PLAYWRIGHT_KEY[
+        lowerKey as keyof typeof CUA_KEY_TO_PLAYWRIGHT_KEY
+      ]
+    : key;
+};
+
+export async function takeHyperbrowserAction(
+  state: CUAState,
+  config: LangGraphRunnableConfig
+): Promise<CUAUpdate> {
+  if (!state.instanceId) {
+    throw new Error("Can not take computer action without an instance ID.");
+  }
+
+  const message = state.messages[state.messages.length - 1];
+  const toolOutputs = getToolOutputs(message);
+  if (!toolOutputs?.length) {
+    // This should never happen, but include the check for proper type narrowing.
+    throw new Error(
+      "Can not take computer action without a computer call in the last message."
+    );
+  }
+
+  const instance = await getHyperbrowserInstance(state.instanceId, config);
+
+  let { streamUrl, browserState } = state;
+
+  if (!browserState) {
+    throw new Error("Browser state not found.");
+  }
+  const { browser } = browserState;
+  if (!browser) {
+    throw new Error("Browser not found.");
+  }
+  const currentContext = browser.contexts()[0];
+  let page = browserState.currentPage ?? currentContext.pages()[0];
+
+  currentContext.on("page", (newPage: Page) => {
+    page = newPage;
+    if (!browserState) {
+      browserState = {
+        browser,
+        currentPage: newPage,
+      };
+    } else {
+      browserState.currentPage = newPage;
+    }
+  });
+
+  if (!streamUrl) {
+    streamUrl = instance.liveUrl;
+    config.writer?.({
+      streamUrl,
+    });
+  }
+
+  const output = toolOutputs[toolOutputs.length - 1];
+  const { action, call_id } = output;
+  let computerCallToolMsg: BaseMessageLike | undefined;
+  const actionType = action.type;
+
+  try {
+    switch (actionType) {
+      case "click": {
+        const { x, y, button } = action;
+        switch (button) {
+          case "back":
+            await page.goBack({ timeout: 30_000 });
+            break;
+          case "forward":
+            await page.goForward({ timeout: 30_000 });
+            break;
+          case "wheel":
+            await page.mouse.wheel(x, y);
+            break;
+          case "left":
+            await page.mouse.click(x, y, { button: "left" });
+            break;
+          case "right":
+            await page.mouse.click(x, y, { button: "right" });
+            break;
+          default:
+            throw new Error(`Unknown button: ${button}`);
+        }
+        break;
+      }
+
+      case "scroll": {
+        const { x, y, scroll_x: scrollX, scroll_y: scrollY } = action;
+        await page.mouse.move(x, y);
+        await page.evaluate(`window.scrollBy(${scrollX}, ${scrollY})`);
+        break;
+      }
+
+      case "keypress": {
+        const { keys } = action;
+        const mappedKeys = keys.map((key) => translateKey(key));
+        for (const key of mappedKeys) {
+          await page.keyboard.down(key);
+        }
+        for (const key of [...mappedKeys].reverse()) {
+          await page.keyboard.up(key);
+        }
+        break;
+      }
+
+      case "type": {
+        const { text } = action;
+        // console.log(`Action: type text '${text}'`);
+        await page.keyboard.type(text);
+        break;
+      }
+
+      case "wait": {
+        // console.log(`Action: wait`);
+        await page.waitForTimeout(2000);
+        break;
+      }
+
+      case "screenshot": {
+        // Nothing to do as screenshot is taken at each turn
+        // console.log(`Action: screenshot`);
+        break;
+      }
+
+      case "double_click": {
+        const { x, y } = action;
+        // console.log(`Action: double click at (${x}, ${y})`);
+        await page.mouse.click(x, y, { button: "left", clickCount: 2 });
+        break;
+      }
+
+      case "drag": {
+        const { path } = action;
+
+        // console.log(`Action: drag with ${path.length} points`);
+
+        if (path.length < 2) {
+          throw new Error(
+            "Invalid drag path: must contain at least a start and end point"
+          );
+        }
+
+        await page.mouse.move(path[0].x, path[0].y);
+        await page.mouse.down();
+
+        for (const { x, y } of path) {
+          await page.mouse.move(x, y);
+          await page.waitForTimeout(40 + Math.floor(Math.random() * 40)); // Random delay between 40-79ms to simulate human dragging
+        }
+
+        await page.mouse.up();
+        break;
+      }
+
+      case "move": {
+        const { x, y } = action;
+        // console.log(`Action: move to (${x}, ${y})`);
+        await page.mouse.move(x, y);
+        break;
+      }
+
+      default:
+        throw new Error(`Unknown action type: ${actionType}`);
+    }
+    await sleep(1_000);
+    const screenshot = await page.screenshot({ timeout: 15_000 });
+    const b64Screenshot = Buffer.from(screenshot).toString("base64");
+    const screenshotUrl = `data:image/png;base64,${b64Screenshot}`;
+    computerCallToolMsg = {
+      type: "tool",
+      tool_call_id: call_id,
+      content: screenshotUrl,
+      additional_kwargs: { type: "computer_call_output" },
+    };
+  } catch (error) {
+    console.error(
+      `\n\nFailed to execute computer call: ${actionType}\n\n`,
+      error
+    );
+    console.error(`Computer call details: ${output}`);
+    computerCallToolMsg = {
+      type: "tool",
+      tool_call_id: call_id,
+      content: `data:image/jpeg;base64,${DUMMY_SCREENSHOT}`,
+      additional_kwargs: { type: "computer_call_output", status: "incomplete" },
+    };
+  }
+  return {
+    messages: computerCallToolMsg ? [computerCallToolMsg] : [],
+    instanceId: instance.id,
+    streamUrl,
+    browserState,
+  };
+}

--- a/libs/langgraph-cua/src/nodes/take-computer-action.ts
+++ b/libs/langgraph-cua/src/nodes/take-computer-action.ts
@@ -7,7 +7,8 @@ import {
 import { LangGraphRunnableConfig } from "@langchain/langgraph";
 import { BaseMessageLike } from "@langchain/core/messages";
 import { CUAState, CUAUpdate, getConfigurationWithDefaults } from "../types.js";
-import { getInstance, getToolOutputs } from "../utils.js";
+import { getScrapybaraInstance, getToolOutputs } from "../utils.js";
+import { takeHyperbrowserAction } from "./take-browser-action.js";
 
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
@@ -45,7 +46,7 @@ const isBrowserInstance = (
 ): instance is BrowserInstance =>
   "authenticate" in instance && typeof instance.authenticate === "function";
 
-export async function takeComputerAction(
+export async function takeScrapybaraAction(
   state: CUAState,
   config: LangGraphRunnableConfig
 ): Promise<CUAUpdate> {
@@ -63,7 +64,7 @@ export async function takeComputerAction(
     );
   }
 
-  const instance = await getInstance(state.instanceId, config);
+  const instance = await getScrapybaraInstance(state.instanceId, config);
 
   let { authenticatedId } = state;
   if (
@@ -188,4 +189,18 @@ export async function takeComputerAction(
     streamUrl,
     authenticatedId,
   };
+}
+
+export async function takeComputerAction(
+  state: CUAState,
+  config: LangGraphRunnableConfig
+): Promise<CUAUpdate> {
+  const { provider } = getConfigurationWithDefaults(config);
+  if (provider === "scrapybara") {
+    return takeScrapybaraAction(state, config);
+  } else if (provider === "hyperbrowser") {
+    return takeHyperbrowserAction(state, config);
+  } else {
+    throw new Error(`Unsupported provider: ${provider}`);
+  }
 }

--- a/libs/langgraph-cua/src/types.ts
+++ b/libs/langgraph-cua/src/types.ts
@@ -5,6 +5,7 @@ import {
   LangGraphRunnableConfig,
   MessagesAnnotation,
 } from "@langchain/langgraph";
+import { Browser, Page } from "playwright-core";
 
 // Copied from the OpenAI example repository
 // https://github.com/openai/openai-cua-sample-app/blob/eb2d58ba77ffd3206d3346d6357093647d29d99c/utils.py#L13
@@ -16,6 +17,8 @@ export const BLOCKED_DOMAINS = [
   "suspiciouspins.com",
   "ilanbigio.com",
 ];
+
+export type Provider = "scrapybara" | "hyperbrowser";
 
 export type CUAEnvironment = "web" | "ubuntu" | "windows";
 
@@ -47,9 +50,26 @@ export const CUAAnnotation = Annotation.Root({
     reducer: (_state, update) => update,
     default: () => undefined,
   }),
+  /**
+   * The state of the browser instance.
+   */
+  browserState: Annotation<
+    { browser: Browser | undefined; currentPage: Page | undefined } | undefined
+  >({
+    reducer: (_state, update) => update,
+    default: () => undefined,
+  }),
 });
 
 export const CUAConfigurable = Annotation.Root({
+  /**
+   * The provider to use for the browser instance.
+   * @default "scrapybara"
+   */
+  provider: Annotation<Provider>({
+    reducer: (_state, update) => update,
+    default: () => "scrapybara",
+  }),
   /**
    * The API key to use for Scrapybara.
    * @default {process.env.SCRAPYBARA_API_KEY}
@@ -57,6 +77,31 @@ export const CUAConfigurable = Annotation.Root({
   scrapybaraApiKey: Annotation<string | undefined>({
     reducer: (_state, update) => update,
     default: () => getEnvironmentVariable("SCRAPYBARA_API_KEY"),
+  }),
+  /**
+   * The API key to use for Hyperbrowser.
+   * @default {process.env.HYPERBROWSER_API_KEY}
+   */
+  hyperbrowserApiKey: Annotation<string | undefined>({
+    reducer: (_state, update) => update,
+    default: () => getEnvironmentVariable("HYPERBROWSER_API_KEY"),
+  }),
+  /**
+   * Parameters to use for configuring the Hyperbrowser session, such as screen dimensions.
+   * For more information on the available parameters, see the [Hyperbrowser API documentation](https://docs.hyperbrowser.ai/sessions/overview/session-parameters).
+   */
+  sessionParams: Annotation<
+    | {
+        screen?: {
+          width: number;
+          height: number;
+        };
+        [key: string]: unknown;
+      }
+    | undefined
+  >({
+    reducer: (_state, update) => update,
+    default: () => undefined,
   }),
   /**
    * The number of hours to keep the virtual machine running before it times out.
@@ -128,9 +173,14 @@ export function getConfigurationWithDefaults(
   config: LangGraphRunnableConfig
 ): typeof CUAConfigurable.State {
   return {
+    provider: config.configurable?.provider ?? "scrapybara",
     scrapybaraApiKey:
       config.configurable?.scrapybaraApiKey ||
       getEnvironmentVariable("SCRAPYBARA_API_KEY"),
+    hyperbrowserApiKey:
+      config.configurable?.hyperbrowserApiKey ||
+      getEnvironmentVariable("HYPERBROWSER_API_KEY"),
+    sessionParams: config.configurable?.sessionParams ?? {},
     timeoutHours: config.configurable?.timeoutHours ?? 1,
     zdrEnabled: config.configurable?.zdrEnabled ?? false,
     environment: config.configurable?.environment ?? "web",

--- a/yarn.lock
+++ b/yarn.lock
@@ -929,6 +929,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hyperbrowser/sdk@npm:^0.40.0":
+  version: 0.40.0
+  resolution: "@hyperbrowser/sdk@npm:0.40.0"
+  dependencies:
+    form-data: ^4.0.1
+    node-fetch: 2.7.0
+    zod: ^3.24.1
+    zod-to-json-schema: ^3.24.1
+  checksum: 95f198979a344e5cb70a4adc706257732c88eabbf8461fda4f23aedb4283ab3d76de449270b2b7c7a119187fd4784442a1b9c157b3e99a0869fa8d751fde9963
+  languageName: node
+  linkType: hard
+
 "@iarna/toml@npm:2.2.5":
   version: 2.2.5
   resolution: "@iarna/toml@npm:2.2.5"
@@ -1897,6 +1909,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@langchain/langgraph-cua@workspace:libs/langgraph-cua"
   dependencies:
+    "@hyperbrowser/sdk": ^0.40.0
     "@jest/globals": ^29.5.0
     "@langchain/langgraph": "workspace:*"
     "@langchain/openai": ^0.4.9
@@ -1919,6 +1932,7 @@ __metadata:
     jest: ^29.5.0
     jest-environment-node: ^29.6.4
     openai: ^4.87.3
+    playwright-core: ^1.51.1
     prettier: ^2.8.3
     release-it: ^17.6.0
     scrapybara: ^2.4.4
@@ -6230,6 +6244,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-set-tostringtag@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "es-set-tostringtag@npm:2.1.0"
+  dependencies:
+    es-errors: ^1.3.0
+    get-intrinsic: ^1.2.6
+    has-tostringtag: ^1.0.2
+    hasown: ^2.0.2
+  checksum: 789f35de4be3dc8d11fdcb91bc26af4ae3e6d602caa93299a8c45cf05d36cc5081454ae2a6d3afa09cceca214b76c046e4f8151e092e6fc7feeb5efb9e794fc6
+  languageName: node
+  linkType: hard
+
 "es-shim-unscopables@npm:^1.0.0, es-shim-unscopables@npm:^1.0.2":
   version: 1.0.2
   resolution: "es-shim-unscopables@npm:1.0.2"
@@ -7285,6 +7311,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"form-data@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "form-data@npm:4.0.2"
+  dependencies:
+    asynckit: ^0.4.0
+    combined-stream: ^1.0.8
+    es-set-tostringtag: ^2.1.0
+    mime-types: ^2.1.12
+  checksum: e887298b22c13c7c9c5a8ba3716f295a479a13ca78bfd855ef11cbce1bcf22bc0ae2062e94808e21d46e5c667664a1a1a8a7f57d7040193c1fefbfb11af58aab
+  languageName: node
+  linkType: hard
+
 "formdata-node@npm:^4.3.2":
   version: 4.4.1
   resolution: "formdata-node@npm:4.4.1"
@@ -7433,7 +7471,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.3.0":
+"get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.2.6, get-intrinsic@npm:^1.3.0":
   version: 1.3.0
   resolution: "get-intrinsic@npm:1.3.0"
   dependencies:
@@ -9937,18 +9975,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:3.3.2":
-  version: 3.3.2
-  resolution: "node-fetch@npm:3.3.2"
-  dependencies:
-    data-uri-to-buffer: ^4.0.0
-    fetch-blob: ^3.1.4
-    formdata-polyfill: ^4.0.10
-  checksum: 06a04095a2ddf05b0830a0d5302699704d59bda3102894ea64c7b9d4c865ecdff2d90fd042df7f5bc40337266961cb6183dcc808ea4f3000d024f422b462da92
-  languageName: node
-  linkType: hard
-
-"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7, node-fetch@npm:^2.7.0":
+"node-fetch@npm:2.7.0, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7, node-fetch@npm:^2.7.0":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:
@@ -9959,6 +9986,17 @@ __metadata:
     encoding:
       optional: true
   checksum: d76d2f5edb451a3f05b15115ec89fc6be39de37c6089f1b6368df03b91e1633fd379a7e01b7ab05089a25034b2023d959b47e59759cb38d88341b2459e89d6e5
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:3.3.2":
+  version: 3.3.2
+  resolution: "node-fetch@npm:3.3.2"
+  dependencies:
+    data-uri-to-buffer: ^4.0.0
+    fetch-blob: ^3.1.4
+    formdata-polyfill: ^4.0.10
+  checksum: 06a04095a2ddf05b0830a0d5302699704d59bda3102894ea64c7b9d4c865ecdff2d90fd042df7f5bc40337266961cb6183dcc808ea4f3000d024f422b462da92
   languageName: node
   linkType: hard
 
@@ -10822,6 +10860,15 @@ __metadata:
   version: 1.3.6
   resolution: "platform@npm:1.3.6"
   checksum: 6f472a09c61d418c7e26c1c16d0bdc029549d512dbec6526216a1e59ec68100d07007d0097dcba69dddad883d6f2a83361b4bdfe0094a3d9a2af24158643d85e
+  languageName: node
+  linkType: hard
+
+"playwright-core@npm:^1.51.1":
+  version: 1.51.1
+  resolution: "playwright-core@npm:1.51.1"
+  bin:
+    playwright-core: cli.js
+  checksum: 1eb37e22e97435a5ed6389b4caa666fbe618348861cae97e67586e20c8fed9ac3d3dc899ff3b9237d0ddfcf087d5b552b80be247e246fc45b75282f96be714bb
   languageName: node
   linkType: hard
 
@@ -13488,6 +13535,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"zod-to-json-schema@npm:^3.24.1":
+  version: 3.24.5
+  resolution: "zod-to-json-schema@npm:3.24.5"
+  peerDependencies:
+    zod: ^3.24.1
+  checksum: dc4e5e4c06e9a5494e4b1d8c8363ac907f9d488f36c8e4923e1e5ac4f91f737722f99200cd92a409551e7456d960734d4cabd37935234ca95e290572468ffc08
+  languageName: node
+  linkType: hard
+
 "zod@npm:^3.22.3, zod@npm:^3.22.4, zod@npm:^3.23.8":
   version: 3.23.8
   resolution: "zod@npm:3.23.8"
@@ -13495,7 +13551,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.24.0":
+"zod@npm:^3.24.0, zod@npm:^3.24.1":
   version: 3.24.2
   resolution: "zod@npm:3.24.2"
   checksum: c02455c09678c5055c636d64f9fcda2424fea0aa46ac7d9681e7f41990bc55f488bcd84b9d7cfef0f6e906f51f55b245239d92a9f726248aa74c5b84edf00c2d


### PR DESCRIPTION
This PR adds Hyperbrowser as an optional provider for using with LangGraph and CUA. It uses [Hyperbrowser](https://docs.hyperbrowser.ai/) browser session and playwright to allow CUA to interact with the browser page. Scrapybara is kept as the default provider.
