### PR TITLE
feat(langgraph): use createReactAgent description for supervisor agent handoffs

### DIFF
--- a/.changeset/olive-crabs-clap.md
+++ b/.changeset/olive-crabs-clap.md
@@ -1,0 +1,6 @@
+---
+"@langchain/langgraph-supervisor": patch
+"@langchain/langgraph": patch
+---
+
+feat(langgraph): use createReactAgent description for supervisor agent handoffs

--- a/libs/langgraph-supervisor/src/handoff.ts
+++ b/libs/langgraph-supervisor/src/handoff.ts
@@ -17,7 +17,13 @@ function _normalizeAgentName(agentName: string): string {
   return agentName.trim().replace(WHITESPACE_RE, "_").toLowerCase();
 }
 
-const createHandoffTool = ({ agentName }: { agentName: string }) => {
+const createHandoffTool = ({
+  agentName,
+  agentDescription,
+}: {
+  agentName: string;
+  agentDescription?: string;
+}) => {
   /**
    * Create a tool that can handoff control to the requested agent.
    *
@@ -53,7 +59,7 @@ const createHandoffTool = ({ agentName }: { agentName: string }) => {
     {
       name: toolName,
       schema: z.object({}),
-      description: "Ask another agent for help.",
+      description: agentDescription ?? "Ask another agent for help.",
     }
   );
   return handoffTool;

--- a/libs/langgraph-supervisor/src/supervisor.ts
+++ b/libs/langgraph-supervisor/src/supervisor.ts
@@ -208,7 +208,10 @@ const createSupervisor = <
   }
 
   const handoffTools = agents.map((agent) =>
-    createHandoffTool({ agentName: agent.name! })
+    createHandoffTool({
+      agentName: agent.name!,
+      agentDescription: (agent as { description?: string }).description,
+    })
   );
   const allTools = [...(tools ?? []), ...handoffTools];
 
@@ -271,9 +274,7 @@ const createSupervisor = <
     builder = builder.addNode(
       agent.name!,
       makeCallAgent(agent, outputMode, addHandoffBackMessages, supervisorName),
-      {
-        subgraphs: [agent],
-      }
+      { subgraphs: [agent] }
     );
     builder = builder.addEdge(agent.name!, supervisorAgent.name!);
   }

--- a/libs/langgraph-supervisor/src/supervisor.ts
+++ b/libs/langgraph-supervisor/src/supervisor.ts
@@ -207,11 +207,8 @@ const createSupervisor = <
     agentNames.add(agent.name);
   }
 
-  const handoffTools = agents.map((agent) =>
-    createHandoffTool({
-      agentName: agent.name!,
-      agentDescription: (agent as { description?: string }).description,
-    })
+  const handoffTools = agents.map(({ name, description }) =>
+    createHandoffTool({ agentName: name!, agentDescription: description })
   );
   const allTools = [...(tools ?? []), ...handoffTools];
 

--- a/libs/langgraph/src/graph/state.ts
+++ b/libs/langgraph/src/graph/state.ts
@@ -749,6 +749,7 @@ export class StateGraph<
     interruptBefore,
     interruptAfter,
     name,
+    description,
   }: {
     checkpointer?: BaseCheckpointSaver | boolean;
     store?: BaseStore;
@@ -756,6 +757,7 @@ export class StateGraph<
     interruptBefore?: N[] | All;
     interruptAfter?: N[] | All;
     name?: string;
+    description?: string;
   } = {}): CompiledStateGraph<
     Prettify<S>,
     Prettify<U>,
@@ -801,6 +803,7 @@ export class StateGraph<
       store,
       cache,
       name,
+      description,
     });
 
     // attach nodes, edges and branches
@@ -880,8 +883,32 @@ export class CompiledStateGraph<
 > {
   declare builder: StateGraph<unknown, S, U, N, I, O, C, NodeReturnType>;
 
+  /**
+   * The description of the compiled graph.
+   * This is used by the supervisor agent to describe the handoff to the agent.
+   */
+  description?: string;
+
   /** @internal */
   _metaRegistry: SchemaMetaRegistry = schemaMetaRegistry;
+
+  constructor({
+    description,
+    ...rest
+  }: { description?: string } & ConstructorParameters<
+    typeof CompiledGraph<
+      N,
+      S,
+      U,
+      StateType<ToStateDefinition<C>>,
+      UpdateType<ToStateDefinition<I>>,
+      StateType<ToStateDefinition<O>>,
+      NodeReturnType
+    >
+  >[0]) {
+    super(rest);
+    this.description = description;
+  }
 
   attachNode(key: typeof START, node?: never): void;
 

--- a/libs/langgraph/src/prebuilt/react_agent_executor.ts
+++ b/libs/langgraph/src/prebuilt/react_agent_executor.ts
@@ -565,6 +565,12 @@ export type CreateReactAgentParams<
   name?: string;
 
   /**
+   * An optional description for the agent.
+   * This can be used to describe the agent to the underlying supervisor LLM.
+   */
+  description?: string | undefined;
+
+  /**
    * Use to specify how to expose the agent name to the underlying supervisor LLM.
 
       - undefined: Relies on the LLM provider {@link AIMessage#name}. Currently, only OpenAI supports this.
@@ -684,6 +690,7 @@ export function createReactAgent<
     preModelHook,
     postModelHook,
     name,
+    description,
     version = "v1",
     includeAgentName,
   } = params;
@@ -981,11 +988,14 @@ export function createReactAgent<
     allNodeWorkflows.addEdge("tools", entrypoint);
   }
 
-  return allNodeWorkflows.compile({
+  const compiled = allNodeWorkflows.compile({
     checkpointer: checkpointer ?? checkpointSaver,
     interruptBefore,
     interruptAfter,
     store,
     name,
   });
+
+  if (description != null) Object.assign(compiled, { description });
+  return compiled;
 }

--- a/libs/langgraph/src/prebuilt/react_agent_executor.ts
+++ b/libs/langgraph/src/prebuilt/react_agent_executor.ts
@@ -988,14 +988,12 @@ export function createReactAgent<
     allNodeWorkflows.addEdge("tools", entrypoint);
   }
 
-  const compiled = allNodeWorkflows.compile({
+  return allNodeWorkflows.compile({
     checkpointer: checkpointer ?? checkpointSaver,
     interruptBefore,
     interruptAfter,
     store,
     name,
+    description,
   });
-
-  if (description != null) Object.assign(compiled, { description });
-  return compiled;
 }


### PR DESCRIPTION
Opted to specify `description` in `createReactAgent` instead of proposed solution in #1509, since we're already include the `name` property in `createReactAgent`, used for the handoff tool name.

Closes #1509
