### PR TITLE
fix: handle subgraph custom events in stream processing

### DIFF
--- a/.changeset/true-ties-sin.md
+++ b/.changeset/true-ties-sin.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): handle subgraph custom events in stream processing of useStream


### PR DESCRIPTION
# Fix: Handle Subgraph Custom Events in Stream Processing

## Problem
When `streamSubgraphs: true` is enabled, subgraph custom events (`custom|subgraph_id|node_id`) are not processed because the stream only checks for exact `event === "custom"` matches.

## Solution
Updated event processing to handle both standard custom events and subgraph custom events by checking for events that start with "custom|".

## Changes
- Modified event condition: `event === "custom" || event.startsWith("custom|")`
- Updated `EventStreamEvent` type to include subgraph variants
- Fixed null/undefined handling in stream processing functions

## Testing
- TypeScript compilation passes
- Maintains backward compatibility
- Follows existing pattern for subgraph message events

This ensures UI components from subgraphs are properly rendered when streaming is enabled. Greetings from [Captide](https://www.captide.ai)!