### PR TITLE
fix(sdk): expose `toolCalls` and `getToolCalls` on `BaseStream` for all `useStream` usages

### DIFF
--- a/libs/sdk/src/tests/stream-types.test-d.ts
+++ b/libs/sdk/src/tests/stream-types.test-d.ts
@@ -1,6 +1,10 @@
 import { describe, test, expectTypeOf } from "vitest";
 import type { BaseMessage } from "@langchain/core/messages";
-import type { Message } from "../types.messages.js";
+import type {
+  Message,
+  DefaultToolCall,
+  ToolCallWithResult,
+} from "../types.messages.js";
 import type { ThreadState } from "../schema.js";
 import type { BagTemplate } from "../types.template.js";
 import type { BaseStream, ResolveStreamInterface } from "../ui/stream/index.js";
@@ -26,6 +30,27 @@ describe("ResolveStreamInterface resolves plain state types to BaseStream", () =
       BagTemplate
     >;
     expectTypeOf<Resolved>().toExtend<BaseStream<Record<string, unknown>>>();
+  });
+
+  test("BaseStream exposes toolCalls for plain state types", () => {
+    type GeneratorState = {
+      messages: Message[];
+    };
+
+    type Resolved = ResolveStreamInterface<GeneratorState, BagTemplate>;
+    expectTypeOf<Resolved>().toHaveProperty("toolCalls");
+    expectTypeOf<Resolved["toolCalls"]>().toEqualTypeOf<
+      ToolCallWithResult<DefaultToolCall>[]
+    >();
+  });
+
+  test("BaseStream exposes getToolCalls for plain state types", () => {
+    type GeneratorState = {
+      messages: Message[];
+    };
+
+    type Resolved = ResolveStreamInterface<GeneratorState, BagTemplate>;
+    expectTypeOf<Resolved>().toHaveProperty("getToolCalls");
   });
 });
 

--- a/libs/sdk/src/ui/stream/agent.ts
+++ b/libs/sdk/src/ui/stream/agent.ts
@@ -7,11 +7,7 @@
  * @module
  */
 
-import type {
-  DefaultToolCall,
-  AIMessage,
-  ToolCallWithResult,
-} from "../../types.messages.js";
+import type { DefaultToolCall } from "../../types.messages.js";
 import type { BagTemplate } from "../../types.template.js";
 import type { BaseStream } from "./base.js";
 import type { UseStreamOptions } from "../types.js";
@@ -75,10 +71,7 @@ import type { UseStreamOptions } from "../types.js";
  * ```
  *
  * @remarks
- * This interface adds tool calling on top of {@link UseGraphStream}:
- * - `toolCalls` - Array of tool calls paired with their results
- * - `getToolCalls(message)` - Get tool calls for a specific AI message
- *
+ * This interface extends {@link BaseStream} with typed tool calls (inherited from BaseStream).
  * It does NOT include subagent streaming features. For those, use
  * {@link UseDeepAgentStream} with `createDeepAgent`.
  */
@@ -86,55 +79,7 @@ export interface UseAgentStream<
   StateType extends Record<string, unknown> = Record<string, unknown>,
   ToolCall = DefaultToolCall,
   Bag extends BagTemplate = BagTemplate,
-> extends BaseStream<StateType, ToolCall, Bag> {
-  /**
-   * Tool calls paired with their results.
-   *
-   * Each entry contains the tool call request and its corresponding result.
-   * Useful for rendering tool invocations and their outputs together.
-   *
-   * @example
-   * ```typescript
-   * stream.toolCalls.map(({ call, result }) => (
-   *   <ToolCallCard
-   *     name={call.name}
-   *     args={call.args}
-   *     result={result}
-   *   />
-   * ));
-   * ```
-   */
-  toolCalls: ToolCallWithResult<ToolCall>[];
-
-  /**
-   * Get tool calls for a specific AI message.
-   *
-   * Use this to find which tool calls were initiated by a particular
-   * assistant message, useful for rendering tool calls inline with messages.
-   *
-   * @param message - The AI message to get tool calls for
-   * @returns Array of tool calls initiated by the message
-   *
-   * @example
-   * ```typescript
-   * messages.map(message => {
-   *   if (message.type === "ai") {
-   *     const calls = stream.getToolCalls(message);
-   *     return (
-   *       <>
-   *         <MessageBubble message={message} />
-   *         {calls.map(tc => <ToolCallCard key={tc.call.id} {...tc} />)}
-   *       </>
-   *     );
-   *   }
-   *   return <MessageBubble message={message} />;
-   * });
-   * ```
-   */
-  getToolCalls: (
-    message: AIMessage<ToolCall>
-  ) => ToolCallWithResult<ToolCall>[];
-}
+> extends BaseStream<StateType, ToolCall, Bag> {}
 
 /**
  * Options for configuring an agent stream.

--- a/libs/sdk/src/ui/stream/base.ts
+++ b/libs/sdk/src/ui/stream/base.ts
@@ -11,7 +11,12 @@ import type { Client } from "../../client.js";
 import type { ThreadState, Interrupt } from "../../schema.js";
 import type { StreamMode, ToolProgress } from "../../types.stream.js";
 import type { StreamEvent } from "../../types.js";
-import type { Message, DefaultToolCall } from "../../types.messages.js";
+import type {
+  Message,
+  DefaultToolCall,
+  AIMessage,
+  ToolCallWithResult,
+} from "../../types.messages.js";
 import type { BagTemplate } from "../../types.template.js";
 import type { Sequence } from "../branching.js";
 import type {
@@ -113,7 +118,7 @@ export interface BaseStream<
    */
   submit: (
     values: GetUpdateType<Bag, StateType> | null | undefined,
-    options?: SubmitOptions<StateType, GetConfigurableType<Bag>>
+    options?: SubmitOptions<StateType, GetConfigurableType<Bag>>,
   ) => Promise<void>;
 
   /**
@@ -150,7 +155,7 @@ export interface BaseStream<
    */
   getMessagesMetadata: (
     message: Message<ToolCall>,
-    index?: number
+    index?: number,
   ) => MessageMetadata<StateType> | undefined;
 
   /**
@@ -186,7 +191,7 @@ export interface BaseStream<
         event: StreamEvent;
         data: unknown;
       }) => boolean;
-    }
+    },
   ) => Promise<void>;
 
   /**
@@ -203,6 +208,54 @@ export interface BaseStream<
     StateType,
     SubmitOptions<StateType, GetConfigurableType<Bag>>
   >;
+
+  /**
+   * Tool calls paired with their results.
+   *
+   * Each entry contains the tool call request and its corresponding result.
+   * Useful for rendering tool invocations and their outputs together.
+   *
+   * @example
+   * ```typescript
+   * stream.toolCalls.map(({ call, result }) => (
+   *   <ToolCallCard
+   *     name={call.name}
+   *     args={call.args}
+   *     result={result}
+   *   />
+   * ));
+   * ```
+   */
+  toolCalls: ToolCallWithResult<ToolCall>[];
+
+  /**
+   * Get tool calls for a specific AI message.
+   *
+   * Use this to find which tool calls were initiated by a particular
+   * assistant message, useful for rendering tool calls inline with messages.
+   *
+   * @param message - The AI message to get tool calls for
+   * @returns Array of tool calls initiated by the message
+   *
+   * @example
+   * ```typescript
+   * messages.map(message => {
+   *   if (message.type === "ai") {
+   *     const calls = stream.getToolCalls(message);
+   *     return (
+   *       <>
+   *         <MessageBubble message={message} />
+   *         {calls.map(tc => <ToolCallCard key={tc.call.id} {...tc} />)}
+   *       </>
+   *     );
+   *   }
+   *   return <MessageBubble message={message} />;
+   * });
+   * ```
+   */
+  getToolCalls: (
+    message: AIMessage<ToolCall>,
+  ) => ToolCallWithResult<ToolCall>[];
 }
 
 // Note: BaseStreamOptions is not defined here - we use UseStreamOptions from types.ts

--- a/libs/sdk/src/ui/stream/index.ts
+++ b/libs/sdk/src/ui/stream/index.ts
@@ -169,8 +169,7 @@ export type InferSubagentStates<T> = T extends { "~deepAgentTypes": unknown }
  *    - Excludes: subagents, getSubagentsByType
  *
  * 3. **CompiledGraph** / **Default** → {@link BaseStream}
- *    - Includes: values, messages, submit, stop
- *    - Does NOT include: toolCalls, subagents (not applicable to raw graphs)
+ *    - Includes: values, messages, toolCalls, getToolCalls, submit, stop
  *
  * @template T - The agent or graph type (use `typeof agent` or `typeof graph`)
  * @template Bag - Type configuration bag for interrupts, configurable, etc.


### PR DESCRIPTION
Thank you for contributing to LangGraph.js! Your PR will appear in our next release under the title you set above.

## Problem

When users call `useStream<AgentState>` with a plain TypeScript interface (e.g. `interface AgentState { messages: BaseMessage[] }`), the returned object does **not** expose `toolCalls` or `getToolCalls`. But the docs show these properties as available and they do work when using `useStream<typeof myAgent>`.

Root cause: `toolCalls` and `getToolCalls` were only defined on `UseAgentStream`, which is the return type when using `useStream<typeof myAgent>` (a compiled `createAgent` result). When users pass a plain interface, `ResolveStreamInterface<T>` resolves to `BaseStream` — which was missing those properties despite them being **implemented at runtime** in both `stream.lgp.tsx` and `stream.custom.tsx`.

## Fix

Move `toolCalls` and `getToolCalls` from `UseAgentStream` to `BaseStream` so they are available for all `useStream<T>` usages.

## Changes

- **`libs/sdk/src/ui/stream/base.ts`**: Added `AIMessage` and `ToolCallWithResult` to imports; added `toolCalls: ToolCallWithResult<ToolCall>[]` and `getToolCalls(message)` to `BaseStream<StateType, ToolCall, Bag>`.
- **`libs/sdk/src/ui/stream/agent.ts`**: Removed now-duplicate `toolCalls`/`getToolCalls` from `UseAgentStream` (now inherited from `BaseStream`) and cleaned up unused imports.
- **`libs/sdk/src/ui/stream/index.ts`**: Updated `ResolveStreamInterface` docstring that incorrectly stated `BaseStream` does NOT include `toolCalls`.
- **`libs/sdk/src/tests/stream-types.test-d.ts`**: Added two type regression tests confirming `toolCalls` and `getToolCalls` are present on plain-state-type streams.

## Testing

All 298 existing tests pass. Two new type-level tests added.

Fixes langchain-ai/langchainjs#10483