### PR TITLE
fix(langgraph): split .langgraph.metadata() into metadata() and jsonSchemaExtra()

### DIFF
--- a/libs/langgraph/src/graph/zod/plugin.ts
+++ b/libs/langgraph/src/graph/zod/plugin.ts
@@ -9,7 +9,9 @@ interface ZodLangGraphTypes<T extends z.ZodTypeAny, Output> {
     options?: z.ZodType<Input>
   ): z.ZodType<Output, z.ZodEffectsDef<T>, Input>;
 
-  metadata(payload: {
+  metadata(payload: Record<string, unknown>): T;
+
+  jsonSchemaExtra(payload: {
     langgraph_nodes?: string[];
     langgraph_type?: "prompt";
 
@@ -45,10 +47,18 @@ try {
           type Output = z.infer<typeof zodThis>;
 
           return {
-            metadata(jsonSchemaExtra: Meta<Output, Output>["jsonSchemaExtra"]) {
+            jsonSchemaExtra(
+              jsonSchemaExtra: Meta<Output, Output>["jsonSchemaExtra"]
+            ) {
               extendMeta(zodThis, (meta) => ({ ...meta, jsonSchemaExtra }));
               return zodThis;
             },
+
+            metadata(metadata: Meta<Output, Output>["metadata"]) {
+              extendMeta(zodThis, (meta) => ({ ...meta, metadata }));
+              return zodThis;
+            },
+
             reducer<Input>(
               fn: (a: Output, arg: Input) => Output,
               schema?: z.ZodType<Input>

--- a/libs/langgraph/src/graph/zod/schema.ts
+++ b/libs/langgraph/src/graph/zod/schema.ts
@@ -11,8 +11,8 @@ function applyPlugin(
     /** Apply .langgraph.reducer calls */
     reducer?: boolean;
 
-    /** Apply .langgraph.metadata() calls  */
-    jsonSchemaExtra?: boolean;
+    /** Apply .langgraph.jsonSchemaExtra() and .langgraph.metadata() calls  */
+    extra?: boolean;
 
     /** Apply .partial() */
     partial?: boolean;
@@ -20,7 +20,7 @@ function applyPlugin(
 ) {
   const cacheKey = [
     `reducer:${actions.reducer ?? false}`,
-    `jsonSchemaExtra:${actions.jsonSchemaExtra ?? false}`,
+    `extra:${actions.extra ?? false}`,
     `partial:${actions.partial ?? false}`,
   ].join("|");
 
@@ -35,9 +35,10 @@ function applyPlugin(
           const meta = getMeta(input);
           let output = actions.reducer ? meta?.reducer?.schema ?? input : input;
 
-          if (actions.jsonSchemaExtra) {
+          if (actions.extra) {
             const strMeta = JSON.stringify({
               ...meta?.jsonSchemaExtra,
+              metadata: meta?.metadata ?? meta?.jsonSchemaExtra?.metadata,
               description: output.description ?? input.description,
             });
 
@@ -138,11 +139,7 @@ export function getUpdateTypeSchema(graph: unknown): JsonSchema | undefined {
   if (!schemaDef) return undefined;
 
   return toJsonSchema(
-    applyPlugin(schemaDef, {
-      reducer: true,
-      jsonSchemaExtra: true,
-      partial: true,
-    })
+    applyPlugin(schemaDef, { reducer: true, extra: true, partial: true })
   );
 }
 
@@ -156,11 +153,7 @@ export function getInputTypeSchema(graph: unknown): JsonSchema | undefined {
   const schemaDef = graph.builder._inputRuntimeDefinition;
   if (!schemaDef) return undefined;
   return toJsonSchema(
-    applyPlugin(schemaDef, {
-      reducer: true,
-      jsonSchemaExtra: true,
-      partial: true,
-    })
+    applyPlugin(schemaDef, { reducer: true, extra: true, partial: true })
   );
 }
 
@@ -173,7 +166,7 @@ export function getOutputTypeSchema(graph: unknown): JsonSchema | undefined {
   if (!isGraphWithZodLike(graph)) return undefined;
   const schemaDef = graph.builder._outputRuntimeDefinition;
   if (!schemaDef) return undefined;
-  return toJsonSchema(applyPlugin(schemaDef, { jsonSchemaExtra: true }));
+  return toJsonSchema(applyPlugin(schemaDef, { extra: true }));
 }
 
 /**
@@ -185,5 +178,5 @@ export function getConfigTypeSchema(graph: unknown): JsonSchema | undefined {
   if (!isGraphWithZodLike(graph)) return undefined;
   const configDef = graph.builder._configRuntimeSchema;
   if (!configDef) return undefined;
-  return toJsonSchema(applyPlugin(configDef, { jsonSchemaExtra: true }));
+  return toJsonSchema(applyPlugin(configDef, { extra: true }));
 }

--- a/libs/langgraph/src/graph/zod/state.ts
+++ b/libs/langgraph/src/graph/zod/state.ts
@@ -13,6 +13,7 @@ export interface Meta<ValueType, UpdateType = ValueType> {
 
     [key: string]: unknown;
   };
+  metadata?: Record<string, unknown>;
   reducer?: {
     schema?: z.ZodType<UpdateType>;
     fn: (a: ValueType, b: UpdateType) => ValueType;

--- a/libs/langgraph/src/tests/pregel.test.ts
+++ b/libs/langgraph/src/tests/pregel.test.ts
@@ -10420,10 +10420,11 @@ graph TD;
       prompt: z
         .string()
         .min(1)
-        .langgraph.metadata({
+        .langgraph.jsonSchemaExtra({
           langgraph_nodes: ["agent"],
           langgraph_type: "prompt",
-        }),
+        })
+        .langgraph.metadata({ random: "hello" }),
     });
 
     const graph = new StateGraph(schema, config)
@@ -10455,6 +10456,7 @@ graph TD;
           type: "string",
           langgraph_nodes: ["agent"],
           langgraph_type: "prompt",
+          metadata: { random: "hello" },
           minLength: 1,
         },
       },


### PR DESCRIPTION
Mimicks the same behaviour seen in Pydantic Field(metadata={...}) vs Field(json_schema_extra={...})
