### PR TITLE
fix(langgraph): propagate recursionLimit and signal in RemoteGraph

### DIFF
--- a/libs/langgraph/src/pregel/remote.ts
+++ b/libs/langgraph/src/pregel/remote.ts
@@ -262,6 +262,7 @@ export class RemoteGraph<
       tags: sanitizedConfig.tags ?? [],
       metadata: sanitizedConfig.metadata ?? {},
       configurable: newConfigurable,
+      recursion_limit: sanitizedConfig.recursionLimit,
     };
   }
 
@@ -435,6 +436,7 @@ export class RemoteGraph<
         interruptAfter: interruptAfter as string[],
         streamSubgraphs,
         ifNotExists: "create",
+        signal: mergedConfig.signal,
       }
     )) {
       let mode;

--- a/libs/langgraph/src/tests/remote.test.ts
+++ b/libs/langgraph/src/tests/remote.test.ts
@@ -5,6 +5,7 @@ import { RemoteGraph } from "../pregel/remote.js";
 import { gatherIterator } from "../utils.js";
 import { Command, INTERRUPT, Send } from "../constants.js";
 import { GraphInterrupt } from "../errors.js";
+import { RunnableConfig } from "@langchain/core/runnables";
 
 describe("RemoteGraph", () => {
   test("withConfig", () => {
@@ -526,8 +527,54 @@ describe("RemoteGraph", () => {
         interruptBefore: undefined,
         interruptAfter: undefined,
         streamSubgraphs: false,
+        signal: undefined,
         ifNotExists: "create",
       },
+    ]);
+  });
+
+  test("invoke propagates recursionLimit and other config keys to API", async () => {
+    const client = new Client({});
+    let streamArgs: unknown[] | undefined;
+    vi.spyOn(client.runs, "stream").mockImplementation(async function* (
+      ...args
+    ) {
+      streamArgs = args;
+      yield {
+        event: "values",
+        data: { messages: [{ type: "human", content: "world" }] },
+      };
+    });
+
+    const remotePregel = new RemoteGraph({
+      client,
+      graphId: "test_graph_id",
+    });
+
+    const config: RunnableConfig = {
+      configurable: {
+        thread_id: "thread_1",
+        custom_key: "custom_value",
+      },
+      recursionLimit: 10,
+      tags: ["test", "invoke"],
+      metadata: { source: "test", version: "1.0" },
+      signal: new AbortController().signal,
+    };
+
+    await remotePregel.invoke({}, config);
+
+    expect(streamArgs).toEqual([
+      "thread_1",
+      "test_graph_id",
+      expect.objectContaining({
+        signal: config.signal,
+        config: expect.objectContaining({
+          configurable: config.configurable,
+          recursion_limit: config.recursionLimit,
+          tags: config.tags,
+        }),
+      }),
     ]);
   });
 });


### PR DESCRIPTION
 Fixes #1237
