### PR TITLE
fix(langgraph): avoid double acquire of ReadableStreamDefaultReader when `web-streams-polyfill` is active

### DIFF
--- a/.changeset/hip-plants-serve.md
+++ b/.changeset/hip-plants-serve.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph": patch
+---
+
+Fix "This stream has already been locked for exclusive reading by another reader" error when using `web-streams-polyfill`

--- a/libs/langgraph/src/pregel/stream.ts
+++ b/libs/langgraph/src/pregel/stream.ts
@@ -13,7 +13,7 @@ export class IterableReadableStreamWithAbortSignal<
 > extends IterableReadableStream<T> {
   protected _abortController: AbortController;
 
-  protected _reader: ReadableStreamDefaultReader<T>;
+  protected _innerReader: ReadableStreamDefaultReader<T>;
 
   /**
    * @param readableStream - The stream to wrap.
@@ -43,7 +43,7 @@ export class IterableReadableStreamWithAbortSignal<
       },
     });
     this._abortController = ac;
-    this._reader = reader;
+    this._innerReader = reader;
   }
 
   /**
@@ -53,7 +53,7 @@ export class IterableReadableStreamWithAbortSignal<
    */
   override async cancel(reason?: unknown) {
     this._abortController.abort(reason);
-    this._reader.releaseLock();
+    this._innerReader.releaseLock();
   }
 
   /**


### PR DESCRIPTION
`IterableReadableStreamWithAbortSignal._reader` was shadowing the `ReadableStream._reader` in `web-streams-polyfill`, thus async iterator methods were checking the incorrect reader for `locked` status.
