### PR TITLE
feat(supervisor): add MiniMax as first-class LLM provider

### DIFF
--- a/examples/minimax-agent/package.json
+++ b/examples/minimax-agent/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@examples/minimax-agent",
+  "type": "module",
+  "private": true,
+  "devDependencies": {
+    "@langchain/core": "^1.0.1",
+    "@langchain/langgraph": "workspace:*",
+    "@langchain/langgraph-supervisor": "workspace:*",
+    "@langchain/openai": "^1.0.0",
+    "dotenv": "^16.4.5",
+    "tsx": "^4.19.3",
+    "zod": "^3.23.8"
+  }
+}

--- a/examples/minimax-agent/src/agent.ts
+++ b/examples/minimax-agent/src/agent.ts
@@ -1,0 +1,122 @@
+/**
+ * MiniMax ReAct Agent Example
+ *
+ * This example demonstrates how to use MiniMax's M2.7 model as the LLM
+ * provider for a LangGraph ReAct agent with tool calling.
+ *
+ * MiniMax provides an OpenAI-compatible API, so it works seamlessly with
+ * @langchain/openai's ChatOpenAI or the dedicated ChatMiniMax wrapper
+ * from @langchain/langgraph-supervisor.
+ *
+ * Prerequisites:
+ *   export MINIMAX_API_KEY="your-api-key"
+ *
+ * Run:
+ *   npx tsx src/agent.ts
+ */
+
+import { z } from "zod";
+import { HumanMessage } from "@langchain/core/messages";
+import { tool } from "@langchain/core/tools";
+import { MemorySaver } from "@langchain/langgraph";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+import { ChatMiniMax } from "@langchain/langgraph-supervisor";
+
+// Create a MiniMax model instance
+const model = new ChatMiniMax({
+  model: "MiniMax-M2.7",
+  apiKey: process.env.MINIMAX_API_KEY,
+  temperature: 0.01,
+});
+
+// Define tools for the agent
+const getWeather = tool(
+  async ({ city }) => {
+    const weatherData: Record<string, string> = {
+      "san francisco": "60°F, foggy",
+      "new york": "75°F, sunny",
+      beijing: "85°F, clear",
+      london: "55°F, rainy",
+    };
+    const key = city.toLowerCase();
+    return weatherData[key] ?? `Weather data not available for ${city}`;
+  },
+  {
+    name: "get_weather",
+    description: "Get the current weather for a city.",
+    schema: z.object({
+      city: z.string().describe("The name of the city"),
+    }),
+  }
+);
+
+const calculate = tool(
+  async ({ expression }) => {
+    try {
+      // Simple expression evaluator for basic math
+      const result = Function(`"use strict"; return (${expression})`)();
+      return `${expression} = ${result}`;
+    } catch {
+      return `Cannot evaluate: ${expression}`;
+    }
+  },
+  {
+    name: "calculate",
+    description: "Evaluate a mathematical expression.",
+    schema: z.object({
+      expression: z.string().describe("The math expression to evaluate"),
+    }),
+  }
+);
+
+// Create a ReAct agent with MiniMax model
+const checkpointer = new MemorySaver();
+const agent = createReactAgent({
+  llm: model,
+  tools: [getWeather, calculate],
+  checkpointSaver: checkpointer,
+});
+
+// Run the agent
+async function main() {
+  console.log("MiniMax ReAct Agent Example\n");
+
+  // First interaction
+  const result1 = await agent.invoke(
+    {
+      messages: [
+        new HumanMessage("What's the weather in San Francisco and Beijing?"),
+      ],
+    },
+    { configurable: { thread_id: "minimax-demo" } }
+  );
+
+  console.log("Q: What's the weather in San Francisco and Beijing?");
+  console.log(
+    "A:",
+    result1.messages[result1.messages.length - 1].content,
+    "\n"
+  );
+
+  // Follow-up with memory
+  const result2 = await agent.invoke(
+    {
+      messages: [
+        new HumanMessage(
+          "What's the temperature difference between those two cities?"
+        ),
+      ],
+    },
+    { configurable: { thread_id: "minimax-demo" } }
+  );
+
+  console.log(
+    "Q: What's the temperature difference between those two cities?"
+  );
+  console.log(
+    "A:",
+    result2.messages[result2.messages.length - 1].content
+  );
+}
+
+main().catch(console.error);

--- a/examples/minimax-agent/src/supervisor.ts
+++ b/examples/minimax-agent/src/supervisor.ts
@@ -1,0 +1,127 @@
+/**
+ * MiniMax Multi-Agent Supervisor Example
+ *
+ * This example shows how to use MiniMax models with LangGraph's
+ * multi-agent supervisor pattern. A supervisor agent coordinates
+ * between specialized worker agents using tool-based handoffs.
+ *
+ * Prerequisites:
+ *   export MINIMAX_API_KEY="your-api-key"
+ *
+ * Run:
+ *   npx tsx src/supervisor.ts
+ */
+
+import { z } from "zod";
+import { HumanMessage } from "@langchain/core/messages";
+import { tool } from "@langchain/core/tools";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+import { ChatMiniMax, createSupervisor } from "@langchain/langgraph-supervisor";
+
+// Create MiniMax model instances
+// Use M2.7 (latest, most capable) for the supervisor
+const supervisorModel = new ChatMiniMax({
+  model: "MiniMax-M2.7",
+  apiKey: process.env.MINIMAX_API_KEY,
+  temperature: 0.01,
+});
+
+// Use M2.7-highspeed for workers (faster, cost-effective)
+const workerModel = new ChatMiniMax({
+  model: "MiniMax-M2.7-highspeed",
+  apiKey: process.env.MINIMAX_API_KEY,
+  temperature: 0.01,
+});
+
+// Define tools for each specialist agent
+const searchWeb = tool(
+  async ({ query }) => {
+    // Simulated web search results
+    return `Search results for "${query}": Found 3 relevant articles about the topic.`;
+  },
+  {
+    name: "search_web",
+    description: "Search the web for information on a topic.",
+    schema: z.object({
+      query: z.string().describe("The search query"),
+    }),
+  }
+);
+
+const analyzeData = tool(
+  async ({ data }) => {
+    return `Analysis of "${data}": Key findings - growth trend detected, 3 anomalies noted.`;
+  },
+  {
+    name: "analyze_data",
+    description: "Analyze data and provide insights.",
+    schema: z.object({
+      data: z.string().describe("The data or topic to analyze"),
+    }),
+  }
+);
+
+// Create specialized agents
+const researcher = createReactAgent({
+  llm: workerModel,
+  tools: [searchWeb],
+  name: "researcher",
+  description: "Expert researcher who searches the web for information.",
+  prompt:
+    "You are an expert researcher. Use web search to find relevant information. " +
+    "Be thorough in your research and provide detailed findings.",
+});
+
+const analyst = createReactAgent({
+  llm: workerModel,
+  tools: [analyzeData],
+  name: "analyst",
+  description: "Data analyst who provides insights from data.",
+  prompt:
+    "You are a skilled data analyst. Analyze the data provided to you " +
+    "and return clear, actionable insights.",
+});
+
+// Create the supervisor
+const workflow = createSupervisor({
+  agents: [researcher, analyst],
+  llm: supervisorModel,
+  prompt:
+    "You are a team supervisor managing a researcher and an analyst. " +
+    "Delegate research tasks to the researcher and analysis tasks to the analyst. " +
+    "Coordinate between them to provide comprehensive answers.",
+});
+
+// Compile and run
+async function main() {
+  console.log("MiniMax Multi-Agent Supervisor Example\n");
+
+  const app = workflow.compile();
+
+  const result = await app.invoke({
+    messages: [
+      new HumanMessage(
+        "Research the latest trends in AI agent frameworks, then analyze the key patterns."
+      ),
+    ],
+  });
+
+  console.log("Q: Research AI agent framework trends and analyze patterns\n");
+
+  // Print the conversation flow
+  for (const msg of result.messages) {
+    const role =
+      msg._getType() === "human"
+        ? "User"
+        : msg._getType() === "ai"
+          ? msg.name ?? "AI"
+          : "Tool";
+    const content =
+      typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content);
+    if (content) {
+      console.log(`[${role}]: ${content.slice(0, 200)}`);
+    }
+  }
+}
+
+main().catch(console.error);

--- a/examples/minimax-agent/tsconfig.json
+++ b/examples/minimax-agent/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@tsconfig/recommended",
+  "compilerOptions": {
+    "outDir": "../dist",
+    "rootDir": "./src",
+    "target": "ES2021",
+    "module": "ES2020",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "declaration": true,
+    "strict": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/libs/langgraph-core/README.md
+++ b/libs/langgraph-core/README.md
@@ -61,6 +61,46 @@ const result = await agent.invoke({
 });
 ```
 
+### Using with MiniMax
+
+LangGraph also supports [MiniMax](https://www.minimax.io) models via the OpenAI-compatible API. Use the `ChatMiniMax` wrapper from `@langchain/langgraph-supervisor` for automatic temperature clamping and think-tag stripping:
+
+```ts
+// npm install @langchain/langgraph-supervisor @langchain/openai
+import { createReactAgent, tool } from "langchain";
+import { ChatMiniMax } from "@langchain/langgraph-supervisor";
+import { z } from "zod";
+
+const search = tool(
+  async ({ query }) => {
+    return "It's 30 degrees and sunny.";
+  },
+  {
+    name: "search",
+    description: "Call to search the web.",
+    schema: z.object({
+      query: z.string().describe("The query to search for."),
+    }),
+  }
+);
+
+const model = new ChatMiniMax({
+  model: "MiniMax-M2.7", // or "MiniMax-M2.7-highspeed"
+  apiKey: process.env.MINIMAX_API_KEY,
+});
+
+const agent = createReactAgent({
+  llm: model,
+  tools: [search],
+});
+
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "what is the weather in beijing" }],
+});
+```
+
+See the [MiniMax agent example](./examples/minimax-agent/) for more patterns including multi-agent supervisor.
+
 ## Full-stack Quickstart
 
 Get started quickly by building a full-stack LangGraph application using the [`create-agent-chat-app`](https://www.npmjs.com/package/create-agent-chat-app) CLI:

--- a/libs/langgraph-supervisor/src/index.ts
+++ b/libs/langgraph-supervisor/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./supervisor.js";
+export * from "./minimax.js";

--- a/libs/langgraph-supervisor/src/minimax.ts
+++ b/libs/langgraph-supervisor/src/minimax.ts
@@ -1,0 +1,129 @@
+import { ChatOpenAI, type ChatOpenAIFields } from "@langchain/openai";
+import {
+  AIMessage,
+  type BaseMessage,
+  type BaseMessageFields,
+} from "@langchain/core/messages";
+import type { ChatResult } from "@langchain/core/outputs";
+import type { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
+
+const MINIMAX_BASE_URL = "https://api.minimax.io/v1";
+
+const MINIMAX_MODELS = [
+  "MiniMax-M2.7",
+  "MiniMax-M2.7-highspeed",
+  "MiniMax-M2.5",
+  "MiniMax-M2.5-highspeed",
+] as const;
+
+type MiniMaxModel = (typeof MINIMAX_MODELS)[number];
+
+const THINK_TAG_REGEX = /<think>[\s\S]*?<\/think>/g;
+
+/**
+ * Clamp temperature to MiniMax's accepted range.
+ * MiniMax accepts temperature in [0, 1.0].
+ */
+function clampTemperature(temperature: number | undefined): number {
+  if (temperature === undefined || temperature === null) return 0.01;
+  return Math.max(0, Math.min(1, temperature));
+}
+
+/**
+ * Strip `<think>...</think>` blocks from a message's content.
+ * MiniMax M2.5+ models may include reasoning traces wrapped in think tags.
+ */
+function stripThinkTags(content: string): string {
+  return content.replace(THINK_TAG_REGEX, "").trim();
+}
+
+export interface ChatMiniMaxFields extends Omit<ChatOpenAIFields, "model"> {
+  /**
+   * MiniMax model to use. Defaults to "MiniMax-M2.7".
+   */
+  model?: MiniMaxModel | (string & {});
+
+  /**
+   * Whether to strip `<think>` reasoning tags from responses.
+   * Defaults to true.
+   */
+  stripThinking?: boolean;
+}
+
+/**
+ * Chat model wrapper for MiniMax's OpenAI-compatible API.
+ *
+ * MiniMax provides large language models (M2.7, M2.5, etc.) accessible via
+ * an OpenAI-compatible API endpoint at `https://api.minimax.io/v1`.
+ *
+ * This class extends `ChatOpenAI` with MiniMax-specific handling:
+ * - Automatic temperature clamping to [0, 1.0]
+ * - Stripping of `<think>` reasoning tags from M2.5+ model responses
+ * - Pre-configured base URL for the MiniMax API
+ *
+ * @example
+ * ```ts
+ * import { ChatMiniMax } from "@langchain/langgraph-supervisor";
+ *
+ * const model = new ChatMiniMax({
+ *   model: "MiniMax-M2.7",
+ *   apiKey: process.env.MINIMAX_API_KEY,
+ * });
+ * ```
+ */
+export class ChatMiniMax extends ChatOpenAI {
+  stripThinking: boolean;
+
+  constructor(fields?: ChatMiniMaxFields) {
+    const {
+      stripThinking = true,
+      model = "MiniMax-M2.7",
+      temperature,
+      ...rest
+    } = fields ?? {};
+
+    super({
+      ...rest,
+      model,
+      temperature: clampTemperature(temperature),
+      apiKey: rest.apiKey ?? process.env.MINIMAX_API_KEY,
+      configuration: {
+        ...rest.configuration,
+        baseURL: rest.configuration?.baseURL ?? MINIMAX_BASE_URL,
+      },
+    });
+
+    this.stripThinking = stripThinking;
+  }
+
+  override _llmType(): string {
+    return "minimax";
+  }
+
+  override async _generate(
+    messages: BaseMessage[],
+    options: this["ParsedCallOptions"],
+    runManager?: CallbackManagerForLLMRun
+  ): Promise<ChatResult> {
+    const result = await super._generate(messages, options, runManager);
+
+    if (this.stripThinking) {
+      for (const generation of result.generations) {
+        const msg = generation.message;
+        if (typeof msg.content === "string" && msg.content.includes("<think>")) {
+          const strippedContent = stripThinkTags(msg.content);
+          generation.message = new AIMessage({
+            ...msg,
+            content: strippedContent,
+          } as BaseMessageFields);
+          generation.text = strippedContent;
+        }
+      }
+    }
+
+    return result;
+  }
+}
+
+export { MINIMAX_MODELS, MINIMAX_BASE_URL, clampTemperature, stripThinkTags };
+export type { MiniMaxModel };

--- a/libs/langgraph-supervisor/src/supervisor.ts
+++ b/libs/langgraph-supervisor/src/supervisor.ts
@@ -31,7 +31,10 @@ export type { AgentNameMode };
 export { withAgentName };
 
 type OutputMode = "full_history" | "last_message";
-const PROVIDERS_WITH_PARALLEL_TOOL_CALLS_PARAM = new Set(["ChatOpenAI"]);
+const PROVIDERS_WITH_PARALLEL_TOOL_CALLS_PARAM = new Set([
+  "ChatOpenAI",
+  "ChatMiniMax",
+]);
 
 // type guards
 type ChatModelWithBindTools = BaseChatModel & {

--- a/libs/langgraph-supervisor/src/tests/minimax.int.test.ts
+++ b/libs/langgraph-supervisor/src/tests/minimax.int.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { HumanMessage } from "@langchain/core/messages";
+import { tool } from "@langchain/core/tools";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+import { ChatMiniMax } from "../minimax.js";
+import { createSupervisor } from "../supervisor.js";
+
+// Integration tests require MINIMAX_API_KEY to be set
+const MINIMAX_API_KEY = process.env.MINIMAX_API_KEY;
+
+describe.skipIf(!MINIMAX_API_KEY)("ChatMiniMax integration tests", () => {
+  it("should create a ChatMiniMax instance with default config", () => {
+    const model = new ChatMiniMax({
+      apiKey: MINIMAX_API_KEY,
+    });
+    expect(model).toBeDefined();
+  });
+
+  it("should invoke ChatMiniMax and get a response", async () => {
+    const model = new ChatMiniMax({
+      model: "MiniMax-M2.7",
+      apiKey: MINIMAX_API_KEY,
+      temperature: 0.01,
+    });
+
+    const response = await model.invoke([
+      new HumanMessage("Say 'hello' and nothing else."),
+    ]);
+
+    expect(response).toBeDefined();
+    expect(typeof response.content).toBe("string");
+    expect((response.content as string).toLowerCase()).toContain("hello");
+    // Verify think tags are stripped
+    expect(response.content).not.toContain("<think>");
+  });
+
+  it("should work with tool calling", async () => {
+    const model = new ChatMiniMax({
+      model: "MiniMax-M2.7",
+      apiKey: MINIMAX_API_KEY,
+      temperature: 0.01,
+    });
+
+    const weatherTool = tool(
+      async ({ city }) => `The weather in ${city} is sunny, 25°C.`,
+      {
+        name: "get_weather",
+        description: "Get the current weather for a city.",
+        schema: z.object({
+          city: z.string().describe("The city name"),
+        }),
+      }
+    );
+
+    const agent = createReactAgent({
+      llm: model,
+      tools: [weatherTool],
+    });
+
+    const result = await agent.invoke({
+      messages: [
+        new HumanMessage("What's the weather in Beijing? Use the get_weather tool."),
+      ],
+    });
+
+    expect(result).toBeDefined();
+    expect(result.messages).toBeDefined();
+    expect(result.messages.length).toBeGreaterThan(1);
+
+    // The final message should contain weather info
+    const lastMessage = result.messages[result.messages.length - 1];
+    expect(typeof lastMessage.content).toBe("string");
+  });
+
+  it("should work with supervisor multi-agent pattern", async () => {
+    const model = new ChatMiniMax({
+      model: "MiniMax-M2.7",
+      apiKey: MINIMAX_API_KEY,
+      temperature: 0.01,
+    });
+
+    const calcTool = tool(
+      async ({ a, b }) => `${a + b}`,
+      {
+        name: "add",
+        description: "Add two numbers together.",
+        schema: z.object({
+          a: z.number().describe("First number"),
+          b: z.number().describe("Second number"),
+        }),
+      }
+    );
+
+    const calcAgent = createReactAgent({
+      llm: model,
+      tools: [calcTool],
+      name: "calculator",
+      description: "A calculator agent that can add numbers.",
+    });
+
+    const workflow = createSupervisor({
+      agents: [calcAgent],
+      llm: model,
+      prompt:
+        "You are a supervisor. Delegate math questions to the calculator agent.",
+    });
+
+    const app = workflow.compile();
+    const result = await app.invoke({
+      messages: [new HumanMessage("What is 3 + 5?")],
+    });
+
+    expect(result).toBeDefined();
+    expect(result.messages).toBeDefined();
+    expect(result.messages.length).toBeGreaterThan(0);
+  });
+});

--- a/libs/langgraph-supervisor/src/tests/minimax.test.ts
+++ b/libs/langgraph-supervisor/src/tests/minimax.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect, vi } from "vitest";
+import { z } from "zod";
+import { AIMessage, HumanMessage } from "@langchain/core/messages";
+import { tool } from "@langchain/core/tools";
+import { createReactAgent } from "@langchain/langgraph/prebuilt";
+import {
+  clampTemperature,
+  stripThinkTags,
+  MINIMAX_BASE_URL,
+  MINIMAX_MODELS,
+} from "../minimax.js";
+import { createSupervisor } from "../supervisor.js";
+import { FakeToolCallingChatModel } from "./utils.js";
+
+describe("MiniMax utilities", () => {
+  describe("clampTemperature", () => {
+    it("should clamp temperature below 0 to 0", () => {
+      expect(clampTemperature(-0.5)).toBe(0);
+    });
+
+    it("should clamp temperature above 1 to 1", () => {
+      expect(clampTemperature(1.5)).toBe(1);
+    });
+
+    it("should keep valid temperature unchanged", () => {
+      expect(clampTemperature(0.7)).toBe(0.7);
+    });
+
+    it("should handle temperature of 0", () => {
+      expect(clampTemperature(0)).toBe(0);
+    });
+
+    it("should handle temperature of 1", () => {
+      expect(clampTemperature(1)).toBe(1);
+    });
+
+    it("should return 0.01 for undefined", () => {
+      expect(clampTemperature(undefined)).toBe(0.01);
+    });
+  });
+
+  describe("stripThinkTags", () => {
+    it("should strip single think block", () => {
+      const input =
+        "<think>Let me reason about this...</think>The answer is 42.";
+      expect(stripThinkTags(input)).toBe("The answer is 42.");
+    });
+
+    it("should strip multiple think blocks", () => {
+      const input =
+        "<think>First thought</think>Hello <think>Second thought</think>World";
+      expect(stripThinkTags(input)).toBe("Hello World");
+    });
+
+    it("should handle multiline think blocks", () => {
+      const input =
+        "<think>\nStep 1: Consider the problem\nStep 2: Solve it\n</think>\nThe solution is here.";
+      expect(stripThinkTags(input)).toBe("The solution is here.");
+    });
+
+    it("should return content unchanged when no think tags present", () => {
+      const input = "Just a normal response without any think tags.";
+      expect(stripThinkTags(input)).toBe(input);
+    });
+
+    it("should handle empty content", () => {
+      expect(stripThinkTags("")).toBe("");
+    });
+
+    it("should trim whitespace after stripping", () => {
+      const input = "  <think>reasoning</think>  Result  ";
+      expect(stripThinkTags(input)).toBe("Result");
+    });
+  });
+
+  describe("constants", () => {
+    it("should have correct MiniMax base URL", () => {
+      expect(MINIMAX_BASE_URL).toBe("https://api.minimax.io/v1");
+    });
+
+    it("should have expected MiniMax models", () => {
+      expect(MINIMAX_MODELS).toContain("MiniMax-M2.7");
+      expect(MINIMAX_MODELS).toContain("MiniMax-M2.7-highspeed");
+      expect(MINIMAX_MODELS).toContain("MiniMax-M2.5");
+      expect(MINIMAX_MODELS).toContain("MiniMax-M2.5-highspeed");
+    });
+  });
+});
+
+describe("Supervisor with MiniMax-style model", () => {
+  it("should work with a model mimicking ChatMiniMax behavior", async () => {
+    // Create a FakeToolCallingChatModel that simulates MiniMax behavior
+    const supervisorMessages = [
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "transfer_to_worker",
+            args: {},
+            id: "call_minimax_1",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new AIMessage({
+        content: "Task completed by the worker agent.",
+      }),
+    ];
+
+    const workerMessages = [
+      new AIMessage({
+        content: "I have completed the assigned task.",
+      }),
+    ];
+
+    const supervisorModel = new FakeToolCallingChatModel({
+      responses: supervisorMessages,
+    });
+
+    const workerModel = new FakeToolCallingChatModel({
+      responses: workerMessages,
+    });
+
+    const workerTool = tool(async (_args) => "Task result", {
+      name: "execute_task",
+      description: "Execute a task.",
+      schema: z.object({
+        task: z.string().describe("The task to execute"),
+      }),
+    });
+
+    const workerAgent = createReactAgent({
+      llm: workerModel,
+      tools: [workerTool],
+      name: "worker",
+      description: "A worker agent that executes tasks.",
+    });
+
+    const workflow = createSupervisor({
+      agents: [workerAgent],
+      llm: supervisorModel,
+      prompt: "You are a supervisor managing a worker agent.",
+    });
+
+    const app = workflow.compile();
+    expect(app).toBeDefined();
+
+    const result = await app.invoke({
+      messages: [new HumanMessage("Execute the task please.")],
+    });
+
+    expect(result).toBeDefined();
+    expect(result.messages).toBeDefined();
+    expect(result.messages.length).toBeGreaterThan(0);
+
+    // Final message should be the supervisor's completion message
+    const lastMessage = result.messages[result.messages.length - 1];
+    expect(lastMessage.content).toBe(
+      "Task completed by the worker agent."
+    );
+  });
+
+  it("should handle think tags in model responses", async () => {
+    // Simulate a MiniMax M2.5 model that includes think tags
+    const supervisorMessages = [
+      new AIMessage({
+        content:
+          "<think>Let me think about which agent to delegate to...</think>",
+        tool_calls: [
+          {
+            name: "transfer_to_analyst",
+            args: {},
+            id: "call_think_1",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new AIMessage({
+        content:
+          "<think>The analyst has provided the results. Let me summarize.</think>The analysis is complete. Revenue grew 15% year over year.",
+      }),
+    ];
+
+    const analystMessages = [
+      new AIMessage({
+        content:
+          "<think>Analyzing the data...</think>Revenue data shows 15% YoY growth.",
+      }),
+    ];
+
+    const supervisorModel = new FakeToolCallingChatModel({
+      responses: supervisorMessages,
+    });
+
+    const analystModel = new FakeToolCallingChatModel({
+      responses: analystMessages,
+    });
+
+    const analyzeTool = tool(async (_args) => "Revenue: $1.2M (up 15%)", {
+      name: "analyze_data",
+      description: "Analyze financial data.",
+      schema: z.object({
+        query: z.string().describe("Analysis query"),
+      }),
+    });
+
+    const analystAgent = createReactAgent({
+      llm: analystModel,
+      tools: [analyzeTool],
+      name: "analyst",
+      description: "A financial analyst agent.",
+    });
+
+    const workflow = createSupervisor({
+      agents: [analystAgent],
+      llm: supervisorModel,
+      prompt: "You are a supervisor managing an analyst.",
+    });
+
+    const app = workflow.compile();
+    const result = await app.invoke({
+      messages: [new HumanMessage("Analyze the revenue data.")],
+    });
+
+    expect(result).toBeDefined();
+    expect(result.messages).toBeDefined();
+
+    // The final message content includes think tags (stripping is done by ChatMiniMax, not the supervisor)
+    const lastMessage = result.messages[result.messages.length - 1];
+    expect(lastMessage.content).toContain("analysis is complete");
+  });
+
+  it("should work with multiple agents using MiniMax-style model", async () => {
+    const supervisorMessages = [
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "transfer_to_researcher",
+            args: {},
+            id: "call_mm_multi_1",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            name: "transfer_to_writer",
+            args: {},
+            id: "call_mm_multi_2",
+            type: "tool_call",
+          },
+        ],
+      }),
+      new AIMessage({
+        content: "Article about AI trends has been written.",
+      }),
+    ];
+
+    const researcherMessages = [
+      new AIMessage({
+        content: "AI trends: 1) Multi-modal models 2) Agent frameworks 3) Edge AI",
+      }),
+    ];
+
+    const writerMessages = [
+      new AIMessage({
+        content: "Article draft: Top 3 AI Trends for 2024...",
+      }),
+    ];
+
+    const supervisorModel = new FakeToolCallingChatModel({
+      responses: supervisorMessages,
+    });
+
+    const researcherModel = new FakeToolCallingChatModel({
+      responses: researcherMessages,
+    });
+
+    const writerModel = new FakeToolCallingChatModel({
+      responses: writerMessages,
+    });
+
+    const searchTool = tool(async (_args) => "AI trend results", {
+      name: "web_search",
+      description: "Search the web.",
+      schema: z.object({ query: z.string() }),
+    });
+
+    const writeTool = tool(async (_args) => "Article written", {
+      name: "write_article",
+      description: "Write an article.",
+      schema: z.object({ topic: z.string() }),
+    });
+
+    const researcher = createReactAgent({
+      llm: researcherModel,
+      tools: [searchTool],
+      name: "researcher",
+      description: "Research agent that searches the web.",
+    });
+
+    const writer = createReactAgent({
+      llm: writerModel,
+      tools: [writeTool],
+      name: "writer",
+      description: "Writer agent that creates articles.",
+    });
+
+    const workflow = createSupervisor({
+      agents: [researcher, writer],
+      llm: supervisorModel,
+      prompt: "You are a team supervisor managing a researcher and a writer.",
+    });
+
+    const app = workflow.compile();
+    const result = await app.invoke({
+      messages: [
+        new HumanMessage("Write an article about the latest AI trends."),
+      ],
+    });
+
+    expect(result).toBeDefined();
+    expect(result.messages).toBeDefined();
+    expect(result.messages.length).toBeGreaterThan(0);
+
+    const lastMessage = result.messages[result.messages.length - 1];
+    expect(lastMessage.content).toBe(
+      "Article about AI trends has been written."
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -539,6 +539,30 @@ importers:
         specifier: ^3.23.2
         version: 3.25.1(zod@4.3.6)
 
+  examples/minimax-agent:
+    devDependencies:
+      '@langchain/core':
+        specifier: '>=1.1.27'
+        version: 1.1.31(@opentelemetry/api@1.9.0)(openai@6.27.0(ws@8.19.0)(zod@4.3.6))
+      '@langchain/langgraph':
+        specifier: workspace:*
+        version: link:../../libs/langgraph-core
+      '@langchain/langgraph-supervisor':
+        specifier: workspace:*
+        version: link:../../libs/langgraph-supervisor
+      '@langchain/openai':
+        specifier: ^1.0.0
+        version: 1.2.13(@langchain/core@1.1.31(@opentelemetry/api@1.9.0)(openai@6.27.0(ws@8.19.0)(zod@4.3.6)))(ws@8.19.0)
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      zod:
+        specifier: ^4.3.5
+        version: 4.3.6
+
   examples/multi_agent:
     devDependencies:
       '@langchain/anthropic':


### PR DESCRIPTION
## Summary

Add MiniMax as a first-class LLM provider for LangGraph.js agents and multi-agent supervisors.

- **`ChatMiniMax` class** in `@langchain/langgraph-supervisor` extending `ChatOpenAI` with:
  - Automatic temperature clamping to MiniMax's accepted range [0, 1.0]
  - Think-tag stripping (`<think>...</think>`) for M2.5+ model reasoning traces
  - Pre-configured base URL (`https://api.minimax.io/v1`)
  - Auto-detection of `MINIMAX_API_KEY` environment variable
- **Supervisor integration**: Added `ChatMiniMax` to `PROVIDERS_WITH_PARALLEL_TOOL_CALLS_PARAM` for proper tool-calling behavior
- **Examples**: Complete `examples/minimax-agent/` with ReAct agent and multi-agent supervisor patterns
- **README**: Added MiniMax usage section with code example

### Models supported
- `MiniMax-M2.7` (latest, most capable)
- `MiniMax-M2.7-highspeed` (faster, cost-effective)
- `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` (204K context)

## Test plan

- [x] 17 unit tests passing (temperature clamping, think-tag stripping, supervisor workflows)
- [x] 4 integration tests passing (live API calls: model invocation, tool calling, supervisor pattern)
- [x] All 7 existing supervisor tests continue to pass (no regressions)

**Files changed**: 11 files, 929 additions, 1 deletion

---
*MiniMax provides large language models via an OpenAI-compatible API at `https://api.minimax.io/v1`.*