### PR TITLE
Add node finished configurable

### DIFF
--- a/libs/langgraph/src/constants.ts
+++ b/libs/langgraph/src/constants.ts
@@ -28,7 +28,8 @@ export const SELF = "__self__";
 export const TASKS = "__pregel_tasks";
 export const PUSH = "__pregel_push";
 export const PULL = "__pregel_pull";
-
+export const NODE_FINISHED = "__pregel_node_finished";
+// holds an async callback to be called when a node is finished
 export const TASK_NAMESPACE = "6ba7b831-9dad-11d1-80b4-00c04fd430c8";
 export const NULL_TASK_ID = "00000000-0000-0000-0000-000000000000";
 

--- a/libs/langgraph/src/pregel/algo.ts
+++ b/libs/langgraph/src/pregel/algo.ts
@@ -46,6 +46,7 @@ import {
   NULL_TASK_ID,
   CONFIG_KEY_SCRATCHPAD,
   CONFIG_KEY_WRITES,
+  NODE_FINISHED,
 } from "../constants.js";
 import { PregelExecutableTask, PregelTaskDescription } from "./types.js";
 import { EmptyChannelError, InvalidUpdateError } from "../errors.js";
@@ -641,6 +642,7 @@ export function _prepareSingleTask<
                   ...(configurable[CONFIG_KEY_WRITES] || []),
                 ].filter((w) => w[0] === NULL_TASK_ID || w[0] === taskId),
                 [CONFIG_KEY_SCRATCHPAD]: {},
+                [NODE_FINISHED]: configurable[NODE_FINISHED],
                 checkpoint_id: undefined,
                 checkpoint_ns: taskCheckpointNamespace,
               },
@@ -774,6 +776,7 @@ export function _prepareSingleTask<
                     ...(configurable[CONFIG_KEY_WRITES] || []),
                   ].filter((w) => w[0] === NULL_TASK_ID || w[0] === taskId),
                   [CONFIG_KEY_SCRATCHPAD]: {},
+                  [NODE_FINISHED]: configurable[NODE_FINISHED],
                   checkpoint_id: undefined,
                   checkpoint_ns: taskCheckpointNamespace,
                 },

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -55,6 +55,8 @@ import {
   INPUT,
   RESUME,
   PUSH,
+  NODE_FINISHED,
+  TAG_HIDDEN,
 } from "../constants.js";
 import {
   PregelExecutableTask,
@@ -1286,6 +1288,7 @@ export class Pregel<
             }
           );
           // Timeouts will be thrown
+          // TODO: Handle the onNodeEnd stuff here
           for await (const { task, error } of taskStream) {
             if (error !== undefined) {
               if (isGraphBubbleUp(error)) {
@@ -1308,6 +1311,14 @@ export class Pregel<
                 throw error;
               }
             } else {
+              if (config.configurable?.[NODE_FINISHED]) {
+                if (
+                  task.config === null ||
+                  !task.config?.tags?.includes(TAG_HIDDEN)
+                ) {
+                  await config.configurable[NODE_FINISHED](task.name as string);
+                }
+              }
               loop.putWrites(task.id, task.writes);
             }
           }


### PR DESCRIPTION
For JS graphs, fetch the nodes executed information at the end of each stream.