### PR TITLE
[Feature] Add onerror cb for submit

### DIFF
--- a/libs/sdk/src/react/stream.tsx
+++ b/libs/sdk/src/react/stream.tsx
@@ -471,6 +471,7 @@ export function useStream<
           return undefined;
         },
         onError(error) {
+          submitOptions?.onError?.(error);
           options.onError?.(error, callbackMeta);
         },
       }

--- a/libs/sdk/src/react/types.tsx
+++ b/libs/sdk/src/react/types.tsx
@@ -399,6 +399,7 @@ export interface SubmitOptions<
   multitaskStrategy?: MultitaskStrategy;
   onCompletion?: OnCompletionBehavior;
   onDisconnect?: DisconnectMode;
+  onError?: (error: unknown) => void;
   feedbackKeys?: string[];
   streamMode?: Array<StreamMode>;
   optimisticValues?:


### PR DESCRIPTION
<!--
Thank you for contributing to LangGraph.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langgraphjs/blob/main/CONTRIBUTING.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Current Situation:
We are currently using the onError callback within useStream to handle all errors. However, this approach seems too generic and is primarily suitable for logging purposes rather than robust error handling.

Problem:
The generic error handling is not sufficient for user-facing scenarios where specific error conditions require particular user actions, such as retrying an operation.

Sample Use Case:

- A user submits a request to initiate a stream.
- The stream operation fails.
- The application needs to display a specific error message to the user, along with an option to retry the operation.