### PR TITLE
feat(langgraph-api): Add kind: StudioUser for consistent interops

### DIFF
--- a/libs/langgraph-api/package.json
+++ b/libs/langgraph-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/langgraph-api",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "type": "module",
   "engines": {
     "node": "^18.19.0 || >=20.16.0"

--- a/libs/langgraph-api/src/auth/custom.mts
+++ b/libs/langgraph-api/src/auth/custom.mts
@@ -76,7 +76,7 @@ export const auth = (): MiddlewareHandler => {
       c.req.header("x-auth-scheme") === "langsmith"
     ) {
       c.set("auth", {
-        user: STUDIO_USER,
+        user: { ...STUDIO_USER, kind: "StudioUser" },
         scopes: STUDIO_USER.permissions.slice(),
       });
       return next();


### PR DESCRIPTION
In Py, we add "kind: StudioUser" to the user dict and use the logged in identity for the identity.

This adds a common check.