### PR TITLE
fix(langgraph): change return value of getWriter

### DIFF
--- a/libs/langgraph/src/pregel/utils/config.ts
+++ b/libs/langgraph/src/pregel/utils/config.ts
@@ -142,7 +142,7 @@ export function getWriter(
     );
   }
 
-  return runConfig?.configurable?.writer;
+  return runConfig?.writer || runConfig?.configurable?.writer;
 }
 
 /**


### PR DESCRIPTION
writer exists in runConfig.
 fix getWriter to correctly pass writer.