### PR TITLE
fix(sdk): prevent stale client closure in useStream hook

### DIFF
--- a/libs/sdk/src/react/stream.lgp.tsx
+++ b/libs/sdk/src/react/stream.lgp.tsx
@@ -127,7 +127,7 @@ function useThreadHistory<StateType extends Record<string, unknown>>(
       setState({ key, data: undefined, error: undefined, isLoading: false });
       return Promise.resolve([]);
     },
-    [options.passthrough]
+    [options.passthrough, key]
   );
 
   useEffect(() => {


### PR DESCRIPTION
Fixes #1840.

This change prevents the `useStream` hook from capturing a stale client reference
after a token refresh. The callback is now updated when the client configuration
changes, ensuring fresh authentication is always used and avoiding 403 errors.

Tests:
- pnpm --filter @langchain/langgraph-sdk test