### PR TITLE
fix: bump qs to >=6.14.2 to resolve CVE-2026-2391

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
       "cheerio": "^1.0.0-rc.12",
       "semver": "^7.0.0",
       "zod": "^4.3.5",
-      "axios": ">=1.13.5"
+      "axios": ">=1.13.5",
+      "qs": ">=6.14.2"
     },
     "onlyBuiltDependencies": [
       "@swc/core",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   semver: ^7.0.0
   zod: ^4.3.5
   axios: '>=1.13.5'
+  qs: '>=6.14.2'
 
 importers:
 
@@ -6649,8 +6650,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.14.1:
-    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
   quansync@1.0.0:
@@ -12556,7 +12557,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.14.1:
+  qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
 
@@ -12824,7 +12825,7 @@ snapshots:
       form-data-encoder: 4.1.0
       formdata-node: 6.0.3
       node-fetch: 2.7.0
-      qs: 6.14.1
+      qs: 6.15.0
       readable-stream: 4.7.0
       url-join: 4.0.1
       zod: 4.3.5
@@ -13490,7 +13491,7 @@ snapshots:
   url@0.11.4:
     dependencies:
       punycode: 1.4.1
-      qs: 6.14.1
+      qs: 6.15.0
 
   use-stick-to-bottom@1.1.1(react@19.2.3):
     dependencies:


### PR DESCRIPTION
qs >= 6.7.0, <= 6.14.1 is vulnerable to arrayLimit bypass in comma parsing that allows denial of service. Added pnpm override to force
>=6.14.2; resolved to 6.15.0.

