### PR TITLE
feat(langgraph): return interrupts with `streamMode: "values"`

### DIFF
--- a/libs/langgraph/src/constants.ts
+++ b/libs/langgraph/src/constants.ts
@@ -172,14 +172,38 @@ export function _isSend(x: unknown): x is Send {
   return x instanceof Send;
 }
 
-export type Interrupt = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  value?: any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Interrupt<Value = any> = {
+  value?: Value;
   // eslint-disable-next-line @typescript-eslint/ban-types
   when: "during" | (string & {});
   resumable?: boolean;
   ns?: string[];
 };
+
+/**
+ * Checks if the given graph invoke / stream chunk contains interrupt.
+ *
+ * @example
+ * ```ts
+ * import { INTERRUPT, isInterrupted } from "@langchain/langgraph";
+ *
+ * const values = await graph.invoke({ foo: "bar" });
+ * if (isInterrupted<string>(values)) {
+ *   const interrupt = values[INTERRUPT][0].value;
+ * }
+ * ```
+ *
+ * @param values - The values to check.
+ * @returns `true` if the values contain an interrupt, `false` otherwise.
+ */
+export function isInterrupted<Value = unknown>(
+  values: unknown
+): values is { [INTERRUPT]: Interrupt<Value>[] } {
+  if (!values || typeof values !== "object") return false;
+  if (!(INTERRUPT in values)) return false;
+  return Array.isArray(values[INTERRUPT]);
+}
 
 export type CommandParams<
   Resume = unknown,

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -61,6 +61,7 @@ import {
   END,
   CONFIG_KEY_NODE_FINISHED,
   Interrupt,
+  isInterrupted,
 } from "../constants.js";
 import {
   PregelExecutableTask,
@@ -2133,21 +2134,12 @@ export class Pregel<
 
     let latest: OutputType | undefined;
 
-    const isInterruptValues = (
-      values: unknown
-    ): values is { [INTERRUPT]: Interrupt[] } => {
-      if (!values || typeof values !== "object") return false;
-      if (!(INTERRUPT in values)) return false;
-      return Array.isArray(values[INTERRUPT]);
-    };
-
     for await (const chunk of stream) {
       if (streamMode === "values") {
-        const values = chunk as OutputType;
-        if (isInterruptValues(values)) {
-          interruptChunks.push(values[INTERRUPT]);
+        if (isInterrupted(chunk)) {
+          interruptChunks.push(chunk[INTERRUPT]);
         } else {
-          latest = values;
+          latest = chunk as OutputType;
         }
       } else {
         chunks.push(chunk);

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -382,7 +382,7 @@ export class Pregel<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ConfigurableFieldType extends Record<string, any> = StrRecord<string, any>,
     InputType = PregelInputType,
-    OutputType = PregelOutputType & { [INTERRUPT]?: Interrupt[] },
+    OutputType = PregelOutputType,
     StreamUpdatesType = InputType,
     StreamValuesType = OutputType
   >

--- a/libs/langgraph/src/pregel/loop.ts
+++ b/libs/langgraph/src/pregel/loop.ts
@@ -859,13 +859,10 @@ export class PregelLoop {
       }
 
       // Emit INTERRUPT event
+      const interrupts = { [INTERRUPT]: (error as GraphInterrupt).interrupts };
       this._emit([
-        [
-          "updates",
-          {
-            [INTERRUPT]: (error as GraphInterrupt).interrupts,
-          },
-        ],
+        ["updates", interrupts],
+        ["values", interrupts],
       ]);
     }
     return suppress;

--- a/libs/langgraph/src/pregel/types.ts
+++ b/libs/langgraph/src/pregel/types.ts
@@ -40,14 +40,6 @@ type StreamDebugOutput = Record<string, any>;
 
 type DefaultStreamMode = "updates";
 
-type StreamValuesType<StreamValues> = StreamValues extends object
-  ? StreamValues & { __interrupt__?: Interrupt[] }
-  : StreamValues;
-
-type StreamUpdateType<StreamUpdates, Nodes> = {
-  [key in Nodes extends string ? Nodes : string]: StreamUpdates;
-} & { __interrupt__?: Interrupt[] };
-
 export type StreamOutputMap<
   TStreamMode extends StreamMode | StreamMode[] | undefined,
   TStreamSubgraphs extends boolean,
@@ -67,15 +59,22 @@ export type StreamOutputMap<
 ) extends infer Multiple extends StreamMode
   ? [TStreamSubgraphs] extends [true]
     ? {
-        values: [string[], "values", StreamValuesType<StreamValues>];
-        updates: [string[], "updates", StreamUpdateType<StreamUpdates, Nodes>];
+        values: [string[], "values", StreamValues];
+        updates: [
+          string[],
+          "updates",
+          Record<Nodes extends string ? Nodes : string, StreamUpdates>
+        ];
         messages: [string[], "messages", StreamMessageOutput];
         custom: [string[], "custom", StreamCustomOutput];
         debug: [string[], "debug", StreamDebugOutput];
       }[Multiple]
     : {
-        values: ["values", StreamValuesType<StreamValues>];
-        updates: ["updates", StreamUpdateType<StreamUpdates, Nodes>];
+        values: ["values", StreamValues];
+        updates: [
+          "updates",
+          Record<Nodes extends string ? Nodes : string, StreamUpdates>
+        ];
         messages: ["messages", StreamMessageOutput];
         custom: ["custom", StreamCustomOutput];
         debug: ["debug", StreamDebugOutput];
@@ -85,15 +84,18 @@ export type StreamOutputMap<
     ) extends infer Single extends StreamMode
   ? [TStreamSubgraphs] extends [true]
     ? {
-        values: [string[], StreamValuesType<StreamValues>];
-        updates: [string[], StreamUpdateType<StreamUpdates, Nodes>];
+        values: [string[], StreamValues];
+        updates: [
+          string[],
+          Record<Nodes extends string ? Nodes : string, StreamUpdates>
+        ];
         messages: [string[], StreamMessageOutput];
         custom: [string[], StreamCustomOutput];
         debug: [string[], StreamDebugOutput];
       }[Single]
     : {
-        values: StreamValuesType<StreamValues>;
-        updates: StreamUpdateType<StreamUpdates, Nodes>;
+        values: StreamValues;
+        updates: Record<Nodes extends string ? Nodes : string, StreamUpdates>;
         messages: StreamMessageOutput;
         custom: StreamCustomOutput;
         debug: StreamDebugOutput;

--- a/libs/langgraph/src/tests/func.test.ts
+++ b/libs/langgraph/src/tests/func.test.ts
@@ -688,7 +688,19 @@ export function runFuncTests(
         // ideally the withCheckpointer = false case would throw an error here, see https://github.com/langchain-ai/langgraphjs/issues/796
         const firstRun = await graph.invoke("the correct ", config);
 
-        expect(firstRun).toBeUndefined();
+        expect(firstRun).toEqual({
+          __interrupt__: [
+            {
+              ns: [
+                expect.stringMatching(/^interruptGraph:/),
+                expect.stringMatching(/^interruptTask:/),
+              ],
+              resumable: true,
+              value: "Please provide input",
+              when: "during",
+            },
+          ],
+        });
         expect(taskCallCount).toBe(1);
         expect(graphCallCount).toBe(1);
 
@@ -741,7 +753,16 @@ export function runFuncTests(
 
         // First run, interrupted at bar
         const firstRun = await graph.invoke({ a: "" }, config);
-        expect(firstRun).toBeUndefined();
+        expect(firstRun).toEqual({
+          __interrupt__: [
+            {
+              ns: [expect.stringMatching(/^interruptGraph:/)],
+              resumable: true,
+              value: "Provide value for bar:",
+              when: "during",
+            },
+          ],
+        });
 
         // Resume with an answer
         const result = await graph.invoke(
@@ -780,7 +801,19 @@ export function runFuncTests(
 
         // First run, interrupted at bar
         const firstRun = await graph.invoke({ a: "" }, config);
-        expect(firstRun).toBeUndefined();
+        expect(firstRun).toEqual({
+          __interrupt__: [
+            {
+              ns: [
+                expect.stringMatching(/^interruptGraph:/),
+                expect.stringMatching(/^bar:/),
+              ],
+              resumable: true,
+              value: "Provide value for bar:",
+              when: "during",
+            },
+          ],
+        });
 
         // Resume with an answer
         const result = await graph.invoke(
@@ -809,7 +842,16 @@ export function runFuncTests(
 
         // First run should interrupt
         const firstRun = await graph.invoke({ a: 5 }, config);
-        expect(firstRun).toBeUndefined();
+        expect(firstRun).toEqual({
+          __interrupt__: [
+            {
+              ns: [expect.stringMatching(/^falsyGraph:/)],
+              resumable: true,
+              value: "test",
+              when: "during",
+            },
+          ],
+        });
 
         // Resume with answer
         const result = await graph.invoke(
@@ -844,7 +886,16 @@ export function runFuncTests(
 
         // First run should interrupt
         const firstRun = await graph.invoke([], config);
-        expect(firstRun).toBeUndefined();
+        expect(firstRun).toEqual({
+          __interrupt__: [
+            {
+              ns: [expect.stringMatching(/^graph:/)],
+              resumable: true,
+              value: { a: "boo1" },
+              when: "during",
+            },
+          ],
+        });
 
         // Resume with first answer
         const secondRun = await graph.invoke(
@@ -853,7 +904,16 @@ export function runFuncTests(
         );
 
         // TODO: make this return something other than null when we figure out a interrupt return value
-        expect(secondRun).toBeNull();
+        expect(secondRun).toEqual({
+          __interrupt__: [
+            {
+              ns: [expect.stringMatching(/^graph:/)],
+              resumable: true,
+              value: { a: "boo2" },
+              when: "during",
+            },
+          ],
+        });
 
         // Resume with second answer
         const thirdRun = await graph.invoke(
@@ -861,7 +921,16 @@ export function runFuncTests(
           config
         );
 
-        expect(thirdRun).toBeNull();
+        expect(thirdRun).toEqual({
+          __interrupt__: [
+            {
+              ns: [expect.stringMatching(/^graph:/)],
+              resumable: true,
+              value: { a: "boo3" },
+              when: "during",
+            },
+          ],
+        });
 
         // Resume with final answer and get result
         const result = await graph.invoke(new Command({ resume: "c" }), config);
@@ -904,7 +973,19 @@ export function runFuncTests(
         const config = { configurable: { thread_id } };
 
         let result = await program.invoke([], config);
-        expect(result).toBeUndefined();
+        expect(result).toEqual({
+          __interrupt__: [
+            {
+              ns: [
+                expect.stringMatching(/^program:/),
+                expect.stringMatching(/^add-participant:/),
+              ],
+              resumable: true,
+              value: "Hey do you want to add James?",
+              when: "during",
+            },
+          ],
+        });
 
         let currTasks = (await program.getState(config)).tasks;
         expect(currTasks[0].interrupts).toHaveLength(1);
@@ -922,7 +1003,19 @@ export function runFuncTests(
         expect(currTasks[0].interrupts[0].when).toEqual("during");
 
         result = await program.invoke(new Command({ resume: true }), config);
-        expect(result).toBeNull();
+        expect(result).toEqual({
+          __interrupt__: [
+            {
+              ns: [
+                expect.stringMatching(/^program:/),
+                expect.stringMatching(/^add-participant:/),
+              ],
+              resumable: true,
+              value: "Hey do you want to add Will?",
+              when: "during",
+            },
+          ],
+        });
 
         currTasks = (await program.getState(config)).tasks;
         expect(currTasks[0].interrupts).toHaveLength(1);

--- a/libs/langgraph/src/tests/pregel.test-d.ts
+++ b/libs/langgraph/src/tests/pregel.test-d.ts
@@ -10,7 +10,7 @@ import { gatherIterator } from "../utils.js";
 import { StreamMode } from "../pregel/types.js";
 import { task, entrypoint } from "../func/index.js";
 import { initializeAsyncLocalStorageSingleton } from "../setup/async_local_storage.js";
-import type { Interrupt } from "../constants.js";
+import { INTERRUPT, isInterrupted } from "../constants.js";
 
 beforeAll(() => {
   // Will occur naturally if user imports from main `@langchain/langgraph` endpoint.
@@ -40,16 +40,15 @@ it("state graph annotation", async () => {
 
   const input = { foo: "bar" };
 
-  expectTypeOf(await graph.invoke(input)).toExtend<{
-    foo: string[];
-    __interrupt__?: Interrupt[];
-  }>();
+  const values = await graph.invoke(input);
+  expectTypeOf(values).toExtend<{ foo: string[] }>();
+
+  if (isInterrupted<string>(values)) {
+    expectTypeOf(values[INTERRUPT][0].value).toExtend<string | undefined>();
+  }
 
   expectTypeOf(await gatherIterator(graph.stream(input))).toExtend<
-    (
-      | Record<"one" | "two" | "three", { foo?: string[] | string }>
-      | { __interrupt__: Interrupt[] }
-    )[]
+    Record<"one" | "two" | "three", { foo?: string[] | string }>[]
   >();
 
   expectTypeOf(
@@ -74,25 +73,12 @@ it("state graph annotation", async () => {
 
   expectTypeOf(
     await gatherIterator(graph.stream(input, { streamMode: "updates" }))
-  ).toExtend<
-    (
-      | Record<"one" | "two" | "three", { foo?: string[] | string }>
-      | { __interrupt__: Interrupt[] }
-    )[]
-  >();
+  ).toExtend<Record<"one" | "two" | "three", { foo?: string[] | string }>[]>();
 
   expectTypeOf(
     await gatherIterator(graph.stream(input, { streamMode: ["updates"] }))
   ).toExtend<
-    (
-      | [
-          "updates",
-          (
-            | Record<"one" | "two" | "three", { foo?: string[] | string }>
-            | { __interrupt__: Interrupt[] }
-          )
-        ]
-    )[]
+    ["updates", Record<"one" | "two" | "three", { foo?: string[] | string }>][]
   >();
 
   expectTypeOf(
@@ -103,10 +89,7 @@ it("state graph annotation", async () => {
     [
       string[],
       "updates",
-      (
-        | Record<"one" | "two" | "three", { foo?: string[] | string }>
-        | { __interrupt__: Interrupt[] }
-      )
+      Record<"one" | "two" | "three", { foo?: string[] | string }>
     ][]
   >();
 
@@ -118,12 +101,9 @@ it("state graph annotation", async () => {
     (
       | [
           "updates",
-          (
-            | Record<"one" | "two" | "three", { foo?: string[] | string }>
-            | { __interrupt__: Interrupt[] }
-          )
+          Record<"one" | "two" | "three", { foo?: string[] | string }>
         ]
-      | ["values", { foo: string[]; __interrupt__?: Interrupt[] }]
+      | ["values", { foo: string[] }]
     )[]
   >();
 
@@ -139,12 +119,9 @@ it("state graph annotation", async () => {
       | [
           string[],
           "updates",
-          (
-            | Record<"one" | "two" | "three", { foo?: string[] | string }>
-            | { __interrupt__: Interrupt[] }
-          )
+          Record<"one" | "two" | "three", { foo?: string[] | string }>
         ]
-      | [string[], "values", { foo: string[]; __interrupt__?: Interrupt[] }]
+      | [string[], "values", { foo: string[] }]
     )[]
   >();
 
@@ -162,12 +139,9 @@ it("state graph annotation", async () => {
     (
       | [
           "updates",
-          (
-            | Record<"one" | "two" | "three", { foo?: string[] | string }>
-            | { __interrupt__: Interrupt[] }
-          )
+          Record<"one" | "two" | "three", { foo?: string[] | string }>
         ]
-      | ["values", { foo: string[]; __interrupt__?: Interrupt[] }]
+      | ["values", { foo: string[] }]
       | ["debug", Record<string, any>]
       | ["messages", [BaseMessage, Record<string, any>]]
       | ["custom", any]
@@ -189,12 +163,9 @@ it("state graph annotation", async () => {
       | [
           string[],
           "updates",
-          (
-            | Record<"one" | "two" | "three", { foo?: string[] | string }>
-            | { __interrupt__: Interrupt[] }
-          )
+          Record<"one" | "two" | "three", { foo?: string[] | string }>
         ]
-      | [string[], "values", { foo: string[]; __interrupt__?: Interrupt[] }]
+      | [string[], "values", { foo: string[] }]
       | [string[], "debug", Record<string, any>]
       | [string[], "messages", [BaseMessage, Record<string, any>]]
       | [string[], "custom", any]
@@ -220,16 +191,15 @@ it("state graph zod", async () => {
 
   const input = { foo: "bar" };
 
-  expectTypeOf(await graph.invoke(input)).toExtend<{
-    foo: string[];
-    __interrupt__?: Interrupt[];
-  }>();
+  const values = await graph.invoke(input);
+  expectTypeOf(values).toExtend<{ foo: string[] }>();
+
+  if (isInterrupted<string>(values)) {
+    expectTypeOf(values[INTERRUPT][0].value).toExtend<string | undefined>();
+  }
 
   expectTypeOf(await gatherIterator(graph.stream(input))).toExtend<
-    (
-      | Record<"one" | "two" | "three", { foo?: string[] | string }>
-      | { __interrupt__: Interrupt[] }
-    )[]
+    Record<"one" | "two" | "three", { foo?: string[] | string }>[]
   >();
 
   expectTypeOf(
@@ -254,23 +224,12 @@ it("state graph zod", async () => {
 
   expectTypeOf(
     await gatherIterator(graph.stream(input, { streamMode: "updates" }))
-  ).toExtend<
-    (
-      | Record<"one" | "two" | "three", { foo?: string[] | string }>
-      | { __interrupt__: Interrupt[] }
-    )[]
-  >();
+  ).toExtend<Record<"one" | "two" | "three", { foo?: string[] | string }>[]>();
 
   expectTypeOf(
     await gatherIterator(graph.stream(input, { streamMode: ["updates"] }))
   ).toExtend<
-    [
-      "updates",
-      (
-        | Record<"one" | "two" | "three", { foo?: string[] | string }>
-        | { __interrupt__: Interrupt[] }
-      )
-    ][]
+    ["updates", Record<"one" | "two" | "three", { foo?: string[] | string }>][]
   >();
 
   expectTypeOf(
@@ -281,10 +240,7 @@ it("state graph zod", async () => {
     [
       string[],
       "updates",
-      (
-        | Record<"one" | "two" | "three", { foo?: string[] | string }>
-        | { __interrupt__: Interrupt[] }
-      )
+      Record<"one" | "two" | "three", { foo?: string[] | string }>
     ][]
   >();
 
@@ -296,12 +252,9 @@ it("state graph zod", async () => {
     (
       | [
           "updates",
-          (
-            | Record<"one" | "two" | "three", { foo?: string[] | string }>
-            | { __interrupt__: Interrupt[] }
-          )
+          Record<"one" | "two" | "three", { foo?: string[] | string }>
         ]
-      | ["values", { foo: string[]; __interrupt__?: Interrupt[] }]
+      | ["values", { foo: string[] }]
     )[]
   >();
 
@@ -317,12 +270,9 @@ it("state graph zod", async () => {
       | [
           string[],
           "updates",
-          (
-            | Record<"one" | "two" | "three", { foo?: string[] | string }>
-            | { __interrupt__: Interrupt[] }
-          )
+          Record<"one" | "two" | "three", { foo?: string[] | string }>
         ]
-      | [string[], "values", { foo: string[]; __interrupt__?: Interrupt[] }]
+      | [string[], "values", { foo: string[] }]
     )[]
   >();
 
@@ -340,12 +290,9 @@ it("state graph zod", async () => {
     (
       | [
           "updates",
-          (
-            | Record<"one" | "two" | "three", { foo?: string[] | string }>
-            | { __interrupt__: Interrupt[] }
-          )
+          Record<"one" | "two" | "three", { foo?: string[] | string }>
         ]
-      | ["values", { foo: string[]; __interrupt__?: Interrupt[] }]
+      | ["values", { foo: string[] }]
       | ["debug", Record<string, any>]
       | ["messages", [BaseMessage, Record<string, any>]]
       | ["custom", any]
@@ -367,12 +314,9 @@ it("state graph zod", async () => {
       | [
           string[],
           "updates",
-          (
-            | Record<"one" | "two" | "three", { foo?: string[] | string }>
-            | { __interrupt__: Interrupt[] }
-          )
+          Record<"one" | "two" | "three", { foo?: string[] | string }>
         ]
-      | [string[], "values", { foo: string[]; __interrupt__?: Interrupt[] }]
+      | [string[], "values", { foo: string[] }]
       | [string[], "debug", Record<string, any>]
       | [string[], "messages", [BaseMessage, Record<string, any>]]
       | [string[], "custom", any]
@@ -399,10 +343,10 @@ it("functional", async () => {
 
   const input = { input: "test" };
 
-  type UpdateType = Record<string, any> | { __interrupt__: Interrupt[] };
+  type UpdateType = Record<string, any>;
   type ValueType = {
     foo: ({ one: string } | { two: string } | { three: string })[];
-  } & { __interrupt__?: Interrupt[] };
+  };
 
   expectTypeOf(await graph.invoke(input)).toExtend<ValueType>();
   expectTypeOf(await gatherIterator(graph.stream(input))).toExtend<

--- a/libs/langgraph/src/tests/pregel.test-d.ts
+++ b/libs/langgraph/src/tests/pregel.test-d.ts
@@ -10,6 +10,7 @@ import { gatherIterator } from "../utils.js";
 import { StreamMode } from "../pregel/types.js";
 import { task, entrypoint } from "../func/index.js";
 import { initializeAsyncLocalStorageSingleton } from "../setup/async_local_storage.js";
+import type { Interrupt } from "../constants.js";
 
 beforeAll(() => {
   // Will occur naturally if user imports from main `@langchain/langgraph` endpoint.
@@ -39,10 +40,16 @@ it("state graph annotation", async () => {
 
   const input = { foo: "bar" };
 
-  expectTypeOf(await graph.invoke(input)).toExtend<{ foo: string[] }>();
+  expectTypeOf(await graph.invoke(input)).toExtend<{
+    foo: string[];
+    __interrupt__?: Interrupt[];
+  }>();
 
   expectTypeOf(await gatherIterator(graph.stream(input))).toExtend<
-    Record<"one" | "two" | "three", { foo?: string[] | string }>[]
+    (
+      | Record<"one" | "two" | "three", { foo?: string[] | string }>
+      | { __interrupt__: Interrupt[] }
+    )[]
   >();
 
   expectTypeOf(
@@ -67,12 +74,25 @@ it("state graph annotation", async () => {
 
   expectTypeOf(
     await gatherIterator(graph.stream(input, { streamMode: "updates" }))
-  ).toExtend<Record<"one" | "two" | "three", { foo?: string[] | string }>[]>();
+  ).toExtend<
+    (
+      | Record<"one" | "two" | "three", { foo?: string[] | string }>
+      | { __interrupt__: Interrupt[] }
+    )[]
+  >();
 
   expectTypeOf(
     await gatherIterator(graph.stream(input, { streamMode: ["updates"] }))
   ).toExtend<
-    ["updates", Record<"one" | "two" | "three", { foo?: string[] | string }>][]
+    (
+      | [
+          "updates",
+          (
+            | Record<"one" | "two" | "three", { foo?: string[] | string }>
+            | { __interrupt__: Interrupt[] }
+          )
+        ]
+    )[]
   >();
 
   expectTypeOf(
@@ -83,7 +103,10 @@ it("state graph annotation", async () => {
     [
       string[],
       "updates",
-      Record<"one" | "two" | "three", { foo?: string[] | string }>
+      (
+        | Record<"one" | "two" | "three", { foo?: string[] | string }>
+        | { __interrupt__: Interrupt[] }
+      )
     ][]
   >();
 
@@ -95,9 +118,12 @@ it("state graph annotation", async () => {
     (
       | [
           "updates",
-          Record<"one" | "two" | "three", { foo?: string[] | string }>
+          (
+            | Record<"one" | "two" | "three", { foo?: string[] | string }>
+            | { __interrupt__: Interrupt[] }
+          )
         ]
-      | ["values", { foo: string[] }]
+      | ["values", { foo: string[]; __interrupt__?: Interrupt[] }]
     )[]
   >();
 
@@ -113,9 +139,12 @@ it("state graph annotation", async () => {
       | [
           string[],
           "updates",
-          Record<"one" | "two" | "three", { foo?: string[] | string }>
+          (
+            | Record<"one" | "two" | "three", { foo?: string[] | string }>
+            | { __interrupt__: Interrupt[] }
+          )
         ]
-      | [string[], "values", { foo: string[] }]
+      | [string[], "values", { foo: string[]; __interrupt__?: Interrupt[] }]
     )[]
   >();
 
@@ -133,9 +162,12 @@ it("state graph annotation", async () => {
     (
       | [
           "updates",
-          Record<"one" | "two" | "three", { foo?: string[] | string }>
+          (
+            | Record<"one" | "two" | "three", { foo?: string[] | string }>
+            | { __interrupt__: Interrupt[] }
+          )
         ]
-      | ["values", { foo: string[] }]
+      | ["values", { foo: string[]; __interrupt__?: Interrupt[] }]
       | ["debug", Record<string, any>]
       | ["messages", [BaseMessage, Record<string, any>]]
       | ["custom", any]
@@ -157,9 +189,12 @@ it("state graph annotation", async () => {
       | [
           string[],
           "updates",
-          Record<"one" | "two" | "three", { foo?: string[] | string }>
+          (
+            | Record<"one" | "two" | "three", { foo?: string[] | string }>
+            | { __interrupt__: Interrupt[] }
+          )
         ]
-      | [string[], "values", { foo: string[] }]
+      | [string[], "values", { foo: string[]; __interrupt__?: Interrupt[] }]
       | [string[], "debug", Record<string, any>]
       | [string[], "messages", [BaseMessage, Record<string, any>]]
       | [string[], "custom", any]
@@ -185,10 +220,16 @@ it("state graph zod", async () => {
 
   const input = { foo: "bar" };
 
-  expectTypeOf(await graph.invoke(input)).toExtend<{ foo: string[] }>();
+  expectTypeOf(await graph.invoke(input)).toExtend<{
+    foo: string[];
+    __interrupt__?: Interrupt[];
+  }>();
 
   expectTypeOf(await gatherIterator(graph.stream(input))).toExtend<
-    Record<"one" | "two" | "three", { foo?: string[] | string }>[]
+    (
+      | Record<"one" | "two" | "three", { foo?: string[] | string }>
+      | { __interrupt__: Interrupt[] }
+    )[]
   >();
 
   expectTypeOf(
@@ -213,12 +254,23 @@ it("state graph zod", async () => {
 
   expectTypeOf(
     await gatherIterator(graph.stream(input, { streamMode: "updates" }))
-  ).toExtend<Record<"one" | "two" | "three", { foo?: string[] | string }>[]>();
+  ).toExtend<
+    (
+      | Record<"one" | "two" | "three", { foo?: string[] | string }>
+      | { __interrupt__: Interrupt[] }
+    )[]
+  >();
 
   expectTypeOf(
     await gatherIterator(graph.stream(input, { streamMode: ["updates"] }))
   ).toExtend<
-    ["updates", Record<"one" | "two" | "three", { foo?: string[] | string }>][]
+    [
+      "updates",
+      (
+        | Record<"one" | "two" | "three", { foo?: string[] | string }>
+        | { __interrupt__: Interrupt[] }
+      )
+    ][]
   >();
 
   expectTypeOf(
@@ -229,7 +281,10 @@ it("state graph zod", async () => {
     [
       string[],
       "updates",
-      Record<"one" | "two" | "three", { foo?: string[] | string }>
+      (
+        | Record<"one" | "two" | "three", { foo?: string[] | string }>
+        | { __interrupt__: Interrupt[] }
+      )
     ][]
   >();
 
@@ -241,9 +296,12 @@ it("state graph zod", async () => {
     (
       | [
           "updates",
-          Record<"one" | "two" | "three", { foo?: string[] | string }>
+          (
+            | Record<"one" | "two" | "three", { foo?: string[] | string }>
+            | { __interrupt__: Interrupt[] }
+          )
         ]
-      | ["values", { foo: string[] }]
+      | ["values", { foo: string[]; __interrupt__?: Interrupt[] }]
     )[]
   >();
 
@@ -259,9 +317,12 @@ it("state graph zod", async () => {
       | [
           string[],
           "updates",
-          Record<"one" | "two" | "three", { foo?: string[] | string }>
+          (
+            | Record<"one" | "two" | "three", { foo?: string[] | string }>
+            | { __interrupt__: Interrupt[] }
+          )
         ]
-      | [string[], "values", { foo: string[] }]
+      | [string[], "values", { foo: string[]; __interrupt__?: Interrupt[] }]
     )[]
   >();
 
@@ -279,9 +340,12 @@ it("state graph zod", async () => {
     (
       | [
           "updates",
-          Record<"one" | "two" | "three", { foo?: string[] | string }>
+          (
+            | Record<"one" | "two" | "three", { foo?: string[] | string }>
+            | { __interrupt__: Interrupt[] }
+          )
         ]
-      | ["values", { foo: string[] }]
+      | ["values", { foo: string[]; __interrupt__?: Interrupt[] }]
       | ["debug", Record<string, any>]
       | ["messages", [BaseMessage, Record<string, any>]]
       | ["custom", any]
@@ -303,9 +367,12 @@ it("state graph zod", async () => {
       | [
           string[],
           "updates",
-          Record<"one" | "two" | "three", { foo?: string[] | string }>
+          (
+            | Record<"one" | "two" | "three", { foo?: string[] | string }>
+            | { __interrupt__: Interrupt[] }
+          )
         ]
-      | [string[], "values", { foo: string[] }]
+      | [string[], "values", { foo: string[]; __interrupt__?: Interrupt[] }]
       | [string[], "debug", Record<string, any>]
       | [string[], "messages", [BaseMessage, Record<string, any>]]
       | [string[], "custom", any]
@@ -332,10 +399,10 @@ it("functional", async () => {
 
   const input = { input: "test" };
 
-  type UpdateType = Record<string, any>;
+  type UpdateType = Record<string, any> | { __interrupt__: Interrupt[] };
   type ValueType = {
     foo: ({ one: string } | { two: string } | { three: string })[];
-  };
+  } & { __interrupt__?: Interrupt[] };
 
   expectTypeOf(await graph.invoke(input)).toExtend<ValueType>();
   expectTypeOf(await gatherIterator(graph.stream(input))).toExtend<

--- a/libs/langgraph/src/tests/python_port/checkpoint.test.ts
+++ b/libs/langgraph/src/tests/python_port/checkpoint.test.ts
@@ -816,6 +816,14 @@ describe("Checkpoint Tests (Python port)", () => {
     expect(result1).toEqual({
       my_key: "value one",
       market: "DE",
+      __interrupt__: [
+        {
+          value: "Just because...",
+          resumable: true,
+          when: "during",
+          ns: [expect.stringMatching(/^tool_two:/)],
+        },
+      ],
     });
 
     expect(tool_two_node_count).toBe(1);
@@ -860,9 +868,7 @@ describe("Checkpoint Tests (Python port)", () => {
 
     // Assert that we got the expected outputs including an interrupt
     expect(results1).toEqual([
-      {
-        tool_one: { my_key: " one" },
-      },
+      { tool_one: { my_key: " one" } },
       {
         __interrupt__: [
           expect.objectContaining({
@@ -909,6 +915,14 @@ describe("Checkpoint Tests (Python port)", () => {
     expect(result3).toEqual({
       my_key: "value ⛰️ one",
       market: "DE",
+      __interrupt__: [
+        {
+          value: "Just because...",
+          resumable: true,
+          when: "during",
+          ns: [expect.stringMatching(/^tool_two:/)],
+        },
+      ],
     });
 
     // Check the state

--- a/libs/langgraph/src/tests/python_port/graph_structure.test.ts
+++ b/libs/langgraph/src/tests/python_port/graph_structure.test.ts
@@ -1445,12 +1445,7 @@ describe("Graph Structure Tests (Python port)", () => {
 
     // Test stream with interrupt
     const interruptedStreamResults = await gatherIterator(
-      await appWithInterrupt.stream(
-        {
-          query: "what is weather in sf",
-        },
-        config
-      )
+      appWithInterrupt.stream({ query: "what is weather in sf" }, config)
     );
 
     expect(interruptedStreamResults).toEqual([
@@ -1463,7 +1458,7 @@ describe("Graph Structure Tests (Python port)", () => {
 
     // Resume from interrupt
     const resumedResults = await gatherIterator(
-      await appWithInterrupt.stream(null, config)
+      appWithInterrupt.stream(null, config)
     );
 
     expect(resumedResults).toEqual([{ qa: { answer: "doc1,doc2,doc3,doc4" } }]);
@@ -1582,9 +1577,7 @@ describe("Graph Structure Tests (Python port)", () => {
 
     // Test stream
     const streamResults = await gatherIterator(
-      await app.stream({
-        query: "what is weather in sf",
-      })
+      app.stream({ query: "what is weather in sf" })
     );
 
     expect(streamResults).toEqual([
@@ -1607,12 +1600,7 @@ describe("Graph Structure Tests (Python port)", () => {
 
     // Test stream with interrupt
     const interruptedStreamResults = await gatherIterator(
-      await appWithInterrupt.stream(
-        {
-          query: "what is weather in sf",
-        },
-        config
-      )
+      appWithInterrupt.stream({ query: "what is weather in sf" }, config)
     );
 
     expect(interruptedStreamResults).toEqual([
@@ -1626,7 +1614,7 @@ describe("Graph Structure Tests (Python port)", () => {
 
     // Resume from interrupt
     const resumedResults = await gatherIterator(
-      await appWithInterrupt.stream(null, config)
+      appWithInterrupt.stream(null, config)
     );
 
     expect(resumedResults).toEqual([{ qa: { answer: "doc1,doc2,doc3,doc4" } }]);
@@ -2200,6 +2188,7 @@ describe("Graph Structure Tests (Python port)", () => {
     );
     expect(invokeResult1).toEqual({
       my_key: "hi my value",
+      __interrupt__: [],
     });
 
     const invokeResult2 = await app.invoke(null, { ...config1, debug: true });
@@ -2254,6 +2243,7 @@ describe("Graph Structure Tests (Python port)", () => {
     expect(streamValuesResults1).toEqual([
       { my_key: "my value" },
       { my_key: "hi my value" },
+      { __interrupt__: [] },
     ]);
 
     const streamValuesResults2 = await gatherIterator(

--- a/libs/langgraph/src/tests/python_port/interrupt.test.ts
+++ b/libs/langgraph/src/tests/python_port/interrupt.test.ts
@@ -342,6 +342,14 @@ describe("Async Pregel Interrupt Tests (Python port)", () => {
     expect(result1).toEqual({
       my_key: "value",
       market: "DE",
+      __interrupt__: [
+        {
+          value: "Just because...",
+          resumable: true,
+          when: "during",
+          ns: [expect.stringMatching(/^tool_two:.*$/)],
+        },
+      ],
     });
 
     expect(toolTwoNodeCount).toBe(1);
@@ -500,6 +508,17 @@ describe("Async Pregel Interrupt Tests (Python port)", () => {
     expect(result1).toEqual({
       my_key: "value",
       market: "DE",
+      __interrupt__: [
+        {
+          value: "Just because...",
+          resumable: true,
+          when: "during",
+          ns: [
+            expect.stringMatching(/^tool_two:.*$/),
+            expect.stringMatching(/^do:.*$/),
+          ],
+        },
+      ],
     });
 
     expect(toolTwoNodeCount).toBe(1);
@@ -660,13 +679,33 @@ describe("Async Pregel Interrupt Tests (Python port)", () => {
 
     // First invocation - writes from "awhile" are applied to last chunk
     const result1 = await graph.invoke({ hello: "world" }, thread);
-    expect(result1).toEqual({ hello: "world again" });
+    expect(result1).toEqual({
+      hello: "world again",
+      __interrupt__: [
+        {
+          value: "I am bad",
+          resumable: true,
+          when: "during",
+          ns: [expect.stringMatching(/^bad:.*$/)],
+        },
+      ],
+    });
     expect(innerTaskCancelled).toBe(false);
     expect(awhileCount).toBe(1);
 
     // Second invocation with debug mode
     const result2 = await graph.invoke(null, thread);
-    expect(result2).toEqual({ hello: "world again" });
+    expect(result2).toEqual({
+      hello: "world again",
+      __interrupt__: [
+        {
+          value: "I am bad",
+          resumable: true,
+          when: "during",
+          ns: [expect.stringMatching(/^bad:.*$/)],
+        },
+      ],
+    });
     expect(innerTaskCancelled).toBe(false);
     expect(awhileCount).toBe(1);
 

--- a/libs/langgraph/src/web.ts
+++ b/libs/langgraph/src/web.ts
@@ -49,6 +49,8 @@ export {
   isCommand,
   START,
   END,
+  INTERRUPT,
+  isInterrupted,
   type Interrupt,
 } from "./constants.js";
 export {


### PR DESCRIPTION
Partial port of https://github.com/langchain-ai/langgraph/pull/4374, does not tackle multi-resumes for now
