### PR TITLE
fix: bump axios to >=1.13.5 to resolve CVE-2026-25639

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
       "@langchain/langgraph-checkpoint": "workspace:*",
       "cheerio": "^1.0.0-rc.12",
       "semver": "^7.0.0",
-      "zod": "^4.3.5"
+      "zod": "^4.3.5",
+      "axios": ">=1.13.5"
     },
     "onlyBuiltDependencies": [
       "@swc/core",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   cheerio: ^1.0.0-rc.12
   semver: ^7.0.0
   zod: ^4.3.5
+  axios: '>=1.13.5'
 
 importers:
 
@@ -4187,8 +4188,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.13.2:
-    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
+  axios@1.13.5:
+    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
   b4a@1.7.3:
     resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
@@ -8531,7 +8532,7 @@ snapshots:
     dependencies:
       '@octokit/rest': 21.1.1
       '@rollup/wasm-node': 4.55.3
-      axios: 1.13.2
+      axios: 1.13.5
       commander: 11.1.0
       glob: 10.5.0
       lodash: 4.17.23
@@ -9869,7 +9870,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.13.2:
+  axios@1.13.5:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5


### PR DESCRIPTION
## Security Alert Patch

Resolves 1 Dependabot security alert (high severity).

### Packages Updated

| Package | Old Version | New Constraint | Strategy | CVEs Resolved |
|---------|------------|----------------|----------|---------------|
| `axios` | 1.13.2 | `>=1.13.5` | C — pnpm override | CVE-2026-25639 |

### CVE Details

- **CVE-2026-25639** ([GHSA-43fc-jf86-j433](https://github.com/advisories/GHSA-43fc-jf86-j433)) — `axios` >= 1.0.0, <= 1.13.4 is vulnerable to Denial of Service via `__proto__` key in `mergeConfig`. Fixed in 1.13.5.

### Fix Strategy

`axios` is a transitive dependency pulled in by `@langchain/scripts@0.1.4` (which declares `axios: ^1.6.7`). There is no newer version of `@langchain/scripts` that bumps axios above the vulnerable range. A `pnpm.overrides` constraint was added to the root `package.json` to force the minimum safe version:

```json
"axios": ">=1.13.5"
```

Remove this override once `@langchain/scripts` releases a version that requires `axios >= 1.13.5`.

### Verification

- [x] Lockfile regenerated — resolved version is now `1.13.5`
- [x] No other changes introduced

🤖 Submitted by langster-patch