### PR TITLE
feat(langgraph): add "tasks" and "checkpoints" stream mode

### DIFF
--- a/libs/langgraph/src/pregel/types.ts
+++ b/libs/langgraph/src/pregel/types.ts
@@ -21,7 +21,14 @@ import { LangGraphRunnableConfig } from "./runnable_types.js";
 /**
  * Selects the type of output you'll receive when streaming from the graph. See [Streaming](/langgraphjs/how-tos/#streaming) for more details.
  */
-export type StreamMode = "values" | "updates" | "debug" | "messages" | "custom";
+export type StreamMode =
+  | "values"
+  | "updates"
+  | "debug"
+  | "messages"
+  | "checkpoints"
+  | "tasks"
+  | "custom";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type PregelInputType = any;
@@ -38,6 +45,36 @@ type StreamCustomOutput = any;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type StreamDebugOutput = Record<string, any>;
 
+type StreamCheckpointsOutput<StreamValues> = {
+  values: StreamValues;
+  next: string[];
+  config: RunnableConfig;
+  metadata?: CheckpointMetadata;
+  parentConfig?: RunnableConfig | undefined;
+  tasks: PregelTaskDescription[];
+};
+
+interface StreamTasksOutputBase {
+  id: string;
+  name: string;
+  interrupts: Interrupt[];
+}
+
+export interface StreamTasksCreateOutput<StreamValues>
+  extends StreamTasksOutputBase {
+  input: StreamValues;
+  triggers: string[];
+}
+
+export interface StreamTasksResultOutput<Keys, StreamUpdates>
+  extends StreamTasksOutputBase {
+  result: [Keys, StreamUpdates][];
+}
+
+export type StreamTasksOutput<StreamUpdates, StreamValues, Nodes = string> =
+  | StreamTasksCreateOutput<StreamValues>
+  | StreamTasksResultOutput<Nodes, StreamUpdates>;
+
 type DefaultStreamMode = "updates";
 
 export type StreamOutputMap<
@@ -45,7 +82,7 @@ export type StreamOutputMap<
   TStreamSubgraphs extends boolean,
   StreamUpdates,
   StreamValues,
-  Nodes = string
+  Nodes
 > = (
   undefined extends TStreamMode
     ? []
@@ -67,6 +104,16 @@ export type StreamOutputMap<
         ];
         messages: [string[], "messages", StreamMessageOutput];
         custom: [string[], "custom", StreamCustomOutput];
+        checkpoints: [
+          string[],
+          "checkpoints",
+          StreamCheckpointsOutput<StreamValues>
+        ];
+        tasks: [
+          string[],
+          "tasks",
+          StreamTasksOutput<StreamUpdates, StreamValues>
+        ];
         debug: [string[], "debug", StreamDebugOutput];
       }[Multiple]
     : {
@@ -77,6 +124,8 @@ export type StreamOutputMap<
         ];
         messages: ["messages", StreamMessageOutput];
         custom: ["custom", StreamCustomOutput];
+        checkpoints: ["checkpoints", StreamCheckpointsOutput<StreamValues>];
+        tasks: ["tasks", StreamTasksOutput<StreamUpdates, StreamValues, Nodes>];
         debug: ["debug", StreamDebugOutput];
       }[Multiple]
   : (
@@ -91,6 +140,11 @@ export type StreamOutputMap<
         ];
         messages: [string[], StreamMessageOutput];
         custom: [string[], StreamCustomOutput];
+        checkpoints: [string[], StreamCheckpointsOutput<StreamValues>];
+        tasks: [
+          string[],
+          StreamTasksOutput<StreamUpdates, StreamValues, Nodes>
+        ];
         debug: [string[], StreamDebugOutput];
       }[Single]
     : {
@@ -98,6 +152,8 @@ export type StreamOutputMap<
         updates: Record<Nodes extends string ? Nodes : string, StreamUpdates>;
         messages: StreamMessageOutput;
         custom: StreamCustomOutput;
+        checkpoints: StreamCheckpointsOutput<StreamValues>;
+        tasks: StreamTasksOutput<StreamUpdates, StreamValues, Nodes>;
         debug: StreamDebugOutput;
       }[Single]
   : never;

--- a/libs/langgraph/src/pregel/types.ts
+++ b/libs/langgraph/src/pregel/types.ts
@@ -60,18 +60,17 @@ interface StreamTasksOutputBase {
   interrupts: Interrupt[];
 }
 
-export interface StreamTasksCreateOutput<StreamValues>
-  extends StreamTasksOutputBase {
+interface StreamTasksCreateOutput<StreamValues> extends StreamTasksOutputBase {
   input: StreamValues;
   triggers: string[];
 }
 
-export interface StreamTasksResultOutput<Keys, StreamUpdates>
+interface StreamTasksResultOutput<Keys, StreamUpdates>
   extends StreamTasksOutputBase {
   result: [Keys, StreamUpdates][];
 }
 
-export type StreamTasksOutput<StreamUpdates, StreamValues, Nodes = string> =
+type StreamTasksOutput<StreamUpdates, StreamValues, Nodes = string> =
   | StreamTasksCreateOutput<StreamValues>
   | StreamTasksResultOutput<Nodes, StreamUpdates>;
 

--- a/libs/langgraph/src/tests/pregel.test-d.ts
+++ b/libs/langgraph/src/tests/pregel.test-d.ts
@@ -67,7 +67,10 @@ it("state graph annotation", async () => {
 
   expectTypeOf(
     await gatherIterator(
-      graph.stream(input, { streamMode: ["values"], subgraphs: true })
+      graph.stream(input, {
+        streamMode: ["values"],
+        subgraphs: true,
+      })
     )
   ).toExtend<[string[], "values", { foo: string[] }][]>();
 
@@ -83,7 +86,10 @@ it("state graph annotation", async () => {
 
   expectTypeOf(
     await gatherIterator(
-      graph.stream(input, { streamMode: ["updates"], subgraphs: true })
+      graph.stream(input, {
+        streamMode: ["updates"],
+        subgraphs: true,
+      })
     )
   ).toExtend<
     [
@@ -145,30 +151,14 @@ it("state graph annotation", async () => {
       | ["debug", Record<string, any>]
       | ["messages", [BaseMessage, Record<string, any>]]
       | ["custom", any]
-    )[]
-  >();
-
-  expectTypeOf(
-    await gatherIterator(
-      graph.stream(input, {
-        streamMode: ["updates", "values"] as
-          | StreamMode
-          | StreamMode[]
-          | undefined,
-        subgraphs: true,
-      })
-    )
-  ).toExtend<
-    (
+      | ["checkpoints", { values: { foo: string[] } }]
       | [
-          string[],
-          "updates",
-          Record<"one" | "two" | "three", { foo?: string[] | string }>
+          "tasks",
+          { id: string; name: string } & (
+            | { input: unknown }
+            | { result: [string, unknown][] }
+          )
         ]
-      | [string[], "values", { foo: string[] }]
-      | [string[], "debug", Record<string, any>]
-      | [string[], "messages", [BaseMessage, Record<string, any>]]
-      | [string[], "custom", any]
     )[]
   >();
 });
@@ -296,6 +286,14 @@ it("state graph zod", async () => {
       | ["debug", Record<string, any>]
       | ["messages", [BaseMessage, Record<string, any>]]
       | ["custom", any]
+      | ["checkpoints", { values: { foo: string[] } }]
+      | [
+          "tasks",
+          { id: string; name: string } & (
+            | { input: unknown }
+            | { result: [string, unknown][] }
+          )
+        ]
     )[]
   >();
 
@@ -320,6 +318,15 @@ it("state graph zod", async () => {
       | [string[], "debug", Record<string, any>]
       | [string[], "messages", [BaseMessage, Record<string, any>]]
       | [string[], "custom", any]
+      | [string[], "checkpoints", { values: { foo: string[] } }]
+      | [
+          string[],
+          "tasks",
+          { id: string; name: string } & (
+            | { input: unknown }
+            | { result: [string, unknown][] }
+          )
+        ]
     )[]
   >();
 });

--- a/libs/langgraph/src/utils.ts
+++ b/libs/langgraph/src/utils.ts
@@ -103,10 +103,12 @@ export function prefixGenerator<T, Prefix extends string>(
   generator: Generator<T>,
   prefix: Prefix
 ): Generator<[Prefix, T]>;
+
 export function prefixGenerator<T>(
   generator: Generator<T>,
   prefix?: undefined
 ): Generator<T>;
+
 export function prefixGenerator<
   T,
   Prefix extends string | undefined = undefined


### PR DESCRIPTION
Split out the "debug" stream mode into more descriptive "tasks" and "checkpoints" stream mode, while removing the unnecessary wrapper object.

Port of https://github.com/langchain-ai/langgraph/pull/5117
