### PR TITLE
feat(checkpoint-postgres): add task_path support and inline primitive merging

### DIFF
--- a/libs/checkpoint-postgres/src/migrations.ts
+++ b/libs/checkpoint-postgres/src/migrations.ts
@@ -41,5 +41,15 @@ export const getMigrations = (schema: string) => {
     PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id, task_id, idx)
   );`,
     `ALTER TABLE ${SCHEMA_TABLES.checkpoint_blobs} ALTER COLUMN blob DROP not null;`,
+    // Migration 5: no-op (version alignment with Python)
+    `SELECT 1;`,
+    // Migration 6: index on checkpoints.thread_id
+    `CREATE INDEX IF NOT EXISTS checkpoints_thread_id_idx ON ${SCHEMA_TABLES.checkpoints}(thread_id);`,
+    // Migration 7: index on checkpoint_blobs.thread_id
+    `CREATE INDEX IF NOT EXISTS checkpoint_blobs_thread_id_idx ON ${SCHEMA_TABLES.checkpoint_blobs}(thread_id);`,
+    // Migration 8: index on checkpoint_writes.thread_id
+    `CREATE INDEX IF NOT EXISTS checkpoint_writes_thread_id_idx ON ${SCHEMA_TABLES.checkpoint_writes}(thread_id);`,
+    // Migration 9: add task_path column
+    `ALTER TABLE ${SCHEMA_TABLES.checkpoint_writes} ADD COLUMN IF NOT EXISTS task_path TEXT NOT NULL DEFAULT '';`,
   ];
 };

--- a/libs/checkpoint/src/base.ts
+++ b/libs/checkpoint/src/base.ts
@@ -143,7 +143,8 @@ export abstract class BaseCheckpointSaver<V extends string | number = number> {
   abstract putWrites(
     config: RunnableConfig,
     writes: PendingWrite[],
-    taskId: string
+    taskId: string,
+    taskPath?: string
   ): Promise<void>;
 
   /**

--- a/libs/checkpoint/src/memory.ts
+++ b/libs/checkpoint/src/memory.ts
@@ -364,7 +364,9 @@ export class MemorySaver extends BaseCheckpointSaver {
   async putWrites(
     config: RunnableConfig,
     writes: PendingWrite[],
-    taskId: string
+    taskId: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _taskPath?: string
   ): Promise<void> {
     const threadId = config.configurable?.thread_id;
     const checkpointNamespace = config.configurable?.checkpoint_ns;


### PR DESCRIPTION
## Summary

Port `task_path` support from the Python checkpoint-postgres implementation to bring JS to feature parity. This is a non-breaking change.

### Changes:
- Add migrations 5-9 (thread_id indexes + task_path column on checkpoint_writes)
- Add optional `taskPath` parameter to `putWrites()` and `_dumpWrites()`
- Update SQL INSERT/UPSERT statements to include task_path column
- Update pending sends query ordering to sort by task_path, task_id, idx
- Add read-side merging of inline primitive channel_values from checkpoint JSONB
- Add integration tests for task_path and new migrations

### Why:
The Python implementation added `task_path` to support deterministic ordering of pending sends from nested subgraphs and parallel branches. Without it, the JS implementation may aggregate pending sends in non-deterministic order, causing state corruption during replay/forking.

### Backward compatibility:
- task_path column has `DEFAULT ''` — all existing rows are valid
- putWrites parameter is optional with default `""`
- Read-side primitive merging is additive (no-op for pure-JS checkpoints)
- No changes to how data is written for existing callers

### Test plan
- [ ] Integration tests pass with `pnpm test:int` in `libs/checkpoint-postgres`
- [ ] Verify migrations 5-9 run successfully on fresh DB
- [ ] Verify `putWrites` works with and without `taskPath` parameter
- [ ] Verify `task_path` column exists and defaults to empty string
- [ ] Verify pending sends ordering includes task_path