### PR TITLE
fix(langgraph-checkpoint-mongodb): include pendingWrites in list() results

### DIFF
--- a/.changeset/purple-geese-think.md
+++ b/.changeset/purple-geese-think.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint-mongodb": patch
+---
+
+fix(mongodb): include pendingWrites in list() results

--- a/libs/checkpoint-mongodb/src/checkpoint.ts
+++ b/libs/checkpoint-mongodb/src/checkpoint.ts
@@ -241,6 +241,28 @@ export class MongoDBSaver extends BaseCheckpointSaver {
         doc.metadata.value("utf8")
       )) as CheckpointMetadata;
 
+      // Query pending writes for this checkpoint, matching getTuple() behavior
+      const serializedWrites = await this.db
+        .collection(this.checkpointWritesCollectionName)
+        .find({
+          thread_id: doc.thread_id,
+          checkpoint_ns: doc.checkpoint_ns,
+          checkpoint_id: doc.checkpoint_id,
+        })
+        .toArray();
+      const pendingWrites: CheckpointPendingWrite[] = await Promise.all(
+        serializedWrites.map(async (serializedWrite) => {
+          return [
+            serializedWrite.task_id,
+            serializedWrite.channel,
+            await this.serde.loadsTyped(
+              serializedWrite.type,
+              serializedWrite.value.value("utf8")
+            ),
+          ] as CheckpointPendingWrite;
+        })
+      );
+
       yield {
         config: {
           configurable: {
@@ -250,6 +272,7 @@ export class MongoDBSaver extends BaseCheckpointSaver {
           },
         },
         checkpoint,
+        pendingWrites,
         metadata,
         parentConfig: doc.parent_checkpoint_id
           ? {

--- a/libs/checkpoint-mongodb/src/tests/checkpoints.int.test.ts
+++ b/libs/checkpoint-mongodb/src/tests/checkpoints.int.test.ts
@@ -146,6 +146,10 @@ describe("MongoDBSaver", () => {
     const checkpointTuple2 = checkpointTuples[1];
     expect(checkpointTuple1.checkpoint.ts).toBe("2024-04-20T17:19:07.952Z");
     expect(checkpointTuple2.checkpoint.ts).toBe("2024-04-19T17:19:07.952Z");
+
+    // list() should include pendingWrites, matching getTuple()
+    expect(checkpointTuple1.pendingWrites).toEqual([]);
+    expect(checkpointTuple2.pendingWrites).toEqual([["foo", "bar", "baz"]]);
   });
 
   describe("enableTimestamps", () => {

--- a/libs/checkpoint-mongodb/src/tests/checkpoints.test.ts
+++ b/libs/checkpoint-mongodb/src/tests/checkpoints.test.ts
@@ -23,6 +23,13 @@ const createMockClient = () => ({
   })),
 });
 
+const asBinary = (value: unknown) => ({
+  value: (encoding: string) => {
+    expect(encoding).toBe("utf8");
+    return JSON.stringify(value);
+  },
+});
+
 describe("MongoDBSaver", () => {
   it("should set client metadata", async () => {
     const client = createMockClient();
@@ -217,6 +224,151 @@ describe("MongoDBSaver", () => {
         "metadata_search.active": true,
         "metadata_search.optional": null,
       });
+    });
+  });
+
+  describe("list pendingWrites", () => {
+    it("should include pendingWrites in list() results", async () => {
+      const checkpointDoc = {
+        thread_id: "test-thread",
+        checkpoint_ns: "",
+        checkpoint_id: "cp-1",
+        type: "json",
+        checkpoint: asBinary({
+          v: 4,
+          id: "cp-1",
+          ts: "2024-04-19T17:19:07.952Z",
+          channel_values: {},
+          channel_versions: {},
+          versions_seen: {},
+        }),
+        metadata: asBinary({
+          source: "input",
+          step: 1,
+          parents: {},
+        }),
+        parent_checkpoint_id: null,
+      };
+
+      const writeDoc = {
+        task_id: "task-1",
+        channel: "bar",
+        type: "json",
+        value: asBinary("baz"),
+      };
+
+      const writesFindMock = vi.fn(() => ({
+        toArray: vi.fn(() => Promise.resolve([writeDoc])),
+      }));
+
+      const checkpointsFindMock = vi.fn(() => ({
+        sort: vi.fn(() => ({
+          async *[Symbol.asyncIterator]() {
+            yield checkpointDoc;
+          },
+        })),
+      }));
+
+      const collectionMock = vi.fn((name: string) => {
+        if (name === "checkpoints") {
+          return { find: checkpointsFindMock };
+        }
+        if (name === "checkpoint_writes") {
+          return { find: writesFindMock };
+        }
+        throw new Error(`Unexpected collection: ${name}`);
+      });
+
+      const client = {
+        appendMetadata: vi.fn(),
+        db: vi.fn(() => ({
+          collection: collectionMock,
+        })),
+      };
+
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const generator = saver.list({
+        configurable: { thread_id: "test-thread" },
+      });
+      const result = await generator.next();
+
+      expect(result.done).toBe(false);
+      expect(result.value?.pendingWrites).toEqual([["task-1", "bar", "baz"]]);
+      expect(writesFindMock).toHaveBeenCalledWith({
+        thread_id: "test-thread",
+        checkpoint_ns: "",
+        checkpoint_id: "cp-1",
+      });
+
+      const done = await generator.next();
+      expect(done.done).toBe(true);
+    });
+
+    it("should return empty pendingWrites when none exist", async () => {
+      const checkpointDoc = {
+        thread_id: "test-thread",
+        checkpoint_ns: "",
+        checkpoint_id: "cp-1",
+        type: "json",
+        checkpoint: asBinary({
+          v: 4,
+          id: "cp-1",
+          ts: "2024-04-19T17:19:07.952Z",
+          channel_values: {},
+          channel_versions: {},
+          versions_seen: {},
+        }),
+        metadata: asBinary({
+          source: "input",
+          step: 1,
+          parents: {},
+        }),
+        parent_checkpoint_id: null,
+      };
+
+      const writesFindMock = vi.fn(() => ({
+        toArray: vi.fn(() => Promise.resolve([])),
+      }));
+
+      const checkpointsFindMock = vi.fn(() => ({
+        sort: vi.fn(() => ({
+          async *[Symbol.asyncIterator]() {
+            yield checkpointDoc;
+          },
+        })),
+      }));
+
+      const collectionMock = vi.fn((name: string) => {
+        if (name === "checkpoints") {
+          return { find: checkpointsFindMock };
+        }
+        if (name === "checkpoint_writes") {
+          return { find: writesFindMock };
+        }
+        throw new Error(`Unexpected collection: ${name}`);
+      });
+
+      const client = {
+        appendMetadata: vi.fn(),
+        db: vi.fn(() => ({
+          collection: collectionMock,
+        })),
+      };
+
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const generator = saver.list({
+        configurable: { thread_id: "test-thread" },
+      });
+      const result = await generator.next();
+
+      expect(result.done).toBe(false);
+      expect(result.value?.pendingWrites).toEqual([]);
     });
   });
 

--- a/libs/checkpoint-validation/src/spec/list.ts
+++ b/libs/checkpoint-validation/src/spec/list.ts
@@ -119,18 +119,7 @@ export function listTests<T extends BaseCheckpointSaver>(
         } else {
           expect(actualTuplesMap.size).toEqual(expectedTuplesMap.size);
           for (const [key, value] of actualTuplesMap.entries()) {
-            // TODO: MongoDBSaver doesn't return pendingWrites on list, so we need to special case them
-            // see: https://github.com/langchain-ai/langgraphjs/issues/589
-            const checkpointerIncludesPendingWritesOnList =
-              initializer.checkpointerName !==
-              "@langchain/langgraph-checkpoint-mongodb";
-
-            const expectedTuple = expectedTuplesMap.get(key);
-            if (!checkpointerIncludesPendingWritesOnList) {
-              delete expectedTuple?.pendingWrites;
-            }
-
-            expect(value).toEqual(expectedTuple);
+            expect(value).toEqual(expectedTuplesMap.get(key));
           }
         }
       }


### PR DESCRIPTION
## Summary

Fixes #2205
Fixes #589

`MongoDBSaver.list()` does not query or return `pendingWrites` in the yielded `CheckpointTuple` objects. This is inconsistent with `getTuple()` (which correctly queries the writes collection) and with other checkpointer implementations like Postgres.

## Fix

Added the same `pendingWrites` query from `getTuple()` into `list()`, ensuring each yielded checkpoint tuple includes its pending writes.

## Test Plan

- Store checkpoints with pending writes via MongoDBSaver
- Call `list()` and verify `pendingWrites` are populated
- Compare with `getTuple()` output to confirm consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)