### PR TITLE
fix(langgraph-checkpoint-postgres): move serialization outside transaction in put()

### DIFF
--- a/.changeset/twelve-donuts-shout.md
+++ b/.changeset/twelve-donuts-shout.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint-postgres": patch
+---
+
+fix(checkpoint-postgres): move serialization outside transaction in put()

--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -575,16 +575,20 @@ export class PostgresSaver extends BaseCheckpointSaver {
         checkpoint_id: checkpoint.id,
       },
     };
-    const client = await this.pool.connect();
+
+    // Serialize before acquiring a connection so the transaction only contains
+    // INSERT statements.  Serializing inside BEGIN/COMMIT holds the connection
+    // idle while CPU-bound serde runs; under event-loop contention this can
+    // stretch transactions to minutes and starve the connection pool.
     const serializedCheckpoint = this._dumpCheckpoint(checkpoint);
+    const [serializedBlobs, serializedMetadata] = await Promise.all([
+      this._dumpBlobs(thread_id, checkpoint_ns, checkpoint.channel_values, newVersions),
+      this._dumpMetadata(metadata),
+    ]);
+
+    const client = await this.pool.connect();
     try {
       await client.query("BEGIN");
-      const serializedBlobs = await this._dumpBlobs(
-        thread_id,
-        checkpoint_ns,
-        checkpoint.channel_values,
-        newVersions
-      );
       for (const serializedBlob of serializedBlobs) {
         await client.query(
           this.SQL_STATEMENTS.UPSERT_CHECKPOINT_BLOBS_SQL,
@@ -597,7 +601,7 @@ export class PostgresSaver extends BaseCheckpointSaver {
         checkpoint.id,
         checkpoint_id,
         serializedCheckpoint,
-        await this._dumpMetadata(metadata),
+        serializedMetadata,
       ]);
       await client.query("COMMIT");
     } catch (e) {

--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -582,7 +582,12 @@ export class PostgresSaver extends BaseCheckpointSaver {
     // stretch transactions to minutes and starve the connection pool.
     const serializedCheckpoint = this._dumpCheckpoint(checkpoint);
     const [serializedBlobs, serializedMetadata] = await Promise.all([
-      this._dumpBlobs(thread_id, checkpoint_ns, checkpoint.channel_values, newVersions),
+      this._dumpBlobs(
+        thread_id,
+        checkpoint_ns,
+        checkpoint.channel_values,
+        newVersions
+      ),
       this._dumpMetadata(metadata),
     ]);
 


### PR DESCRIPTION
## Problem

`PostgresSaver.put()` calls `_dumpBlobs()` and `_dumpMetadata()` **inside** the `BEGIN`/`COMMIT` transaction block. These are CPU-bound serialization operations that hold a database connection idle while the Node.js event loop processes them.

Under concurrent load (multiple graph executions, LLM streaming, tool calls), event-loop contention delays the `await` resolution between SQL statements. We observed `idle in transaction` with `wait_event=ClientRead` in `pg_stat_activity` lasting **3+ minutes** in production — the DB had finished executing the last INSERT and was waiting for the client to send the next command, but the Node.js process was busy with other async work.

This starves the connection pool and cascades into checkpoint failures for other concurrent graph runs.

## Fix

Move `_dumpBlobs()`, `_dumpMetadata()`, and `_dumpCheckpoint()` **before** `pool.connect()`, so the transaction only contains INSERT statements (pure I/O). Serialization of blobs and metadata is now parallelized with `Promise.all`.

### Before
```
pool.connect()
_dumpCheckpoint()        ← sync, outside txn (ok)
BEGIN
  _dumpBlobs()           ← async serialization INSIDE txn ❌
  INSERT blob 1
  INSERT blob 2 ...
  _dumpMetadata()        ← async serialization INSIDE txn ❌
  INSERT checkpoint
COMMIT
client.release()
```

### After
```
_dumpCheckpoint()        ← sync, before connect
_dumpBlobs()             ← async, before connect ✅
_dumpMetadata()          ← async, before connect ✅ (parallel with blobs)
pool.connect()
BEGIN
  INSERT blob 1
  INSERT blob 2 ...
  INSERT checkpoint
COMMIT
client.release()
```

## Evidence

- `pg_stat_activity` sampling over 2 min showed the same backend PID stuck in `idle in transaction` with `wait_event=ClientRead`, transaction age growing from 1:47 to 3:18
- Last SQL was `INSERT INTO checkpoint_blobs ... ON CONFLICT DO NOTHING` — the DB finished, client never sent the next command
- No `idle_in_transaction_session_timeout` configured, so PG never killed the stalled connection
- Connection pool (`max: 30`) was gradually exhausted by these long-held connections