### PR TITLE
feat(langgraph): add interface for adding multiple nodes in parallel

### DIFF
--- a/libs/langgraph/src/graph/state.ts
+++ b/libs/langgraph/src/graph/state.ts
@@ -383,67 +383,127 @@ export class StateGraph<
     }
   }
 
+  override addNode<K extends string>(
+    nodes:
+      | Record<K, NodeAction<S, U, C>>
+      | [
+          key: K,
+          action: NodeAction<S, U, C>,
+          options?: StateGraphAddNodeOptions
+        ][]
+  ): StateGraph<SD, S, U, N | K, I, O, C>;
+
   override addNode<K extends string, NodeInput = S>(
     key: K,
     action: NodeAction<NodeInput, U, C>,
     options?: StateGraphAddNodeOptions
+  ): StateGraph<SD, S, U, N | K, I, O, C>;
+
+  override addNode<K extends string, NodeInput = S>(
+    ...args:
+      | [
+          key: K,
+          action: NodeAction<NodeInput, U, C>,
+          options?: StateGraphAddNodeOptions
+        ]
+      | [
+          nodes:
+            | Record<K, NodeAction<NodeInput, U, C>>
+            | [
+                key: K,
+                action: NodeAction<NodeInput, U, C>,
+                options?: StateGraphAddNodeOptions
+              ][]
+        ]
   ): StateGraph<SD, S, U, N | K, I, O, C> {
-    if (key in this.channels) {
-      throw new Error(
-        `${key} is already being used as a state attribute (a.k.a. a channel), cannot also be used as a node name.`
-      );
+    function isMultipleNodes(
+      args: unknown[]
+    ): args is [
+      nodes:
+        | Record<K, NodeAction<NodeInput, U, C>>
+        | [
+            key: K,
+            action: NodeAction<NodeInput, U, C>,
+            options?: AddNodeOptions
+          ][]
+    ] {
+      return args.length >= 1 && typeof args[0] !== "string";
     }
 
-    for (const reservedChar of [
-      CHECKPOINT_NAMESPACE_SEPARATOR,
-      CHECKPOINT_NAMESPACE_END,
-    ]) {
-      if (key.includes(reservedChar)) {
+    const nodes = (
+      isMultipleNodes(args) // eslint-disable-line no-nested-ternary
+        ? Array.isArray(args[0])
+          ? args[0]
+          : Object.entries(args[0])
+        : [[args[0], args[1]]]
+    ) as [
+      K,
+      NodeAction<NodeInput, U, C>,
+      StateGraphAddNodeOptions | undefined
+    ][];
+
+    if (nodes.length === 0) {
+      throw new Error("No nodes provided in `addNode`");
+    }
+
+    for (const [key, action, options] of nodes) {
+      if (key in this.channels) {
         throw new Error(
-          `"${reservedChar}" is a reserved character and is not allowed in node names.`
+          `${key} is already being used as a state attribute (a.k.a. a channel), cannot also be used as a node name.`
         );
       }
-    }
-    this.warnIfCompiled(
-      `Adding a node to a graph that has already been compiled. This will not be reflected in the compiled graph.`
-    );
 
-    if (key in this.nodes) {
-      throw new Error(`Node \`${key}\` already present.`);
-    }
-    if (key === END || key === START) {
-      throw new Error(`Node \`${key}\` is reserved.`);
-    }
+      for (const reservedChar of [
+        CHECKPOINT_NAMESPACE_SEPARATOR,
+        CHECKPOINT_NAMESPACE_END,
+      ]) {
+        if (key.includes(reservedChar)) {
+          throw new Error(
+            `"${reservedChar}" is a reserved character and is not allowed in node names.`
+          );
+        }
+      }
+      this.warnIfCompiled(
+        `Adding a node to a graph that has already been compiled. This will not be reflected in the compiled graph.`
+      );
 
-    if (options?.input !== undefined) {
-      this._addSchema(options.input.spec);
-    }
+      if (key in this.nodes) {
+        throw new Error(`Node \`${key}\` already present.`);
+      }
+      if (key === END || key === START) {
+        throw new Error(`Node \`${key}\` is reserved.`);
+      }
 
-    let runnable;
-    if (Runnable.isRunnable(action)) {
-      runnable = action;
-    } else if (typeof action === "function") {
-      runnable = new RunnableCallable({
-        func: action,
-        name: key,
-        trace: false,
-      });
-    } else {
-      runnable = _coerceToRunnable(action);
-    }
-    const nodeSpec: StateGraphNodeSpec<S, U> = {
-      runnable: runnable as unknown as Runnable<S, U>,
-      retryPolicy: options?.retryPolicy,
-      metadata: options?.metadata,
-      input: options?.input?.spec ?? this._schemaDefinition,
-      subgraphs: isPregelLike(runnable)
-        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          [runnable as any]
-        : options?.subgraphs,
-      ends: options?.ends,
-    };
+      if (options?.input !== undefined) {
+        this._addSchema(options.input.spec);
+      }
 
-    this.nodes[key as unknown as N] = nodeSpec;
+      let runnable;
+      if (Runnable.isRunnable(action)) {
+        runnable = action;
+      } else if (typeof action === "function") {
+        runnable = new RunnableCallable({
+          func: action,
+          name: key,
+          trace: false,
+        });
+      } else {
+        runnable = _coerceToRunnable(action);
+      }
+      const nodeSpec: StateGraphNodeSpec<S, U> = {
+        runnable: runnable as unknown as Runnable<S, U>,
+        retryPolicy: options?.retryPolicy,
+        metadata: options?.metadata,
+        input: options?.input?.spec ?? this._schemaDefinition,
+        subgraphs: isPregelLike(runnable)
+          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            [runnable as any]
+          : options?.subgraphs,
+        ends: options?.ends,
+      };
+
+      this.nodes[key as unknown as N] = nodeSpec;
+    }
 
     return this as StateGraph<SD, S, U, N | K, I, O, C>;
   }
@@ -497,7 +557,11 @@ export class StateGraph<
 
   addSequence<K extends string>(
     nodes:
-      | [key: K, action: NodeAction<S, U, C>, options?: StateGraphAddNodeOptions][]
+      | [
+          key: K,
+          action: NodeAction<S, U, C>,
+          options?: StateGraphAddNodeOptions
+        ][]
       | Record<K, NodeAction<S, U, C>>
   ): StateGraph<SD, S, U, N | K, I, O, C> {
     const parsedNodes = Array.isArray(nodes)

--- a/libs/langgraph/src/tests/graph.test.ts
+++ b/libs/langgraph/src/tests/graph.test.ts
@@ -102,4 +102,136 @@ describe("State", () => {
     const result = await graph.invoke({ messages: [] });
     expect(result.messages).toEqual(["from node1", "from node2", "from node3"]);
   });
+
+  it("should add multiple nodes in parallel using array syntax", async () => {
+    const stateGraph = new StateGraph(
+      Annotation.Root({
+        messages: Annotation<string[]>({
+          default: () => [],
+          reducer: (left, right) => [...left, ...right],
+        }),
+      })
+    );
+
+    const graph = stateGraph
+      .addNode([
+        ["node1", () => ({ messages: ["from node1"] })],
+        ["node2", () => ({ messages: ["from node2"] })],
+        ["node3", () => ({ messages: ["from node3"] })],
+      ])
+      .addEdge(START, "node1")
+      .addEdge("node1", "node2")
+      .addEdge("node2", "node3")
+      .addEdge("node3", END)
+      .compile();
+
+    const result = await graph.invoke({ messages: [] });
+    expect(result.messages).toEqual(["from node1", "from node2", "from node3"]);
+  });
+
+  it("should add multiple nodes in parallel using record syntax", async () => {
+    const stateGraph = new StateGraph(
+      Annotation.Root({
+        messages: Annotation<string[]>({
+          default: () => [],
+          reducer: (left, right) => [...left, ...right],
+        }),
+      })
+    );
+
+    const graph = stateGraph
+      .addNode({
+        node1: () => ({ messages: ["from node1"] }),
+        node2: () => ({ messages: ["from node2"] }),
+        node3: () => ({ messages: ["from node3"] }),
+      })
+      .addEdge(START, "node1")
+      .addEdge("node1", "node2")
+      .addEdge("node2", "node3")
+      .addEdge("node3", END)
+      .compile();
+
+    const result = await graph.invoke({ messages: [] });
+    expect(result.messages).toEqual(["from node1", "from node2", "from node3"]);
+  });
+
+  it("should throw error when adding duplicate nodes in parallel", () => {
+    const stateGraph = new StateGraph(
+      Annotation.Root({
+        messages: Annotation<string[]>({
+          default: () => [],
+          reducer: (left, right) => [...left, ...right],
+        }),
+      })
+    );
+
+    // Test duplicate nodes in array syntax
+    expect(() => {
+      stateGraph.addNode([
+        ["duplicate", () => ({ messages: ["from node1"] })],
+        ["duplicate", () => ({ messages: ["from node2"] })],
+      ]);
+    }).toThrow();
+  });
+
+  it("should throw error when adding empty node list", () => {
+    const stateGraph = new StateGraph(
+      Annotation.Root({
+        messages: Annotation<string[]>({
+          default: () => [],
+          reducer: (left, right) => [...left, ...right],
+        }),
+      })
+    );
+
+    // Test empty array syntax
+    expect(() => stateGraph.addNode([])).toThrow(
+      "No nodes provided in `addNode`"
+    );
+
+    // Test empty object syntax
+    expect(() => stateGraph.addNode({})).toThrow(
+      "No nodes provided in `addNode`"
+    );
+  });
+
+  it("should support metadata and subgraphs in parallel node addition", async () => {
+    const stateGraph = new StateGraph(
+      Annotation.Root({
+        messages: Annotation<string[]>({
+          default: () => [],
+          reducer: (left, right) => [...left, ...right],
+        }),
+      })
+    );
+
+    const subgraph = new StateGraph<{ messages: string[] }>({
+      channels: { messages: null },
+    })
+      .addNode("subnode", () => ({ messages: ["from subgraph"] }))
+      .addEdge(START, "subnode")
+      .addEdge("subnode", END)
+      .compile();
+
+    const graph = stateGraph
+      .addNode([
+        [
+          "node1",
+          () => ({ messages: ["from node1"] }),
+          { metadata: { description: "node1" }, subgraphs: [subgraph] },
+        ],
+        [
+          "node2",
+          () => ({ messages: ["from node2"] }),
+          { metadata: { description: "node2" } },
+        ],
+      ])
+      .addEdge(START, "node1")
+      .addEdge("node1", "node2")
+      .addEdge("node2", END)
+      .compile();
+
+    const result = await graph.invoke({ messages: [] });
+    expect(result.messages).toEqual(["from node1", "from node2"]);
+  });
 });


### PR DESCRIPTION
Similar to #1201, it is more desirable to add multiple nodes at once, instead of doing multiple calls to `addNode`. Accepts both the tuple syntax and the `Record<string, function>` syntax.
