### PR TITLE
Supervisor with RemoteGraph assistants

### DIFF
--- a/libs/langgraph-supervisor/src/supervisor.ts
+++ b/libs/langgraph-supervisor/src/supervisor.ts
@@ -78,7 +78,6 @@ const makeCallAgent = (
     if (agent instanceof RemoteGraph) {
       const threadId = config?.configurable?.thread_id;
       const agentThreadId = threadId && agent.name ? uuidv5(agent.name, threadId) : null;
-      // TODO: is this config right? (based on python implementation)
       conf = {
         ...config ?? {},
         configurable: {
@@ -407,7 +406,6 @@ const createSupervisor = <
     builder = builder.addNode(
       agent.name!,
       makeCallAgent(agent, outputMode, addHandoffBackMessages, supervisorName),
-      // TODO: can this just be removed? why is an agent a subgraph of itself? Is adding the node with a the agent graph not enough?
     );
     builder = builder.addEdge(agent.name!, supervisorAgent.name!);
   }

--- a/libs/langgraph-supervisor/src/supervisor.ts
+++ b/libs/langgraph-supervisor/src/supervisor.ts
@@ -20,9 +20,9 @@ import {
   BaseChatModel,
   BindToolsInput,
 } from "@langchain/core/language_models/chat_models";
-import { createHandoffTool, createHandoffBackMessages } from "./handoff.js";
 import { RemoteGraph } from "@langchain/langgraph/remote";
 import { v5 as uuidv5 } from "uuid";
+import { createHandoffTool, createHandoffBackMessages } from "./handoff.js";
 
 export type { AgentNameMode };
 export { withAgentName };
@@ -75,11 +75,13 @@ const makeCallAgent = (
 
   return async (state: Record<string, unknown>, config?: RunnableConfig) => {
     let conf = config;
+    /* eslint-disable-next-line */
     if (agent instanceof RemoteGraph) {
       const threadId = config?.configurable?.thread_id;
-      const agentThreadId = threadId && agent.name ? uuidv5(agent.name, threadId) : null;
+      const agentThreadId =
+        threadId && agent.name ? uuidv5(agent.name, threadId) : null;
       conf = {
-        ...config ?? {},
+        ...(config ?? {}),
         configurable: {
           ...(config?.configurable ?? {}),
           ...{ thread_id: agentThreadId },
@@ -109,13 +111,16 @@ export type CreateSupervisorParams<
   /**
    * List of agents to manage
    */
-  agents: (CompiledStateGraph<
-    AnnotationRootT["State"],
-    AnnotationRootT["Update"],
-    string,
-    AnnotationRootT["spec"],
-    AnnotationRootT["spec"]
-  > | RemoteGraph)[];
+  agents: (
+    | CompiledStateGraph<
+        AnnotationRootT["State"],
+        AnnotationRootT["Update"],
+        string,
+        AnnotationRootT["spec"],
+        AnnotationRootT["spec"]
+      >
+    | RemoteGraph
+  )[];
 
   /**
    * Language model to use for the supervisor
@@ -340,7 +345,9 @@ const createSupervisor = <
   const handoffTools = agents.map((agent) =>
     createHandoffTool({
       agentName: agent.name!,
-      agentDescription: 'description' in agent ? (agent as any).description : undefined
+      agentDescription:
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        "description" in agent ? (agent as any).description : undefined,
     })
   );
   const allTools = [...(tools ?? []), ...handoffTools];
@@ -405,7 +412,7 @@ const createSupervisor = <
   for (const agent of agents) {
     builder = builder.addNode(
       agent.name!,
-      makeCallAgent(agent, outputMode, addHandoffBackMessages, supervisorName),
+      makeCallAgent(agent, outputMode, addHandoffBackMessages, supervisorName)
     );
     builder = builder.addEdge(agent.name!, supervisorAgent.name!);
   }

--- a/libs/langgraph-supervisor/src/tests/supervisorRemote.test.ts
+++ b/libs/langgraph-supervisor/src/tests/supervisorRemote.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { HumanMessage, AIMessage } from "@langchain/core/messages";
+import { v5 as uuidv5 } from "uuid";
+import { RemoteGraph } from "@langchain/langgraph/remote";
+import { createReactAgent, ToolNode } from "@langchain/langgraph/prebuilt";
+import { createSupervisor } from "../supervisor.js";
+import { FakeToolCallingChatModel } from "./utils.js";
+
+class FakeRemoteGraph extends RemoteGraph {
+  public receivedThreadIds: Array<string | undefined> = [];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  override async invoke(_state: any, config?: any) {
+    this.receivedThreadIds.push(config?.configurable?.thread_id);
+    return { messages: [new AIMessage({ content: "remote result" })] };
+  }
+}
+
+describe("Supervisor with RemoteGraph agents", () => {
+  it("propagates per-agent thread_id and exposes handoff tool description", async () => {
+    const ROOT_THREAD_ID = "123e4567-e89b-12d3-a456-426614174000";
+
+    // Supervisor will transfer to the remote agent, then produce a final answer
+    const supervisorMessages = [
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "transfer_to_remote_expert",
+            args: {},
+            id: "call_remote_handoff",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new AIMessage({ content: "done" }),
+    ];
+
+    const supervisorModel = new FakeToolCallingChatModel({
+      responses: supervisorMessages,
+    });
+
+    // Prepare RemoteGraph agent
+    const remote = new FakeRemoteGraph({ graphId: "dummy" });
+    (remote as unknown as { name?: string }).name = "remote_expert";
+    (remote as unknown as { description?: string }).description = "Remote expert doing remote things.";
+
+    // Build supervisor workflow
+    const workflow = createSupervisor({
+      agents: [remote],
+      llm: supervisorModel,
+      prompt: "You are a supervisor managing a remote expert.",
+    });
+
+    // Assert handoff tool includes remote description
+    const toolNode = (
+      workflow.nodes.supervisor.runnable as ReturnType<typeof createReactAgent>
+    ).nodes.tools.bound as ToolNode;
+
+    expect(toolNode.tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "transfer_to_remote_expert",
+          description: "Remote expert doing remote things.",
+        }),
+      ])
+    );
+
+    // Compile and invoke with a root thread id
+    const app = workflow.compile();
+    const result = await app.invoke(
+      { messages: [new HumanMessage({ content: "hi" })] },
+      { configurable: { thread_id: ROOT_THREAD_ID } }
+    );
+
+    expect(result).toBeDefined();
+
+    // Verify per-agent thread id derivation is passed to the RemoteGraph
+    const expectedAgentThreadId = uuidv5("remote_expert", ROOT_THREAD_ID);
+    expect(remote.receivedThreadIds[0]).toBe(expectedAgentThreadId);
+  });
+});


### PR DESCRIPTION
Extends `langgraph-supervisor` with the ability to supervise `RemoteGraph` assistants. This closes a feature-gap with the Python implementation.

Three main parts are changed:

- Accepted type of `agents` is now Union type with `RemoteGraph`
- Thread-id is updated to get a deterministic, but different thread-id. This is needed to invoke RemoteGraph assistants on the same deployment of LangGraph Platform
- Handling of non-existing `description` on `RemoteGraph`

Open question:
- I would like to get feedback on why the `{ subgraphs: [agent] }` line was needed in the first place. I removed it since it is not compatible with `RemoteGraph`

Fixes #1461
