### PR TITLE
feat(langgraph): add addSequence method

### DIFF
--- a/libs/langgraph/src/graph/state.ts
+++ b/libs/langgraph/src/graph/state.ts
@@ -484,7 +484,11 @@ export class StateGraph<
   }
 
   addSequence<K extends string>(
-    nodes: [key: K, action: NodeAction<S, U, C>][]
+    nodes: [
+      key: K,
+      action: NodeAction<S, U, C>,
+      options?: StateGraphAddNodeOptions
+    ][]
   ): StateGraph<SD, S, U, N | K, I, O, C>;
 
   addSequence<K extends string>(
@@ -493,7 +497,7 @@ export class StateGraph<
 
   addSequence<K extends string>(
     nodes:
-      | [key: K, action: NodeAction<S, U, C>][]
+      | [key: K, action: NodeAction<S, U, C>, options?: StateGraphAddNodeOptions][]
       | Record<K, NodeAction<S, U, C>>
   ): StateGraph<SD, S, U, N | K, I, O, C> {
     const parsedNodes = Array.isArray(nodes)
@@ -505,7 +509,7 @@ export class StateGraph<
     }
 
     let previousNode: N | undefined;
-    for (const [key, action] of parsedNodes) {
+    for (const [key, action, options] of parsedNodes) {
       if (key in this.nodes) {
         throw new Error(
           `Node names must be unique: node with the name "${key}" already exists.`
@@ -513,7 +517,7 @@ export class StateGraph<
       }
 
       const validKey = key as unknown as N;
-      this.addNode(validKey, action);
+      this.addNode(validKey, action, options);
       if (previousNode != null) {
         this.addEdge(previousNode, validKey);
       }

--- a/libs/langgraph/src/graph/state.ts
+++ b/libs/langgraph/src/graph/state.ts
@@ -497,7 +497,11 @@ export class StateGraph<
 
   addSequence<K extends string>(
     nodes:
-      | [key: K, action: NodeAction<S, U, C>, options?: StateGraphAddNodeOptions][]
+      | [
+          key: K,
+          action: NodeAction<S, U, C>,
+          options?: StateGraphAddNodeOptions
+        ][]
       | Record<K, NodeAction<S, U, C>>
   ): StateGraph<SD, S, U, N | K, I, O, C> {
     const parsedNodes = Array.isArray(nodes)

--- a/libs/langgraph/src/tests/graph.test.ts
+++ b/libs/langgraph/src/tests/graph.test.ts
@@ -79,4 +79,27 @@ describe("State", () => {
       testval: ["hello", "hi!"],
     });
   });
+
+  it("should support addSequence", async () => {
+    const stateGraph = new StateGraph(
+      Annotation.Root({
+        messages: Annotation<string[]>({
+          default: () => [],
+          reducer: (left, right) => [...left, ...right],
+        }),
+      })
+    );
+
+    const graph = stateGraph
+      .addSequence({
+        node1: () => ({ messages: ["from node1"] }),
+        node2: () => ({ messages: ["from node2"] }),
+        node3: () => ({ messages: ["from node3"] }),
+      })
+      .addEdge(START, "node1")
+      .compile();
+
+    const result = await graph.invoke({ messages: [] });
+    expect(result.messages).toEqual(["from node1", "from node2", "from node3"]);
+  });
 });


### PR DESCRIPTION
Port of https://github.com/langchain-ai/langgraph/pull/2352, allows both `[key: string, action: function][]` and `{ [key: string]: function }`

Objects might be a little bit strange, but I think in current JS engine implementation of `Object.entries` is reasonably defined for us to do this.

>  Within each component of the prototype chain, all non-negative integer keys (those that can be array indices) will be traversed first in ascending order by value, then other string keys in ascending chronological order of property creation.
