### PR TITLE
fix: bump ajv and bn.js to resolve medium security alerts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4067,8 +4067,8 @@ packages:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -4269,8 +4269,8 @@ packages:
   bn.js@4.12.2:
     resolution: {integrity: sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==}
 
-  bn.js@5.2.2:
-    resolution: {integrity: sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==}
+  bn.js@5.2.3:
+    resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -8240,7 +8240,7 @@ snapshots:
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
-      ajv: 6.12.6
+      ajv: 6.14.0
       debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
@@ -9702,7 +9702,7 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
-  ajv@6.12.6:
+  ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -9938,7 +9938,7 @@ snapshots:
 
   bn.js@4.12.2: {}
 
-  bn.js@5.2.2: {}
+  bn.js@5.2.3: {}
 
   boolbase@1.0.0: {}
 
@@ -9985,13 +9985,13 @@ snapshots:
 
   browserify-rsa@4.1.1:
     dependencies:
-      bn.js: 5.2.2
+      bn.js: 5.2.3
       randombytes: 2.1.0
       safe-buffer: 5.2.1
 
   browserify-sign@4.2.5:
     dependencies:
-      bn.js: 5.2.2
+      bn.js: 5.2.3
       browserify-rsa: 4.1.1
       create-hash: 1.2.0
       create-hmac: 1.1.7
@@ -10959,7 +10959,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.3.0
-      ajv: 6.12.6
+      ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3


### PR DESCRIPTION
## Security Alert Patch

Lockfile-only update resolving 2 medium-severity Dependabot alerts. No manifest changes required — pnpm naturally resolves to the latest compatible patch versions within the existing semver ranges already allowed by the parent packages.

### Packages Updated

| Package | Old Version | New Version | Strategy | CVEs Resolved |
|---------|------------|-------------|----------|---------------|
| `ajv` | 6.12.6 | 6.14.0 | Lockfile update (eslint allows `^6.x`) | CVE-2025-69873 |
| `bn.js` | 5.2.2 | 5.2.3 | Lockfile update (browserify-sign/rsa allow `^5.2.x`) | CVE-2026-2739 |

### CVE Details

- **CVE-2025-69873** — `ajv < 6.14.0`: ReDoS when using the `$data` option for dynamic schema validation. Dev-only (eslint toolchain).
- **CVE-2026-2739** — `bn.js < 5.2.3`: Infinite loop when calling `maskn(0)` on any BN instance. Dev-only (vite-plugin-node-polyfills → crypto-browserify).

### Notes

- `bn.js@4.12.2` (used by `elliptic`, `create-ecdh`, etc.) is untouched — forcing it to v5 would break API compatibility with those packages
- `elliptic` (CVE-2025-14505, low severity, no fix available) remains open — skipped per skill rules
- `minimatch` (CVE-2026-26996, high severity) was dismissed as tolerable risk — all usages are dev-only toolchain with no runtime exposure, and the v3→v10 jump would be a breaking change

🤖 Submitted by langster-patch