### PR TITLE
feat (langgraph): Add preModelHook and postModelHook support to createSupervisor

### DIFF
--- a/.changeset/slick-eels-sneeze.md
+++ b/.changeset/slick-eels-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-supervisor": patch
+---
+
+feat(supervisor): add passthrough support for preModelHook and postModelHook

--- a/libs/langgraph-supervisor/src/supervisor.ts
+++ b/libs/langgraph-supervisor/src/supervisor.ts
@@ -92,6 +92,9 @@ export type CreateSupervisorParams<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   StructuredResponseFormat extends Record<string, any> = Record<string, any>
 > = {
+  /**
+   * List of agents to manage
+   */
   agents: CompiledStateGraph<
     AnnotationRootT["State"],
     AnnotationRootT["Update"],
@@ -99,9 +102,29 @@ export type CreateSupervisorParams<
     AnnotationRootT["spec"],
     AnnotationRootT["spec"]
   >[];
+
+  /**
+   * Language model to use for the supervisor
+   */
   llm: LanguageModelLike;
+
+  /**
+   * Tools to use for the supervisor
+   */
   tools?: (StructuredToolInterface | RunnableToolLike | DynamicTool)[];
+
+  /**
+   * An optional prompt for the supervisor. Can be one of:
+   * - `string`: This is converted to a SystemMessage and added to the beginning of the list of messages in state["messages"]
+   * - `SystemMessage`: this is added to the beginning of the list of messages in state["messages"]
+   * - `Function`: This function should take in full graph state and the output is then passed to the language model
+   * - `Runnable`: This runnable should take in full graph state and the output is then passed to the language model
+   */
   prompt?: CreateReactAgentParams["prompt"];
+
+  /**
+   * An optional schema for the final supervisor output.
+   */
   responseFormat?:
     | InteropZodType<StructuredResponseFormat>
     | {
@@ -111,16 +134,75 @@ export type CreateSupervisorParams<
           | Record<string, unknown>;
       }
     | Record<string, unknown>;
+
+  /**
+   * State schema to use for the supervisor graph
+   */
   stateSchema?: AnnotationRootT;
+
+  /**
+   * Context schema to use for the supervisor graph
+   */
   contextSchema?: AnnotationRootT;
+
+  /**
+   * Mode for adding managed agents' outputs to the message history in the multi-agent workflow.
+   * Can be one of:
+   * - `"full_history"`: add the entire agent message history
+   * - `"last_message"`: add only the last message (default)
+   */
   outputMode?: OutputMode;
+
+  /**
+   * Whether to add a pair of (AIMessage, ToolMessage) to the message history
+   * when returning control to the supervisor to indicate that a handoff has occurred
+   */
   addHandoffBackMessages?: boolean;
+
+  /**
+   * Name of the supervisor node
+   */
   supervisorName?: string;
+
+  /**
+   * Use to specify how to expose the agent name to the underlying supervisor LLM.
+   * - `undefined`: Relies on the LLM provider using the name attribute on the AI message. Currently, only OpenAI supports this.
+   * - `"inline"`: Add the agent name directly into the content field of the AI message using XML-style tags.
+   *   Example: "How can I help you" -> "<name>agent_name</name><content>How can I help you?</content>"
+   */
   includeAgentName?: AgentNameMode;
+
+  /**
+   * An optional node to add before the LLM node in the supervisor agent (i.e., the node that calls the LLM).
+   * Useful for managing long message histories (e.g., message trimming, summarization, etc.).
+   *
+   * Pre-model hook must be a callable or a runnable that takes in current graph state and returns a state update in the form of:
+   * ```javascript
+   * {
+   *   messages: [new RemoveMessage({ id: REMOVE_ALL_MESSAGES }), ...],
+   *   llmInputMessages: [...]
+   *   ...
+   * }
+   * ```
+   * **Important**: At least one of `messages` or `llmInputMessages` MUST be provided and will be used as an input to the `agent` node.
+   * The rest of the keys will be added to the graph state.
+   *
+   *
+   * **Warning**: If you are returning `messages` in the pre-model hook, you should OVERWRITE the `messages` key by doing the following:
+   * ```javascript
+   * { messages: [new RemoveMessage({ id: REMOVE_ALL_MESSAGES }), ...newMessages], ... }
+   * ```
+   */
   preModelHook?: CreateReactAgentParams<
     AnnotationRootT,
     StructuredResponseFormat
   >["preModelHook"];
+
+  /**
+   * An optional node to add after the LLM node in the supervisor agent (i.e., the node that calls the LLM).
+   * Useful for implementing human-in-the-loop, guardrails, validation, or other post-processing.
+   * Post-model hook must be a callable or a runnable that takes in current graph state and returns a state update.
+   */
   postModelHook?: CreateReactAgentParams<
     AnnotationRootT,
     StructuredResponseFormat

--- a/libs/langgraph-supervisor/src/supervisor.ts
+++ b/libs/langgraph-supervisor/src/supervisor.ts
@@ -117,8 +117,14 @@ export type CreateSupervisorParams<
   addHandoffBackMessages?: boolean;
   supervisorName?: string;
   includeAgentName?: AgentNameMode;
-  preModelHook?: CreateReactAgentParams["preModelHook"];
-  postModelHook?: CreateReactAgentParams["postModelHook"];
+  preModelHook?: CreateReactAgentParams<
+    AnnotationRootT,
+    StructuredResponseFormat
+  >["preModelHook"];
+  postModelHook?: CreateReactAgentParams<
+    AnnotationRootT,
+    StructuredResponseFormat
+  >["postModelHook"];
 };
 
 /**
@@ -286,7 +292,7 @@ const createSupervisor = <
     tools: allTools,
     prompt,
     responseFormat,
-    stateSchema: schema,
+    stateSchema: schema as AnnotationRootT,
     preModelHook,
     postModelHook,
   });

--- a/libs/langgraph-supervisor/src/supervisor.ts
+++ b/libs/langgraph-supervisor/src/supervisor.ts
@@ -161,10 +161,10 @@ export type CreateSupervisorParams<
  *   // At least one of `messages` or `llmInputMessages` MUST be provided
  *   {
  *     // If provided, will UPDATE the `messages` in the state
- *     "messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), ...],
+ *     messages: [new RemoveMessage({ id: REMOVE_ALL_MESSAGES }), ...],
  *     // If provided, will be used as the input to the LLM,
  *     // and will NOT UPDATE `messages` in the state
- *     "llmInputMessages": [...],
+ *     llmInputMessages: [...]
  *     // Any other state keys that need to be propagated...
  *   }
  *   ```
@@ -173,7 +173,7 @@ export type CreateSupervisorParams<
  *
  *   **Warning**: If you are returning `messages` in the pre-model hook, you should OVERWRITE the `messages` key by doing the following:
  *   ```javascript
- *   {"messages": [RemoveMessage(id=REMOVE_ALL_MESSAGES), ...newMessages], ...}
+ *   { messages: [new RemoveMessage({ id: REMOVE_ALL_MESSAGES }), ...newMessages], ... }
  *   ```
  * @param postModelHook An optional node to add after the LLM node in the supervisor agent (i.e., the node that calls the LLM).
  *   Useful for implementing human-in-the-loop, guardrails, validation, or other post-processing.


### PR DESCRIPTION
### Description
Implemented full support for preModelHook and postModelHook parameters in the createSupervisor function, bringing feature parity with the Python LangGraph implementation.

### Changes Made

1. Added hook parameters to interface: Extended CreateSupervisorParams type to include preModelHook and postModelHook parameters with proper typing from CreateReactAgentParams
2. Implemented parameter passing: Updated the createSupervisor function to accept and pass through the hook parameters to the underlying createReactAgent call
3. Added comprehensive documentation: Enhanced JSDoc comments with detailed documentation for both hook parameters, including:
    - Usage examples showing expected input/output format
    - Important warnings about state management
    - Best practices for message handling
    - Adapted Python documentation to JavaScript conventions

### Issue Fixed
Closes: Supervisor need support pre post model hook

Previously, the supervisor lacked the ability to customize LLM behaviour with pre and post-processing hooks, limiting flexibility for advanced use cases like message trimming, human-in-the-loop workflows, and validation.

### Context
This implementation enables:

**Pre-model hook**: Message history management (trimming, summarization) before LLM calls to handle long conversations and token limits
**Post-model hook**: Human-in-the-loop workflows, guardrails, validation, and other post-processing after LLM responses

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
@dinukapiyadi

Fixes #1555 
