### PR TITLE
fix(langgraph): dispose unused combined signals

### DIFF
--- a/.changeset/olive-bottles-study.md
+++ b/.changeset/olive-bottles-study.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(langgraph): dispose unused combined signals

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -1840,9 +1840,8 @@ export class Pregel<
     const config = {
       recursionLimit: this.config?.recursionLimit,
       ...options,
-      signal: options?.signal
-        ? combineAbortSignals(options.signal, abortController.signal)
-        : abortController.signal,
+      signal: combineAbortSignals(options?.signal, abortController.signal)
+        .signal,
     };
 
     return new IterableReadableStreamWithAbortSignal(
@@ -1896,9 +1895,8 @@ export class Pregel<
 
       // extend the callbacks with the ones from the config
       callbacks: combineCallbacks(this.config?.callbacks, options?.callbacks),
-      signal: options?.signal
-        ? combineAbortSignals(options.signal, abortController.signal)
-        : abortController.signal,
+      signal: combineAbortSignals(options?.signal, abortController.signal)
+        .signal,
     };
 
     return new IterableReadableStreamWithAbortSignal(

--- a/libs/langgraph/src/pregel/types.ts
+++ b/libs/langgraph/src/pregel/types.ts
@@ -595,11 +595,6 @@ export type PregelAbortSignals = {
   /**
    * Aborts when the currently executing task throws any error other than a {@link GraphBubbleUp}
    */
-  errorAbortSignal?: AbortSignal;
-
-  /**
-   * Aborts when the currently executing task throws any error other than a {@link GraphBubbleUp}
-   */
   timeoutAbortSignal?: AbortSignal;
 
   /**


### PR DESCRIPTION
- Avoids hidden chaining of combined abort signals with external signal, thus attaching a listener on each tick.
- Make sure to always remove the event listener on external abort signal when the combined signal is not used anymore
