### PR TITLE
fix(langgraph): stop suggesting public properties and methods of Command when calling invoke

### DIFF
--- a/.changeset/wise-schools-boil.md
+++ b/.changeset/wise-schools-boil.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(langgraph): stop suggesting public properties and methods of Command when calling invoke

--- a/libs/langgraph/src/constants.ts
+++ b/libs/langgraph/src/constants.ts
@@ -87,6 +87,22 @@ export const RESERVED = [
 export const CHECKPOINT_NAMESPACE_SEPARATOR = "|";
 export const CHECKPOINT_NAMESPACE_END = ":";
 
+/** @internal */
+const COMMAND_SYMBOL = Symbol.for("langgraph.command");
+
+/**
+ * Instance of a {@link Command} class.
+ *
+ * This is used to avoid IntelliSense suggesting public fields
+ * of {@link Command} class when a plain object is expected.
+ *
+ * @see {@link Command}
+ * @internal
+ */
+export class CommandInstance {
+  [COMMAND_SYMBOL]: true;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface SendInterface<Node extends string = string, Args = any> {
   node: Node;
@@ -317,7 +333,7 @@ export class Command<
   Resume = unknown,
   Update extends Record<string, unknown> = Record<string, unknown>,
   Nodes extends string = string
-> {
+> extends CommandInstance {
   readonly lg_name = "Command";
 
   lc_direct_tool_output = true;
@@ -353,6 +369,7 @@ export class Command<
   static PARENT = "__parent__";
 
   constructor(args: CommandParams<Resume, Update, Nodes>) {
+    super();
     this.resume = args.resume;
     this.graph = args.graph;
     this.update = args.update;

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -54,6 +54,7 @@ import {
   PUSH,
   CONFIG_KEY_CHECKPOINT_DURING,
   CONFIG_KEY_CHECKPOINT_NS,
+  type CommandInstance,
 } from "../constants.js";
 import {
   GraphRecursionError,
@@ -391,7 +392,7 @@ export class Pregel<
     StreamValuesType = OutputType
   >
   extends PartialRunnable<
-    InputType | Command | null,
+    InputType | CommandInstance | null,
     OutputType,
     PregelOptions<Nodes, Channels, ConfigurableFieldType>
   >
@@ -1809,7 +1810,7 @@ export class Pregel<
     TStreamMode extends StreamMode | StreamMode[] | undefined,
     TSubgraphs extends boolean
   >(
-    input: InputType | Command | null,
+    input: InputType | CommandInstance | null,
     options?: Partial<
       PregelOptions<
         Nodes,
@@ -1862,7 +1863,7 @@ export class Pregel<
    * @inheritdoc
    */
   override streamEvents(
-    input: InputType | Command | null,
+    input: InputType | CommandInstance | null,
     options: Partial<PregelOptions<Nodes, Channels, ConfigurableFieldType>> & {
       version: "v1" | "v2";
     },
@@ -1870,7 +1871,7 @@ export class Pregel<
   ): IterableReadableStream<StreamEvent>;
 
   override streamEvents(
-    input: InputType | Command | null,
+    input: InputType | CommandInstance | null,
     options: Partial<PregelOptions<Nodes, Channels, ConfigurableFieldType>> & {
       version: "v1" | "v2";
       encoding: "text/event-stream";
@@ -1879,7 +1880,7 @@ export class Pregel<
   ): IterableReadableStream<Uint8Array>;
 
   override streamEvents(
-    input: InputType | Command | null,
+    input: InputType | CommandInstance | null,
     options: Partial<PregelOptions<Nodes, Channels, ConfigurableFieldType>> & {
       version: "v1" | "v2";
     },
@@ -2215,7 +2216,7 @@ export class Pregel<
    * @param options The configuration to use for the run.
    */
   override async invoke(
-    input: InputType | Command | null,
+    input: InputType | CommandInstance | null,
     options?: Partial<PregelOptions<Nodes, Channels, ConfigurableFieldType>>
   ): Promise<OutputType> {
     const streamMode = options?.streamMode ?? "values";

--- a/libs/langgraph/src/tests/prebuilt.test.ts
+++ b/libs/langgraph/src/tests/prebuilt.test.ts
@@ -2514,7 +2514,7 @@ describe("ToolNode with Commands", () => {
       ],
     });
 
-    expect(result).toEqual([
+    expect(result).toMatchObject([
       {
         messages: [
           new ToolMessage({
@@ -2549,7 +2549,7 @@ describe("ToolNode with Commands", () => {
       ],
     });
 
-    expect(singleToolResult).toEqual([
+    expect(singleToolResult).toMatchObject([
       new Command({
         update: {
           messages: [
@@ -2575,7 +2575,7 @@ describe("ToolNode with Commands", () => {
       ],
     });
 
-    expect(asyncToolResult).toEqual([
+    expect(asyncToolResult).toMatchObject([
       new Command({
         update: {
           messages: [
@@ -2607,7 +2607,7 @@ describe("ToolNode with Commands", () => {
       ],
     });
 
-    expect(multipleCommandsResult).toEqual([
+    expect(multipleCommandsResult).toMatchObject([
       new Command({
         update: {
           messages: [
@@ -2705,7 +2705,7 @@ describe("ToolNode with Commands", () => {
       }),
     ]);
 
-    expect(result).toEqual([
+    expect(result).toMatchObject([
       [
         new ToolMessage({
           content: "3",
@@ -2736,7 +2736,7 @@ describe("ToolNode with Commands", () => {
         }),
       ]);
 
-      expect(result).toEqual([
+      expect(result).toMatchObject([
         new Command({
           update: [
             // @ts-expect-error: Command typing needs to be updated properly
@@ -2766,7 +2766,7 @@ describe("ToolNode with Commands", () => {
       }),
     ]);
 
-    expect(multipleCommandsResult).toEqual([
+    expect(multipleCommandsResult).toMatchObject([
       new Command({
         update: [
           // @ts-expect-error: Command typing needs to be updated properly
@@ -2854,7 +2854,7 @@ describe("ToolNode with Commands", () => {
       }),
     ]);
 
-    expect(result).toEqual([
+    expect(result).toMatchObject([
       new Command({
         goto: [
           new Send("alice", {


### PR DESCRIPTION
Since TypeScript is a structural type system, it does not distinguish between an instance of Command and an object that has the same shape as a Command, thus `invoke(...) / stream(...)` suggests bogus keys.

<img width="1448" height="946" alt="CleanShot 2025-07-17 at 01 41 14@2x" src="https://github.com/user-attachments/assets/17968eb9-449a-45ac-9120-17a82c16d2f5" />

We can (mis)use Symbols to still validate against an instance of Command while hiding these bogus keys.

<img width="1544" height="990" alt="CleanShot 2025-07-17 at 01 41 32@2x" src="https://github.com/user-attachments/assets/859c6ad6-700b-4e2f-b83f-9481f5ac60dd" />
