### PR TITLE
chore(checkpoint): remove checkpoint["writes"]

### DIFF
--- a/.changeset/two-toes-chew.md
+++ b/.changeset/two-toes-chew.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint": minor
+---
+
+Remove Checkpoint.writes

--- a/libs/checkpoint-mongodb/src/tests/checkpoints.int.test.ts
+++ b/libs/checkpoint-mongodb/src/tests/checkpoints.int.test.ts
@@ -68,7 +68,7 @@ describe("MongoDBSaver", () => {
     const runnableConfig = await saver.put(
       { configurable: { thread_id: "1" } },
       checkpoint1,
-      { source: "update", step: -1, writes: null, parents: {} }
+      { source: "update", step: -1, parents: {} }
     );
     expect(runnableConfig).toEqual({
       configurable: {
@@ -117,7 +117,7 @@ describe("MongoDBSaver", () => {
         },
       },
       checkpoint2,
-      { source: "update", step: -1, writes: null, parents: {} }
+      { source: "update", step: -1, parents: {} }
     );
 
     // verify that parentTs is set and retrieved correctly for second checkpoint
@@ -153,14 +153,12 @@ describe("MongoDBSaver", () => {
     await saver.put({ configurable: { thread_id: "1" } }, emptyCheckpoint(), {
       source: "update",
       step: -1,
-      writes: null,
       parents: {},
     });
 
     await saver.put({ configurable: { thread_id: "2" } }, emptyCheckpoint(), {
       source: "update",
       step: -1,
-      writes: null,
       parents: {},
     });
 

--- a/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
+++ b/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
@@ -343,7 +343,7 @@ describe.each([
     const runnableConfig = await postgresSaver.put(
       { configurable: { thread_id: "1" } },
       checkpoint1,
-      { source: "update", step: -1, writes: null, parents: {} },
+      { source: "update", step: -1, parents: {} },
       checkpoint1.channel_versions
     );
     expect(runnableConfig).toEqual({
@@ -399,7 +399,7 @@ describe.each([
         },
       },
       checkpoint2,
-      { source: "update", step: -1, writes: null, parents: {} },
+      { source: "update", step: -1, parents: {} },
       checkpoint2.channel_versions
     );
 
@@ -410,7 +410,6 @@ describe.each([
     expect(secondCheckpointTuple?.metadata).toEqual({
       source: "update",
       step: -1,
-      writes: null,
       parents: {},
     });
     expect(secondCheckpointTuple?.parentConfig).toEqual({
@@ -443,7 +442,6 @@ describe.each([
     const meta: CheckpointMetadata = {
       source: "update",
       step: -1,
-      writes: null,
       parents: {},
     };
 
@@ -475,7 +473,7 @@ describe.each([
     config = await postgresSaver.put(
       config,
       checkpoint0,
-      { source: "loop", parents: {}, step: 0, writes: null },
+      { source: "loop", parents: {}, step: 0 },
       {}
     );
 
@@ -510,7 +508,7 @@ describe.each([
     config = await postgresSaver.put(
       config,
       checkpoint1,
-      { source: "loop", parents: {}, step: 1, writes: null },
+      { source: "loop", parents: {}, step: 1 },
       {}
     );
 

--- a/libs/checkpoint-sqlite/src/index.ts
+++ b/libs/checkpoint-sqlite/src/index.ts
@@ -39,7 +39,7 @@ interface PendingSendColumn {
 // In the `SqliteSaver.list` method, we need to sanitize the `options.filter` argument to ensure it only contains keys
 // that are part of the `CheckpointMetadata` type. The lines below ensure that we get compile-time errors if the list
 // of keys that we use is out of sync with the `CheckpointMetadata` type.
-const checkpointMetadataKeys = ["source", "step", "writes", "parents"] as const;
+const checkpointMetadataKeys = ["source", "step", "parents"] as const;
 
 type CheckKeys<T, K extends readonly (keyof T)[]> = [K[number]] extends [
   keyof T

--- a/libs/checkpoint-sqlite/src/tests/checkpoints.test.ts
+++ b/libs/checkpoint-sqlite/src/tests/checkpoints.test.ts
@@ -56,7 +56,7 @@ describe("SqliteSaver", () => {
     const runnableConfig = await sqliteSaver.put(
       { configurable: { thread_id: "1" } },
       checkpoint1,
-      { source: "update", step: -1, writes: null, parents: {} }
+      { source: "update", step: -1, parents: {} }
     );
     expect(runnableConfig).toEqual({
       configurable: {
@@ -108,7 +108,6 @@ describe("SqliteSaver", () => {
       {
         source: "update",
         step: -1,
-        writes: null,
         parents: { "": checkpoint1.id },
       }
     );
@@ -153,14 +152,12 @@ describe("SqliteSaver", () => {
     await saver.put({ configurable: { thread_id: "1" } }, emptyCheckpoint(), {
       source: "update",
       step: -1,
-      writes: null,
       parents: {},
     });
 
     await saver.put({ configurable: { thread_id: "2" } }, emptyCheckpoint(), {
       source: "update",
       step: -1,
-      writes: null,
       parents: {},
     });
 
@@ -188,7 +185,6 @@ describe("SqliteSaver", () => {
       source: "loop",
       parents: {},
       step: 0,
-      writes: null,
     });
 
     await saver.putWrites(
@@ -220,7 +216,6 @@ describe("SqliteSaver", () => {
       source: "loop",
       parents: {},
       step: 1,
-      writes: null,
     });
 
     // check that pending sends are attached to checkpoint1

--- a/libs/checkpoint-validation/src/spec/delete_thread.ts
+++ b/libs/checkpoint-validation/src/spec/delete_thread.ts
@@ -25,7 +25,6 @@ export function deleteThreadTests<T extends BaseCheckpointSaver>(
       const meta: CheckpointMetadata = {
         source: "update",
         step: -1,
-        writes: null,
         parents: {},
       };
 

--- a/libs/checkpoint-validation/src/spec/get_tuple.ts
+++ b/libs/checkpoint-validation/src/spec/get_tuple.ts
@@ -268,7 +268,7 @@ export function getTupleTests<T extends BaseCheckpointSaver>(
         config = await checkpointer.put(
           config,
           checkpoint0,
-          { source: "loop", parents: {}, step: 0, writes: null },
+          { source: "loop", parents: {}, step: 0 },
           {}
         );
 
@@ -300,7 +300,7 @@ export function getTupleTests<T extends BaseCheckpointSaver>(
         config = await checkpointer.put(
           config,
           checkpoint1,
-          { source: "loop", parents: {}, step: 1, writes: null },
+          { source: "loop", parents: {}, step: 1 },
           {}
         );
 

--- a/libs/checkpoint-validation/src/spec/list.ts
+++ b/libs/checkpoint-validation/src/spec/list.ts
@@ -156,7 +156,7 @@ export function listTests<T extends BaseCheckpointSaver>(
       config = await checkpointer.put(
         config,
         checkpoint0,
-        { source: "loop", parents: {}, step: 0, writes: null },
+        { source: "loop", parents: {}, step: 0 },
         {}
       );
 
@@ -188,7 +188,7 @@ export function listTests<T extends BaseCheckpointSaver>(
       config = await checkpointer.put(
         config,
         checkpoint1,
-        { source: "loop", parents: {}, step: 1, writes: null },
+        { source: "loop", parents: {}, step: 1 },
         {}
       );
 

--- a/libs/checkpoint-validation/src/test_utils.ts
+++ b/libs/checkpoint-validation/src/test_utils.ts
@@ -84,7 +84,6 @@ export function initialCheckpointTuple({
     metadata: {
       source: "input",
       step: -1,
-      writes: null,
       parents: {},
     },
   };
@@ -181,7 +180,6 @@ export function parentAndChildCheckpointTuplesWithWrites({
       metadata: {
         source: "input",
         step: -1,
-        writes: null,
         parents: {},
       },
       config: {
@@ -212,9 +210,6 @@ export function parentAndChildCheckpointTuplesWithWrites({
       metadata: {
         source: "loop",
         step: 0,
-        writes: {
-          someNode: parentPendingWrites,
-        },
         parents: {
           [checkpoint_ns]: parentCheckpointId,
         },

--- a/libs/checkpoint/src/tests/checkpoints.test.ts
+++ b/libs/checkpoint/src/tests/checkpoints.test.ts
@@ -94,7 +94,7 @@ describe("MemorySaver", () => {
     const runnableConfig = await memorySaver.put(
       { configurable: { thread_id: "1", checkpoint_ns: "" } },
       checkpoint1,
-      { source: "update", step: -1, writes: null, parents: {} }
+      { source: "update", step: -1, parents: {} }
     );
     expect(runnableConfig).toEqual({
       configurable: {
@@ -124,7 +124,6 @@ describe("MemorySaver", () => {
       {
         source: "update",
         step: -1,
-        writes: null,
         parents: {},
       }
     );
@@ -164,7 +163,6 @@ describe("MemorySaver", () => {
       source: "loop",
       parents: {},
       step: 0,
-      writes: null,
     });
 
     await memorySaver.putWrites(
@@ -196,7 +194,6 @@ describe("MemorySaver", () => {
       source: "loop",
       parents: {},
       step: 1,
-      writes: null,
     });
 
     // check that pending sends are attached to checkpoint1
@@ -231,7 +228,6 @@ describe("MemorySaver", () => {
     const meta: CheckpointMetadata = {
       source: "update",
       step: -1,
-      writes: null,
       parents: {},
     };
 

--- a/libs/checkpoint/src/types.ts
+++ b/libs/checkpoint/src/types.ts
@@ -23,6 +23,7 @@ export type CheckpointMetadata<ExtraProperties extends object = object> = {
    * - "fork": The checkpoint was created as a copy of another checkpoint.
    */
   source: "input" | "loop" | "update" | "fork";
+
   /**
    * The step number of the checkpoint.
    * -1 for the first "input" checkpoint.
@@ -30,11 +31,6 @@ export type CheckpointMetadata<ExtraProperties extends object = object> = {
    * ... for the nth checkpoint afterwards.
    */
   step: number;
-  /**
-   * The writes that were made between the previous checkpoint and this one.
-   * Mapping from node name to writes emitted by that node.
-   */
-  writes: Record<string, unknown> | null;
 
   /**
    * The IDs of the parent checkpoints.

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -1153,7 +1153,6 @@ export class Pregel<
           {
             source: "update",
             step: step + 1,
-            writes: {},
             parents: saved?.metadata?.parents ?? {},
           },
           {}
@@ -1245,7 +1244,6 @@ export class Pregel<
             ...checkpointMetadata,
             source: "update",
             step: step + 1,
-            writes: {},
             parents: saved?.metadata?.parents ?? {},
           },
           getNewChannelVersions(
@@ -1286,7 +1284,6 @@ export class Pregel<
           {
             source: "fork",
             step: step + 1,
-            writes: {},
             parents: saved.metadata?.parents ?? {},
           },
           {}
@@ -1384,7 +1381,6 @@ export class Pregel<
           {
             source: "input",
             step: nextStep,
-            writes: Object.fromEntries(inputWrites),
             parents: saved?.metadata?.parents ?? {},
           },
           getNewChannelVersions(
@@ -1632,9 +1628,6 @@ export class Pregel<
         {
           source: "update",
           step: step + 1,
-          writes: Object.fromEntries(
-            validUpdates.map((update) => [update.asNode, update.values])
-          ),
           parents: saved?.metadata?.parents ?? {},
         },
         newVersions

--- a/libs/langgraph/src/pregel/loop.ts
+++ b/libs/langgraph/src/pregel/loop.ts
@@ -432,12 +432,7 @@ export class PregelLoop {
     )) ?? {
       config,
       checkpoint: emptyCheckpoint(),
-      metadata: {
-        source: "input",
-        step: -2,
-        writes: null,
-        parents: {},
-      },
+      metadata: { source: "input", step: -2, parents: {} },
       pendingWrites: [],
     };
     checkpointConfig = {
@@ -724,14 +719,7 @@ export class PregelLoop {
       this._emit(valuesOutput);
       // clear pending writes
       this.checkpointPendingWrites = [];
-      await this._putCheckpoint({
-        source: "loop",
-        writes:
-          mapOutputUpdates(
-            this.outputKeys,
-            Object.values(this.tasks).map((task) => [task, task.writes])
-          ).next().value ?? null,
-      });
+      await this._putCheckpoint({ source: "loop" });
       // after execution, check if we should interrupt
       if (
         shouldInterrupt(
@@ -1067,7 +1055,7 @@ export class PregelLoop {
       // we need to create a new checkpoint for Command(update=...) or Command(goto=...)
       // in case the result of Command(goto=...) is an interrupt.
       // If not done, the checkpoint containing the interrupt will be lost.
-      await this._putCheckpoint({ source: "input", writes: {} });
+      await this._putCheckpoint({ source: "input" });
       this.input = INPUT_DONE;
     } else {
       // map inputs to channel updates
@@ -1097,10 +1085,7 @@ export class PregelLoop {
           this.triggerToNodes
         );
         // save input checkpoint
-        await this._putCheckpoint({
-          source: "input",
-          writes: Object.fromEntries(inputWrites),
-        });
+        await this._putCheckpoint({ source: "input" });
 
         this.input = INPUT_DONE;
       } else if (!(CONFIG_KEY_RESUMING in (this.config.configurable ?? {}))) {

--- a/libs/langgraph/src/tests/pregel.test.ts
+++ b/libs/langgraph/src/tests/pregel.test.ts
@@ -1640,7 +1640,6 @@ export function runPregelTests(
         metadata: {
           source: "loop",
           step: 6,
-          writes: { two: 5 },
           parents: {},
           thread_id: "1",
         },
@@ -1669,7 +1668,6 @@ export function runPregelTests(
         metadata: {
           source: "loop",
           step: 5,
-          writes: {},
           parents: {},
           thread_id: "1",
         },
@@ -1698,7 +1696,6 @@ export function runPregelTests(
         metadata: {
           source: "input",
           step: 4,
-          writes: { input: 3 },
           parents: {},
           thread_id: "1",
         },
@@ -1726,7 +1723,6 @@ export function runPregelTests(
         metadata: {
           source: "loop",
           step: 3,
-          writes: {},
           parents: {},
           thread_id: "1",
         },
@@ -1755,7 +1751,6 @@ export function runPregelTests(
         metadata: {
           source: "input",
           step: 2,
-          writes: { input: 20 },
           parents: {},
           thread_id: "1",
         },
@@ -1776,7 +1771,6 @@ export function runPregelTests(
         metadata: {
           source: "loop",
           step: 1,
-          writes: { two: 4 },
           parents: {},
           thread_id: "1",
         },
@@ -1805,7 +1799,6 @@ export function runPregelTests(
         metadata: {
           source: "loop",
           step: 0,
-          writes: {},
           parents: {},
           thread_id: "1",
         },
@@ -1834,7 +1827,6 @@ export function runPregelTests(
         metadata: {
           source: "input",
           step: -1,
-          writes: { input: 2 },
           parents: {},
           thread_id: "1",
         },
@@ -3101,7 +3093,6 @@ graph TD;
           metadata: {
             source: "update",
             step: 4,
-            writes: { analyzer_one: { docs: ["doc5"] } },
             thread_id: "2",
           },
         });
@@ -3326,13 +3317,11 @@ graph TD;
         {
           source: "loop",
           step: 0,
-          writes: null,
           parents: {},
         },
         {
           source: "input",
           step: -1,
-          writes: { __start__: { my_key: "value ⛰️", market: "DE" } },
           parents: {},
         },
       ]);
@@ -3362,7 +3351,6 @@ graph TD;
         metadata: {
           source: "loop",
           step: 0,
-          writes: null,
           parents: {},
           thread_id: "2",
         },
@@ -3413,7 +3401,6 @@ graph TD;
         {
           source: "loop",
           step: 0,
-          writes: null,
           parents: {},
         },
       ]);
@@ -3449,7 +3436,6 @@ graph TD;
         metadata: {
           source: "loop",
           step: 0,
-          writes: null,
           parents: {},
           thread_id: "1",
         },
@@ -3475,7 +3461,6 @@ graph TD;
         metadata: {
           source: "update",
           step: 1,
-          writes: {},
           parents: {},
           thread_id: "1",
         },
@@ -3575,13 +3560,11 @@ graph TD;
         {
           source: "loop",
           step: 0,
-          writes: null,
           parents: {},
         },
         {
           source: "input",
           step: -1,
-          writes: { __start__: { my_key: "value ⛰️", market: "DE" } },
           parents: {},
         },
       ]);
@@ -3624,7 +3607,6 @@ graph TD;
         metadata: {
           source: "loop",
           step: 0,
-          writes: null,
           thread_id: "2",
           parents: {},
         },
@@ -3656,7 +3638,6 @@ graph TD;
         metadata: {
           source: "update",
           step: 1,
-          writes: {},
           parents: {},
           thread_id: "2",
         },
@@ -4056,11 +4037,6 @@ graph TD;
         metadata: {
           source: "loop",
           step: 1,
-          writes: {
-            agent: {
-              messages: expectedOutputMessages[1],
-            },
-          },
           parents: {},
           thread_id: "1",
         },
@@ -4116,23 +4092,6 @@ graph TD;
           thread_id: "1",
           source: "update",
           step: 2,
-          writes: {
-            agent: {
-              messages: new AIMessage({
-                id: "ai1",
-                content: "",
-                tool_calls: [
-                  {
-                    id: "tool_call123",
-                    name: "search_api",
-                    args: { query: "a different query" },
-                    type: "tool_call",
-                  },
-                ],
-              }),
-              something_extra: "hi there",
-            },
-          },
         },
         config: (await appWithInterruptCheckpointer.getTuple(config))?.config,
         createdAt: (await appWithInterruptCheckpointer.getTuple(config))
@@ -4209,11 +4168,6 @@ graph TD;
           thread_id: "1",
           source: "loop",
           step: 4,
-          writes: {
-            agent: {
-              messages: expectedOutputMessages[3],
-            },
-          },
         },
         createdAt: (await appWithInterruptCheckpointer.getTuple(config))
           ?.checkpoint.ts,
@@ -4269,15 +4223,6 @@ graph TD;
           step: 5,
           parents: {},
           thread_id: "1",
-          writes: {
-            agent: {
-              messages: new AIMessage({
-                content: "answer",
-                id: "ai2",
-              }),
-              something_extra: "hi there",
-            },
-          },
         },
         createdAt: (await appWithInterruptCheckpointer.getTuple(config))
           ?.checkpoint.ts,
@@ -4705,12 +4650,6 @@ graph TD;
           metadata: {
             thread_id: "102",
             source: "loop",
-            writes: {
-              wipeFields: {
-                test: undefined,
-                reducerField: undefined,
-              },
-            },
             step: 2,
             parents: {},
           },
@@ -4751,12 +4690,6 @@ graph TD;
           metadata: {
             thread_id: "102",
             source: "loop",
-            writes: {
-              updateTest: {
-                test: "test",
-                reducerField: "should not be wiped",
-              },
-            },
             step: 1,
             parents: {},
           },
@@ -4794,7 +4727,6 @@ graph TD;
           metadata: {
             thread_id: "102",
             source: "loop",
-            writes: null,
             step: 0,
             parents: {},
           },
@@ -4828,9 +4760,6 @@ graph TD;
           metadata: {
             thread_id: "102",
             source: "input",
-            writes: {
-              __start__: { messages: ["initial input"] },
-            },
             step: -1,
             parents: {},
           },
@@ -5439,7 +5368,6 @@ graph TD;
           metadata: {
             source: "input",
             step: -1,
-            writes: { __start__: { my_key: "value", market: "DE" } },
             parents: {},
           },
           next: ["__start__"],
@@ -5485,7 +5413,6 @@ graph TD;
           metadata: {
             source: "loop",
             step: 0,
-            writes: null,
             parents: {},
           },
           next: ["prepare"],
@@ -5554,7 +5481,6 @@ graph TD;
           metadata: {
             source: "loop",
             step: 1,
-            writes: { prepare: { my_key: " prepared" } },
             parents: {},
           },
           next: ["tool_two_slow"],
@@ -5623,7 +5549,6 @@ graph TD;
           metadata: {
             source: "loop",
             step: 2,
-            writes: { tool_two_slow: { my_key: " slow" } },
             parents: {},
           },
           next: ["finish"],
@@ -5692,7 +5617,6 @@ graph TD;
           metadata: {
             source: "loop",
             step: 3,
-            writes: { finish: { my_key: " finished" } },
             parents: {},
           },
           next: [],
@@ -5791,13 +5715,11 @@ graph TD;
       {
         source: "loop",
         step: 0,
-        writes: null,
         parents: {},
       },
       {
         source: "input",
         step: -1,
-        writes: { __start__: { my_key: "value ⛰️", market: "DE" } },
         parents: {},
       },
     ]);
@@ -5817,7 +5739,6 @@ graph TD;
       metadata: {
         source: "loop",
         step: 0,
-        writes: null,
         parents: {},
         thread_id: "1",
       },
@@ -5839,7 +5760,6 @@ graph TD;
       metadata: {
         source: "loop",
         step: 1,
-        writes: { tool_two_slow: { my_key: " slow" } },
         parents: {},
         thread_id: "1",
       },
@@ -5875,7 +5795,6 @@ graph TD;
       metadata: {
         source: "loop",
         step: 0,
-        writes: null,
         parents: {},
         thread_id: "2",
       },
@@ -5898,7 +5817,6 @@ graph TD;
         source: "loop",
         step: 1,
         thread_id: "2",
-        writes: { tool_two_fast: { my_key: " fast" } },
         parents: {},
       },
       parentConfig: (
@@ -5933,7 +5851,6 @@ graph TD;
       metadata: {
         source: "loop",
         step: 0,
-        writes: null,
         parents: {},
         thread_id: "3",
       },
@@ -5959,7 +5876,6 @@ graph TD;
       metadata: {
         source: "update",
         step: 1,
-        writes: { [START]: { my_key: "key" } },
         parents: {},
         thread_id: "3",
       },
@@ -5981,7 +5897,6 @@ graph TD;
       metadata: {
         source: "loop",
         step: 2,
-        writes: { tool_two_fast: { my_key: " fast" } },
         parents: {},
         thread_id: "3",
       },
@@ -6227,13 +6142,11 @@ graph TD;
         {
           source: "loop",
           step: 0,
-          writes: null,
           parents: {},
         },
         {
           source: "input",
           step: -1,
-          writes: { __start__: { my_key: "value ⛰️", market: "DE" } },
           parents: {},
         },
       ]);
@@ -6242,7 +6155,7 @@ graph TD;
         values: { my_key: "value ⛰️", market: "DE" },
         tasks: [{ name: "tool_two_slow" }],
         next: ["tool_two_slow"],
-        metadata: { source: "loop", step: 0, writes: null },
+        metadata: { source: "loop", step: 0 },
       });
 
       expect(await toolTwo.invoke(null, thread1)).toEqual({
@@ -6260,11 +6173,6 @@ graph TD;
         metadata: {
           source: "loop",
           step: 1,
-          writes: {
-            tool_two_slow: {
-              my_key: " slow",
-            },
-          },
           parents: {},
         },
       });
@@ -6294,7 +6202,7 @@ graph TD;
         },
         tasks: [{ name: "tool_two_fast" }],
         next: ["tool_two_fast"],
-        metadata: { source: "loop", step: 0, writes: null, parents: {} },
+        metadata: { source: "loop", step: 0, parents: {} },
       });
 
       expect(await toolTwo.invoke(null, thread2)).toEqual({
@@ -6312,7 +6220,6 @@ graph TD;
         metadata: {
           source: "loop",
           step: 1,
-          writes: { tool_two_fast: { my_key: " fast" } },
           parents: {},
         },
       });
@@ -6330,7 +6237,7 @@ graph TD;
         values: { my_key: "value", market: "US" },
         tasks: [{ name: "tool_two_fast" }],
         next: ["tool_two_fast"],
-        metadata: { source: "loop", step: 0, writes: null, parents: {} },
+        metadata: { source: "loop", step: 0, parents: {} },
       });
 
       await toolTwo.updateState(thread3, { my_key: "key" });
@@ -6342,7 +6249,6 @@ graph TD;
         metadata: {
           source: "update",
           step: 1,
-          writes: { [START]: { my_key: "key" } },
           parents: {},
         },
       });
@@ -6359,7 +6265,6 @@ graph TD;
         metadata: {
           source: "loop",
           step: 2,
-          writes: { tool_two_fast: { my_key: " fast" } },
           parents: {},
         },
       });
@@ -7357,7 +7262,6 @@ graph TD;
         metadata: {
           parents: {},
           source: "loop",
-          writes: { outer1: { myKey: "hi my value" } },
           step: 1,
           thread_id: "1",
         },
@@ -7412,12 +7316,6 @@ graph TD;
                   "": expect.any(String),
                 },
                 source: "loop",
-                writes: {
-                  inner1: {
-                    myKey: "hi my value here",
-                    myOtherKey: "hi my value",
-                  },
-                },
                 step: 1,
               },
               createdAt: expect.any(String),
@@ -7445,7 +7343,6 @@ graph TD;
           thread_id: "1",
           parents: {},
           source: "loop",
-          writes: { outer1: { myKey: "hi my value" } },
           step: 1,
         },
         createdAt: expect.any(String),
@@ -7491,9 +7388,6 @@ graph TD;
               thread_id: "1",
               parents: {},
               source: "loop",
-              writes: {
-                outer1: { myKey: "hi my value" },
-              },
               step: 1,
             },
             createdAt: expect.any(String),
@@ -7531,7 +7425,6 @@ graph TD;
               parents: {},
               source: "loop",
               step: 0,
-              writes: null,
               thread_id: "1",
             },
             createdAt: expect.any(String),
@@ -7567,7 +7460,6 @@ graph TD;
               thread_id: "1",
               parents: {},
               source: "input",
-              writes: { __start__: { myKey: "my value" } },
               step: -1,
             },
             createdAt: expect.any(String),
@@ -7597,12 +7489,6 @@ graph TD;
             metadata: {
               thread_id: "1",
               source: "loop",
-              writes: {
-                inner1: {
-                  myKey: "hi my value here",
-                  myOtherKey: "hi my value",
-                },
-              },
               step: 1,
               parents: { "": expect.any(String) },
             },
@@ -7642,7 +7528,6 @@ graph TD;
             metadata: {
               thread_id: "1",
               source: "loop",
-              writes: null,
               step: 0,
               parents: { "": expect.any(String) },
             },
@@ -7684,9 +7569,6 @@ graph TD;
             metadata: {
               thread_id: "1",
               source: "input",
-              writes: {
-                __start__: { myKey: "hi my value" },
-              },
               step: -1,
               parents: { "": expect.any(String) },
             },
@@ -7721,9 +7603,6 @@ graph TD;
           thread_id: "1",
           parents: {},
           source: "loop",
-          writes: {
-            outer2: { myKey: "hi my value here and there and back again" },
-          },
           step: 3,
         },
         createdAt: expect.any(String),
@@ -7754,9 +7633,6 @@ graph TD;
             thread_id: "1",
             parents: {},
             source: "loop",
-            writes: {
-              outer2: { myKey: "hi my value here and there and back again" },
-            },
             step: 3,
           },
           createdAt: expect.any(String),
@@ -7791,7 +7667,6 @@ graph TD;
             thread_id: "1",
             parents: {},
             source: "loop",
-            writes: { inner: { myKey: "hi my value here and there" } },
             step: 2,
           },
           createdAt: expect.any(String),
@@ -7834,7 +7709,6 @@ graph TD;
             thread_id: "1",
             parents: {},
             source: "loop",
-            writes: { outer1: { myKey: "hi my value" } },
             step: 1,
           },
           createdAt: expect.any(String),
@@ -7870,7 +7744,6 @@ graph TD;
           metadata: {
             parents: {},
             source: "loop",
-            writes: null,
             step: 0,
             thread_id: "1",
           },
@@ -7906,7 +7779,6 @@ graph TD;
             thread_id: "1",
             parents: {},
             source: "input",
-            writes: { __start__: { myKey: "my value" } },
             step: -1,
           },
           createdAt: expect.any(String),
@@ -8108,7 +7980,6 @@ graph TD;
         metadata: {
           parents: {},
           source: "loop",
-          writes: { parent1: { myKey: "hi my value" } },
           step: 1,
           thread_id: "1",
         },
@@ -8168,7 +8039,6 @@ graph TD;
             "": expect.any(String),
           }),
           source: "loop",
-          writes: { grandchild1: { myKey: "hi my value here" } },
           step: 1,
         },
         createdAt: expect.any(String),
@@ -8226,9 +8096,6 @@ graph TD;
                         "": expect.any(String),
                       }),
                       source: "loop",
-                      writes: {
-                        grandchild1: { myKey: "hi my value here" },
-                      },
                       step: 1,
                       thread_id: "1",
                     },
@@ -8260,7 +8127,6 @@ graph TD;
                 thread_id: "1",
                 parents: { "": expect.any(String) },
                 source: "loop",
-                writes: null,
                 step: 0,
               },
               createdAt: expect.any(String),
@@ -8288,7 +8154,6 @@ graph TD;
           thread_id: "1",
           parents: {},
           source: "loop",
-          writes: { parent1: { myKey: "hi my value" } },
           step: 1,
         },
         createdAt: expect.any(String),
@@ -8342,9 +8207,6 @@ graph TD;
           thread_id: "1",
           parents: {},
           source: "loop",
-          writes: {
-            parent2: { myKey: "hi my value here and there and back again" },
-          },
           step: 3,
         },
         createdAt: expect.any(String),
@@ -8376,9 +8238,6 @@ graph TD;
               thread_id: "1",
               parents: {},
               source: "loop",
-              writes: {
-                parent2: { myKey: "hi my value here and there and back again" },
-              },
               step: 3,
             },
             createdAt: expect.any(String),
@@ -8403,7 +8262,6 @@ graph TD;
             metadata: {
               thread_id: "1",
               source: "loop",
-              writes: { child: { myKey: "hi my value here and there" } },
               step: 2,
               parents: {},
             },
@@ -8457,7 +8315,6 @@ graph TD;
               thread_id: "1",
               parents: {},
               source: "loop",
-              writes: { parent1: { myKey: "hi my value" } },
               step: 1,
             },
             createdAt: expect.any(String),
@@ -8484,7 +8341,6 @@ graph TD;
             },
             metadata: {
               source: "loop",
-              writes: null,
               step: 0,
               parents: {},
               thread_id: "1",
@@ -8521,7 +8377,6 @@ graph TD;
             metadata: {
               thread_id: "1",
               source: "input",
-              writes: { __start__: { myKey: "my value" } },
               step: -1,
               parents: {},
             },
@@ -8565,7 +8420,6 @@ graph TD;
             metadata: {
               thread_id: "1",
               source: "loop",
-              writes: { child1: { myKey: "hi my value here and there" } },
               step: 1,
               parents: { "": expect.any(String) },
             },
@@ -8596,7 +8450,6 @@ graph TD;
             metadata: {
               thread_id: "1",
               source: "loop",
-              writes: null,
               step: 0,
               parents: { "": expect.any(String) },
             },
@@ -8644,7 +8497,6 @@ graph TD;
             metadata: {
               thread_id: "1",
               source: "input",
-              writes: { __start__: { myKey: "hi my value" } },
               step: -1,
               parents: { "": expect.any(String) },
             },
@@ -8687,7 +8539,6 @@ graph TD;
             metadata: {
               thread_id: "1",
               source: "loop",
-              writes: { grandchild2: { myKey: "hi my value here and there" } },
               step: 2,
               parents: expect.objectContaining({
                 "": expect.any(String),
@@ -8720,7 +8571,6 @@ graph TD;
             metadata: {
               thread_id: "1",
               source: "loop",
-              writes: { grandchild1: { myKey: "hi my value here" } },
               step: 1,
               parents: expect.objectContaining({
                 "": expect.any(String),
@@ -8765,7 +8615,6 @@ graph TD;
             metadata: {
               thread_id: "1",
               source: "loop",
-              writes: null,
               step: 0,
               parents: expect.objectContaining({
                 "": expect.any(String),
@@ -8806,7 +8655,6 @@ graph TD;
             metadata: {
               thread_id: "1",
               source: "input",
-              writes: { __start__: { myKey: "hi my value" } },
               step: -1,
               parents: expect.objectContaining({
                 "": expect.any(String),
@@ -8947,7 +8795,6 @@ graph TD;
         metadata: {
           parents: {},
           source: "loop",
-          writes: null,
           step: 0,
           thread_id: "1",
         },
@@ -8982,9 +8829,6 @@ graph TD;
         metadata: {
           step: 1,
           source: "loop",
-          writes: {
-            edit: {},
-          },
           parents: { "": expect.any(String) },
           thread_id: "1",
         },
@@ -9027,9 +8871,6 @@ graph TD;
           thread_id: "1",
           step: 1,
           source: "loop",
-          writes: {
-            edit: {},
-          },
           parents: { "": expect.any(String) },
         },
         createdAt: expect.any(String),
@@ -9086,12 +8927,6 @@ graph TD;
           parents: {},
           thread_id: "1",
           source: "loop",
-          writes: {
-            generateJoke: [
-              { jokes: ["Joke about cats - hohoho"] },
-              { jokes: ["Joke about turtles - hohoho"] },
-            ],
-          },
           step: 1,
         },
         createdAt: expect.any(String),
@@ -9127,12 +8962,6 @@ graph TD;
           metadata: {
             parents: {},
             source: "loop",
-            writes: {
-              generateJoke: [
-                { jokes: ["Joke about cats - hohoho"] },
-                { jokes: ["Joke about turtles - hohoho"] },
-              ],
-            },
             step: 1,
             thread_id: "1",
           },
@@ -9190,7 +9019,6 @@ graph TD;
           metadata: {
             parents: {},
             source: "loop",
-            writes: null,
             step: 0,
             thread_id: "1",
           },
@@ -9227,7 +9055,6 @@ graph TD;
           metadata: {
             parents: {},
             source: "input",
-            writes: { __start__: { subjects: ["cats", "dogs"] } },
             step: -1,
             thread_id: "1",
           },
@@ -9430,7 +9257,6 @@ graph TD;
             tasks: [],
             metadata: {
               source: "loop",
-              writes: { inner_2: { myKey: " and there" } },
               step: 6,
               parents: { "": expect.any(String) },
               thread_id: "1",
@@ -9472,12 +9298,6 @@ graph TD;
             ],
             metadata: {
               source: "loop",
-              writes: {
-                inner_1: {
-                  myKey: " got here",
-                  myOtherKey: " got here and there got here and there",
-                },
-              },
               step: 5,
               parents: { "": expect.any(String) },
               thread_id: "1",
@@ -9522,7 +9342,6 @@ graph TD;
             ],
             metadata: {
               source: "loop",
-              writes: null,
               step: 4,
               parents: { "": expect.any(String) },
               thread_id: "1",
@@ -9561,7 +9380,6 @@ graph TD;
             ],
             metadata: {
               source: "input",
-              writes: { __start__: { myKey: " got here and there" } },
               step: 3,
               parents: { "": expect.any(String) },
               thread_id: "1",
@@ -9592,7 +9410,6 @@ graph TD;
             tasks: [],
             metadata: {
               source: "loop",
-              writes: { inner_2: { myKey: " and there" } },
               step: 2,
               parents: { "": expect.any(String) },
               thread_id: "1",
@@ -9633,7 +9450,6 @@ graph TD;
             ],
             metadata: {
               source: "loop",
-              writes: { inner_1: { myKey: " got here", myOtherKey: "" } },
               step: 1,
               parents: { "": expect.any(String) },
               thread_id: "1",
@@ -9672,7 +9488,6 @@ graph TD;
             ],
             metadata: {
               source: "loop",
-              writes: null,
               step: 0,
               parents: { "": expect.any(String) },
               thread_id: "1",
@@ -9711,7 +9526,6 @@ graph TD;
             ],
             metadata: {
               source: "input",
-              writes: { __start__: { myKey: "" } },
               step: -1,
               parents: { "": expect.any(String) },
               thread_id: "1",
@@ -10467,11 +10281,6 @@ graph TD;
       },
       metadata: {
         source: "loop",
-        writes: {
-          alice: {
-            user_name: "Meow",
-          },
-        },
         step: 1,
         parents: {},
         thread_id: "1",
@@ -10581,16 +10390,6 @@ graph TD;
       metadata: {
         source: "loop",
         thread_id: "1",
-        writes: {
-          bob: {
-            messages: [
-              {
-                role: "assistant",
-                content: "bob",
-              },
-            ],
-          },
-        },
         step: 3,
         parents: {},
       },
@@ -10708,22 +10507,6 @@ graph TD;
       tasks: [],
       metadata: {
         source: "loop",
-        writes: {
-          alice: {
-            messages: [
-              new _AnyIdHumanMessage({
-                content: "get user name",
-              }),
-              new _AnyIdAIMessage({
-                content: "grandkid",
-              }),
-              new _AnyIdAIMessage({
-                content: "robert",
-              }),
-            ],
-            user_name: "jeffrey",
-          },
-        },
         step: 1,
         parents: {},
         thread_id: "1",
@@ -11580,11 +11363,17 @@ graph TD;
     expect(checkpoints.length).toBe(2);
     expect(checkpoints).toMatchObject([
       {
-        metadata: {
-          writes: { nodeA: { foo: "updated" }, nodeB: { baz: "new" } },
+        checkpoint: {
+          channel_values: { foo: "updated", baz: "new" },
+          versions_seen: { nodeA: {}, nodeB: {} },
         },
       },
-      { metadata: { writes: { nodeA: { foo: "bar" } } } },
+      {
+        checkpoint: {
+          channel_values: { foo: "bar" },
+          versions_seen: { nodeA: {} },
+        },
+      },
     ]);
 
     // perform multiple steps at the same time
@@ -11612,11 +11401,17 @@ graph TD;
     expect(checkpoints.length).toBe(2);
     expect(checkpoints).toMatchObject([
       {
-        metadata: {
-          writes: { nodeA: { foo: "updated" }, nodeB: { baz: "new" } },
+        checkpoint: {
+          channel_values: { foo: "updated", baz: "new" },
+          versions_seen: { nodeA: {}, nodeB: {} },
         },
       },
-      { metadata: { writes: { nodeA: { foo: "bar" } } } },
+      {
+        checkpoint: {
+          channel_values: { foo: "bar" },
+          versions_seen: { nodeA: {} },
+        },
+      },
     ]);
 
     // throw error if updating without `asNode`

--- a/libs/langgraph/src/tests/python_port/checkpoint.test.ts
+++ b/libs/langgraph/src/tests/python_port/checkpoint.test.ts
@@ -1246,10 +1246,6 @@ describe("Checkpoint Tests (Python port)", () => {
 
     // First checkpoint (most recent) should have no pending writes
     expect(checkpoints[0]?.pendingWrites).toEqual([]);
-
-    // Check that the metadata in the first checkpoint has writes
-    expect(checkpoints[0]?.metadata?.writes).toBeDefined();
-
     expect(checkpoints[1]?.pendingWrites).toBeDefined();
     expect(checkpoints[2]?.pendingWrites).toBeDefined();
   });

--- a/libs/langgraph/src/tests/python_port/checkpoint.test.ts
+++ b/libs/langgraph/src/tests/python_port/checkpoint.test.ts
@@ -1207,7 +1207,6 @@ describe("Checkpoint Tests (Python port)", () => {
       parents: {},
       source: "loop",
       step: 0,
-      writes: null,
       thread_id: "1",
     });
 

--- a/libs/langgraph/src/tests/python_port/graph_structure.test.ts
+++ b/libs/langgraph/src/tests/python_port/graph_structure.test.ts
@@ -2531,11 +2531,6 @@ describe("Graph Structure Tests (Python port)", () => {
     // Verify metadata structure (not exact values since they can vary)
     expect(state.metadata).toMatchObject({
       source: "loop",
-      writes: {
-        alice: {
-          user_name: "Meow",
-        },
-      },
       thread_id: "1",
       step: 1,
     });

--- a/libs/langgraph/src/tests/python_port/interrupt.test.ts
+++ b/libs/langgraph/src/tests/python_port/interrupt.test.ts
@@ -1053,6 +1053,5 @@ describe("Async Pregel Interrupt Tests (Python port)", () => {
         thread_id: "2",
       })
     );
-    expect(state?.metadata?.writes).toEqual({ alittlewhile: { value: 2 } });
   });
 });


### PR DESCRIPTION
Since we only need to restore from checkpoint values, we do not need to store the update values separately. Removing `writes` from metadata allows us to save space.
