### PR TITLE
feat(checkpoint): allow async serialization / deserialization

### DIFF
--- a/.changeset/tricky-rules-give.md
+++ b/.changeset/tricky-rules-give.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint": minor
+---
+
+Allow asynchronous serialization and deserialization

--- a/libs/checkpoint/src/serde/base.ts
+++ b/libs/checkpoint/src/serde/base.ts
@@ -1,6 +1,6 @@
 export interface SerializerProtocol {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  dumpsTyped(data: any): [string, Uint8Array];
+  dumpsTyped(data: any): Promise<[string, Uint8Array]>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  loadsTyped(type: string, data: Uint8Array | string): any;
+  loadsTyped(type: string, data: Uint8Array | string): Promise<any>;
 }

--- a/libs/checkpoint/src/serde/jsonplus.ts
+++ b/libs/checkpoint/src/serde/jsonplus.ts
@@ -133,7 +133,7 @@ export class JsonPlusSerializer implements SerializerProtocol {
     );
   }
 
-  dumpsTyped(obj: any): [string, Uint8Array] {
+  async dumpsTyped(obj: any): Promise<[string, Uint8Array]> {
     if (obj instanceof Uint8Array) {
       return ["bytes", obj];
     } else {

--- a/libs/checkpoint/src/serde/tests/jsonplus.test.ts
+++ b/libs/checkpoint/src/serde/tests/jsonplus.test.ts
@@ -90,7 +90,7 @@ it.each(VALUES)(
   "should serialize and deserialize %s",
   async (_description, value) => {
     const serde = new JsonPlusSerializer();
-    const [type, serialized] = serde.dumpsTyped(value);
+    const [type, serialized] = await serde.dumpsTyped(value);
     const deserialized = await serde.loadsTyped(type, serialized);
     expect(deserialized).toEqual(value);
   }
@@ -108,7 +108,7 @@ it("Should replace circular JSON inputs", async () => {
   };
   const serde = new JsonPlusSerializer();
   const decoder = new TextDecoder();
-  const [type, serialized] = serde.dumpsTyped(circular);
+  const [type, serialized] = await serde.dumpsTyped(circular);
   expect(type).toEqual("json");
   expect(decoder.decode(serialized)).toEqual(
     `{"a":{"b":{"a":"[Circular]"}},"b":{"a":"[Circular]"}}`

--- a/libs/langgraph/src/tests/python_port/checkpoint.test.ts
+++ b/libs/langgraph/src/tests/python_port/checkpoint.test.ts
@@ -102,11 +102,13 @@ class MemorySaverAssertCheckpointMetadata extends MemorySaver {
     }
 
     // Serialize checkpoint and merged metadata
-    const serializedCheckpoint = this.serde.dumpsTyped(checkpoint)[1];
-    const serializedMergedMetadata = this.serde.dumpsTyped({
-      ...configurable,
-      ...metadata,
-    })[1];
+    const serializedCheckpoint = (await this.serde.dumpsTyped(checkpoint))[1];
+    const serializedMergedMetadata = (
+      await this.serde.dumpsTyped({
+        ...configurable,
+        ...metadata,
+      })
+    )[1];
 
     // Store in the storage with merged metadata
     this.storage[threadId][checkpointNs][checkpoint.id] = [

--- a/libs/langgraph/src/tests/utils.ts
+++ b/libs/langgraph/src/tests/utils.ts
@@ -347,7 +347,7 @@ export class MemorySaverAssertImmutable extends MemorySaver {
         ).toEqual(loaded);
       }
     }
-    const [, serializedCheckpoint] = this.serde.dumpsTyped(checkpoint);
+    const [, serializedCheckpoint] = await this.serde.dumpsTyped(checkpoint);
     // save a copy of the checkpoint
     this.storageForCopies[thread_id][checkpoint.id] = serializedCheckpoint;
 


### PR DESCRIPTION
Deserialization was already async (which was hidden due to our usage of `any`). This implements async serialization as well.

Closes Allowing asynchronous serialization and deserialization within checkpoint savers #529
