### PR TITLE
feat(sdk): allow setting `checkpoint: null` when submitting a run via useStream

### DIFF
--- a/libs/sdk/CHANGELOG.md
+++ b/libs/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @langchain/langgraph-sdk
 
+## 0.0.106
+
+### Patch Changes
+
+- feat(sdk): allow setting `checkpoint: null` when submitting a run via useStream
+
 ## 0.0.105
 
 ### Patch Changes

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langchain/langgraph-sdk",
-  "version": "0.0.105",
+  "version": "0.0.106",
   "description": "Client library for interacting with the LangGraph API",
   "type": "module",
   "scripts": {

--- a/libs/sdk/src/react/stream.tsx
+++ b/libs/sdk/src/react/stream.tsx
@@ -1250,8 +1250,14 @@ export function useStream<
         ...callbackStreamMode,
       ]);
 
-      const checkpoint =
+      let checkpoint =
         submitOptions?.checkpoint ?? threadHead?.checkpoint ?? undefined;
+
+      // Avoid specifying a checkpoint if user explicitly set it to null
+      if (submitOptions?.checkpoint === null) {
+        checkpoint = undefined;
+      }
+
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-expect-error
       if (checkpoint != null) delete checkpoint.thread_id;


### PR DESCRIPTION
If an update to a thread occurs in the background, we may not have access to the most recent history, which could lead to unintentionally creating a fork due to outdated information.
