### PR TITLE
feat(langgraph): use return types from nodes as update type

### DIFF
--- a/.changeset/fuzzy-vans-yell.md
+++ b/.changeset/fuzzy-vans-yell.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph": patch
+---
+
+Use return type of nodes for streamMode: updates types

--- a/.changeset/seven-lamps-matter.md
+++ b/.changeset/seven-lamps-matter.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-cua": minor
+---
+
+feat(cua): Improve update types

--- a/.changeset/slimy-singers-trade.md
+++ b/.changeset/slimy-singers-trade.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-swarm": patch
+---
+
+chore: enforce return types for swarm

--- a/libs/langgraph-cua/src/index.ts
+++ b/libs/langgraph-cua/src/index.ts
@@ -169,8 +169,12 @@ export function createCua<
     throw new Error("timeoutHours must be between 0.01 and 24");
   }
 
-  const nodeBefore = nodeBeforeAction ?? (async () => {});
-  const nodeAfter = nodeAfterAction ?? (async () => {});
+  const nodeBefore =
+    nodeBeforeAction ??
+    ((async () => ({})) as (state: CUAState) => Promise<CUAUpdate>);
+  const nodeAfter =
+    nodeAfterAction ??
+    ((async () => ({})) as (state: CUAState) => Promise<CUAUpdate>);
 
   const StateAnnotation = Annotation.Root({
     ...CUAAnnotation.spec,

--- a/libs/langgraph-cua/src/nodes/create-vm-instance.ts
+++ b/libs/langgraph-cua/src/nodes/create-vm-instance.ts
@@ -1,12 +1,12 @@
 import { LangGraphRunnableConfig } from "@langchain/langgraph";
 import { UbuntuInstance, BrowserInstance, WindowsInstance } from "scrapybara";
-import { CUAState, CUAUpdate, getConfigurationWithDefaults } from "../types.js";
+import { CUAState, getConfigurationWithDefaults } from "../types.js";
 import { getScrapybaraClient } from "../utils.js";
 
 export async function createVMInstance(
   state: CUAState,
   config: LangGraphRunnableConfig
-): Promise<CUAUpdate> {
+) {
   const { instanceId } = state;
   if (instanceId) {
     // Instance already exists, no need to initialize
@@ -46,13 +46,8 @@ export async function createVMInstance(
     // If the streamUrl is not yet defined in state, fetch it, then write to the custom stream
     // so that it's made accessible to the client (or whatever is reading the stream) before any actions are taken.
     const { streamUrl } = await instance.getStreamUrl();
-    return {
-      instanceId: instance.id,
-      streamUrl,
-    };
+    return { instanceId: instance.id, streamUrl };
   }
 
-  return {
-    instanceId: instance.id,
-  };
+  return { instanceId: instance.id };
 }

--- a/libs/langgraph-cua/src/nodes/take-computer-action.ts
+++ b/libs/langgraph-cua/src/nodes/take-computer-action.ts
@@ -5,9 +5,9 @@ import {
   Scrapybara,
 } from "scrapybara";
 import { LangGraphRunnableConfig } from "@langchain/langgraph";
-import { BaseMessageLike } from "@langchain/core/messages";
+import { ToolMessage } from "@langchain/core/messages";
 import { RunnableLambda } from "@langchain/core/runnables";
-import { CUAState, CUAUpdate, getConfigurationWithDefaults } from "../types.js";
+import { CUAState, getConfigurationWithDefaults } from "../types.js";
 import { getInstance, getToolOutputs } from "../utils.js";
 
 async function sleep(ms: number): Promise<void> {
@@ -52,7 +52,7 @@ export async function takeComputerAction(
   {
     uploadScreenshot,
   }: { uploadScreenshot?: (screenshot: string) => Promise<string> }
-): Promise<CUAUpdate> {
+) {
   if (!state.instanceId) {
     throw new Error("Can not take computer action without an instance ID.");
   }
@@ -93,7 +93,7 @@ export async function takeComputerAction(
 
   const output = toolOutputs[toolOutputs.length - 1];
   const { action } = output;
-  let computerCallToolMsg: BaseMessageLike | undefined;
+  let computerCallToolMsg: ToolMessage | undefined;
 
   try {
     let computerResponse: Scrapybara.ComputerResponse;
@@ -180,18 +180,14 @@ export async function takeComputerAction(
       );
     }
 
-    computerCallToolMsg = {
-      type: "tool",
+    computerCallToolMsg = new ToolMessage({
+      content: screenshotContent,
       tool_call_id: output.call_id,
       additional_kwargs: { type: "computer_call_output" },
-      content: screenshotContent,
-    };
+    });
   } catch (e) {
     console.error(
-      {
-        error: e,
-        computerCall: output,
-      },
+      { error: e, computerCall: output },
       "Failed to execute computer call."
     );
   }

--- a/libs/langgraph-swarm/src/swarm.ts
+++ b/libs/langgraph-swarm/src/swarm.ts
@@ -99,7 +99,14 @@ const createSwarm = <
   agents,
   defaultActiveAgent,
   stateSchema,
-}: CreateSwarmParams<AnnotationRootT>) => {
+}: CreateSwarmParams<AnnotationRootT>): StateGraph<
+  AnnotationRootT["spec"],
+  AnnotationRootT["State"],
+  AnnotationRootT["Update"],
+  string,
+  AnnotationRootT["spec"],
+  AnnotationRootT["spec"]
+> => {
   if (stateSchema && !("activeAgent" in stateSchema.spec)) {
     throw new Error("Missing required key 'activeAgent' in stateSchema");
   }

--- a/libs/langgraph-swarm/src/swarm.ts
+++ b/libs/langgraph-swarm/src/swarm.ts
@@ -99,14 +99,7 @@ const createSwarm = <
   agents,
   defaultActiveAgent,
   stateSchema,
-}: CreateSwarmParams<AnnotationRootT>): StateGraph<
-  AnnotationRootT["spec"],
-  AnnotationRootT["State"],
-  AnnotationRootT["Update"],
-  string,
-  AnnotationRootT["spec"],
-  AnnotationRootT["spec"]
-> => {
+}: CreateSwarmParams<AnnotationRootT>) => {
   if (stateSchema && !("activeAgent" in stateSchema.spec)) {
     throw new Error("Missing required key 'activeAgent' in stateSchema");
   }
@@ -145,7 +138,14 @@ const createSwarm = <
     });
   }
 
-  return builder;
+  return builder as StateGraph<
+    AnnotationRootT["spec"],
+    AnnotationRootT["State"],
+    AnnotationRootT["Update"],
+    string,
+    AnnotationRootT["spec"],
+    AnnotationRootT["spec"]
+  >;
 };
 
 export { createSwarm, addActiveAgentRouter, SwarmState };

--- a/libs/langgraph-swarm/src/swarm.ts
+++ b/libs/langgraph-swarm/src/swarm.ts
@@ -130,9 +130,7 @@ const createSwarm = <
     agentNames.add(agent.name);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const builder = new StateGraph<any>(stateSchema ?? SwarmState);
-
+  const builder = new StateGraph(stateSchema ?? SwarmState);
   addActiveAgentRouter(builder, {
     routeTo: [...agentNames],
     defaultActiveAgent,

--- a/libs/langgraph/src/graph/graph.ts
+++ b/libs/langgraph/src/graph/graph.ts
@@ -222,35 +222,35 @@ export class Graph<
     return this.edges;
   }
 
-  addNode<K extends string>(
+  addNode<K extends string, NodeInput = RunInput, NodeOutput = RunOutput>(
     nodes:
-      | Record<K, NodeAction<RunInput, RunOutput, C>>
+      | Record<K, NodeAction<NodeInput, NodeOutput, C>>
       | [
           key: K,
-          action: NodeAction<RunInput, RunOutput, C>,
+          action: NodeAction<NodeInput, NodeOutput, C>,
           options?: AddNodeOptions
         ][]
   ): Graph<N | K, RunInput, RunOutput>;
 
-  addNode<K extends string, NodeInput = RunInput>(
+  addNode<K extends string, NodeInput = RunInput, NodeOutput = RunOutput>(
     key: K,
-    action: NodeAction<NodeInput, RunOutput, C>,
+    action: NodeAction<NodeInput, NodeOutput, C>,
     options?: AddNodeOptions
   ): Graph<N | K, RunInput, RunOutput>;
 
-  addNode<K extends string, NodeInput = RunInput>(
+  addNode<K extends string, NodeInput = RunInput, NodeOutput = RunOutput>(
     ...args:
       | [
           key: K,
-          action: NodeAction<NodeInput, RunOutput, C>,
+          action: NodeAction<NodeInput, NodeOutput, C>,
           options?: AddNodeOptions
         ]
       | [
           nodes:
-            | Record<K, NodeAction<NodeInput, RunOutput, C>>
+            | Record<K, NodeAction<NodeInput, NodeOutput, C>>
             | [
                 key: K,
-                action: NodeAction<NodeInput, RunOutput, C>,
+                action: NodeAction<NodeInput, NodeOutput, C>,
                 options?: AddNodeOptions
               ][]
         ]
@@ -580,14 +580,18 @@ export class CompiledGraph<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   InputType = any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  OutputType = any
+  OutputType = any,
+  NodeReturnType = unknown
 > extends Pregel<
   Record<N | typeof START, PregelNode<State, Update>>,
   Record<N | typeof START | typeof END | string, BaseChannel>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ContextType & Record<string, any>,
   InputType,
-  OutputType
+  OutputType,
+  InputType,
+  OutputType,
+  NodeReturnType
 > {
   declare NodeType: N;
 

--- a/libs/langgraph/src/graph/state.ts
+++ b/libs/langgraph/src/graph/state.ts
@@ -259,9 +259,6 @@ export class StateGraph<
   /** @internal */
   _configRuntimeSchema: InteropZodObject | undefined;
 
-  /** @internal Used only for typing. */
-  _nodeReturnType: NodeReturnType;
-
   constructor(
     fields: SD extends StateDefinition
       ? StateGraphArgsWithInputOutputSchemas<SD, ToStateDefinition<O>>

--- a/libs/langgraph/src/pregel/index.ts
+++ b/libs/langgraph/src/pregel/index.ts
@@ -385,7 +385,8 @@ export class Pregel<
     InputType = PregelInputType,
     OutputType = PregelOutputType,
     StreamUpdatesType = InputType,
-    StreamValuesType = OutputType
+    StreamValuesType = OutputType,
+    NodeReturnType = unknown
   >
   extends PartialRunnable<
     InputType | CommandInstance | null,
@@ -1824,7 +1825,8 @@ export class Pregel<
         TSubgraphs,
         StreamUpdatesType,
         StreamValuesType,
-        keyof Nodes
+        keyof Nodes,
+        NodeReturnType
       >
     >
   > {
@@ -1849,7 +1851,8 @@ export class Pregel<
           TSubgraphs,
           StreamUpdatesType,
           StreamValuesType,
-          keyof Nodes
+          keyof Nodes,
+          NodeReturnType
         >
       >,
       abortController

--- a/libs/langgraph/src/pregel/types.ts
+++ b/libs/langgraph/src/pregel/types.ts
@@ -82,7 +82,8 @@ export type StreamOutputMap<
   TStreamSubgraphs extends boolean,
   StreamUpdates,
   StreamValues,
-  Nodes
+  Nodes,
+  NodeReturnType
 > = (
   undefined extends TStreamMode
     ? []
@@ -100,7 +101,9 @@ export type StreamOutputMap<
         updates: [
           string[],
           "updates",
-          Record<Nodes extends string ? Nodes : string, StreamUpdates>
+          NodeReturnType extends Record<string, unknown>
+            ? { [K in keyof NodeReturnType]?: NodeReturnType[K] }
+            : Record<Nodes extends string ? Nodes : string, StreamUpdates>
         ];
         messages: [string[], "messages", StreamMessageOutput];
         custom: [string[], "custom", StreamCustomOutput];
@@ -120,7 +123,9 @@ export type StreamOutputMap<
         values: ["values", StreamValues];
         updates: [
           "updates",
-          Record<Nodes extends string ? Nodes : string, StreamUpdates>
+          NodeReturnType extends Record<string, unknown>
+            ? { [K in keyof NodeReturnType]?: NodeReturnType[K] }
+            : Record<Nodes extends string ? Nodes : string, StreamUpdates>
         ];
         messages: ["messages", StreamMessageOutput];
         custom: ["custom", StreamCustomOutput];
@@ -136,7 +141,9 @@ export type StreamOutputMap<
         values: [string[], StreamValues];
         updates: [
           string[],
-          Record<Nodes extends string ? Nodes : string, StreamUpdates>
+          NodeReturnType extends Record<string, unknown>
+            ? { [K in keyof NodeReturnType]?: NodeReturnType[K] }
+            : Record<Nodes extends string ? Nodes : string, StreamUpdates>
         ];
         messages: [string[], StreamMessageOutput];
         custom: [string[], StreamCustomOutput];
@@ -149,7 +156,9 @@ export type StreamOutputMap<
       }[Single]
     : {
         values: StreamValues;
-        updates: Record<Nodes extends string ? Nodes : string, StreamUpdates>;
+        updates: NodeReturnType extends Record<string, unknown>
+          ? { [K in keyof NodeReturnType]?: NodeReturnType[K] }
+          : Record<Nodes extends string ? Nodes : string, StreamUpdates>;
         messages: StreamMessageOutput;
         custom: StreamCustomOutput;
         checkpoints: StreamCheckpointsOutput<StreamValues>;

--- a/libs/langgraph/src/tests/errors.test.ts
+++ b/libs/langgraph/src/tests/errors.test.ts
@@ -43,7 +43,7 @@ it("StateGraph bad return type", async () => {
 
   const graph = new StateGraph(StateAnnotation)
     // @ts-expect-error Test invalid return value
-    .addNode("foo", () => ({ my_key: true }))
+    .addNode("foo", () => 123)
     .addEdge("__start__", "foo");
 
   const app = graph.compile({ checkpointer: new MemorySaverAssertImmutable() });

--- a/libs/langgraph/src/tests/errors.test.ts
+++ b/libs/langgraph/src/tests/errors.test.ts
@@ -43,7 +43,7 @@ it("StateGraph bad return type", async () => {
 
   const graph = new StateGraph(StateAnnotation)
     // @ts-expect-error Test invalid return value
-    .addNode("foo", () => "hey")
+    .addNode("foo", () => ({ my_key: true }))
     .addEdge("__start__", "foo");
 
   const app = graph.compile({ checkpointer: new MemorySaverAssertImmutable() });

--- a/libs/langgraph/src/tests/pregel.test-d.ts
+++ b/libs/langgraph/src/tests/pregel.test-d.ts
@@ -33,9 +33,9 @@ it("state graph annotation", async () => {
 
   const graph = new StateGraph(state)
     .addSequence({
-      one: () => ({ foo: "one" }),
-      two: () => ({ foo: "two" }),
-      three: () => ({ foo: "three" }),
+      one: () => ({ foo: "one" as const }),
+      two: () => ({ foo: "two" as const }),
+      three: () => ({ foo: "three" as const }),
     })
     .addEdge("__start__", "one")
     .compile();
@@ -50,7 +50,7 @@ it("state graph annotation", async () => {
   }
 
   expectTypeOf(await gatherIterator(graph.stream(input))).toExtend<
-    Record<"one" | "two" | "three", { foo?: string[] | string }>[]
+    { one?: { foo: "one" }; two?: { foo: "two" }; three?: { foo: "three" } }[]
   >();
 
   expectTypeOf(
@@ -78,12 +78,25 @@ it("state graph annotation", async () => {
 
   expectTypeOf(
     await gatherIterator(graph.stream(input, { streamMode: "updates" }))
-  ).toExtend<Record<"one" | "two" | "three", { foo?: string[] | string }>[]>();
+  ).toExtend<
+    {
+      one?: { foo: "one" };
+      two?: { foo: "two" };
+      three?: { foo: "three" };
+    }[]
+  >();
 
   expectTypeOf(
     await gatherIterator(graph.stream(input, { streamMode: ["updates"] }))
   ).toExtend<
-    ["updates", Record<"one" | "two" | "three", { foo?: string[] | string }>][]
+    [
+      "updates",
+      {
+        one?: { foo: "one" };
+        two?: { foo: "two" };
+        three?: { foo: "three" };
+      }
+    ][]
   >();
 
   expectTypeOf(
@@ -97,7 +110,11 @@ it("state graph annotation", async () => {
     [
       string[],
       "updates",
-      Record<"one" | "two" | "three", { foo?: string[] | string }>
+      {
+        one?: { foo: "one" };
+        two?: { foo: "two" };
+        three?: { foo: "three" };
+      }
     ][]
   >();
 
@@ -109,7 +126,11 @@ it("state graph annotation", async () => {
     (
       | [
           "updates",
-          Record<"one" | "two" | "three", { foo?: string[] | string }>
+          {
+            one?: { foo: "one" };
+            two?: { foo: "two" };
+            three?: { foo: "three" };
+          }
         ]
       | ["values", { foo: string[] }]
     )[]
@@ -127,7 +148,11 @@ it("state graph annotation", async () => {
       | [
           string[],
           "updates",
-          Record<"one" | "two" | "three", { foo?: string[] | string }>
+          {
+            one?: { foo: "one" };
+            two?: { foo: "two" };
+            three?: { foo: "three" };
+          }
         ]
       | [string[], "values", { foo: string[] }]
     )[]
@@ -147,7 +172,11 @@ it("state graph annotation", async () => {
     (
       | [
           "updates",
-          Record<"one" | "two" | "three", { foo?: string[] | string }>
+          {
+            one?: { foo: "one" };
+            two?: { foo: "two" };
+            three?: { foo: "three" };
+          }
         ]
       | ["values", { foo: string[] }]
       | ["debug", Record<string, any>]
@@ -308,9 +337,9 @@ it("state graph zod", async () => {
 
   const graph = new StateGraph(state)
     .addSequence({
-      one: () => ({ foo: "one" }),
-      two: () => ({ foo: "two" }),
-      three: () => ({ foo: "three" }),
+      one: () => ({ foo: "one" as const }),
+      two: () => ({ foo: "two" as const }),
+      three: () => ({ foo: "three" as const }),
     })
     .addEdge("__start__", "one")
     .compile();
@@ -325,7 +354,7 @@ it("state graph zod", async () => {
   }
 
   expectTypeOf(await gatherIterator(graph.stream(input))).toExtend<
-    Record<"one" | "two" | "three", { foo?: string[] | string }>[]
+    { one?: { foo: "one" }; two?: { foo: "two" }; three?: { foo: "three" } }[]
   >();
 
   expectTypeOf(
@@ -350,12 +379,17 @@ it("state graph zod", async () => {
 
   expectTypeOf(
     await gatherIterator(graph.stream(input, { streamMode: "updates" }))
-  ).toExtend<Record<"one" | "two" | "three", { foo?: string[] | string }>[]>();
+  ).toExtend<
+    { one?: { foo: "one" }; two?: { foo: "two" }; three?: { foo: "three" } }[]
+  >();
 
   expectTypeOf(
     await gatherIterator(graph.stream(input, { streamMode: ["updates"] }))
   ).toExtend<
-    ["updates", Record<"one" | "two" | "three", { foo?: string[] | string }>][]
+    [
+      "updates",
+      { one?: { foo: "one" }; two?: { foo: "two" }; three?: { foo: "three" } }
+    ][]
   >();
 
   expectTypeOf(
@@ -366,7 +400,7 @@ it("state graph zod", async () => {
     [
       string[],
       "updates",
-      Record<"one" | "two" | "three", { foo?: string[] | string }>
+      { one?: { foo: "one" }; two?: { foo: "two" }; three?: { foo: "three" } }
     ][]
   >();
 
@@ -378,7 +412,11 @@ it("state graph zod", async () => {
     (
       | [
           "updates",
-          Record<"one" | "two" | "three", { foo?: string[] | string }>
+          {
+            one?: { foo: "one" };
+            two?: { foo: "two" };
+            three?: { foo: "three" };
+          }
         ]
       | ["values", { foo: string[] }]
     )[]
@@ -396,7 +434,11 @@ it("state graph zod", async () => {
       | [
           string[],
           "updates",
-          Record<"one" | "two" | "three", { foo?: string[] | string }>
+          {
+            one?: { foo: "one" };
+            two?: { foo: "two" };
+            three?: { foo: "three" };
+          }
         ]
       | [string[], "values", { foo: string[] }]
     )[]
@@ -416,7 +458,11 @@ it("state graph zod", async () => {
     (
       | [
           "updates",
-          Record<"one" | "two" | "three", { foo?: string[] | string }>
+          {
+            one?: { foo: "one" };
+            two?: { foo: "two" };
+            three?: { foo: "three" };
+          }
         ]
       | ["values", { foo: string[] }]
       | ["debug", Record<string, any>]
@@ -448,7 +494,11 @@ it("state graph zod", async () => {
       | [
           string[],
           "updates",
-          Record<"one" | "two" | "three", { foo?: string[] | string }>
+          {
+            one?: { foo: "one" };
+            two?: { foo: "two" };
+            three?: { foo: "three" };
+          }
         ]
       | [string[], "values", { foo: string[] }]
       | [string[], "debug", Record<string, any>]

--- a/libs/langgraph/src/tests/pregel.test.ts
+++ b/libs/langgraph/src/tests/pregel.test.ts
@@ -12279,7 +12279,7 @@ graph TD;
         }),
       })
     )
-      .addNode("childGraph", childGraph)
+      .addNode("childGraph", (state) => childGraph.invoke(state))
       .addNode("cleanup", (state) => {
         expect(state.humanInputs).toHaveLength(state.prompts.length);
         return {};

--- a/libs/langgraph/src/tests/pregel.test.ts
+++ b/libs/langgraph/src/tests/pregel.test.ts
@@ -12279,7 +12279,7 @@ graph TD;
         }),
       })
     )
-      .addNode("childGraph", (state) => childGraph.invoke(state))
+      .addNode("childGraph", childGraph)
       .addNode("cleanup", (state) => {
         expect(state.humanInputs).toHaveLength(state.prompts.length);
         return {};


### PR DESCRIPTION
Previously we were using the update types of state definition for `streamMode: updates`, which isn't useful in case of `Messages: string | BaseMessage | BaseMessageLike`. 

