### PR TITLE
chore(langgraph): remove interrupt deprecations

### DIFF
--- a/.changeset/brave-carrots-shave.md
+++ b/.changeset/brave-carrots-shave.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph": patch
+---
+
+remove interrupt deprecations docs

--- a/libs/langgraph-core/src/prebuilt/interrupt.ts
+++ b/libs/langgraph-core/src/prebuilt/interrupt.ts
@@ -2,9 +2,6 @@
  * Configuration interface that defines what actions are allowed for a human interrupt.
  * This controls the available interaction options when the graph is paused for human input.
  *
- * @deprecated Use `HumanInterruptConfig` has been moved to {@link https://www.npmjs.com/package/langchain langchain} package.
- * Update your import to `import { HumanInterruptConfig } from "langchain";`
- *
  * @property {boolean} allow_ignore - Whether the human can choose to ignore/skip the current step
  * @property {boolean} allow_respond - Whether the human can provide a text response/feedback
  * @property {boolean} allow_edit - Whether the human can edit the provided content/state
@@ -21,9 +18,6 @@ export interface HumanInterruptConfig {
  * Represents a request for human action within the graph execution.
  * Contains the action type and any associated arguments needed for the action.
  *
- * @deprecated Use `ActionRequest` has been moved to {@link https://www.npmjs.com/package/langchain langchain} package.
- * Update your import to `import { ActionRequest } from "langchain/prebuilt/interrupt";`
- *
  * @property {string} action - The type or name of action being requested (e.g., "Approve XYZ action")
  * @property {Record<string, any>} args - Key-value pairs of arguments needed for the action
  */
@@ -37,9 +31,6 @@ export interface ActionRequest {
  * Represents an interrupt triggered by the graph that requires human intervention.
  * This is passed to the `interrupt` function when execution is paused for human input.
  *
- * @deprecated Use `HumanInterrupt` has been moved to {@link https://www.npmjs.com/package/langchain langchain} package.
- * Update your import to `import { HumanInterrupt } from "langchain/prebuilt/interrupt";`
- *
  * @property {ActionRequest} action_request - The specific action being requested from the human
  * @property {HumanInterruptConfig} config - Configuration defining what actions are allowed
  * @property {string} [description] - Optional detailed description of what input is needed
@@ -52,9 +43,6 @@ export interface HumanInterrupt {
 
 /**
  * The response provided by a human to an interrupt, which is returned when graph execution resumes.
- *
- * @deprecated Use `HumanResponse` has been moved to {@link https://www.npmjs.com/package/langchain langchain} package.
- * Update your import to `import { HumanResponse } from "langchain/prebuilt/interrupt";`
  *
  * @property {("accept"|"ignore"|"response"|"edit")} type - The type of response:
  *   - "accept": Approves the current state without changes


### PR DESCRIPTION
This was an artifact of the v1 sprint -- we originally were going to export these interrupt types in langchain, but we ended up walking back on that

cc @bracesproul @christian-bromann