### PR TITLE
Correct withStructuredOutput usage in plan-and-execute example

### DIFF
--- a/examples/plan-and-execute/plan-and-execute.ipynb
+++ b/examples/plan-and-execute/plan-and-execute.ipynb
@@ -304,7 +304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "7ba67c92",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
<!--
Thank you for contributing to LangGraph.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langgraphjs/blob/main/CONTRIBUTING.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

The plan-and-excute example currently passes the entire `planFunction` object to `withStructuredOutput`, which results in the model returning unparsed JSON.

This PR updates the example to correctly pass only `planFunction.parameters` — the actual JSON schema expected by `withStructuredOutput` — ensuring the model produces properly parsed structured  

