### PR TITLE
fix(redis): use correct key prefix in deleteThread() to clean up writes

### DIFF
--- a/libs/checkpoint-redis/src/index.ts
+++ b/libs/checkpoint-redis/src/index.ts
@@ -675,8 +675,6 @@ export class RedisSaver extends BaseCheckpointSaver {
   async deleteThread(threadId: string): Promise<void> {
     // Delete checkpoints
     const checkpointPattern = `checkpoint:${threadId}:*`;
-    // Use scan for better performance and cluster compatibility
-    // Use keys for simplicity - scan would be better for large datasets
     const checkpointKeys = await (this.client as any).keys(checkpointPattern);
 
     if (checkpointKeys.length > 0) {
@@ -684,13 +682,19 @@ export class RedisSaver extends BaseCheckpointSaver {
     }
 
     // Delete writes
-    const writesPattern = `writes:${threadId}:*`;
-    // Use scan for better performance and cluster compatibility
-    // Use keys for simplicity - scan would be better for large datasets
+    const writesPattern = `checkpoint_write:${threadId}:*`;
     const writesKeys = await (this.client as any).keys(writesPattern);
 
     if (writesKeys.length > 0) {
       await this.client.del(writesKeys);
+    }
+
+    // Delete write registries
+    const zsetPattern = `${WRITE_KEYS_ZSET_PREFIX}:${threadId}:*`;
+    const zsetKeys = await (this.client as any).keys(zsetPattern);
+
+    if (zsetKeys.length > 0) {
+      await this.client.del(zsetKeys);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #2207

`RedisSaver.deleteThread()` uses the wrong key pattern (`writes:`) to find checkpoint writes, but writes are stored with the `checkpoint_write:` prefix. Additionally, it doesn't clean up `write_keys_zset:` entries. This causes orphaned keys and memory leaks in Redis.

## Root Cause

Key pattern mismatch between `putWrites()` (stores with `checkpoint_write:` prefix) and `deleteThread()` (scans with `writes:` prefix).

## Fix

- Changed `writes:${threadId}:*` to `checkpoint_write:${threadId}:*`
- Added `write_keys_zset:` cleanup matching the correct implementation in `ShallowRedisSaver`

The correct pattern already exists in `shallow.ts` L474-487 -- this PR aligns `RedisSaver` with `ShallowRedisSaver`.

## Test Plan

- Store checkpoints and writes for a thread via RedisSaver
- Call deleteThread()
- Before: checkpoint_write:* and write_keys_zset:* keys remain orphaned
- After: all keys for the thread are correctly deleted

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>