### PR TITLE
chore(sdk, api): add description field for assistants

### DIFF
--- a/.changeset/clean-planes-judge.md
+++ b/.changeset/clean-planes-judge.md
@@ -1,0 +1,6 @@
+---
+"@langchain/langgraph-api": patch
+"@langchain/langgraph-sdk": patch
+---
+
+chore(sdk, api): add description field for assistants

--- a/libs/langgraph-api/src/api/assistants.mts
+++ b/libs/langgraph-api/src/api/assistants.mts
@@ -56,6 +56,7 @@ api.post(
         metadata: payload.metadata ?? {},
         if_exists: payload.if_exists ?? "raise",
         name: payload.name ?? "Untitled",
+        description: payload.description,
       },
       c.var.auth
     );

--- a/libs/langgraph-api/src/schemas.mts
+++ b/libs/langgraph-api/src/schemas.mts
@@ -44,6 +44,7 @@ export const AssistantCreate = z
       .union([z.literal("raise"), z.literal("do_nothing")])
       .optional(),
     name: z.string().optional(),
+    description: z.string().optional(),
   })
   .describe("Payload for creating an assistant.");
 
@@ -53,6 +54,7 @@ export const AssistantPatch = z
     config: AssistantConfig.optional(),
     context: z.unknown().optional(),
     name: z.string().optional(),
+    description: z.string().optional(),
     metadata: z
       .object({})
       .catchall(z.any())

--- a/libs/langgraph-api/src/storage/ops.mts
+++ b/libs/langgraph-api/src/storage/ops.mts
@@ -321,6 +321,7 @@ export class FileSystemAssistants implements AssistantsRepo {
       metadata?: Metadata;
       if_exists: OnConflictBehavior;
       name?: string;
+      description?: string;
     },
     auth: AuthContext | undefined
   ): Promise<Assistant> {
@@ -335,6 +336,7 @@ export class FileSystemAssistants implements AssistantsRepo {
         metadata: options.metadata,
         if_exists: options.if_exists,
         name: options.name,
+        description: options.description,
       }
     );
 
@@ -365,6 +367,7 @@ export class FileSystemAssistants implements AssistantsRepo {
         graph_id: options.graph_id,
         metadata: mutable.metadata ?? ({} as Metadata),
         name: options.name || options.graph_id,
+        description: options.description,
       };
 
       STORE.assistant_versions.push({
@@ -376,6 +379,7 @@ export class FileSystemAssistants implements AssistantsRepo {
         metadata: mutable.metadata ?? ({} as Metadata),
         created_at: now,
         name: options.name || options.graph_id,
+        description: options.description,
       });
 
       return STORE.assistants[assistant_id];
@@ -390,6 +394,7 @@ export class FileSystemAssistants implements AssistantsRepo {
       graph_id?: string;
       metadata?: Metadata;
       name?: string;
+      description?: string;
     },
     auth: AuthContext | undefined
   ): Promise<Assistant> {
@@ -402,6 +407,7 @@ export class FileSystemAssistants implements AssistantsRepo {
         config: options?.config,
         metadata: options?.metadata,
         name: options?.name,
+        description: options?.description,
       }
     );
 
@@ -440,6 +446,10 @@ export class FileSystemAssistants implements AssistantsRepo {
       if (options?.name != null) {
         assistant["name"] = options?.name ?? assistant["name"];
       }
+      if (options?.description != null) {
+        assistant["description"] =
+          options?.description ?? assistant["description"];
+      }
 
       if (metadata != null) {
         assistant["metadata"] = metadata ?? assistant["metadata"];
@@ -463,6 +473,7 @@ export class FileSystemAssistants implements AssistantsRepo {
         config: options?.config ?? assistant["config"],
         context: options?.context ?? assistant["context"],
         name: options?.name ?? assistant["name"],
+        description: options?.description ?? assistant["description"],
         metadata: metadata ?? assistant["metadata"],
         created_at: now,
       };

--- a/libs/langgraph-api/src/storage/types.mts
+++ b/libs/langgraph-api/src/storage/types.mts
@@ -60,6 +60,7 @@ export interface RunnableConfig {
 
 export interface Assistant {
   name: string | undefined;
+  description: string | undefined;
   assistant_id: string;
   graph_id: string;
   created_at: Date;
@@ -79,6 +80,7 @@ export interface AssistantVersion {
   metadata: Metadata;
   created_at: Date;
   name: string | undefined;
+  description: string | undefined;
 }
 
 export interface RunKwargs {
@@ -403,6 +405,7 @@ export interface AssistantsRepo {
       metadata?: Metadata;
       if_exists: OnConflictBehavior;
       name?: string;
+      description?: string;
     },
     auth: AuthContext | undefined
   ): Promise<Assistant>;
@@ -415,6 +418,7 @@ export interface AssistantsRepo {
       graph_id?: string;
       metadata?: Metadata;
       name?: string;
+      description?: string;
     },
     auth: AuthContext | undefined
   ): Promise<Assistant>;

--- a/libs/langgraph-api/tests/api.test.mts
+++ b/libs/langgraph-api/tests/api.test.mts
@@ -71,14 +71,31 @@ describe("assistants", () => {
     const graphId = "agent";
     const config = { configurable: { model_name: "gpt" } };
 
-    let res = await client.assistants.create({ graphId, config });
-    expect(res).toMatchObject({ graph_id: graphId, config });
+    let res = await client.assistants.create({
+      graphId,
+      config,
+      description: "foo",
+    });
+    expect(res).toMatchObject({
+      graph_id: graphId,
+      config,
+      description: "foo",
+    });
 
     const metadata = { name: "woof" };
-    await client.assistants.update(res.assistant_id, { graphId, metadata });
+    await client.assistants.update(res.assistant_id, {
+      graphId,
+      metadata,
+      description: "bar",
+    });
 
     res = await client.assistants.get(res.assistant_id);
-    expect(res).toMatchObject({ graph_id: graphId, config, metadata });
+    expect(res).toMatchObject({
+      graph_id: graphId,
+      config,
+      metadata,
+      description: "bar",
+    });
 
     await client.assistants.delete(res.assistant_id);
     await expect(() => client.assistants.get(res.assistant_id)).rejects.toThrow(

--- a/libs/sdk/src/auth/types.ts
+++ b/libs/sdk/src/auth/types.ts
@@ -21,6 +21,7 @@ interface AssistantCreate {
   context?: Maybe<unknown>;
   if_exists?: Maybe<"raise" | "do_nothing">;
   name?: Maybe<string>;
+  description?: Maybe<string>;
   graph_id: string;
 }
 
@@ -42,6 +43,7 @@ interface AssistantUpdate {
   context?: Maybe<unknown>;
   graph_id?: Maybe<string>;
   name?: Maybe<string>;
+  description?: Maybe<string>;
   version?: Maybe<number>;
 }
 


### PR DESCRIPTION
This adds the optional `description` field to the `Assistant` model (for parity with the Python version).