### PR TITLE
fix(langgraph): goto + interrupt handling

### DIFF
--- a/libs/langgraph/src/pregel/loop.ts
+++ b/libs/langgraph/src/pregel/loop.ts
@@ -806,6 +806,9 @@ export class PregelLoop {
 
     const { configurable } = this.config;
 
+    // eslint-disable-next-line prefer-destructuring
+    const isResuming = this.isResuming;
+
     // take resume value from parent
     const scratchpad = configurable?.[
       CONFIG_KEY_SCRATCHPAD
@@ -860,7 +863,7 @@ export class PregelLoop {
         this.checkpointerGetNextVersion
       );
     }
-    if (this.isResuming) {
+    if (isResuming) {
       for (const channelName of Object.keys(this.channels)) {
         if (this.checkpoint.channel_versions[channelName] !== undefined) {
           const version = this.checkpoint.channel_versions[channelName];
@@ -923,7 +926,7 @@ export class PregelLoop {
     }
     if (!this.isNested) {
       this.config = patchConfigurable(this.config, {
-        [CONFIG_KEY_RESUMING]: this.isResuming,
+        [CONFIG_KEY_RESUMING]: isResuming,
       });
     }
   }

--- a/libs/langgraph/src/pregel/loop.ts
+++ b/libs/langgraph/src/pregel/loop.ts
@@ -822,11 +822,9 @@ export class PregelLoop {
       const hasGoto =
         !!this.input.goto &&
         (!Array.isArray(this.input.goto) || this.input.goto.length > 0);
-
       if (hasResume && this.checkpointer == null) {
         throw new Error("Cannot use Command(resume=...) without checkpointer");
       }
-
       if (hasResume && (hasUpdate || hasGoto)) {
         throw new Error(
           "Cannot use Command(resume=...) with Command(update=...) or Command(goto=...)"
@@ -873,10 +871,8 @@ export class PregelLoop {
         this.checkpointerGetNextVersion
       );
     }
-
     const isCommandUpdateOrGoto =
       isCommand(this.input) && nullWrites.length > 0;
-
     if (this.isResuming || isCommandUpdateOrGoto) {
       for (const channelName of Object.keys(this.channels)) {
         if (this.checkpoint.channel_versions[channelName] !== undefined) {
@@ -896,7 +892,6 @@ export class PregelLoop {
       );
       this._emit(valuesOutput);
     }
-
     if (this.isResuming) {
       this.input = INPUT_RESUMING;
     } else if (isCommandUpdateOrGoto) {

--- a/libs/langgraph/src/tests/pregel.test.ts
+++ b/libs/langgraph/src/tests/pregel.test.ts
@@ -3245,7 +3245,6 @@ graph TD;
         .addEdge("__start__", "agent")
         .addConditionalEdges("agent", shouldContinue)
         .addEdge("tools", "agent");
-
       const inputMessage = new HumanMessage({
         id: "foo",
         content: "what is weather in sf",
@@ -3308,7 +3307,6 @@ graph TD;
       const res = await builder.compile().invoke({
         messages: [inputMessage],
       });
-
       expect(res).toEqual({
         messages: expectedOutputMessages,
       });


### PR DESCRIPTION
1. `Command(goto=...)` needs to be treated separately from `Command(update=...)` and `Command(goto=....)` w.r.t. writes and checkpoints. If a checkpoint is not created, the pending write will get lost if the `Command(goto=...)` enters into a node that interrupts
2. We actually did create a new checkpoint pre-#1023 (`isResuming=false`), but because we mapped and wrote the input twice, it also scheduled the start node. Thus, adding a new branch for non-resume Command seems reasonable to me. 