### PR TITLE
feat: Add initialThreadLoaded

### DIFF
--- a/libs/sdk/src/react/stream.tsx
+++ b/libs/sdk/src/react/stream.tsx
@@ -697,6 +697,11 @@ export interface UseStream<
   isThreadLoading: boolean;
 
   /**
+   * Has the initial set of threads and their data been successfully loaded.
+   */
+  initialThreadLoaded: boolean;
+
+  /**
    * Stops the stream.
    */
   stop: () => void;
@@ -1416,6 +1421,7 @@ export function useStream<
 
     history: flatHistory,
     isThreadLoading: history.isLoading && history.data == null,
+    initialThreadLoaded: history.data != null,
 
     get experimental_branchTree() {
       if (historyLimit === false) {


### PR DESCRIPTION
https://forum.langchain.com/t/usestream-how-to-detect-first-history-loaded/1132/1

We need a flag to indicate that a thread is loaded.

We have an `isThreadLoading` flag, but it starts as false and is a dynamic flag.Whether the thread is currently being loaded.

For a loaded state, we need a separate flag. So I created a flag `initialThreadLoaded`

Example: A chat application component might have `initialThreadLoaded` to track if it has fetched the first set of messages. This is useful for:

- Showing a loading spinner only on the first load.
- Preventing redundant initial data fetches.
- Showing a "welcome" message or onboarding UI after the data is available.
