### PR TITLE
fix(langgraph): allow resume + update at the same time

### DIFF
--- a/libs/langgraph/src/pregel/loop.ts
+++ b/libs/langgraph/src/pregel/loop.ts
@@ -818,17 +818,8 @@ export class PregelLoop {
 
     if (isCommand(this.input)) {
       const hasResume = this.input.resume != null;
-      const hasUpdate = this.input.update != null;
-      const hasGoto =
-        !!this.input.goto &&
-        (!Array.isArray(this.input.goto) || this.input.goto.length > 0);
       if (hasResume && this.checkpointer == null) {
         throw new Error("Cannot use Command(resume=...) without checkpointer");
-      }
-      if (hasResume && (hasUpdate || hasGoto)) {
-        throw new Error(
-          "Cannot use Command(resume=...) with Command(update=...) or Command(goto=...)"
-        );
       }
 
       const writes: { [key: string]: PendingWrite[] } = {};

--- a/libs/langgraph/src/tests/pregel.test.ts
+++ b/libs/langgraph/src/tests/pregel.test.ts
@@ -10617,12 +10617,15 @@ graph TD;
       },
     ]);
 
-    await graph.invoke(new Command({ resume: "resume" }), { configurable });
+    await graph.invoke(
+      new Command({ resume: "resume", update: { messages: ["update: resume"] } }),
+      { configurable }
+    );
     state = await graph.getState({ configurable });
 
     expect(state.next).toEqual([]);
     expect(state.values).toEqual({
-      messages: ["input", "update", "interrupt: resume"],
+      messages: ["input", "update", "update: resume", "interrupt: resume"],
     });
   });
 }

--- a/libs/langgraph/src/tests/pregel.test.ts
+++ b/libs/langgraph/src/tests/pregel.test.ts
@@ -10618,7 +10618,10 @@ graph TD;
     ]);
 
     await graph.invoke(
-      new Command({ resume: "resume", update: { messages: ["update: resume"] } }),
+      new Command({
+        resume: "resume",
+        update: { messages: ["update: resume"] },
+      }),
       { configurable }
     );
     state = await graph.getState({ configurable });


### PR DESCRIPTION
Closes Command resume with update throws, but docs show that it shouldn't. #1109
