### PR TITLE
Fix Typos in Documentation and Example Notebooks

### DIFF
--- a/examples/how-tos/define-state.ipynb
+++ b/examples/how-tos/define-state.ipynb
@@ -189,7 +189,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Above, we set the value of `question` and `answer` to `null`, as it does not contain a default value. To set a default value, the channel should be implemented how the `messages` key is, with the `default` factory returing the default value. The `reducer` function is optional, and can be added to the channel object if needed."
+        "Above, we set the value of `question` and `answer` to `null`, as it does not contain a default value. To set a default value, the channel should be implemented how the `messages` key is, with the `default` factory returning the default value. The `reducer` function is optional, and can be added to the channel object if needed."
       ]
     },
     {

--- a/examples/multi_agent/hierarchical_agent_teams.ipynb
+++ b/examples/multi_agent/hierarchical_agent_teams.ipynb
@@ -539,7 +539,7 @@
         "The research team will have a search agent and a web scraping \"research_agent\"\n",
         "as the two worker nodes. Let's create those, as well as the team supervisor.\n",
         "(Note: If you are running deno in a jupyter notebook, the web scraper won't work\n",
-        "out of the box. We have commented out this code to accomodate this challenge)\n"
+        "out of the box. We have commented out this code to accommodate this challenge)\n"
       ]
     },
     {


### PR DESCRIPTION


Description:  
This pull request corrects minor typographical errors in the documentation and example Jupyter notebooks. Specifically, it fixes the spelling of "returning" and "accommodate" in the following files:

- examples/how-tos/define-state.ipynb
- examples/multi_agent/hierarchical_agent_teams.ipynb

No functional changes were made; these edits are for clarity and accuracy in the documentation.
