### PR TITLE
chore(langgraph): include system ids in metadata

### DIFF
--- a/libs/langgraph-core/src/pregel/messages.test.ts
+++ b/libs/langgraph-core/src/pregel/messages.test.ts
@@ -143,8 +143,94 @@ describe("StreamMessagesHandler", () => {
 
       expect(handler.metadatas[runId]).toEqual([
         ["ns1", "ns2"],
-        { tags: [], name: "ModelName", ...metadata },
+        {
+          tags: [],
+          name: "ModelName",
+          ...metadata,
+          // checkpoint_ns is added as backwards-compat key
+          checkpoint_ns: "ns1|ns2",
+        },
       ]);
+    });
+
+    it("should strip task ID suffix from checkpoint_ns in stream metadata", () => {
+      const handler = new StreamMessagesHandler(vi.fn());
+
+      const runId = "run-456";
+      const metadata = {
+        langgraph_checkpoint_ns: "agent:abc123-uuid",
+        other_meta: "value",
+      };
+
+      handler.handleChatModelStart(
+        {} as Serialized,
+        [],
+        runId,
+        undefined,
+        {},
+        [],
+        metadata,
+        "ModelName"
+      );
+
+      const storedMeta = handler.metadatas[runId]!;
+      // Namespace array uses the full task checkpoint ns
+      expect(storedMeta[0]).toEqual(["agent:abc123-uuid"]);
+      // Stream metadata should have checkpoint_ns stripped of task ID
+      expect(storedMeta[1].langgraph_checkpoint_ns).toBe("agent:");
+      // Backwards-compatible checkpoint_ns key
+      expect(storedMeta[1].checkpoint_ns).toBe("agent:");
+    });
+
+    it("should preserve checkpoint_ns when no CHECKPOINT_NAMESPACE_END present", () => {
+      const handler = new StreamMessagesHandler(vi.fn());
+
+      const runId = "run-789";
+      const metadata = {
+        langgraph_checkpoint_ns: "simple-ns",
+        other_meta: "value",
+      };
+
+      handler.handleChatModelStart(
+        {} as Serialized,
+        [],
+        runId,
+        undefined,
+        {},
+        [],
+        metadata,
+        "ModelName"
+      );
+
+      const storedMeta = handler.metadatas[runId]!;
+      expect(storedMeta[1].langgraph_checkpoint_ns).toBe("simple-ns");
+    });
+
+    it("should not overwrite existing checkpoint_ns in metadata", () => {
+      const handler = new StreamMessagesHandler(vi.fn());
+
+      const runId = "run-999";
+      const metadata = {
+        langgraph_checkpoint_ns: "agent:abc123-uuid",
+        checkpoint_ns: "original-ns",
+      };
+
+      handler.handleChatModelStart(
+        {} as Serialized,
+        [],
+        runId,
+        undefined,
+        {},
+        [],
+        metadata,
+        "ModelName"
+      );
+
+      const storedMeta = handler.metadatas[runId]!;
+      // Existing checkpoint_ns should be preserved
+      expect(storedMeta[1].checkpoint_ns).toBe("original-ns");
+      // But langgraph_checkpoint_ns should still be updated
+      expect(storedMeta[1].langgraph_checkpoint_ns).toBe("agent:");
     });
 
     it("should not store metadata when TAG_NOSTREAM is present", () => {

--- a/libs/langgraph-core/src/pregel/messages.ts
+++ b/libs/langgraph-core/src/pregel/messages.ts
@@ -18,7 +18,12 @@ import {
 } from "@langchain/core/outputs";
 import { ChainValues } from "@langchain/core/utils/types";
 
-import { TAG_HIDDEN, TAG_NOSTREAM } from "../constants.js";
+import {
+  CHECKPOINT_NAMESPACE_END,
+  CHECKPOINT_NAMESPACE_SEPARATOR,
+  TAG_HIDDEN,
+  TAG_NOSTREAM,
+} from "../constants.js";
 import { StreamChunk } from "./stream.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -115,9 +120,28 @@ export class StreamMessagesHandler extends BaseCallbackHandler {
       // Include legacy LangGraph SDK tag
       (!tags || (!tags.includes(TAG_NOSTREAM) && !tags.includes("nostream")))
     ) {
+      const taskCheckpointNs = metadata.langgraph_checkpoint_ns as string;
+      // Strip the task ID suffix to get the canonical checkpoint namespace.
+      const lastEnd = taskCheckpointNs.lastIndexOf(CHECKPOINT_NAMESPACE_END);
+      const checkpointNs =
+        lastEnd !== -1
+          ? `${taskCheckpointNs.substring(0, lastEnd)}${CHECKPOINT_NAMESPACE_END}`
+          : taskCheckpointNs;
+
+      const streamMetadata: Record<string, unknown> = {
+        tags,
+        name,
+        ...metadata,
+        langgraph_checkpoint_ns: checkpointNs,
+      };
+      // Preserve backwards-compatible streamed checkpoint metadata shape.
+      if (!("checkpoint_ns" in streamMetadata)) {
+        streamMetadata.checkpoint_ns = checkpointNs;
+      }
+
       this.metadatas[runId] = [
-        (metadata.langgraph_checkpoint_ns as string).split("|"),
-        { tags, name, ...metadata },
+        taskCheckpointNs.split(CHECKPOINT_NAMESPACE_SEPARATOR),
+        streamMetadata,
       ];
     }
   }

--- a/libs/langgraph-core/src/pregel/utils/config.test.ts
+++ b/libs/langgraph-core/src/pregel/utils/config.test.ts
@@ -67,10 +67,11 @@ describe("ensureLangGraphConfig", () => {
 
     const result = ensureLangGraphConfig(config1, config2);
 
-    // The implementation completely replaces objects rather than merging them
+    // The implementation completely replaces objects rather than merging them.
+    // Only allowlisted configurable keys are propagated to metadata.
     expect(result).toEqual({
       tags: ["tag2"],
-      metadata: { key2: "value2", option2: "value2" },
+      metadata: { key2: "value2" },
       callbacks: undefined,
       recursionLimit: 25,
       configurable: { option2: "value2" },
@@ -93,9 +94,9 @@ describe("ensureLangGraphConfig", () => {
     const result = ensureLangGraphConfig();
 
     expect(result.tags).toEqual(["storage-tag"]);
+    // Only allowlisted keys from configurable are copied to metadata
     expect(result.metadata || {}).toEqual({
       storage: "value",
-      storageOption: "value",
     });
     expect(result.configurable).toEqual({ storageOption: "value" });
     expect(result.callbacks).toEqual({ type: "copied-callback" });
@@ -118,16 +119,27 @@ describe("ensureLangGraphConfig", () => {
     expect(result.metadata).toEqual({});
   });
 
-  it("should copy scalar values to metadata from configurable", () => {
+  it("should only copy allowlisted configurable keys to metadata", () => {
     AsyncLocalStorageProviderSingleton.getRunnableConfig = vi
       .fn()
       .mockReturnValue(undefined);
 
     const config = {
       configurable: {
-        stringValue: "string",
-        numberValue: 42,
-        booleanValue: true,
+        thread_id: "th-123",
+        checkpoint_id: "ckpt-1",
+        checkpoint_ns: "ns-1",
+        task_id: "task-1",
+        run_id: "run-456",
+        assistant_id: "asst-789",
+        graph_id: "graph-0",
+        cron_id: "cron-1",
+        // These should NOT be copied to metadata
+        model: "gpt-4o",
+        user_id: "uid-1",
+        langgraph_auth_user_id: "user-1",
+        some_api_key: "secret",
+        custom_setting: 42,
         objectValue: { should: "not be copied" },
         __privateValue: "should not be copied",
       },
@@ -136,10 +148,14 @@ describe("ensureLangGraphConfig", () => {
     const result = ensureLangGraphConfig(config);
 
     expect(result.metadata).toEqual({
-      stringValue: "string",
-      numberValue: 42,
-      booleanValue: true,
-      // objectValue and __privateValue should not be copied
+      thread_id: "th-123",
+      checkpoint_id: "ckpt-1",
+      checkpoint_ns: "ns-1",
+      task_id: "task-1",
+      run_id: "run-456",
+      assistant_id: "asst-789",
+      graph_id: "graph-0",
+      cron_id: "cron-1",
     });
   });
 
@@ -149,15 +165,87 @@ describe("ensureLangGraphConfig", () => {
       .mockReturnValue(undefined);
 
     const config = {
-      metadata: { key: "original value" },
+      metadata: { thread_id: "original value" },
       configurable: {
-        key: "should not overwrite",
+        thread_id: "should not overwrite",
       },
     };
 
     const result = ensureLangGraphConfig(config);
 
-    expect(result.metadata?.key).toEqual("original value");
+    expect(result.metadata?.thread_id).toEqual("original value");
+  });
+
+  it("should propagate all allowlisted configurable keys to metadata", () => {
+    AsyncLocalStorageProviderSingleton.getRunnableConfig = vi
+      .fn()
+      .mockReturnValue(undefined);
+
+    const config = {
+      configurable: {
+        thread_id: "th-123",
+        checkpoint_id: "ckpt-1",
+        checkpoint_ns: "ns-1",
+        task_id: "task-1",
+        run_id: "run-456",
+        assistant_id: "asst-789",
+        graph_id: "graph-0",
+        cron_id: "cron-1",
+        // non-allowlisted keys
+        model: "gpt-4o",
+        user_id: "uid-1",
+        langgraph_auth_user_id: "user-1",
+        some_api_key: "secret",
+        custom_setting: { nested: true },
+      },
+      metadata: { nooverride: 18 },
+    };
+
+    const result = ensureLangGraphConfig(config);
+
+    // Allowlisted keys should be in metadata
+    expect(result.metadata).toEqual({
+      nooverride: 18,
+      thread_id: "th-123",
+      checkpoint_id: "ckpt-1",
+      checkpoint_ns: "ns-1",
+      task_id: "task-1",
+      run_id: "run-456",
+      assistant_id: "asst-789",
+      graph_id: "graph-0",
+      cron_id: "cron-1",
+    });
+
+    // Non-allowlisted keys should NOT appear
+    expect(result.metadata).not.toHaveProperty("model");
+    expect(result.metadata).not.toHaveProperty("user_id");
+    expect(result.metadata).not.toHaveProperty("langgraph_auth_user_id");
+    expect(result.metadata).not.toHaveProperty("some_api_key");
+    expect(result.metadata).not.toHaveProperty("custom_setting");
+  });
+
+  it("should not overwrite metadata with allowlisted configurable keys", () => {
+    AsyncLocalStorageProviderSingleton.getRunnableConfig = vi
+      .fn()
+      .mockReturnValue(undefined);
+
+    const config = {
+      configurable: {
+        thread_id: "from-configurable",
+        run_id: "from-configurable",
+      },
+      metadata: {
+        thread_id: "from-metadata",
+        run_id: "from-metadata",
+      },
+    };
+
+    const result = ensureLangGraphConfig(config);
+
+    expect(result.metadata).toEqual({
+      thread_id: "from-metadata",
+      run_id: "from-metadata",
+    });
   });
 });
 

--- a/libs/langgraph-core/src/pregel/utils/config.ts
+++ b/libs/langgraph-core/src/pregel/utils/config.ts
@@ -89,21 +89,38 @@ export function ensureLangGraphConfig(
     }
   }
 
-  for (const [key, value] of Object.entries(empty.configurable!)) {
-    empty.metadata = empty.metadata ?? {};
-    if (
-      !key.startsWith("__") &&
-      (typeof value === "string" ||
-        typeof value === "number" ||
-        typeof value === "boolean") &&
-      !(key in empty.metadata!)
-    ) {
-      empty.metadata[key] = value;
+  const configurable = empty.configurable;
+  const metadata = empty.metadata;
+  if (configurable && metadata != null) {
+    for (const key of PROPAGATE_TO_METADATA) {
+      if (key in metadata) {
+        continue;
+      }
+      const value = configurable[key];
+      if (value) {
+        metadata[key] = value;
+      }
     }
   }
 
   return empty;
 }
+
+/**
+ * Configurable keys that should be propagated to user-visible metadata
+ * (e.g. streamed with messages). Only string values are copied, and
+ * existing metadata keys are never overwritten.
+ */
+const PROPAGATE_TO_METADATA = new Set([
+  "thread_id",
+  "checkpoint_id",
+  "checkpoint_ns",
+  "task_id",
+  "run_id",
+  "assistant_id",
+  "graph_id",
+  "cron_id",
+]);
 
 /**
  * A helper utility function that returns the {@link BaseStore} that was set when the graph was initialized


### PR DESCRIPTION
## Summary

Port of [langchain-ai/langgraph#7383](https://github.com/langchain-ai/langgraph/pull/7383). Depends on [langchain-ai/langchainjs#10680](https://github.com/langchain-ai/langchainjs/pull/10680) for the `@langchain/core` tracer-level metadata changes.

Replaces the blanket "copy all configurable primitives to metadata" behavior in `ensureLangGraphConfig` with an explicit allowlist of system IDs. This prevents arbitrary configurable keys (API keys, custom settings, nested objects) from leaking into user-visible streamed metadata, while ensuring important identifiers like `thread_id`, `run_id`, and `checkpoint_ns` are always present.

Keys that should only appear in LangSmith traces (e.g. `user_id`, `langgraph_auth_user_id`) are no longer copied to metadata here — they are instead handled at the `@langchain/core` tracer level via `applyConfigurableMetadataToTracers` (from the companion langchainjs PR).

## Changes

### `@langchain/langgraph`

**`pregel/utils/config.ts`** — `ensureLangGraphConfig` now uses a `PROPAGATE_TO_METADATA` allowlist (`thread_id`, `checkpoint_id`, `checkpoint_ns`, `task_id`, `run_id`, `assistant_id`, `graph_id`, `cron_id`) instead of copying every primitive from `configurable` to `metadata`. Non-allowlisted keys remain in `configurable` only.

**`pregel/messages.ts`** — `handleChatModelStart` now strips the task UUID suffix from `langgraph_checkpoint_ns` before storing stream metadata. Creates a shallow copy of metadata to avoid mutating the shared callback dict, and adds a backwards-compatible `checkpoint_ns` key.
