### PR TITLE
fix(@langchain/langgraph): export missing symbol

### DIFF
--- a/.changeset/good-pugs-reply.md
+++ b/.changeset/good-pugs-reply.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(@langchain/langgraph): export missing `CommandInstance` symbol

--- a/libs/langgraph/src/graph/index.ts
+++ b/libs/langgraph/src/graph/index.ts
@@ -20,3 +20,6 @@ export {
   REMOVE_ALL_MESSAGES,
   type Messages,
 } from "./message.js";
+export {
+  CommandInstance,
+} from "../constants.js";

--- a/libs/langgraph/src/graph/index.ts
+++ b/libs/langgraph/src/graph/index.ts
@@ -20,6 +20,4 @@ export {
   REMOVE_ALL_MESSAGES,
   type Messages,
 } from "./message.js";
-export {
-  CommandInstance,
-} from "../constants.js";
+export { CommandInstance } from "../constants.js";


### PR DESCRIPTION
The `CommandInstance` symbol is currently not exported which causes the following TS error when using `Command` type anywhere:

```
The inferred type of 'clientConfigSchema' cannot be named without a reference to '.pnpm/@langchain+langgraph@1.0.0-alpha.1_@langchain+core@libs+langchain-core_react-dom@18.3.1_4b608615381ea52bef92f957a3a7853a/node_modules/@langchain/langgraph'. This is likely not portable. A type annotation is necessary.ts(2742)
```