### PR TITLE
docs: clarify cron schedule interpretation as UTC

### DIFF
--- a/libs/sdk/src/schema.ts
+++ b/libs/sdk/src/schema.ts
@@ -235,7 +235,7 @@ export interface Cron {
   /** The end date to stop running the cron. */
   end_time: Optional<string>;
 
-  /** The schedule to run, cron format. */
+  /** The schedule to run, cron format. Schedules are interpreted in UTC. */
   schedule: string;
 
   /** The time the cron was created. */

--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -213,7 +213,7 @@ export interface RunsCreatePayload extends RunsInvokePayload {
 
 export interface CronsCreatePayload extends RunsCreatePayload {
   /**
-   * Schedule for running the Cron Job
+   * Schedule for running the Cron Job. Schedules are interpreted in UTC.
    */
   schedule: string;
 


### PR DESCRIPTION
Add UTC timezone note to cron schedule docstrings in JS SDK.

Mirrors the Python SDK change that added "Schedules are interpreted in UTC." to cron schedule documentation.