### PR TITLE
fix(cli): allow description field on config

### DIFF
--- a/.changeset/pretty-mice-boil.md
+++ b/.changeset/pretty-mice-boil.md
@@ -1,0 +1,6 @@
+---
+"@langchain/langgraph-api": patch
+"@langchain/langgraph-cli": patch
+---
+
+support description property for `langgraph.json`

--- a/libs/langgraph-api/src/cli/spawn.mts
+++ b/libs/langgraph-api/src/cli/spawn.mts
@@ -9,7 +9,7 @@ export async function spawnServer(
   },
   context: {
     config: {
-      graphs: Record<string, string>;
+      graphs: Record<string, string | { path: string; description?: string }>;
       ui?: Record<string, string>;
       ui_config?: { shared?: string[] };
       auth?: { path?: string; disable_studio_auth?: boolean };

--- a/libs/langgraph-api/src/preload.mjs
+++ b/libs/langgraph-api/src/preload.mjs
@@ -10,14 +10,16 @@ const options = JSON.parse(lastArg || "{}");
 // find the first file, as `parentURL` needs to be a valid file URL
 // if no graph found, just assume a dummy default file, which should
 // be working fine as well.
-const graphFiles = Object.values(options.graphs).map((i) => {
-  if (typeof i === "string") {
-    return i.split(":").at(0);
-  } else if (i && typeof i === "object" && i.path) {
-    return i.path.split(":").at(0);
-  }
-  return null;
-}).filter(Boolean);
+const graphFiles = Object.values(options.graphs)
+  .map((i) => {
+    if (typeof i === "string") {
+      return i.split(":").at(0);
+    } else if (i && typeof i === "object" && i.path) {
+      return i.path.split(":").at(0);
+    }
+    return null;
+  })
+  .filter(Boolean);
 const firstGraphFile = graphFiles.at(0) || "index.mts";
 
 // enforce API @langchain/langgraph resolution

--- a/libs/langgraph-api/src/preload.mjs
+++ b/libs/langgraph-api/src/preload.mjs
@@ -10,10 +10,15 @@ const options = JSON.parse(lastArg || "{}");
 // find the first file, as `parentURL` needs to be a valid file URL
 // if no graph found, just assume a dummy default file, which should
 // be working fine as well.
-const firstGraphFile =
-  Object.values(options.graphs)
-    .flatMap((i) => i.split(":").at(0))
-    .at(0) || "index.mts";
+const graphFiles = Object.values(options.graphs).map((i) => {
+  if (typeof i === "string") {
+    return i.split(":").at(0);
+  } else if (i && typeof i === "object" && i.path) {
+    return i.path.split(":").at(0);
+  }
+  return null;
+}).filter(Boolean);
+const firstGraphFile = graphFiles.at(0) || "index.mts";
 
 // enforce API @langchain/langgraph resolution
 register("./graph/load.hooks.mjs", import.meta.url, {

--- a/libs/langgraph-cli/src/docker/docker.mts
+++ b/libs/langgraph-cli/src/docker/docker.mts
@@ -179,7 +179,10 @@ async function updateGraphPaths(
   config: Config,
   localDeps: LocalDeps
 ) {
-  for (const [graphId, importStr] of Object.entries(config.graphs)) {
+  for (const [graphId, graphDef] of Object.entries(config.graphs)) {
+    const importStr = typeof graphDef === "string" ? graphDef : graphDef.path;
+    const description =
+      typeof graphDef === "string" ? undefined : graphDef.description;
     let [moduleStr, attrStr] = importStr.split(":", 2);
     if (!moduleStr || !attrStr) {
       throw new Error(
@@ -226,7 +229,13 @@ async function updateGraphPaths(
           }
         }
 
-        config["graphs"][graphId] = `${moduleStr}:${attrStr}`;
+        const resolvedPath = `${moduleStr}:${attrStr}`;
+        config["graphs"][graphId] = description
+          ? {
+              path: resolvedPath,
+              description,
+            }
+          : resolvedPath;
       }
     }
   }

--- a/libs/langgraph-cli/src/utils/config.mts
+++ b/libs/langgraph-cli/src/utils/config.mts
@@ -47,7 +47,6 @@ const BaseConfigSchema = z.object({
       disable_threads: z.boolean().default(false),
       disable_runs: z.boolean().default(false),
       disable_store: z.boolean().default(false),
-      disable_mcp: z.boolean().default(false),
       disable_meta: z.boolean().default(false),
       cors: z
         .object({


### PR DESCRIPTION
This PR allows for graph descriptions to exist within `langgraph.json`. When specified, LGP serves an `/mcp` endpoint which allows you to call your graphs like MCP tools. 

Note that we currently don't support MCP within the local dev server which we emit a warning for