### PR TITLE
fix(*): set proper url prefix for package reference

### DIFF
--- a/libs/checkpoint-mongodb/package.json
+++ b/libs/checkpoint-mongodb/package.json
@@ -10,7 +10,8 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git@github.com:langchain-ai/langgraphjs.git"
+    "url": "git+ssh://git@github.com/langchain-ai/langgraphjs.git",
+    "directory": "libs/checkpoint-mongodb"
   },
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/langgraph-checkpoint-mongodb",

--- a/libs/checkpoint-postgres/package.json
+++ b/libs/checkpoint-postgres/package.json
@@ -10,7 +10,8 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git@github.com:langchain-ai/langgraphjs.git"
+    "url": "git+ssh://git@github.com/langchain-ai/langgraphjs.git",
+    "directory": "libs/checkpoint-postgres"
   },
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/langgraph-checkpoint-postgres",

--- a/libs/checkpoint-redis/package.json
+++ b/libs/checkpoint-redis/package.json
@@ -10,7 +10,8 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git@github.com:langchain-ai/langgraphjs.git"
+    "url": "git+ssh://git@github.com/langchain-ai/langgraphjs.git",
+    "directory": "libs/checkpoint-redis"
   },
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/langgraph-checkpoint-redis",

--- a/libs/checkpoint-sqlite/package.json
+++ b/libs/checkpoint-sqlite/package.json
@@ -10,7 +10,8 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git@github.com:langchain-ai/langgraphjs.git"
+    "url": "git+ssh://git@github.com/langchain-ai/langgraphjs.git",
+    "directory": "libs/checkpoint-sqlite"
   },
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/langgraph-checkpoint-sqlite",

--- a/libs/checkpoint-validation/package.json
+++ b/libs/checkpoint-validation/package.json
@@ -10,7 +10,8 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git@github.com:langchain-ai/langgraphjs.git"
+    "url": "git+ssh://git@github.com/langchain-ai/langgraphjs.git",
+    "directory": "libs/checkpoint-validation"
   },
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/langgraph-checkpoint-validation",

--- a/libs/checkpoint/package.json
+++ b/libs/checkpoint/package.json
@@ -10,7 +10,8 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git@github.com:langchain-ai/langgraphjs.git"
+    "url": "git+ssh://git@github.com/langchain-ai/langgraphjs.git",
+    "directory": "libs/checkpoint"
   },
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/langgraph-checkpoint",

--- a/libs/create-langgraph/package.json
+++ b/libs/create-langgraph/package.json
@@ -10,7 +10,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:langchain-ai/langgraphjs-api.git"
+    "url": "git+ssh://git@github.com/langchain-ai/langgraphjs.git",
+    "directory": "libs/create-langgraph"
   },
   "scripts": {
     "clean": "rm -rf dist/ .turbo/",

--- a/libs/langgraph-api/package.json
+++ b/libs/langgraph-api/package.json
@@ -47,7 +47,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:langchain-ai/langgraphjs-api.git"
+    "url": "git+ssh://git@github.com/langchain-ai/langgraphjs.git",
+    "directory": "libs/langgraph-api"
   },
   "scripts": {
     "clean": "rm -rf dist/ .turbo/ ./tests/graphs/.langgraph_api/",

--- a/libs/langgraph-cli/package.json
+++ b/libs/langgraph-cli/package.json
@@ -16,7 +16,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:langchain-ai/langgraphjs-api.git"
+    "url": "git+ssh://git@github.com/langchain-ai/langgraphjs.git",
+    "directory": "libs/langgraph-cli"
   },
   "scripts": {
     "clean": "rm -rf dist/ .turbo/",

--- a/libs/langgraph-core/package.json
+++ b/libs/langgraph-core/package.json
@@ -10,7 +10,8 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git@github.com:langchain-ai/langgraphjs.git"
+    "url": "git+ssh://git@github.com/langchain-ai/langgraphjs.git",
+    "directory": "libs/langgraph-core"
   },
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=@langchain/langgraph",

--- a/libs/langgraph-cua/package.json
+++ b/libs/langgraph-cua/package.json
@@ -11,7 +11,8 @@
   "homepage": "https://github.com/langchain-ai/langgraphjs/blob/main/libs/langgraph-cua/README.md",
   "repository": {
     "type": "git",
-    "url": "git@github.com:langchain-ai/langgraphjs.git"
+    "url": "git+ssh://git@github.com/langchain-ai/langgraphjs.git",
+    "directory": "libs/langgraph-cua"
   },
   "scripts": {
     "build": "yarn turbo build:internal",

--- a/libs/langgraph-supervisor/package.json
+++ b/libs/langgraph-supervisor/package.json
@@ -10,7 +10,8 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git@github.com:langchain-ai/langgraphjs.git"
+    "url": "git+ssh://git@github.com/langchain-ai/langgraphjs.git",
+    "directory": "libs/langgraph-supervisor"
   },
   "scripts": {
     "build": "yarn turbo build:internal",

--- a/libs/langgraph-swarm/package.json
+++ b/libs/langgraph-swarm/package.json
@@ -10,7 +10,8 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git@github.com:langchain-ai/langgraphjs.git"
+    "url": "git+ssh://git@github.com/langchain-ai/langgraphjs.git",
+    "directory": "libs/langgraph-swarm"
   },
   "scripts": {
     "build": "yarn turbo build:internal",

--- a/libs/langgraph-ui/package.json
+++ b/libs/langgraph-ui/package.json
@@ -15,7 +15,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:langchain-ai/langgraphjs-api.git"
+    "url": "git+ssh://git@github.com/langchain-ai/langgraphjs.git",
+    "directory": "libs/langgraph-ui"
   },
   "scripts": {
     "clean": "rm -rf dist/ .turbo/",

--- a/libs/langgraph/package.json
+++ b/libs/langgraph/package.json
@@ -11,7 +11,8 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git@github.com:langchain-ai/langgraphjs.git"
+    "url": "git+ssh://git@github.com/langchain-ai/langgraphjs.git",
+    "directory": "libs/langgraph"
   },
   "scripts": {
     "build": "yarn turbo:command build:internal --filter=langgraph",

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -3,6 +3,11 @@
   "version": "1.2.0",
   "description": "Client library for interacting with the LangGraph API",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/langchain-ai/langgraphjs.git",
+    "directory": "libs/sdk"
+  },
   "scripts": {
     "clean": "rm -rf dist/ dist-cjs/",
     "build": "yarn turbo:command build:internal --filter=@langchain/langgraph-sdk",


### PR DESCRIPTION
NPM supports the following formats for referencing a git repository:
- git+https://github.com/user/repo.git
- git+ssh://git@github.com/user/repo.git

This patch ensures all packages follow that and I added a directory as well.