### PR TITLE
fix(langgraph): zod 4 registry reducer schema

### DIFF
--- a/libs/langgraph/src/graph/zod/zod-registry.ts
+++ b/libs/langgraph/src/graph/zod/zod-registry.ts
@@ -1,3 +1,4 @@
+import type * as core from "zod/v4/core";
 import { getInteropZodDefaultGetter } from "@langchain/core/utils/types";
 import { $ZodType, $ZodRegistry, $replace } from "zod/v4/core";
 import { SchemaMeta, SchemaMetaRegistry, schemaMetaRegistry } from "./meta.js";
@@ -43,6 +44,32 @@ export class LanggraphZodMetaRegistry<
       }
     }
     return super.add(schema, ..._meta);
+  }
+}
+
+// Augment the zod/v4 module nudging the `register` method
+// to use the user provided input schema if specified.
+declare module "zod/v4" {
+  export interface ZodType<
+    out Output = unknown,
+    out Input = unknown,
+    out Internals extends core.$ZodTypeInternals<
+      Output,
+      Input
+    > = core.$ZodTypeInternals<Output, Input>
+  > extends core.$ZodType<Output, Input, Internals> {
+    register<
+      R extends LanggraphZodMetaRegistry,
+      TOutput = core.output<this>,
+      TInput = core.input<this>,
+      TInternals extends core.$ZodTypeInternals<
+        TOutput,
+        TInput
+      > = core.$ZodTypeInternals<TOutput, TInput>
+    >(
+      registry: R,
+      meta: SchemaMeta<TOutput, TInput>
+    ): ZodType<TOutput, TInput, TInternals>;
   }
 }
 

--- a/libs/langgraph/src/graph/zod/zod-registry.ts
+++ b/libs/langgraph/src/graph/zod/zod-registry.ts
@@ -1,9 +1,14 @@
 // @ts-expect-error If zod/v4 is not imported, the module augmentation will fail in build
-import type { ZodType } from "zod/v4"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import { z, type ZodType } from "zod/v4"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import type * as core from "zod/v4/core";
 import { getInteropZodDefaultGetter } from "@langchain/core/utils/types";
 import { $ZodType, $ZodRegistry, $replace } from "zod/v4/core";
-import { SchemaMeta, SchemaMetaRegistry, schemaMetaRegistry } from "./meta.js";
+import {
+  type ReducedZodChannel,
+  type SchemaMeta,
+  type SchemaMetaRegistry,
+  schemaMetaRegistry,
+} from "./meta.js";
 
 /**
  * A Zod v4-compatible meta registry that extends the base registry.
@@ -71,7 +76,10 @@ declare module "zod/v4" {
     >(
       registry: R,
       meta: SchemaMeta<TOutput, TInput>
-    ): ZodType<TOutput, TInput, TInternals>;
+    ): ReducedZodChannel<
+      ZodType<TOutput, TInput, TInternals>,
+      ZodType<TOutput, TInput, TInternals>
+    >;
   }
 }
 

--- a/libs/langgraph/src/graph/zod/zod-registry.ts
+++ b/libs/langgraph/src/graph/zod/zod-registry.ts
@@ -9,6 +9,7 @@ import {
   type SchemaMetaRegistry,
   schemaMetaRegistry,
 } from "./meta.js";
+import { StateGraph } from "../state.js";
 
 /**
  * A Zod v4-compatible meta registry that extends the base registry.
@@ -76,10 +77,7 @@ declare module "zod/v4" {
     >(
       registry: R,
       meta: SchemaMeta<TOutput, TInput>
-    ): ReducedZodChannel<
-      ZodType<TOutput, TInput, TInternals>,
-      ZodType<TOutput, TInput, TInternals>
-    >;
+    ): ReducedZodChannel<this, ZodType<TOutput, TInput, TInternals>>;
   }
 }
 

--- a/libs/langgraph/src/graph/zod/zod-registry.ts
+++ b/libs/langgraph/src/graph/zod/zod-registry.ts
@@ -1,3 +1,5 @@
+// @ts-expect-error If zod/v4 is not imported, the module augmentation will fail in build
+import type { ZodType } from "zod/v4"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import type * as core from "zod/v4/core";
 import { getInteropZodDefaultGetter } from "@langchain/core/utils/types";
 import { $ZodType, $ZodRegistry, $replace } from "zod/v4/core";

--- a/libs/langgraph/src/graph/zod/zod-registry.ts
+++ b/libs/langgraph/src/graph/zod/zod-registry.ts
@@ -9,7 +9,6 @@ import {
   type SchemaMetaRegistry,
   schemaMetaRegistry,
 } from "./meta.js";
-import { StateGraph } from "../state.js";
 
 /**
  * A Zod v4-compatible meta registry that extends the base registry.

--- a/libs/langgraph/src/graph/zod/zod-registry.ts
+++ b/libs/langgraph/src/graph/zod/zod-registry.ts
@@ -1,5 +1,5 @@
 // @ts-expect-error If zod/v4 is not imported, the module augmentation will fail in build
-import { z, type ZodType } from "zod/v4"; // eslint-disable-line @typescript-eslint/no-unused-vars
+import type { ZodType } from "zod/v4"; // eslint-disable-line @typescript-eslint/no-unused-vars
 import type * as core from "zod/v4/core";
 import { getInteropZodDefaultGetter } from "@langchain/core/utils/types";
 import { $ZodType, $ZodRegistry, $replace } from "zod/v4/core";


### PR DESCRIPTION
`.registry(...)` does not support modifying the `input` Zod internal, thus the input types for graphs are incorrectly inferred to output type. Goal is to augment `ZodType` with an overloaded `.registry(LanggraphZodMetaRegistry)` method, that casts the return type to proper schema.