### PR TITLE
fix(api): unintended schema inference to BaseMessage[] for all state keys when `strictFunctionTypes: true`

### DIFF
--- a/.changeset/cute-comics-refuse.md
+++ b/.changeset/cute-comics-refuse.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-api": patch
+---
+
+fix(api): unintended schema inference to BaseMessage[] for all state keys when `strictFunctionTypes: true`

--- a/libs/langgraph-api/src/graph/parser/parser.mts
+++ b/libs/langgraph-api/src/graph/parser/parser.mts
@@ -390,7 +390,7 @@ export class SubgraphExtractor {
           }[];
       exportSymbol: string;
     }[],
-    options?: { strict?: boolean }
+    options?: { strict?: boolean; tsConfigOptions?: Record<string, unknown> }
   ): Record<string, GraphSchema>[] {
     if (!target.length) throw new Error("No graphs found");
 
@@ -456,7 +456,11 @@ export class SubgraphExtractor {
         path.dirname(tsconfigPath)
       );
 
-      compilerOptions = { ...parsedTsconfig.options, ...compilerOptions };
+      compilerOptions = {
+        ...parsedTsconfig.options,
+        ...compilerOptions,
+        ...((options?.tsConfigOptions ?? {}) as ts.CompilerOptions),
+      };
     }
 
     const vfsHost = vfs.createVirtualCompilerHost(system, compilerOptions, ts);

--- a/libs/langgraph-api/src/graph/parser/schema/types.template.mts
+++ b/libs/langgraph-api/src/graph/parser/schema/types.template.mts
@@ -18,10 +18,15 @@ type AnyGraph = {
   compile: (...args: any[]) => any;
 };
 
-type Wrap<T> = (a: T) => void;
+export type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends <
+  T
+>() => T extends Y ? 1 : 2
+  ? true
+  : false;
+
 type MatchBaseMessage<T> = T extends BaseMessage ? BaseMessage : never;
 type MatchBaseMessageArray<T> = T extends Array<infer C>
-  ? Wrap<MatchBaseMessage<C>> extends Wrap<BaseMessage>
+  ? Equals<MatchBaseMessage<C>, BaseMessage> extends true
     ? BaseMessage[]
     : never
   : never;
@@ -37,9 +42,9 @@ type Inspect<T, TDepth extends Array<0> = []> = TDepth extends [0, 0, 0]
   ? {
       [K in keyof T]: 0 extends 1 & T[K]
         ? T[K]
-        : Wrap<MatchBaseMessageArray<T[K]>> extends Wrap<BaseMessage[]>
+        : Equals<MatchBaseMessageArray<T[K]>, BaseMessage[]> extends true
         ? BaseMessage[]
-        : Wrap<MatchBaseMessage<T[K]>> extends Wrap<BaseMessage>
+        : Equals<MatchBaseMessage<T[K]>, BaseMessage> extends true
         ? BaseMessage
         : Inspect<T[K], [0, ...TDepth]>;
     }

--- a/libs/langgraph-api/tests/parser.test.mts
+++ b/libs/langgraph-api/tests/parser.test.mts
@@ -997,29 +997,32 @@ test.concurrent(
 );
 
 test.concurrent("`strictFunctionTypes: false`", { timeout: 30_000 }, () => {
-  const schemas = SubgraphExtractor.extractSchemas([
-    {
-      sourceFile: [
-        {
-          path: "graph.mts",
-          main: true,
-          contents: dedent`
-            import { StateGraph, MessagesAnnotation, Annotation, START, END } from "@langchain/langgraph";
+  const schemas = SubgraphExtractor.extractSchemas(
+    [
+      {
+        sourceFile: [
+          {
+            path: "graph.mts",
+            main: true,
+            contents: dedent`
+              import { StateGraph, MessagesAnnotation, Annotation, START, END } from "@langchain/langgraph";
 
-            export const graph = new StateGraph(Annotation.Root({
-              messages: MessagesAnnotation.spec.messages,
-              state: Annotation<string>,
-            }))
-              .addNode("node", () => ({}))
-              .addEdge(START, "node")
-              .addEdge("node", END)
-              .compile();
-          `,
-        },
-      ],
-      exportSymbol: "graph",
-    },
-  ], { tsConfigOptions: { strictFunctionTypes: false } });
+              export const graph = new StateGraph(Annotation.Root({
+                messages: MessagesAnnotation.spec.messages,
+                state: Annotation<string>,
+              }))
+                .addNode("node", () => ({}))
+                .addEdge(START, "node")
+                .addEdge("node", END)
+                .compile();
+            `,
+          },
+        ],
+        exportSymbol: "graph",
+      },
+    ],
+    { tsConfigOptions: { strictFunctionTypes: false } }
+  );
 
   const schema = schemas[0];
   expect(schema.graph).toMatchObject({

--- a/libs/langgraph-api/tests/parser.test.mts
+++ b/libs/langgraph-api/tests/parser.test.mts
@@ -995,3 +995,43 @@ test.concurrent(
     ]);
   }
 );
+
+test.concurrent("`strictFunctionTypes: false`", { timeout: 30_000 }, () => {
+  const schemas = SubgraphExtractor.extractSchemas([
+    {
+      sourceFile: [
+        {
+          path: "graph.mts",
+          main: true,
+          contents: dedent`
+            import { StateGraph, MessagesAnnotation, Annotation, START, END } from "@langchain/langgraph";
+
+            export const graph = new StateGraph(Annotation.Root({
+              messages: MessagesAnnotation.spec.messages,
+              state: Annotation<string>,
+            }))
+              .addNode("node", () => ({}))
+              .addEdge(START, "node")
+              .addEdge("node", END)
+              .compile();
+          `,
+        },
+      ],
+      exportSymbol: "graph",
+    },
+  ], { tsConfigOptions: { strictFunctionTypes: false } });
+
+  const schema = schemas[0];
+  expect(schema.graph).toMatchObject({
+    state: {
+      type: "object",
+      properties: {
+        messages: {
+          type: "array",
+          items: { $ref: "#/definitions/BaseMessage" },
+        },
+        state: { type: "string" },
+      },
+    },
+  });
+});


### PR DESCRIPTION
Use Equals type utility instead of Wrap
