### PR TITLE
fix(sdk): buffer subagent messages instead of dropping them

### DIFF
--- a/.changeset/fuzzy-emus-doubt.md
+++ b/.changeset/fuzzy-emus-doubt.md
@@ -1,0 +1,9 @@
+---
+"@langchain/langgraph-sdk": patch
+"@langchain/react": patch
+"@langchain/vue": patch
+"@langchain/svelte": patch
+"@langchain/angular": patch
+---
+
+fix(sdk): buffer subagent messages instead of dropping them

--- a/libs/sdk/src/ui/manager.test.ts
+++ b/libs/sdk/src/ui/manager.test.ts
@@ -1213,6 +1213,47 @@ describe("StreamManager", () => {
       expect(subagents).toHaveLength(1);
       expect(subagents[0]?.status).toBe("pending");
     });
+
+    it("replays buffered subagent messages after namespace matching", () => {
+      const mgr = new SubagentManager({
+        subagentToolNames: ["task"],
+      });
+
+      mgr.registerFromToolCalls(toolCalls, "msg-1");
+
+      mgr.addMessageToSubagent(
+        "pregel-task-1",
+        {
+          id: "sub-ai-1",
+          type: "ai",
+          content: "",
+          tool_calls: [
+            {
+              id: "search-1",
+              name: "search_web",
+              args: { query: "AI trends" },
+            },
+          ],
+        },
+        undefined
+      );
+
+      expect(mgr.getSubagent("call_1")?.toolCalls).toHaveLength(0);
+
+      mgr.addMessageToSubagent(
+        "pregel-task-1",
+        {
+          id: "sub-human-1",
+          type: "human",
+          content: "Research AI trends",
+        },
+        undefined
+      );
+
+      const subagent = mgr.getSubagent("call_1");
+      expect(subagent?.toolCalls).toHaveLength(1);
+      expect(subagent?.toolCalls[0]?.call.name).toBe("search_web");
+    });
   });
 
   describe("SubagentManager aiMessageId update (OpenAI ID replacement)", () => {

--- a/libs/sdk/src/ui/subagents.ts
+++ b/libs/sdk/src/ui/subagents.ts
@@ -168,6 +168,19 @@ export class SubagentManager<ToolCall = DefaultToolCall> {
   private pendingMatches = new Map<string, string>(); // namespaceId -> description
 
   /**
+   * Messages received before we can map a subgraph namespace to the public
+   * subagent tool-call ID. Once the mapping is established, these messages are
+   * replayed so early tool calls are not lost.
+   */
+  private pendingMessages = new Map<
+    string,
+    Array<{
+      serialized: Message<DefaultToolCall>;
+      metadata?: Record<string, unknown>;
+    }>
+  >();
+
+  /**
    * Message managers for each subagent.
    * Uses the same MessageTupleManager as the main stream for proper
    * message chunk concatenation.
@@ -215,6 +228,33 @@ export class SubagentManager<ToolCall = DefaultToolCall> {
       }
     }
     return messages;
+  }
+
+  /**
+   * Buffer a subagent message until we can resolve its namespace to a tool call.
+   */
+  private queuePendingMessage(
+    namespaceId: string,
+    serialized: Message<DefaultToolCall>,
+    metadata?: Record<string, unknown>
+  ) {
+    const pending = this.pendingMessages.get(namespaceId) ?? [];
+    pending.push({ serialized, metadata });
+    this.pendingMessages.set(namespaceId, pending);
+  }
+
+  /**
+   * Replay any buffered messages once a namespace has been mapped.
+   */
+  private flushPendingMessages(namespaceId: string) {
+    const pending = this.pendingMessages.get(namespaceId);
+    if (!pending?.length)
+      return;
+
+    this.pendingMessages.delete(namespaceId);
+    pending.forEach(({ serialized, metadata }) => {
+      this.addMessageToSubagent(namespaceId, serialized, metadata);
+    });
   }
 
   /**
@@ -308,6 +348,7 @@ export class SubagentManager<ToolCall = DefaultToolCall> {
         });
         this.onSubagentChange?.();
       }
+      this.flushPendingMessages(namespaceId);
       return toolCallId;
     };
 
@@ -616,6 +657,7 @@ export class SubagentManager<ToolCall = DefaultToolCall> {
       this.subagents.set(toolCall.id, execution);
       // Create a message manager for this subagent
       this.getMessageManager(toolCall.id);
+      this.flushPendingMessages(toolCall.id);
       hasChanges = true;
     }
 
@@ -720,10 +762,10 @@ export class SubagentManager<ToolCall = DefaultToolCall> {
     const existing = this.subagents.get(toolCallId);
 
     // If we still don't have a match, the mapping hasn't been established yet.
-    // Don't create a placeholder - just skip this message.
-    // The values event will establish the mapping, and subsequent messages
-    // will be routed correctly.
+    // Buffer the message so early AI/tool-call chunks are replayed once the
+    // values event or a later human message establishes the mapping.
     if (!existing) {
+      this.queuePendingMessage(namespaceId, serialized, metadata);
       return;
     }
 
@@ -822,6 +864,7 @@ export class SubagentManager<ToolCall = DefaultToolCall> {
     this.namespaceToToolCallId.clear();
     this.messageManagers.clear();
     this.pendingMatches.clear();
+    this.pendingMessages.clear();
     this.onSubagentChange?.();
   }
 

--- a/libs/sdk/src/ui/subagents.ts
+++ b/libs/sdk/src/ui/subagents.ts
@@ -248,8 +248,7 @@ export class SubagentManager<ToolCall = DefaultToolCall> {
    */
   private flushPendingMessages(namespaceId: string) {
     const pending = this.pendingMessages.get(namespaceId);
-    if (!pending?.length)
-      return;
+    if (!pending?.length) return;
 
     this.pendingMessages.delete(namespaceId);
     pending.forEach(({ serialized, metadata }) => {


### PR DESCRIPTION
- buffer subagent messages that arrive before a subgraph namespace has been matched to its public tool-call ID
- replay those buffered messages once the mapping is established so retained subagent summaries correctly surface latest tool calls, args, and derived file activity
- add a regression test covering the case where an internal subagent AI message with tool calls arrives before the matching human message/namespace resolution
