### PR TITLE
fix(langgraph): respect meta defaults in `LastValue`

### DIFF
--- a/.changeset/tender-keys-flow.md
+++ b/.changeset/tender-keys-flow.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph": patch
+---
+
+respect meta defaults in `LastValue`

--- a/libs/langgraph-core/src/channels/last_value.ts
+++ b/libs/langgraph-core/src/channels/last_value.ts
@@ -15,8 +15,15 @@ export class LastValue<Value> extends BaseChannel<Value, Value, Value> {
   // value is an array so we don't misinterpret an update to undefined as no write
   value: [Value] | [] = [];
 
+  constructor(protected initialValueFactory?: () => Value) {
+    super();
+    if (initialValueFactory) {
+      this.value = [initialValueFactory()];
+    }
+  }
+
   fromCheckpoint(checkpoint?: Value) {
-    const empty = new LastValue<Value>();
+    const empty = new LastValue<Value>(this.initialValueFactory);
     if (typeof checkpoint !== "undefined") {
       empty.value = [checkpoint];
     }

--- a/libs/langgraph-core/src/graph/zod/meta.ts
+++ b/libs/langgraph-core/src/graph/zod/meta.ts
@@ -163,7 +163,7 @@ export class SchemaMetaRegistry {
           InferInteropZodOutput<typeof channelSchema>
         >(meta.reducer.fn, meta.default);
       } else {
-        channels[key] = new LastValue();
+        channels[key] = new LastValue(meta?.default);
       }
     }
     return channels as InteropZodToStateDefinition<T>;


### PR DESCRIPTION
This fixes some unintuitive behavior stemming from how we add defaults to channels defined using zod:

```typescript
// When used inside of a graph, this was converted into
// a LastValue channel which doesn't have anyway to provide
// a default value. If you used it in this way, these default values
// would actually never make it to tasks
const StateObject = z.object({
  foo: z.number().register(registry, {
    default: () => 42,
  })
});

// When used inside of a graph, this was converted into
// a binop channel that does let you supply a default value
// factory (because there was a reducer property)
const StateObject2 = z.object({
  foo: z.number().registry(registry, {
    reducer: {},
    default: () => 42,
  })
});
```