### PR TITLE
feat(checkpoint-mongo): add TTL support via MongoDB index

### DIFF
--- a/libs/checkpoint-mongodb/src/index.ts
+++ b/libs/checkpoint-mongodb/src/index.ts
@@ -36,11 +36,22 @@ export class MongoDBSaver extends BaseCheckpointSaver {
   checkpointWritesCollectionName = "checkpoint_writes";
 
   async setup(): Promise<void> {
-    await this.db.createIndex(
-      this.checkpointCollectionName,
-      { _createdAtForTTL: 1 },
-      { expireAfterSeconds: 60 * 60 }
-    );
+    if (this.ttl != null) {
+      const { expireAfterSeconds } = this.ttl;
+      await Promise.all([
+        this.db.createIndex(
+          this.checkpointCollectionName,
+          { _createdAtForTTL: 1 },
+          { expireAfterSeconds }
+        ),
+        this.db.createIndex(
+          this.checkpointWritesCollectionName,
+          { _createdAtForTTL: 1 },
+          { expireAfterSeconds }
+        ),
+      ]);
+    }
+
     this.isSetup = true;
   }
 


### PR DESCRIPTION
## Description
This PR adds optional TTL (Time-To-Live) support to the MongoDB-backed checkpoint saver in the `@langchain/langgraph-checkpoint` package.

---

## What's New

### ✅ Added `enableTTL` param in constructor:

```ts
export type MongoDBSaverParams = {
  client: MongoClient;
  dbName?: string;
  checkpointCollectionName?: string;
  checkpointWritesCollectionName?: string;

  // ✅ Change 1: Optional TTL toggle
  enableTTL?: boolean;
};
```

---

### ✅ Stored `enableTTL` in class and defaulted it:

```ts
this.enableTTL = enableTTL ?? false;
```

---

### ✅ Conditionally included TTL timestamp during checkpoint `put`:

```ts
const doc = {
  parent_checkpoint_id: config.configurable?.checkpoint_id,
  type: checkpointType,
  checkpoint: serializedCheckpoint,
  metadata: serializedMetadata,

  // ✅ Change 2: TTL timestamp only if enabled
  ...(this.enableTTL ? { _createdAtForTTL: new Date() } : {}),
};
```

---

## Why This Matters

In long-running or high-frequency LangGraph applications, stale checkpoints can accumulate and consume storage.  
This update allows users to **opt-in** to automatic cleanup by using MongoDB’s native TTL index on the `_createdAtForTTL` field.

---

## Example TTL Index Creation (Manual Step)

```js
// 🔁 This will auto-delete checkpoints after 1 hour
db.checkpoints.createIndex(
  { _createdAtForTTL: 1 },
  { expireAfterSeconds: 3600 }
);
```

---

## Non-Breaking

- TTL is fully **opt-in**
- Existing functionality is untouched if `enableTTL` is **not set**
- Zero breaking changes for existing users or systems

---

## Final Notes

Massive thanks to the LangGraph team for making such a cool platform 🙌  
If you'd like to credit or tag me for the contribution, here’s my handle:

**GitHub**: `@sdip0971`  


