### PR TITLE
langgraph: use ToolNode correctly if passed as 'tools' to createReactAgent

### DIFF
--- a/libs/langgraph/src/prebuilt/react_agent_executor.ts
+++ b/libs/langgraph/src/prebuilt/react_agent_executor.ts
@@ -446,10 +446,13 @@ export function createReactAgent<
   } = params;
 
   let toolClasses: (StructuredToolInterface | DynamicTool | RunnableToolLike)[];
+  let toolNode: ToolNode;
   if (!Array.isArray(tools)) {
     toolClasses = tools.tools;
+    toolNode = tools;
   } else {
     toolClasses = tools;
+    toolNode = new ToolNode(tools);
   }
 
   let modelWithTools: LanguageModelLike;
@@ -533,7 +536,7 @@ export function createReactAgent<
     stateSchema ?? createReactAgentAnnotation<StructuredResponseFormat>()
   )
     .addNode("agent", callModel)
-    .addNode("tools", new ToolNode(toolClasses))
+    .addNode("tools", toolNode)
     .addEdge(START, "agent");
 
   if (responseFormat !== undefined) {


### PR DESCRIPTION


<!--
Thank you for contributing to LangGraph.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langgraphjs/blob/main/CONTRIBUTING.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
