### PR TITLE
fix(pregel/utils): propagate abort reason in combineAbortSignals

### DIFF
--- a/.changeset/gorgeous-clocks-fail.md
+++ b/.changeset/gorgeous-clocks-fail.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(pregel/utils): propagate abort reason in combineAbortSignals

--- a/libs/langgraph/src/pregel/utils/index.ts
+++ b/libs/langgraph/src/pregel/utils/index.ts
@@ -162,7 +162,8 @@ export function combineAbortSignals(...x: (AbortSignal | undefined)[]): {
 
   const combinedController = new AbortController();
   const listener = () => {
-    combinedController.abort();
+    const reason = signals.find((s) => s.aborted)?.reason;
+    combinedController.abort(reason);
     signals.forEach((s) => s.removeEventListener("abort", listener));
   };
 

--- a/libs/langgraph/src/pregel/utils/index.ts
+++ b/libs/langgraph/src/pregel/utils/index.ts
@@ -150,7 +150,7 @@ export function combineAbortSignals(...x: (AbortSignal | undefined)[]): {
   signal: AbortSignal | undefined;
   dispose?: () => void;
 } {
-  const signals = [...new Set(x.filter((s) => s !== undefined))];
+  const signals = [...new Set(x.filter(Boolean))] as AbortSignal[];
 
   if (signals.length === 0) {
     return { signal: undefined, dispose: undefined };
@@ -169,8 +169,9 @@ export function combineAbortSignals(...x: (AbortSignal | undefined)[]): {
 
   signals.forEach((s) => s.addEventListener("abort", listener, { once: true }));
 
-  if (signals.some((s) => s.aborted)) {
-    combinedController.abort();
+  const hasAlreadyAbortedSignal = signals.find((s) => s.aborted);
+  if (hasAlreadyAbortedSignal) {
+    combinedController.abort(hasAlreadyAbortedSignal.reason);
   }
 
   return {

--- a/libs/langgraph/src/tests/pregel/pregel.utils.test.ts
+++ b/libs/langgraph/src/tests/pregel/pregel.utils.test.ts
@@ -12,6 +12,15 @@ describe("combineAbortSignals", () => {
     controller1.abort("abort signal 1");
     controller2.abort("abort signal 2");
     expect(signal?.aborted).toBe(true);
-    expect(signal?.reason).toBe("abort signal 2");
+    expect(signal?.reason).toBe('abort signal 1');
+  });
+
+  it("aborts immediately if one signal is already aborted", () => {
+    const controller1 = new AbortController();
+    const controller2 = new AbortController();
+    controller2.abort('abort signal 2');
+    const { signal } = combineAbortSignals(controller1.signal, controller2.signal);
+    expect(signal?.aborted).toBe(true);
+    expect(signal?.reason).toBe('abort signal 2');
   });
 });

--- a/libs/langgraph/src/tests/pregel/pregel.utils.test.ts
+++ b/libs/langgraph/src/tests/pregel/pregel.utils.test.ts
@@ -12,15 +12,18 @@ describe("combineAbortSignals", () => {
     controller1.abort("abort signal 1");
     controller2.abort("abort signal 2");
     expect(signal?.aborted).toBe(true);
-    expect(signal?.reason).toBe('abort signal 1');
+    expect(signal?.reason).toBe("abort signal 1");
   });
 
   it("aborts immediately if one signal is already aborted", () => {
     const controller1 = new AbortController();
     const controller2 = new AbortController();
-    controller2.abort('abort signal 2');
-    const { signal } = combineAbortSignals(controller1.signal, controller2.signal);
+    controller2.abort("abort signal 2");
+    const { signal } = combineAbortSignals(
+      controller1.signal,
+      controller2.signal
+    );
     expect(signal?.aborted).toBe(true);
-    expect(signal?.reason).toBe('abort signal 2');
+    expect(signal?.reason).toBe("abort signal 2");
   });
 });

--- a/libs/langgraph/src/tests/pregel/pregel.utils.test.ts
+++ b/libs/langgraph/src/tests/pregel/pregel.utils.test.ts
@@ -5,10 +5,13 @@ describe("combineAbortSignals", () => {
   it("should combine multiple abort signals", () => {
     const controller1 = new AbortController();
     const controller2 = new AbortController();
-    const { signal } = combineAbortSignals(controller1.signal, controller2.signal);
-    controller1.abort('abort signal 1');
-    controller2.abort('abort signal 2');
+    const { signal } = combineAbortSignals(
+      controller1.signal,
+      controller2.signal
+    );
+    controller1.abort("abort signal 1");
+    controller2.abort("abort signal 2");
     expect(signal?.aborted).toBe(true);
-    expect(signal?.reason).toBe('abort signal 2');
+    expect(signal?.reason).toBe("abort signal 2");
   });
 });

--- a/libs/langgraph/src/tests/pregel/pregel.utils.test.ts
+++ b/libs/langgraph/src/tests/pregel/pregel.utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { combineAbortSignals } from "../../pregel/utils/index.js";
+
+describe("combineAbortSignals", () => {
+  it("should combine multiple abort signals", () => {
+    const controller1 = new AbortController();
+    const controller2 = new AbortController();
+    const { signal } = combineAbortSignals(controller1.signal, controller2.signal);
+    controller1.abort('abort signal 1');
+    controller2.abort('abort signal 2');
+    expect(signal?.aborted).toBe(true);
+    expect(signal?.reason).toBe('abort signal 2');
+  });
+});


### PR DESCRIPTION
### Summary
- Propagate `AbortSignal.reason` in `combineAbortSignals` so the combined signal carries through the originating abort reason.
- Add a unit test to validate reason propagation and combined abort behavior.

### Why
- Preserves cancellation context across combined signals (e.g., distinguish timeout vs. user-initiated cancels).
- Aligns with the WHATWG AbortController semantics where `abort(reason)` is surfaced to consumers.
- Improves debugging and error handling in Pregel flows that rely on abort reasons.

### How
- Forward the `.reason` from the source signal that triggers the abort to the combined controller.
- Clean up listeners after abort to avoid leaks.

### Tests
- New test `libs/langgraph/src/tests/pregel/pregel.utils.test.ts` covering combined signal behavior and reason propagation.

Fixes # (issue)