### PR TITLE
deps(langgraph): upgrade to TypeScript 5.8.x

### DIFF
--- a/libs/checkpoint-mongodb/tsconfig.cjs.json
+++ b/libs/checkpoint-mongodb/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node10",
     "declaration": false
   },
   "exclude": ["node_modules", "dist", "docs", "**/tests"]

--- a/libs/checkpoint-mongodb/tsconfig.json
+++ b/libs/checkpoint-mongodb/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "ES2021",
     "lib": ["ES2021", "ES2022.Object", "DOM"],
     "module": "ES2020",
-    "moduleResolution": "nodenext",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "declaration": true,
     "noImplicitReturns": true,

--- a/libs/checkpoint-postgres/tsconfig.cjs.json
+++ b/libs/checkpoint-postgres/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node10",
     "declaration": false
   },
   "exclude": ["node_modules", "dist", "docs", "**/tests"]

--- a/libs/checkpoint-postgres/tsconfig.json
+++ b/libs/checkpoint-postgres/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "ES2021",
     "lib": ["ES2021", "ES2022.Object", "DOM"],
     "module": "ES2020",
-    "moduleResolution": "nodenext",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "declaration": true,
     "noImplicitReturns": true,

--- a/libs/checkpoint-sqlite/tsconfig.cjs.json
+++ b/libs/checkpoint-sqlite/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node10",
     "declaration": false
   },
   "exclude": ["node_modules", "dist", "docs", "**/tests"]

--- a/libs/checkpoint-sqlite/tsconfig.json
+++ b/libs/checkpoint-sqlite/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "ES2021",
     "lib": ["ES2021", "ES2022.Object", "DOM"],
     "module": "ES2020",
-    "moduleResolution": "nodenext",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "declaration": true,
     "noImplicitReturns": true,

--- a/libs/checkpoint-validation/tsconfig.cjs.json
+++ b/libs/checkpoint-validation/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node10",
     "declaration": false
   },
   "include": ["src/**/*.ts"],

--- a/libs/checkpoint-validation/tsconfig.json
+++ b/libs/checkpoint-validation/tsconfig.json
@@ -7,7 +7,7 @@
     "lib": ["ES2021", "ES2022.Object", "DOM"],
     "types": ["node", "jest"],
     "module": "ES2022",
-    "moduleResolution": "NodeNext",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "declaration": true,
     "noImplicitReturns": true,

--- a/libs/checkpoint/tsconfig.cjs.json
+++ b/libs/checkpoint/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node10",
     "declaration": false
   },
   "exclude": ["node_modules", "dist", "docs", "**/tests"]

--- a/libs/checkpoint/tsconfig.json
+++ b/libs/checkpoint/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "ES2021",
     "lib": ["ES2021", "ES2022.Object", "DOM"],
     "module": "ES2020",
-    "moduleResolution": "nodenext",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "declaration": true,
     "noImplicitReturns": true,

--- a/libs/langgraph-cua/tsconfig.cjs.json
+++ b/libs/langgraph-cua/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node10",
     "declaration": false
   },
   "exclude": ["node_modules", "dist", "docs", "**/*.test.ts"]

--- a/libs/langgraph-cua/tsconfig.json
+++ b/libs/langgraph-cua/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "ES2021",
     "lib": ["ES2021", "ES2022.Object", "DOM"],
     "module": "ES2020",
-    "moduleResolution": "nodenext",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "declaration": true,
     "noImplicitReturns": true,

--- a/libs/langgraph-supervisor/tsconfig.cjs.json
+++ b/libs/langgraph-supervisor/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node10",
     "declaration": false
   },
   "exclude": ["node_modules", "dist", "docs", "**/*.test.ts"]

--- a/libs/langgraph-supervisor/tsconfig.json
+++ b/libs/langgraph-supervisor/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "ES2021",
     "lib": ["ES2021", "ES2022.Object", "DOM"],
     "module": "ES2020",
-    "moduleResolution": "nodenext",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "declaration": true,
     "noImplicitReturns": true,

--- a/libs/langgraph-swarm/src/swarm.test.ts
+++ b/libs/langgraph-swarm/src/swarm.test.ts
@@ -24,7 +24,7 @@ class FakeChatModel extends FakeStreamingChatModel {
     super(fields);
     this.idx = 0;
     this.sleep = fields.sleep ?? this.sleep;
-    this.responses = fields.responses;
+    this.responses = fields.responses ?? [];
     this.thrownErrorString = fields.thrownErrorString;
   }
 

--- a/libs/langgraph-swarm/tsconfig.cjs.json
+++ b/libs/langgraph-swarm/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node10",
     "declaration": false
   },
   "exclude": ["node_modules", "dist", "docs", "**/*.test.ts"]

--- a/libs/langgraph-swarm/tsconfig.json
+++ b/libs/langgraph-swarm/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "ES2021",
     "lib": ["ES2021", "ES2022.Object", "DOM"],
     "module": "ES2020",
-    "moduleResolution": "nodenext",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "declaration": true,
     "noImplicitReturns": true,

--- a/libs/langgraph/src/constants.ts
+++ b/libs/langgraph/src/constants.ts
@@ -173,8 +173,9 @@ export function _isSend(x: unknown): x is Send {
 
 export type Interrupt = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  value: any;
-  when: "during";
+  value?: any;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  when: "during" | (string & {});
   resumable?: boolean;
   ns?: string[];
 };

--- a/libs/langgraph/src/pregel/algo.ts
+++ b/libs/langgraph/src/pregel/algo.ts
@@ -1084,6 +1084,8 @@ function _scratchpad({
         );
         return nullResume;
       }
+
+      return undefined;
     },
   };
   return scratchpad;

--- a/libs/langgraph/tsconfig.cjs.json
+++ b/libs/langgraph/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node10",
     "declaration": false
   },
   "exclude": ["node_modules", "dist", "docs", "**/tests"]

--- a/libs/langgraph/tsconfig.json
+++ b/libs/langgraph/tsconfig.json
@@ -6,7 +6,7 @@
     "target": "ES2021",
     "lib": ["ES2021", "ES2022.Object", "ES2022.Error", "DOM"],
     "module": "ES2020",
-    "moduleResolution": "nodenext",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "declaration": true,
     "noImplicitReturns": true,

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   },
   "resolutions": {
     "cheerio": "^1.0.0-rc.12",
-    "typescript": "4.9.5",
     "semver": "^7.0.0"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14195,23 +14195,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.9.5":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
+"typescript@npm:^4.9.5 || ^5.4.5, typescript@npm:^5.2.2, typescript@npm:^5.4.5":
+  version: 5.8.3
+  resolution: "typescript@npm:5.8.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
+  checksum: cb1d081c889a288b962d3c8ae18d337ad6ee88a8e81ae0103fa1fecbe923737f3ba1dbdb3e6d8b776c72bc73bfa6d8d850c0306eed1a51377d2fccdfd75d92c4
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"
+"typescript@patch:typescript@^4.9.5 || ^5.4.5#~builtin<compat/typescript>, typescript@patch:typescript@^5.2.2#~builtin<compat/typescript>, typescript@patch:typescript@^5.4.5#~builtin<compat/typescript>":
+  version: 5.8.3
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#~builtin<compat/typescript>::version=5.8.3&hash=77c9e2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 1f8f3b6aaea19f0f67cba79057674ba580438a7db55057eb89cc06950483c5d632115c14077f6663ea76fd09fce3c190e6414bb98582ec80aa5a4eaf345d5b68
+  checksum: 1b503525a88ff0ff5952e95870971c4fb2118c17364d60302c21935dedcd6c37e6a0a692f350892bafcef6f4a16d09073fe461158547978d2f16fbe4cb18581c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Turns out that `moduleResolution: node10` will achieve the same result as setting `src/package.json` to `{}` (verified via git worktrees).

Also switching `moduleResolution: bundler` for ESM build, after which I've compared the build output of `libs/checkpoint` via `diff -r -q`.
