### PR TITLE
Fix Command(resume) for Zod Schemas

### DIFF
--- a/libs/langgraph/src/graph/state.ts
+++ b/libs/langgraph/src/graph/state.ts
@@ -857,6 +857,12 @@ export class CompiledStateGraph<
     input: UpdateType<ToStateDefinition<I>>
   ): Promise<UpdateType<ToStateDefinition<I>>> {
     const inputSchema = this.builder._inputRuntimeDefinition;
+    if (isCommand(input)) {
+      const parsedInput = input;
+      if (input.update && isAnyZodObject(inputSchema))
+        parsedInput.update = inputSchema.parse(input.update);
+      return parsedInput;
+    }
     if (isAnyZodObject(inputSchema)) return inputSchema.parse(input);
     return input;
   }


### PR DESCRIPTION
Previously, the zod schema would be applied to the input even if it were a `Command`.

Skip that to avoid dropping resume/goto/etc.