### PR TITLE
fix(docs): Correct link to previous example in agent supervisor notebook

### DIFF
--- a/examples/multi_agent/agent_supervisor.ipynb
+++ b/examples/multi_agent/agent_supervisor.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Agent Supervisor\n",
     "\n",
-    "The [previous example](./multi-agent-collaboration.ipynb) routed messages\n",
+    "The [previous example](./multi_agent_collaboration.ipynb) routed messages\n",
     "automatically based on the output of the initial researcher agent.\n",
     "\n",
     "We can also choose to use an LLM to orchestrate the different agents.\n",


### PR DESCRIPTION
This pull request includes a small change to the `examples/multi_agent/agent_supervisor.ipynb` file. The change corrects a hyperlink to the previous example by updating the file path.

* [`examples/multi_agent/agent_supervisor.ipynb`](diffhunk://#diff-57549f2955f57bb0c736ea4e6ce9b693d29090d8dde3f87b330835034d5a9455L10-R10): Corrected the hyperlink to the previous example by changing the file path from `./multi-agent-collaboration.ipynb` to `./multi_agent_collaboration.ipynb`.