### PR TITLE
release(supervisor): 0.0.13

### DIFF
--- a/libs/langgraph-supervisor/package.json
+++ b/libs/langgraph-supervisor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/langgraph-supervisor",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "LangGraph Multi-Agent Supervisor",
   "type": "module",
   "engines": {
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "@langchain/core": "^0.3.40",
-    "@langchain/langgraph": "^0.2.72"
+    "@langchain/langgraph": "^0.2.72 || ^0.3.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2297,7 +2297,7 @@ __metadata:
     zod: ^3.23.8
   peerDependencies:
     "@langchain/core": ^0.3.40
-    "@langchain/langgraph": ^0.2.72
+    "@langchain/langgraph": ^0.2.72 || ^0.3.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Relax `peerDependencies` constraint to support `@langchain/langgraph 0.3.x`
