### PR TITLE
chore(langgraph): deprecate old state definition syntax

### DIFF
--- a/.changeset/spicy-kids-make.md
+++ b/.changeset/spicy-kids-make.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph": patch
+---
+
+Mark StateGraph({ channel }) constructor deprecated

--- a/libs/langgraph/src/graph/state.ts
+++ b/libs/langgraph/src/graph/state.ts
@@ -261,14 +261,20 @@ export class StateGraph<
   constructor(
     fields: SD extends StateDefinition
       ?
-          | SD
           | AnnotationRoot<SD>
-          | StateGraphArgs<S>
           | StateGraphArgsWithStateSchema<
               SD,
               ToStateDefinition<I>,
               ToStateDefinition<O>
             >
+      : never,
+    configSchema?: C | AnnotationRoot<ToStateDefinition<C>>
+  );
+
+  /** @deprecated Use `Annotation.Root` or `zod` for state definition instead. */
+  constructor(
+    fields: SD extends StateDefinition
+      ? SD | StateGraphArgs<S>
       : StateGraphArgs<S>,
     configSchema?: C | AnnotationRoot<ToStateDefinition<C>>
   );

--- a/libs/langgraph/src/tests/pregel.test.ts
+++ b/libs/langgraph/src/tests/pregel.test.ts
@@ -1978,12 +1978,12 @@ export function runPregelTests(
   });
 
   it("should allow a conditional edge after a send", async () => {
-    const State = {
+    const State = Annotation.Root({
       items: Annotation<string[]>({
         reducer: (a, b) => a.concat(b),
       }),
-    };
-    const sendForFun = (state: StateType<typeof State>) => {
+    });
+    const sendForFun = (state: typeof State.State) => {
       return [new Send("2", state), new Send("2", state)];
     };
     const routeToThree = () => "3";


### PR DESCRIPTION
Use Annotation.Root or Zod for state definition instead.
