### PR TITLE
fix(langgraph): handle empty messages

### DIFF
--- a/.changeset/smooth-dragons-drive.md
+++ b/.changeset/smooth-dragons-drive.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(langgraph): handle empty messages

--- a/libs/langgraph/src/prebuilt/tool_node.ts
+++ b/libs/langgraph/src/prebuilt/tool_node.ts
@@ -260,7 +260,8 @@ export function toolsCondition(
     : state.messages[state.messages.length - 1];
 
   if (
-    message !== undefined && "tool_calls" in message &&
+    message !== undefined &&
+    "tool_calls" in message &&
     ((message as AIMessage).tool_calls?.length ?? 0) > 0
   ) {
     return "tools";

--- a/libs/langgraph/src/prebuilt/tool_node.ts
+++ b/libs/langgraph/src/prebuilt/tool_node.ts
@@ -260,7 +260,7 @@ export function toolsCondition(
     : state.messages[state.messages.length - 1];
 
   if (
-    "tool_calls" in message &&
+    message !== undefined && "tool_calls" in message &&
     ((message as AIMessage).tool_calls?.length ?? 0) > 0
   ) {
     return "tools";


### PR DESCRIPTION
Gracefully handle empty messages when deciding conditional mapping to "tools" or END

If messages is empty, message is assigned to `undefined`, and "tool_calls" in message will throw.