### PR TITLE
fix(supervisor): merge child bound config before invoke

### DIFF
--- a/.changeset/tidy-days-end.md
+++ b/.changeset/tidy-days-end.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-supervisor": patch
+---
+
+supervisor: merge child agent's bound config with invocation config on handoff

--- a/libs/langgraph-supervisor/src/supervisor.ts
+++ b/libs/langgraph-supervisor/src/supervisor.ts
@@ -1,6 +1,10 @@
 import { LanguageModelLike } from "@langchain/core/language_models/base";
 import { StructuredToolInterface, DynamicTool } from "@langchain/core/tools";
-import { RunnableToolLike } from "@langchain/core/runnables";
+import {
+  RunnableConfig,
+  RunnableToolLike,
+  mergeConfigs,
+} from "@langchain/core/runnables";
 import { InteropZodType } from "@langchain/core/utils/types";
 import {
   START,
@@ -71,8 +75,11 @@ const makeCallAgent = (
     );
   }
 
-  return async (state: Record<string, unknown>) => {
-    const output = await agent.invoke(state);
+  return async (state: Record<string, unknown>, config?: RunnableConfig) => {
+    // Merge the child agent's bound config with the supervisor-provided config
+    const mergedConfig = mergeConfigs(agent?.config, config);
+
+    const output = await agent.invoke(state, mergedConfig);
     let { messages } = output;
 
     if (outputMode === "last_message") {

--- a/libs/langgraph-supervisor/src/tests/supervisor_tags.propagation.test.ts
+++ b/libs/langgraph-supervisor/src/tests/supervisor_tags.propagation.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { AIMessage } from "@langchain/core/messages";
+import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+import { Serialized } from "@langchain/core/load/serializable";
+import { ChainValues } from "@langchain/core/utils/types";
+import { createSupervisor } from "../supervisor.js";
+import { FakeToolCallingChatModel } from "./utils.js";
+
+describe("supervisor preserves child agent bound tags", () => {
+  it("agent.withConfig({ tags }) appears on agent span when invoked by supervisor", async () => {
+    const TAG = "child_agent_tag";
+
+    const seen: {
+      runType: string;
+      runName?: string;
+      tags?: string[];
+      metadata?: Record<string, unknown>;
+    }[] = [];
+
+    // Spy handler to capture tags at run starts
+    class SpyHandler extends BaseCallbackHandler {
+      name = "SpyHandler";
+
+      // Manager invokes "handle*" methods on handlers. Capture tags from the appropriate position.
+      async handleChainStart(
+        _chain: Serialized,
+        _inputs: ChainValues,
+        _runId?: string,
+        _runType?: string,
+        tags?: string[],
+        metadata?: Record<string, unknown>,
+        runName?: string
+      ) {
+        seen.push({ runType: "chain", runName, tags, metadata });
+      }
+
+      async handleToolStart(
+        _tool: Serialized,
+        _input: string,
+        _runId?: string,
+        _parentRunId?: string,
+        tags?: string[],
+        metadata?: Record<string, unknown>,
+        runName?: string
+      ) {
+        seen.push({ runType: "tool", runName, tags, metadata });
+      }
+
+      async handleLLMStart(
+        _llm: Serialized,
+        _prompts: string[],
+        _runId?: string,
+        _parentRunId?: string,
+        _extraParams?: Record<string, unknown>,
+        tags?: string[],
+        metadata?: Record<string, unknown>,
+        runName?: string
+      ) {
+        seen.push({ runType: "llm", runName, tags, metadata });
+      }
+    }
+    const spy = new SpyHandler();
+
+    // Supervisor model: tool-calls into our agent, then final answer
+    const supervisorModel = new FakeToolCallingChatModel({
+      responses: [
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            {
+              name: "transfer_to_childagent",
+              args: {},
+              id: "call_handoff",
+              type: "tool_call",
+            },
+          ],
+        }),
+        new AIMessage({ content: "done" }),
+      ],
+    });
+
+    // Child agent model: produce a single final message
+    const agentModel = new FakeToolCallingChatModel({
+      responses: [new AIMessage({ content: "classified" })],
+    });
+
+    const worker = createReactAgent({
+      llm: agentModel,
+      tools: [],
+      name: "childAgent",
+      prompt: "you are terse",
+    }).withConfig({ tags: [TAG], runName: "agent:child_agent" });
+
+    const sup = createSupervisor({ agents: [worker], llm: supervisorModel });
+
+    const app = sup.compile();
+    await app.invoke(
+      { messages: [{ role: "user", content: "hi" }] },
+      { callbacks: [spy] }
+    );
+
+    const agentChain = seen.find(
+      (e) =>
+        e.runType === "chain" &&
+        Array.isArray(e.tags) &&
+        e.tags.includes(TAG) &&
+        (e.metadata as { langgraph_node?: string } | undefined)
+          ?.langgraph_node === "childAgent"
+    );
+    expect(agentChain).toBeTruthy();
+    expect(agentChain?.tags).toEqual(expect.arrayContaining([TAG]));
+  });
+});


### PR DESCRIPTION
### Summary
- Ensure child agent invocations via the supervisor inherit bound config (tags/metadata) consistently by merging configs before invoking the child and relying on the merged config for propagation.

### Motivation
- Handoffs from the supervisor to child agents did not reliably inherit child-bound tags/metadata. This aligns the supervisor path with existing `mergeConfigs(boundConfig, invocationConfig)` usage across the repo.

### Changes
- Update `libs/langgraph-supervisor/src/supervisor.ts`:
  - Use `mergeConfigs(agent?.config, config)` before `agent.invoke(...)`.
- Add test `libs/langgraph-supervisor/src/tests/supervisor_tags.propagation.test.ts`:
  - Assert that a child node’s chain event (scoped by `metadata.langgraph_node === "childAgent"`) includes the child-bound tag.

### Testing
- Lint/format/build run locally.
- All tests pass:
  - `yarn workspace @langchain/langgraph-supervisor test` (7/7 passing).

### Backwards Compatibility
- No public API changes.
- Behavior now matches the repo’s established pattern for config propagation.