### PR TITLE
chore: switch to yarn publish

### DIFF
--- a/.changeset/smart-streets-tickle.md
+++ b/.changeset/smart-streets-tickle.md
@@ -1,7 +1,0 @@
----
-"@langchain/langgraph-api": patch
-"@langchain/langgraph-cli": patch
-"@langchain/langgraph-ui": patch
----
-
-Fix invalid package.json dependencies

--- a/libs/langgraph-api/CHANGELOG.md
+++ b/libs/langgraph-api/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @langchain/langgraph-api
 
+## 0.0.43
+
+### Patch Changes
+
+- ce0a39a: Fix invalid package.json dependencies
+- Updated dependencies [ce0a39a]
+  - @langchain/langgraph-ui@0.0.43
+
 ## 0.0.42
 
 ### Patch Changes

--- a/libs/langgraph-api/package.json
+++ b/libs/langgraph-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/langgraph-api",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "type": "module",
   "engines": {
     "node": "^18.19.0 || >=20.16.0"

--- a/libs/langgraph-cli/CHANGELOG.md
+++ b/libs/langgraph-cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @langchain/langgraph-cli
 
+## 0.0.43
+
+### Patch Changes
+
+- ce0a39a: Fix invalid package.json dependencies
+- Updated dependencies [ce0a39a]
+  - @langchain/langgraph-api@0.0.43
+
 ## 0.0.42
 
 ### Patch Changes

--- a/libs/langgraph-cli/package.json
+++ b/libs/langgraph-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/langgraph-cli",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "type": "module",
   "engines": {
     "node": "^18.19.0 || >=20.16.0"

--- a/libs/langgraph-ui/CHANGELOG.md
+++ b/libs/langgraph-ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @langchain/langgraph-ui
 
+## 0.0.43
+
+### Patch Changes
+
+- ce0a39a: Fix invalid package.json dependencies
+
 ## 0.0.42
 
 ### Patch Changes

--- a/libs/langgraph-ui/package.json
+++ b/libs/langgraph-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/langgraph-ui",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "type": "module",
   "engines": {
     "node": "^18.19.0 || >=20.16.0"


### PR DESCRIPTION
Turns out that `changesets` invokes `npm publish` instead of `yarn npm publish`. This in turn publishes packages without `workspace:*` being replaced before, causing invalid packages to be published.
