### PR TITLE
feat(docs): Add create-agent-chat-app to readme quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@
 > [!NOTE]
 > Looking for the Python version? See the [Python repo](https://github.com/langchain-ai/langgraph) and the [Python docs](https://langchain-ai.github.io/langgraph/).
 
+## Quickstart
+
+To quickly get started building a full-stack application with LangGraph, we recommend using the [`create-agent-chat-app`](https://www.npmjs.com/package/create-agent-chat-app) CLI. This will install a chat interface which you can use to interact with your agent, and up to 4 prebuilt agents to include in your application:
+
+```bash
+npx create-agent-chat-app@latest
+```
+
+The CLI will guide you through setting up a full-stack application with LangGraph. It allows you to configure every part of your application and agent, including:
+
+- 🧠 A selection of 4 prebuilt agents to choose from (ReAct, Memory, Research and Retrieval)
+- 🌐 Next.js or Vite for the frontend chat interface
+- 📦 `npm`, `yarn` or `pnpm` for package management
+
+<hr />
+
 LangGraph — used by Replit, Uber, LinkedIn, GitLab and more — is a low-level orchestration framework for building controllable agents. While langchain provides integrations and composable components to streamline LLM application development, the LangGraph library enables agent orchestration — offering customizable architectures, long-term memory, and human-in-the-loop to reliably handle complex tasks.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -8,22 +8,6 @@
 > [!NOTE]
 > Looking for the Python version? See the [Python repo](https://github.com/langchain-ai/langgraph) and the [Python docs](https://langchain-ai.github.io/langgraph/).
 
-## Quickstart
-
-To quickly get started building a full-stack application with LangGraph, we recommend using the [`create-agent-chat-app`](https://www.npmjs.com/package/create-agent-chat-app) CLI. This will install a chat interface which you can use to interact with your agent, and up to 4 prebuilt agents to include in your application:
-
-```bash
-npx create-agent-chat-app@latest
-```
-
-The CLI will guide you through setting up a full-stack application with LangGraph. It allows you to configure every part of your application and agent, including:
-
-- 🧠 A selection of 4 prebuilt agents to choose from (ReAct, Memory, Research and Retrieval)
-- 🌐 Next.js or Vite for the frontend chat interface
-- 📦 `npm`, `yarn` or `pnpm` for package management
-
-<hr />
-
 LangGraph — used by Replit, Uber, LinkedIn, GitLab and more — is a low-level orchestration framework for building controllable agents. While langchain provides integrations and composable components to streamline LLM application development, the LangGraph library enables agent orchestration — offering customizable architectures, long-term memory, and human-in-the-loop to reliably handle complex tasks.
 
 ```bash
@@ -71,6 +55,20 @@ const result = await agent.invoke(
   }
 );
 ```
+
+## Full-stack Quickstart
+
+Get started quickly by building a full-stack LangGraph application using the [`create-agent-chat-app`](https://www.npmjs.com/package/create-agent-chat-app) CLI:
+
+```bash
+npx create-agent-chat-app@latest
+```
+
+The CLI sets up a chat interface and helps you configure your application, including:
+
+- 🧠 Choice of 4 prebuilt agents (ReAct, Memory, Research, Retrieval)
+- 🌐 Frontend framework (Next.js or Vite)
+- 📦 Package manager (`npm`, `yarn`, or `pnpm`)
 
 ## Why use LangGraph?
 

--- a/libs/langgraph/README.md
+++ b/libs/langgraph/README.md
@@ -8,6 +8,20 @@
 > [!NOTE]
 > Looking for the Python version? See the [Python repo](https://github.com/langchain-ai/langgraph) and the [Python docs](https://langchain-ai.github.io/langgraph/).
 
+## Quickstart
+
+To quickly get started building a full-stack application with LangGraph, we recommend using the [`create-agent-chat-app`](https://www.npmjs.com/package/create-agent-chat-app) CLI. This will install a chat interface which you can use to interact with your agent, and up to 4 prebuilt agents to include in your application:
+
+```bash
+npx create-agent-chat-app@latest
+```
+
+The CLI will guide you through setting up a full-stack application with LangGraph. It allows you to configure every part of your application and agent, including:
+
+- 🧠 A selection of 4 prebuilt agents to choose from (ReAct, Memory, Research and Retrieval)
+- 🌐 Next.js or Vite for the frontend chat interface
+- 📦 `npm`, `yarn` or `pnpm` for package management
+
 LangGraph — used by Replit, Uber, LinkedIn, GitLab and more — is a low-level orchestration framework for building controllable agents. While langchain provides integrations and composable components to streamline LLM application development, the LangGraph library enables agent orchestration — offering customizable architectures, long-term memory, and human-in-the-loop to reliably handle complex tasks.
 
 ```bash

--- a/libs/langgraph/README.md
+++ b/libs/langgraph/README.md
@@ -22,6 +22,8 @@ The CLI will guide you through setting up a full-stack application with LangGrap
 - 🌐 Next.js or Vite for the frontend chat interface
 - 📦 `npm`, `yarn` or `pnpm` for package management
 
+<hr />
+
 LangGraph — used by Replit, Uber, LinkedIn, GitLab and more — is a low-level orchestration framework for building controllable agents. While langchain provides integrations and composable components to streamline LLM application development, the LangGraph library enables agent orchestration — offering customizable architectures, long-term memory, and human-in-the-loop to reliably handle complex tasks.
 
 ```bash

--- a/libs/langgraph/README.md
+++ b/libs/langgraph/README.md
@@ -8,22 +8,6 @@
 > [!NOTE]
 > Looking for the Python version? See the [Python repo](https://github.com/langchain-ai/langgraph) and the [Python docs](https://langchain-ai.github.io/langgraph/).
 
-## Quickstart
-
-To quickly get started building a full-stack application with LangGraph, we recommend using the [`create-agent-chat-app`](https://www.npmjs.com/package/create-agent-chat-app) CLI. This will install a chat interface which you can use to interact with your agent, and up to 4 prebuilt agents to include in your application:
-
-```bash
-npx create-agent-chat-app@latest
-```
-
-The CLI will guide you through setting up a full-stack application with LangGraph. It allows you to configure every part of your application and agent, including:
-
-- 🧠 A selection of 4 prebuilt agents to choose from (ReAct, Memory, Research and Retrieval)
-- 🌐 Next.js or Vite for the frontend chat interface
-- 📦 `npm`, `yarn` or `pnpm` for package management
-
-<hr />
-
 LangGraph — used by Replit, Uber, LinkedIn, GitLab and more — is a low-level orchestration framework for building controllable agents. While langchain provides integrations and composable components to streamline LLM application development, the LangGraph library enables agent orchestration — offering customizable architectures, long-term memory, and human-in-the-loop to reliably handle complex tasks.
 
 ```bash
@@ -71,6 +55,20 @@ const result = await agent.invoke(
   }
 );
 ```
+
+## Full-stack Quickstart
+
+Get started quickly by building a full-stack LangGraph application using the [`create-agent-chat-app`](https://www.npmjs.com/package/create-agent-chat-app) CLI:
+
+```bash
+npx create-agent-chat-app@latest
+```
+
+The CLI sets up a chat interface and helps you configure your application, including:
+
+- 🧠 Choice of 4 prebuilt agents (ReAct, Memory, Research, Retrieval)
+- 🌐 Frontend framework (Next.js or Vite)
+- 📦 Package manager (`npm`, `yarn`, or `pnpm`)
 
 ## Why use LangGraph?
 


### PR DESCRIPTION
Proposing adding the `create-agent-chat-app` command under a `Quickstart` section to the LangGraph docs.