### PR TITLE
fix(ci): fix deploy_docs workflow

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -41,10 +41,10 @@ jobs:
             uv pip install "git+https://${GITHUB_TOKEN}@github.com/langchain-ai/mkdocs-material-insiders.git"
           fi
 
-      - name: Use Node.js 18.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v6
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: "yarn"
 
       - name: Install dependencies


### PR DESCRIPTION
Fixing these CI errors:

```
file:///home/runner/work/langgraphjs/langgraphjs/node_modules/rolldown/dist/shared/rolldown-build-ciWo5RN-.mjs:8
import { styleText } from "node:util";
         ^^^^^^^^^
SyntaxError: The requested module 'node:util' does not provide an export named 'styleText'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:123:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:191:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:337:24)
    at async loadESM (node:internal/process/esm_loader:34:7)
    at async handleMainPromise (node:internal/modules/run_main:106:12)
```