### PR TITLE
fix(api): bypass custom auth middleware when requesting JS/CSS assets

### DIFF
--- a/.changeset/bumpy-roses-lie.md
+++ b/.changeset/bumpy-roses-lie.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-api": patch
+---
+
+Skip auth middleware when requesting JS/CSS assets for built-in generative UI

--- a/libs/langgraph-api/src/auth/custom.mts
+++ b/libs/langgraph-api/src/auth/custom.mts
@@ -28,6 +28,9 @@ export const auth = (): MiddlewareHandler => {
     // skip for /info
     if (c.req.path === "/info") return next();
 
+    // skip for UI asset requests
+    if (c.req.path.startsWith("/ui") && c.req.method === "GET") return next();
+
     if (
       !isStudioAuthDisabled() &&
       c.req.header("x-auth-scheme") === "langsmith"


### PR DESCRIPTION
Closes #1425
