### PR TITLE
release(cua): 0.0.6

### DIFF
--- a/libs/langgraph-cua/package.json
+++ b/libs/langgraph-cua/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/langgraph-cua",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "An implementation of a computer use agent (CUA) using LangGraph",
   "type": "module",
   "engines": {
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@langchain/core": "^0.3.43",
-    "@langchain/langgraph": "^0.2.57",
+    "@langchain/langgraph": "^0.2.57 || ^0.3.0",
     "@langchain/openai": ">=0.5.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2246,7 +2246,7 @@ __metadata:
     zod: ^3.23.8
   peerDependencies:
     "@langchain/core": ^0.3.43
-    "@langchain/langgraph": ^0.2.57
+    "@langchain/langgraph": ^0.2.57 || ^0.3.0
     "@langchain/openai": ">=0.5.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Relax `peerDependencies` constraint to support `@langchain/langgraph 0.3.x`
