### PR TITLE
feat(sdk): managing thread externally from useStream hook

### DIFF
--- a/.changeset/honest-mirrors-tell.md
+++ b/.changeset/honest-mirrors-tell.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+Add support for managing thread state manually outside of useStream hook via `experimental_thread` option

--- a/libs/sdk/src/react/index.ts
+++ b/libs/sdk/src/react/index.ts
@@ -7,4 +7,5 @@ export type {
   UseStreamCustom,
   UseStreamCustomOptions,
   UseStreamTransport,
+  UseStreamThread,
 } from "./types.js";

--- a/libs/sdk/src/react/stream.lgp.tsx
+++ b/libs/sdk/src/react/stream.lgp.tsx
@@ -26,6 +26,7 @@ import type {
   RunCallbackMeta,
   SubmitOptions,
   MessageMetadata,
+  UseStreamThread,
 } from "./types.js";
 import { Client, getClientConfigHash } from "../client.js";
 import type { Message } from "../types.messages.js";
@@ -63,10 +64,11 @@ function useThreadHistory<StateType extends Record<string, unknown>>(
   threadId: string | undefined | null,
   limit: boolean | number,
   options: {
+    passthrough: boolean;
     submittingRef: RefObject<string | null>;
     onError?: (error: unknown, run?: RunCallbackMeta) => void;
   }
-) {
+): UseStreamThread<StateType> {
   const key = getFetchHistoryKey(client, threadId, limit);
   const [state, setState] = useState<{
     key: string | undefined;
@@ -91,6 +93,9 @@ function useThreadHistory<StateType extends Record<string, unknown>>(
       threadId: string | undefined | null,
       limit: boolean | number
     ): Promise<ThreadState<StateType>[]> => {
+      // If only passthrough is enabled, don't fetch history
+      if (options.passthrough) return Promise.resolve([]);
+
       const client = clientRef.current;
       const key = getFetchHistoryKey(client, threadId, limit);
 
@@ -121,7 +126,7 @@ function useThreadHistory<StateType extends Record<string, unknown>>(
       setState({ key, data: undefined, error: undefined, isLoading: false });
       return Promise.resolve([]);
     },
-    []
+    [options.passthrough]
   );
 
   useEffect(() => {
@@ -257,10 +262,17 @@ export function useStreamLGP<
       ? options.fetchStateHistory.limit ?? false
       : options.fetchStateHistory ?? false;
 
-  const history = useThreadHistory<StateType>(client, threadId, historyLimit, {
-    submittingRef: threadIdStreamingRef,
-    onError: options.onError,
-  });
+  const builtInHistory = useThreadHistory<StateType>(
+    client,
+    threadId,
+    historyLimit,
+    {
+      passthrough: options.experimental_thread != null,
+      submittingRef: threadIdStreamingRef,
+      onError: options.onError,
+    }
+  );
+  const history = options.experimental_thread ?? builtInHistory;
 
   const getMessages = (value: StateType): Message[] => {
     const messagesKey = options.messagesKey ?? "messages";
@@ -273,7 +285,7 @@ export function useStreamLGP<
   };
 
   const [branch, setBranch] = useState<string>("");
-  const branchContext = getBranchContext(branch, history.data);
+  const branchContext = getBranchContext(branch, history.data ?? undefined);
 
   const historyValues =
     branchContext.threadHead?.values ??
@@ -483,7 +495,7 @@ export function useStreamLGP<
 
           if (shouldRefetch) {
             const newHistory = await history.mutate(usableThreadId!);
-            const lastHead = newHistory.at(0);
+            const lastHead = newHistory?.at(0);
             if (lastHead) {
               // We now have the latest update from /history
               // Thus we can clear the local stream state
@@ -538,7 +550,7 @@ export function useStreamLGP<
         async onSuccess() {
           runMetadataStorage?.removeItem(`lg:stream:${threadId}`);
           const newHistory = await history.mutate(threadId);
-          const lastHead = newHistory.at(0);
+          const lastHead = newHistory?.at(0);
           if (lastHead) options.onFinish?.(lastHead, callbackMeta);
         },
         onError(error) {

--- a/libs/sdk/src/react/types.tsx
+++ b/libs/sdk/src/react/types.tsx
@@ -94,6 +94,15 @@ export interface RunCallbackMeta {
   thread_id: string;
 }
 
+export interface UseStreamThread<StateType extends Record<string, unknown>> {
+  data: ThreadState<StateType>[] | null | undefined;
+  error: unknown;
+  isLoading: boolean;
+  mutate: (
+    mutateId?: string
+  ) => Promise<ThreadState<StateType>[] | null | undefined>;
+}
+
 export interface UseStreamOptions<
   StateType extends Record<string, unknown> = Record<string, unknown>,
   Bag extends BagTemplate = BagTemplate
@@ -272,6 +281,12 @@ export interface UseStreamOptions<
    * @default true
    */
   fetchStateHistory?: boolean | { limit: number };
+
+  /**
+   * Manage the thread state externally.
+   * @experimental
+   */
+  experimental_thread?: UseStreamThread<StateType>;
 }
 
 interface RunMetadataStorage {


### PR DESCRIPTION
Adds the ability to replace built-in state fetching of threads with React Query / SWR
