### PR TITLE
feat(langgraph): speed up prepareSingleTask by 20x

### DIFF
--- a/.changeset/cute-results-repair.md
+++ b/.changeset/cute-results-repair.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph": patch
+---
+
+feat(langgraph): speed up prepareSingleTask by 20x

--- a/libs/langgraph/src/pregel/algo.ts
+++ b/libs/langgraph/src/pregel/algo.ts
@@ -840,11 +840,8 @@ export function _prepareSingleTask<
     const seen = checkpoint.versions_seen[name] ?? {};
     const triggers = proc.triggers
       .filter((chan) => {
-        const result = readChannel(channels, chan, false, true);
-        const isEmptyChannelError =
-          // eslint-disable-next-line no-instanceof/no-instanceof
-          result instanceof Error &&
-          result.name === EmptyChannelError.unminifiable_name;
+        // here we're only checking if the channel is not empty
+        const isEmptyChannelError = !channels[chan].isAvailable();
         return (
           !isEmptyChannelError &&
           (checkpoint.channel_versions[chan] ?? nullVersion) >

--- a/libs/langgraph/src/pregel/utils/index.ts
+++ b/libs/langgraph/src/pregel/utils/index.ts
@@ -4,19 +4,25 @@ import type {
   ChannelVersions,
   CheckpointMetadata,
 } from "@langchain/langgraph-checkpoint";
-import { CONFIG_KEY_CHECKPOINT_MAP } from "../../constants.js";
+import { CONFIG_KEY_CHECKPOINT_MAP, START } from "../../constants.js";
 
 export function getNullChannelVersion(currentVersions: ChannelVersions) {
-  const versionValues = Object.values(currentVersions);
-  const versionType =
-    versionValues.length > 0 ? typeof versionValues[0] : undefined;
-  let nullVersion: number | string | undefined;
-  if (versionType === "number") {
-    nullVersion = 0;
-  } else if (versionType === "string") {
-    nullVersion = "";
+  // Short circuit for commonly used channels such as __start__
+  // (used by StateGraph)
+  const startVersion = typeof currentVersions[START];
+  if (startVersion === "number") return 0;
+  if (startVersion === "string") return "";
+
+  // Defer back to obtaining a first key from channel versions
+  for (const key in currentVersions) {
+    if (!Object.prototype.hasOwnProperty.call(currentVersions, key)) continue;
+    const versionType = typeof currentVersions[key];
+    if (versionType === "number") return 0;
+    if (versionType === "string") return "";
+    break;
   }
-  return nullVersion;
+
+  return undefined;
 }
 
 export function getNewChannelVersions(


### PR DESCRIPTION
- Avoid calling `channel.get()` when only checking for availability
- Avoid enumerating all channels just to obtain a null channel version
- Short-circuit to a well-known channel when obtaining channel version

Cuts down the `sequential_1000` benchmark from 32s down to 1.32s.
