### PR TITLE
feat(store): enhance PostgresStore to support shared pg.Pool instances

### DIFF
--- a/.changeset/add-pool-support-to-postgres-store.md
+++ b/.changeset/add-pool-support-to-postgres-store.md
@@ -1,0 +1,36 @@
+---
+"@langchain/langgraph-checkpoint-postgres": minor
+---
+
+Add support for passing a preconfigured `pg.Pool` to `PostgresStore`, enabling a single connection pool to be shared between `PostgresSaver` and `PostgresStore` for better resource management.
+
+**What changed:**
+
+- `PostgresStoreConfig` now accepts an optional `pool` field for passing a preconfigured `pg.Pool` instance directly. If both `pool` and `connectionOptions` are provided, `pool` takes precedence.
+- Added a new `PostgresStore.fromPool(pool, options?)` static factory method for convenience.
+- When an external pool is provided, `store.stop()` will no longer close the pool — the caller retains ownership of the pool lifecycle.
+
+**Why:**
+
+Previously, `PostgresStore` always created its own internal pool, which meant a server using both a `PostgresSaver` and a `PostgresStore` would hold two separate connection pools. This made it impossible to share connections across use cases and led to unnecessary resource consumption.
+
+**How to update your code:**
+
+```typescript
+import pg from "pg";
+import { PostgresSaver } from "@langchain/langgraph-checkpoint-postgres";
+import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
+
+// Create a single shared pool
+const pool = new pg.Pool({ connectionString: "postgresql://..." });
+
+// Share it between the saver and the store
+const saver = new PostgresSaver(pool);
+const store = PostgresStore.fromPool(pool);
+
+// Or pass it via the constructor
+const store2 = new PostgresStore({ pool });
+
+await saver.setup();
+await store.setup();
+```

--- a/libs/checkpoint-postgres/src/store/modules/types.ts
+++ b/libs/checkpoint-postgres/src/store/modules/types.ts
@@ -182,7 +182,30 @@ export interface PutOptions {
 
 export interface PostgresStoreConfig {
   /**
+   * A preconfigured pg.Pool instance.
+   *
+   * When provided, this pool will be used directly and will NOT be closed
+   * when the store is stopped -- the caller retains ownership of the pool
+   * lifecycle. This enables sharing a single pool between PostgresSaver
+   * and PostgresStore for better resource management.
+   *
+   * If both `pool` and `connectionOptions` are provided, `pool` takes
+   * precedence.
+   *
+   * @example
+   * ```typescript
+   * const pool = new Pool({ connectionString: "postgresql://..." });
+   * const saver = new PostgresSaver(pool);
+   * const store = new PostgresStore({ pool });
+   * ```
+   */
+  pool?: pg.Pool;
+
+  /**
    * PostgreSQL connection string or connection configuration object.
+   * A new pool will be created internally from these options.
+   *
+   * Ignored if `pool` is provided.
    *
    * @example
    * // Connection string
@@ -197,7 +220,7 @@ export interface PostgresStoreConfig {
    *   password: "password"
    * }
    */
-  connectionOptions: string | pg.PoolConfig;
+  connectionOptions?: string | pg.PoolConfig;
 
   /**
    * Database schema name to use for store tables.


### PR DESCRIPTION
## Summary

PostgresSaver supports passing in a preconfigured pool instance. PostgresStore should support this as well, otherwise you will need to have two Pools running per server in order to use these features in tandem. This puts a lot of connection pressure on the database.

## Changes

- Updated PostgresStoreConfig to accept a preconfigured pg.Pool.
- Added fromPool static method for creating PostgresStore instances from an existing pool.
- Modified connection handling to allow sharing a pool between PostgresStore and PostgresSaver.
- Updated stop method to conditionally close the pool based on ownership.
- Added integration tests for pool sharing functionality.

<!--
Thank you for contributing to LangGraph.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langgraphjs/blob/main/CONTRIBUTING.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->
