### PR TITLE
Fix: Correct typo in "Subscribed" error message

### DIFF
--- a/libs/langgraph/src/pregel/validate.test.ts
+++ b/libs/langgraph/src/pregel/validate.test.ts
@@ -148,7 +148,7 @@ describe("validateGraph", () => {
         inputChannels,
         outputChannels,
       })
-    ).toThrow("Subcribed channel 'nonexistent' not in channels");
+    ).toThrow("Subscribed channel 'nonexistent' not in channels");
   });
 
   it("should throw when a singular input channel is not subscribed by any node", () => {

--- a/libs/langgraph/src/pregel/validate.ts
+++ b/libs/langgraph/src/pregel/validate.ts
@@ -55,7 +55,7 @@ export function validateGraph<
   for (const chan of subscribedChannels) {
     if (!(chan in channels)) {
       throw new GraphValidationError(
-        `Subcribed channel '${String(chan)}' not in channels`
+        `Subscribed channel '${String(chan)}' not in channels`
       );
     }
   }


### PR DESCRIPTION


**Description:**

```
This PR addresses a minor typo in an error message related to channel subscriptions.

- Corrected "Subcribed" to "Subscribed" in the validation error message.
- Updated the corresponding unit test to expect the corrected error message.
```
