### PR TITLE
Prevent values from getting overrwritten on interrupt event

### DIFF
--- a/.changeset/soft-kings-burn.md
+++ b/.changeset/soft-kings-burn.md
@@ -1,0 +1,8 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): preserve messages on interrupt values events
+
+Add a regression test for interrupt-only `values` payloads to ensure
+previously streamed messages are not overwritten when `__interrupt__` is emitted.

--- a/libs/sdk/src/ui/manager.test.ts
+++ b/libs/sdk/src/ui/manager.test.ts
@@ -536,6 +536,52 @@ describe("StreamManager", () => {
       expect(values.__interrupt__[0].id).toBe("int-A");
     });
 
+    it("should not overwrite existing messages with interrupt-only values payloads", async () => {
+      const events = [
+        {
+          event: "values" as const,
+          data: {
+            messages: [{ id: "m-1", content: "hello", type: "human" }],
+          } as unknown as TestState,
+        },
+        {
+          event: "values" as const,
+          data: {
+            __interrupt__: [{ id: "int-A", value: "approve?" }],
+            messages: [],
+          } as unknown as TestState,
+        },
+      ];
+
+      const action = async () => createMockStream(events);
+      const onError = vi.fn();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (streamManager as any).enqueue(action, {
+        getMessages: (values: TestState) => values.messages ?? [],
+        setMessages: (current: TestState, messages: TestState["messages"]) => ({
+          ...current,
+          messages,
+        }),
+        initialValues: { messages: [] },
+        callbacks: {},
+        onSuccess: () => undefined,
+        onError,
+      });
+
+      expect(onError).not.toHaveBeenCalled();
+
+      const values = streamManager.values as unknown as {
+        __interrupt__: Array<{ id: string; value: string }>;
+        messages: Array<{ id: string; content: string }>;
+      };
+      expect(values.__interrupt__).toHaveLength(1);
+      expect(values.__interrupt__[0].id).toBe("int-A");
+      expect(values.messages).toHaveLength(1);
+      expect(values.messages[0].id).toBe("m-1");
+      expect(values.messages[0].content).toBe("hello");
+    });
+
     it("should clear stale __interrupt__ on new stream and show only remaining", async () => {
       // First stream: two parallel interrupts
       const firstStreamEvents = [

--- a/libs/sdk/src/ui/manager.ts
+++ b/libs/sdk/src/ui/manager.ts
@@ -951,7 +951,6 @@ export class StreamManager<
 
                 return {
                   ...prev,
-                  ...interruptData,
                   __interrupt__: interrupts,
                 } as unknown as StateType;
               });


### PR DESCRIPTION
Issue:

In multi-agent sustem with handoffs like this example: https://docs.langchain.com/oss/python/langchain/multi-agent/handoffs#multiple-agent-subgraphs, if we trigger an interrupt from an agent within a swarm workflow, the interrupt is propagated and sent twice, the last interrupt contains values from the main graphs state, which is always going to be behind the state of the agent from where interrupt is triggered. So, temporarily, the message data becomes empty, it gets refilled when interrupt is resumed

Fixes:

Do not update values when interrupt is recieved, just update the interrupt in the state with the latest __interrupt data.


