### PR TITLE
fix(langgraph-checkpoint-mongodb): MongoDB checkpointer metadata filter

### DIFF
--- a/.changeset/fix-mongodb-metadata-filter.md
+++ b/.changeset/fix-mongodb-metadata-filter.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint-mongodb": patch
+---
+
+fix: metadata filter in list() now works by querying a plain JSON shadow copy instead of the serialized binary blob

--- a/libs/checkpoint-mongodb/src/checkpoint.ts
+++ b/libs/checkpoint-mongodb/src/checkpoint.ts
@@ -210,7 +210,7 @@ export class MongoDBSaver extends BaseCheckpointSaver {
             `Invalid filter value for key "${key}": filter values must be primitives (string, number, boolean, or null)`
           );
         }
-        query[`metadata.${key}`] = value;
+        query[`metadata_search.${key}`] = value;
       });
     }
 
@@ -305,6 +305,7 @@ export class MongoDBSaver extends BaseCheckpointSaver {
       type: checkpointType,
       checkpoint: serializedCheckpoint,
       metadata: serializedMetadata,
+      metadata_search: metadata,
     };
     const upsertQuery = {
       thread_id,

--- a/libs/checkpoint-mongodb/src/index.ts
+++ b/libs/checkpoint-mongodb/src/index.ts
@@ -175,7 +175,7 @@ export class MongoDBSaver extends BaseCheckpointSaver {
             `Invalid filter value for key "${key}": filter values must be primitives (string, number, boolean, or null)`
           );
         }
-        query[`metadata.${key}`] = value;
+        query[`metadata_search.${key}`] = value;
       });
     }
 
@@ -258,6 +258,7 @@ export class MongoDBSaver extends BaseCheckpointSaver {
       type: checkpointType,
       checkpoint: serializedCheckpoint,
       metadata: serializedMetadata,
+      metadata_search: metadata,
     };
     const upsertQuery = {
       thread_id,

--- a/libs/checkpoint-mongodb/src/tests/checkpoints.test.ts
+++ b/libs/checkpoint-mongodb/src/tests/checkpoints.test.ts
@@ -122,6 +122,104 @@ describe("MongoDBSaver", () => {
     });
   });
 
+  describe("metadata filtering", () => {
+    const createCapturingMockClient = () => {
+      const findMock = vi.fn(() => ({
+        sort: vi.fn(() => ({
+          async *[Symbol.asyncIterator]() {
+            // Empty iterator
+          },
+        })),
+      }));
+      const updateOneMock = vi.fn().mockResolvedValue({ acknowledged: true });
+
+      const collectionMock = {
+        find: findMock,
+        updateOne: updateOneMock,
+      };
+
+      const client = {
+        appendMetadata: vi.fn(),
+        db: vi.fn(() => ({
+          collection: vi.fn(() => collectionMock),
+        })),
+      };
+
+      return { client, findMock, updateOneMock };
+    };
+
+    it("should store metadata_search as plain JSON in put()", async () => {
+      const { client, updateOneMock } = createCapturingMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const checkpoint = {
+        v: 4,
+        id: "cp-1",
+        ts: "2024-04-19T17:19:07.952Z",
+        channel_values: {},
+        channel_versions: {},
+        versions_seen: {},
+      };
+      const metadata = {
+        source: "input" as const,
+        step: 1,
+        parents: {},
+      };
+
+      await saver.put(
+        { configurable: { thread_id: "test-thread" } },
+        checkpoint,
+        metadata
+      );
+
+      expect(updateOneMock).toHaveBeenCalledWith(
+        {
+          thread_id: "test-thread",
+          checkpoint_ns: "",
+          checkpoint_id: "cp-1",
+        },
+        expect.objectContaining({
+          $set: expect.objectContaining({
+            metadata_search: metadata,
+          }),
+        }),
+        { upsert: true }
+      );
+
+      const setDoc = updateOneMock.mock.calls[0][1].$set;
+      expect(setDoc.metadata).toBeDefined();
+      expect(setDoc.metadata).not.toEqual(metadata);
+    });
+
+    it("should query metadata_search fields in list()", async () => {
+      const { client, findMock } = createCapturingMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const config = { configurable: { thread_id: "test-thread" } };
+      const filter = {
+        source: "input",
+        step: 1,
+        active: true,
+        optional: null,
+      };
+
+      const generator = saver.list(config, { filter });
+      await generator.next();
+
+      expect(findMock).toHaveBeenCalledWith({
+        thread_id: "test-thread",
+        "metadata_search.source": "input",
+        "metadata_search.step": 1,
+        "metadata_search.active": true,
+        "metadata_search.optional": null,
+      });
+    });
+  });
+
   describe("configurable validation", () => {
     it("should return undefined when thread_id is missing in getTuple", async () => {
       const client = createMockClient();


### PR DESCRIPTION
## Summary
- The `list()` method's metadata filter queried `metadata.${key}` against a serialized binary blob, making it silently nonfunctional (dead code)
- Added a plain JSON `metadata_search` field alongside the serialized `metadata` in `put()`, and updated `list()` to query against it
- This is consistent with how Postgres (native JSONB `@>`) and SQLite (`jsonb(CAST(...))`) handle metadata filtering

## Test plan
- [x] Existing unit tests pass (6/6)
- [ ] Integration test with real MongoDB to verify filter works against `metadata_search`

Fixes #1591

🤖 Generated with [Claude Code](https://claude.com/claude-code)