### PR TITLE
fix: use comprehensive RediSearch tag escaping

### DIFF
--- a/libs/checkpoint-redis/src/index.ts
+++ b/libs/checkpoint-redis/src/index.ts
@@ -264,9 +264,8 @@ export class RedisSaver extends BaseCheckpointSaver {
 
       // Add thread_id constraint if provided
       if (config?.configurable?.thread_id) {
-        const threadId = config.configurable.thread_id.replace(
-          /[-.@]/g,
-          "\\$&"
+        const threadId = escapeRediSearchTagValue(
+          config.configurable.thread_id
         );
         queryParts.push(`(@thread_id:{${threadId}})`);
       }
@@ -279,7 +278,7 @@ export class RedisSaver extends BaseCheckpointSaver {
           // We'll store it as "__empty__" in the index
           queryParts.push(`(@checkpoint_ns:{__empty__})`);
         } else {
-          const escapedNs = checkpointNs.replace(/[-.@]/g, "\\$&");
+          const escapedNs = escapeRediSearchTagValue(checkpointNs);
           queryParts.push(`(@checkpoint_ns:{${escapedNs}})`);
         }
       }


### PR DESCRIPTION
## Summary
- Replace incomplete inline regex (`/[-.@]/g`) with the existing `escapeRediSearchTagValue` utility for `thread_id` and `checkpoint_ns` query parameters in `RedisSaver.list()`
- The utility covers the full set of RediSearch special characters (`, . < > { } [ ] " ' : ; ! @ # $ % ^ & * ( ) - + = ~ | ? /` plus backslashes and whitespace), preventing potential query injection or malformed queries when these values contain special characters
- Fixes CodeQL alerts (`js/incomplete-sanitization`)

## Test plan
- [x] Existing `checkpoint-redis` integration tests pass
- [x] Verify `thread_id` and `checkpoint_ns` values containing special characters (e.g., colons, brackets, pipes) are correctly escaped in RediSearch queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)