### PR TITLE
fix(createReactAgent): update deprecation messages to contain reactAgent

### DIFF
--- a/.changeset/red-ladybugs-fly.md
+++ b/.changeset/red-ladybugs-fly.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(createReactAgent): update deprecation messages to contain reactAgent

--- a/libs/langgraph-swarm/README.md
+++ b/libs/langgraph-swarm/README.md
@@ -28,7 +28,7 @@ export OPENAI_API_KEY=<your_api_key>
 ```ts
 import { z } from "zod";
 import { ChatOpenAI } from "@langchain/openai";
-import { tool, createReactAgent } from "langchain";
+import { tool, createAgent } from "langchain";
 import { MemorySaver } from "@langchain/langgraph";
 import { createSwarm, createHandoffTool } from "@langchain/langgraph-swarm";
 
@@ -48,14 +48,14 @@ const add = tool(
 );
 
 // Create agents with handoff tools
-const alice = createReactAgent({
+const alice = createAgent({
   llm: model,
   tools: [add, createHandoffTool({ agentName: "Bob" })],
   name: "Alice",
   prompt: "You are Alice, an addition expert."
 });
 
-const bob = createReactAgent({
+const bob = createAgent({
   llm: model,
   tools: [createHandoffTool({ 
     agentName: "Alice", 

--- a/libs/langgraph/src/prebuilt/react_agent_executor.ts
+++ b/libs/langgraph/src/prebuilt/react_agent_executor.ts
@@ -480,7 +480,7 @@ type ToAnnotationRoot<A extends AnyAnnotationRoot | InteropZodObject> =
 
 /**
  * @deprecated `CreateReactAgentParams` has been moved to {@link https://www.npmjs.com/package/langchain langchain} package.
- * Update your import to `import { CreateReactAgentParams } from "langchain";`
+ * Update your import to `import { CreateAgentParams } from "langchain";`
  */
 export type CreateReactAgentParams<
   A extends AnyAnnotationRoot | InteropZodObject = AnyAnnotationRoot,
@@ -623,7 +623,7 @@ export type CreateReactAgentParams<
 
 /**
  * @deprecated `createReactAgent` has been moved to {@link https://www.npmjs.com/package/langchain langchain} package.
- * Update your import to `import { createReactAgent } from "langchain";`
+ * Update your import to `import { createAgent } from "langchain";`
  *
  * Creates a StateGraph agent that relies on a chat model utilizing tool calling.
  *


### PR DESCRIPTION
We have renamed `createReactAgent` to `createAgent` in `langchain` and need to update the deprecation messages.