### PR TITLE
chore: use 'vitest run' to unblock release script

### DIFF
--- a/libs/checkpoint/package.json
+++ b/libs/checkpoint/package.json
@@ -21,9 +21,8 @@
     "lint": "yarn lint:eslint && yarn lint:dpdm",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:dpdm",
     "prepack": "yarn build",
-    "test": "vitest",
+    "test": "vitest run",
     "test:watch": "vitest watch",
-    "test:single": "vitest run",
     "test:int": "vitest run --mode int",
     "format": "prettier --config .prettierrc --write \"src\"",
     "format:check": "prettier --config .prettierrc --check \"src\""

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -21,10 +21,9 @@
     "lint": "yarn lint:eslint && yarn lint:dpdm",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:dpdm",
     "prepack": "yarn build",
-    "test": "vitest",
+    "test": "vitest run",
     "test:browser": "vitest run --mode browser",
     "test:watch": "vitest watch",
-    "test:single": "vitest run",
     "test:int": "vitest run --mode int",
     "format": "prettier --config .prettierrc --write \"src\"",
     "format:check": "prettier --config .prettierrc --check \"src\""


### PR DESCRIPTION
Fixes an issue that blocks the release script from continuing after tests passed.

We changed the `test` scripts to enter into vitest watch mode by default, so in order to release you had to add `CI=true` to tell vitest that it shouldn't do that.