### PR TITLE
fix(sdk): useStream race condition when flushing messages

### DIFF
--- a/.changeset/afraid-ghosts-ask.md
+++ b/.changeset/afraid-ghosts-ask.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+Fix useStream race condition when flushing messages

--- a/libs/sdk/src/react/stream.tsx
+++ b/libs/sdk/src/react/stream.tsx
@@ -896,6 +896,7 @@ export function useStream<
   clearCallbackRef.current = () => {
     setStreamError(undefined);
     setStreamValues(null);
+    messageManagerRef.current.clear();
   };
 
   const historyLimit =
@@ -1091,9 +1092,6 @@ export function useStream<
       }
     } finally {
       setIsLoading(false);
-
-      // Assumption: messages are already handled, we can clear the manager
-      messageManagerRef.current.clear();
       submittingRef.current = false;
       abortRef.current = null;
     }


### PR DESCRIPTION
`clear()` might be invoked before `setStreamValues` setter has been finished.
