### PR TITLE
[Feature] Add onerr callback for submit

### DIFF
--- a/libs/sdk/src/react/stream.custom.tsx
+++ b/libs/sdk/src/react/stream.custom.tsx
@@ -231,6 +231,7 @@ export function useStreamCustom<
 
         onSuccess: () => undefined,
         onError(error) {
+          submitOptions?.onError?.(error, undefined);
           options.onError?.(error, undefined);
         },
       }

--- a/libs/sdk/src/react/stream.lgp.tsx
+++ b/libs/sdk/src/react/stream.lgp.tsx
@@ -608,6 +608,7 @@ export function useStreamLGP<
           return undefined;
         },
         onError(error) {
+          submitOptions?.onError?.(error, callbackMeta);
           options.onError?.(error, callbackMeta);
         },
         onFinish() {

--- a/libs/sdk/src/ui/types.ts
+++ b/libs/sdk/src/ui/types.ts
@@ -1238,6 +1238,11 @@ export interface SubmitOptions<
    * before the thread is actually created.
    */
   threadId?: string;
+
+  /**
+   * Callback that is called when an error occurs during submission.
+   */
+  onError?: (error: unknown, run: RunCallbackMeta | undefined) => void;
 }
 
 /**
@@ -1303,5 +1308,5 @@ export type CustomSubmitOptions<
   ConfigurableType extends Record<string, unknown> = Record<string, unknown>
 > = Pick<
   SubmitOptions<StateType, ConfigurableType>,
-  "optimisticValues" | "context" | "command" | "config"
+  "optimisticValues" | "context" | "command" | "config" | "onError"
 >;


### PR DESCRIPTION
<!--
Thank you for contributing to LangGraph.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langgraphjs/blob/main/CONTRIBUTING.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Current Situation:
We are currently using the onError callback within useStream to handle all errors. However, this approach seems too generic and is primarily suitable for logging purposes rather than robust error handling.

Problem:
The generic error handling is not sufficient for user-facing scenarios where specific error conditions require particular user actions, such as retrying an operation.

Sample Use Case:

- A user submits a request to initiate a stream.
- The stream operation fails.
- The application needs to display a specific error message to the user, along with an option to retry the operation.
- No handle error, detect submit failed since internal submit using callback and don't throw the exeception