### PR TITLE
feat(sdk): expose stream metadata from messages via `getMessagesMetadata`

### DIFF
--- a/.changeset/green-roses-appear.md
+++ b/.changeset/green-roses-appear.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+feat(sdk): expose stream metadata from messages via `getMessagesMetadata`

--- a/libs/sdk-validation/src/tests/stream.test.tsx
+++ b/libs/sdk-validation/src/tests/stream.test.tsx
@@ -846,7 +846,7 @@ describe("useStream", () => {
 
                   {metadata?.streamMetadata && (
                     <div data-testid="stream-metadata">
-                      {JSON.stringify(metadata.streamMetadata, null, 2)}
+                      {metadata.streamMetadata?.langgraph_node as string}
                     </div>
                   )}
                 </div>
@@ -871,9 +871,7 @@ describe("useStream", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("message-0")).toHaveTextContent("Hello");
-      expect(screen.getByTestId("stream-metadata")).toHaveTextContent(
-        `"langgraph_node": "agent"`
-      );
+      expect(screen.getByTestId("stream-metadata")).toHaveTextContent("agent");
     });
   });
 });

--- a/libs/sdk-validation/src/tests/stream.test.tsx
+++ b/libs/sdk-validation/src/tests/stream.test.tsx
@@ -823,4 +823,57 @@ describe("useStream", () => {
       expect(screen.getByTestId("message-1").textContent).toBe("Hey");
     });
   });
+
+  it("streamMetadata", async () => {
+    const user = userEvent.setup();
+
+    function TestComponent() {
+      const { submit, messages, getMessagesMetadata } = useStream({
+        assistantId: "agent",
+        apiKey: "test-api-key",
+      });
+
+      return (
+        <div>
+          <div data-testid="messages">
+            {messages.map((msg, i) => {
+              const metadata = getMessagesMetadata(msg, i);
+              return (
+                <div key={msg.id ?? i} data-testid={`message-${i}`}>
+                  {typeof msg.content === "string"
+                    ? msg.content
+                    : JSON.stringify(msg.content)}
+
+                  {metadata?.streamMetadata && (
+                    <div data-testid="stream-metadata">
+                      {JSON.stringify(metadata.streamMetadata, null, 2)}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          <button
+            data-testid="submit"
+            onClick={() =>
+              submit({ messages: [{ content: "Hello", type: "human" }] })
+            }
+          >
+            Send
+          </button>
+        </div>
+      );
+    }
+
+    render(<TestComponent />);
+
+    await user.click(screen.getByTestId("submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("message-0")).toHaveTextContent("Hello");
+      expect(screen.getByTestId("stream-metadata")).toHaveTextContent(
+        `"langgraph_node": "agent"`
+      );
+    });
+  });
 });


### PR DESCRIPTION
Sometimes it is still useful to obtain message metadata sent as part of `messages-tuple` stream mode, even though these are only ephemeral in nature. 