### PR TITLE
fix(langgraph): fail fast when interrupt is called without checkpointer

### DIFF
--- a/libs/langgraph/src/interrupt.ts
+++ b/libs/langgraph/src/interrupt.ts
@@ -1,11 +1,15 @@
 import { AsyncLocalStorageProviderSingleton } from "@langchain/core/singletons";
 import { RunnableConfig } from "@langchain/core/runnables";
-import { type PendingWrite } from "@langchain/langgraph-checkpoint";
-import { GraphInterrupt } from "./errors.js";
+import {
+  BaseCheckpointSaver,
+  type PendingWrite,
+} from "@langchain/langgraph-checkpoint";
+import { GraphInterrupt, GraphValueError } from "./errors.js";
 import {
   CONFIG_KEY_CHECKPOINT_NS,
   CONFIG_KEY_SCRATCHPAD,
   CONFIG_KEY_SEND,
+  CONFIG_KEY_CHECKPOINTER,
   CHECKPOINT_NAMESPACE_SEPARATOR,
   RESUME,
 } from "./constants.js";
@@ -67,6 +71,9 @@ export function interrupt<I = unknown, R = any>(value: I): R {
   if (!conf) {
     throw new Error("No configurable found in config");
   }
+
+  const checkpointer: BaseCheckpointSaver = conf[CONFIG_KEY_CHECKPOINTER];
+  if (!checkpointer) throw new GraphValueError("No checkpointer set");
 
   // Track interrupt index
   const scratchpad: PregelScratchpad = conf[CONFIG_KEY_SCRATCHPAD];

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -976,7 +976,7 @@ export class Pregel<
     const checkpointer: BaseCheckpointSaver =
       config.configurable?.[CONFIG_KEY_CHECKPOINTER] ?? this.checkpointer;
     if (!checkpointer) {
-      throw new Error("No checkpointer set");
+      throw new GraphValueError("No checkpointer set");
     }
 
     const checkpointNamespace: string =

--- a/libs/langgraph/src/pregel/retry.ts
+++ b/libs/langgraph/src/pregel/retry.ts
@@ -30,10 +30,17 @@ const DEFAULT_RETRY_ON_HANDLER = (error: any) => {
   ) {
     return false;
   }
+
+  // Thrown when interrupt is called without a checkpointer
+  if (error.name === "GraphValueError") {
+    return false;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if ((error as any)?.code === "ECONNABORTED") {
     return false;
   }
+
   const status =
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (error as any)?.response?.status ?? (error as any)?.status;


### PR DESCRIPTION
Closes devX: fail fast on interrupts with no checkpointer #796
