### PR TITLE
chore: update LG cloud verbiage

### DIFF
--- a/docs/docs/agents/deployment.md
+++ b/docs/docs/agents/deployment.md
@@ -94,4 +94,4 @@ LangGraph Studio Web is a specialized UI that you can connect to LangGraph API s
 
 ## Deployment
 
-Once your LangGraph app is running locally, you can deploy it using LangGraph Cloud or self-hosted options. Refer to the [deployment options guide](https://langchain-ai.github.io/langgraph/tutorials/deployment/) for detailed instructions on all supported deployment models.
+Once your LangGraph app is running locally, you can deploy it using LangSmith Deployment or self-hosted options. Refer to the [deployment options guide](https://langchain-ai.github.io/langgraph/tutorials/deployment/) for detailed instructions on all supported deployment models.

--- a/docs/docs/agents/ui.md
+++ b/docs/docs/agents/ui.md
@@ -4,7 +4,7 @@ You can use a prebuilt chat UI for interacting with any LangGraph agent through 
 
 ## Run agent in UI
 
-First, set up LangGraph API server [locally](./deployment.md#launch-langgraph-server-locally) or deploy your agent on [LangGraph Cloud](https://langchain-ai.github.io/langgraph/cloud/quick_start/).
+First, set up LangGraph API server [locally](./deployment.md#launch-langgraph-server-locally) or deploy your agent on [LangSmith Deployment](https://langchain-ai.github.io/langgraph/cloud/quick_start/).
 
 Then, navigate to [Agent Chat UI](https://agentchat.vercel.app), or clone the repository and [run the dev server locally](https://github.com/langchain-ai/agent-chat-ui?tab=readme-ov-file#setup):
 

--- a/libs/langgraph-api/src/cli/spawn.mts
+++ b/libs/langgraph-api/src/cli/spawn.mts
@@ -53,7 +53,7 @@ export async function spawnServer(
 - 🎨 Studio UI: \x1b[36m${studioUrl}\x1b[0m
 
 This in-memory server is designed for development and testing.
-For production use, please use LangGraph Cloud.
+For production use, please use LangSmith Deployment.
 
 `);
 

--- a/libs/langgraph-cli/src/cli/docker.mts
+++ b/libs/langgraph-cli/src/cli/docker.mts
@@ -138,7 +138,7 @@ builder
           dedent`
             # Uncomment the following line to add your LangSmith API key
             # LANGSMITH_API_KEY=your-api-key
-            # Or if you have a LangGraph Cloud license key, then uncomment the following line:
+            # Or if you have a LangSmith Deployment license key, then uncomment the following line:
             # LANGGRAPH_CLOUD_LICENSE_KEY=your-license-key
             # Add any other environment variables go below...
           `

--- a/libs/langgraph-cli/src/cli/up.mts
+++ b/libs/langgraph-cli/src/cli/up.mts
@@ -83,7 +83,7 @@ builder
     logger.info("Starting LangGraph API server...");
     logger.warn(
       dedent`
-        For local dev, requires env var LANGSMITH_API_KEY with access to LangGraph Cloud closed beta.
+        For local dev, requires env var LANGSMITH_API_KEY with access to LangSmith Deployment.
         For production use, requires a license key in env var LANGGRAPH_CLOUD_LICENSE_KEY.
       `
     );

--- a/libs/langgraph-core/src/pregel/remote.ts
+++ b/libs/langgraph-core/src/pregel/remote.ts
@@ -124,7 +124,7 @@ const getStreamModes = (
  * APIs that implement the LangGraph Server API specification.
  *
  * For example, the `RemoteGraph` class can be used to call APIs from deployments
- * on LangGraph Cloud.
+ * on LangSmith Deployment.
  *
  * `RemoteGraph` behaves the same way as a `StateGraph` and can be used directly as
  * a node in another `StateGraph`.


### PR DESCRIPTION
LG Cloud/Platform has been renamed to LangSmith Deployment