### PR TITLE
fix(docs): remove incorrect comment

### DIFF
--- a/examples/how-tos/subgraph.ipynb
+++ b/examples/how-tos/subgraph.ipynb
@@ -227,7 +227,7 @@
     "import { StateGraph, Annotation } from \"@langchain/langgraph\";\n",
     "\n",
     "const SubgraphAnnotation = Annotation.Root({\n",
-    "  bar: Annotation<string>, // note that this key is shared with the parent graph state\n",
+    "  bar: Annotation<string>,\n",
     "  baz: Annotation<string>,\n",
     "});\n",
     "\n",


### PR DESCRIPTION
The comment on the "Add function that invokes subgraph" code example is incorrect; bar is not shared with the parent subgraph state.

<!--
Thank you for contributing to LangGraph.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langgraphjs/blob/main/CONTRIBUTING.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->
