### PR TITLE
feat(swarm): Add an optional state update function to support custom state updates during handover

### DIFF
--- a/libs/langgraph-swarm/src/handoff.ts
+++ b/libs/langgraph-swarm/src/handoff.ts
@@ -28,6 +28,7 @@ function _normalizeAgentName(agentName: string): string {
 interface CreateHandoffToolParams {
   agentName: string;
   description?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   updateState?: (state: any) => Record<string, any>;
 }
 

--- a/libs/langgraph-swarm/src/handoff.ts
+++ b/libs/langgraph-swarm/src/handoff.ts
@@ -28,6 +28,7 @@ function _normalizeAgentName(agentName: string): string {
 interface CreateHandoffToolParams {
   agentName: string;
   description?: string;
+  updateState?: (state: any) => Record<string, any>;
 }
 
 // type guard
@@ -45,6 +46,7 @@ function isDynamicTool(
 const createHandoffTool = ({
   agentName,
   description,
+  updateState,
 }: CreateHandoffToolParams) => {
   /**
    * Create a tool that can handoff control to the requested agent.
@@ -56,6 +58,7 @@ const createHandoffTool = ({
    *   nodes as well as the tool names accepted by LLM providers
    *   (the tool name will look like this: `transfer_to_<agent_name>`).
    * @param description - Optional description for the handoff tool.
+   * @param updateState - Optional function to customize state updates during handoff.
    */
   const toolName = `transfer_to_${_normalizeAgentName(agentName)}`;
   const toolDescription = description || `Ask agent '${agentName}' for help`;
@@ -74,13 +77,22 @@ const createHandoffTool = ({
       // inject the current agent state
       const state =
         getCurrentTaskInput() as (typeof MessagesAnnotation)["State"];
+
+      // Base update object containing essential state updates
+      const baseUpdate = {
+        messages: state.messages.concat(toolMessage),
+        activeAgent: agentName,
+      };
+
+      // Merge custom updates with base updates if updateState function is provided
+      const finalUpdate = updateState
+        ? { ...baseUpdate, ...updateState(state) }
+        : baseUpdate;
+
       return new Command({
         goto: agentName,
         graph: Command.PARENT,
-        update: {
-          messages: state.messages.concat(toolMessage),
-          activeAgent: agentName,
-        },
+        update: finalUpdate,
       });
     },
     {


### PR DESCRIPTION
When I was using the handoff feature, I found that my state.current_plan was never updating, no matter what I tried.

Initially, I thought it was my mistake and tried many different ways to set the LangGraph state, but none of them worked.

Later, I examined the source code for createHandOff and discovered that when using a Command to jump to a new Node, the state wasn't being passed along. This caused my current_plan to remain null. So, I made a modification by adding a new parameter to persist the state.

```ts
const update_plan = tool(
    async (input, config: ToolRunnableConfig) => {
        return new Command<typeof DeepResearchState.State>({
            update: {
                current_plan: input, // not working
                messages: [
                    new ToolMessage({
                        content: "完成计划更新",
                        tool_call_id: config.toolCall!.id!,
                    }),
                ],
            },
        });
    },
    {
        name: "update_plan",
        description: "Update plan for this chat",
        schema: Plan,
    }
);

const planner_agent = createReactAgent({
    name: "planner",
    llm,
    tools: [
        // SequentialThinkingTool,
        update_plan,
        createHandoffTool({ agentName: "researcher", description: "进行研究" }),
        createHandoffTool({ agentName: "reporter", description: "进行总结" }),
    ],
    prompt: async (state) => {
        const data = await apply_prompt_template("deep_research_planner.md", state as any);
        return [new SystemMessage(data), ...state.messages];
    },
    stateSchema: DeepResearchState,
});
```