### PR TITLE
fix(langgraph): memory leak when using AbortSignal.any(...)

### DIFF
--- a/libs/langgraph/src/pregel/utils/index.ts
+++ b/libs/langgraph/src/pregel/utils/index.ts
@@ -123,10 +123,12 @@ export function combineAbortSignals(...signals: AbortSignal[]): AbortSignal {
     return signals[0];
   }
 
-  if ("any" in AbortSignal) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (AbortSignal as any).any(signals);
-  }
+  // AbortSignal.any() does seem to suffer from memory leaks
+  // @see https://github.com/nodejs/node/issues/55328
+  // if ("any" in AbortSignal) {
+  //   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  //   return (AbortSignal as any).any(signals);
+  // }
   const combinedController = new AbortController();
   const listener = () => {
     combinedController.abort();


### PR DESCRIPTION
Replacing to our polyfill does seem to avoid spurious memory leaks on v22.14. See https://github.com/nodejs/node/issues/55328 for more details
