### PR TITLE
feat(core): add v2 in process streaming

### DIFF
--- a/examples/streaming/README.md
+++ b/examples/streaming/README.md
@@ -1,0 +1,161 @@
+# In-Process Streaming Examples
+
+Runnable examples demonstrating `graph.streamV2()` — the ergonomic in-process
+streaming API for LangGraph.
+
+## Setup
+
+```bash
+# From the monorepo root
+pnpm install
+
+# Set your API key
+export ANTHROPIC_API_KEY=sk-...
+```
+
+## Examples
+
+Each example is a self-contained script that can be run with `npx tsx`.
+
+### `basic.ts` — Protocol event iteration
+
+The simplest starting point. Iterates all `ProtocolEvent` objects from a tool-calling
+graph and awaits the final output.
+
+```bash
+npx tsx src/basic.ts
+```
+
+Shows: `for await (const event of run)`, `await run.output`
+
+### `messages.ts` — Streaming text tokens
+
+Demonstrates the `.messages` projection. Each yielded `ChatModelStream` exposes
+`.text` as both an `AsyncIterable<string>` (for token-by-token streaming) and a
+`PromiseLike<string>` (for the full text). Also shows `.usage` for token counts.
+
+```bash
+npx tsx src/messages.ts
+```
+
+Shows: `run.messages`, `message.text`, `message.usage`
+
+### `subgraphs.ts` — Recursive subgraph observation
+
+A research pipeline with two sequential subgraphs (researcher → analyst). Shows
+three ways to observe the subgraph tree:
+
+1. Flat event stream — all events, dispatched by `event.method`
+2. Subgraph discovery — `run.subgraphs` yields `SubgraphRunStream` per child
+3. Concurrent consumption — messages and subgraphs consumed in parallel
+
+```bash
+npx tsx src/subgraphs.ts
+```
+
+Shows: `run.subgraphs`, `sub.messages`, `sub.name`, `sub.index`, recursive walking
+
+### `custom-reducer.ts` — Domain-specific projections
+
+Extends `streamV2()` with a custom `StreamReducer` that counts tool calls and
+tracks token usage. The reducer is passed via the `reducers` option; its
+projections appear on `run.extensions`.
+
+```bash
+npx tsx src/custom-reducer.ts
+```
+
+Shows: `StreamReducer`, `graph.streamV2(input, { reducers: [...] })`, `run.extensions`
+
+### `parallel.ts` — Concurrent projection consumption
+
+All projections on `GraphRunStream` share the same underlying `EventLog`, so
+multiple `for await` loops can run concurrently without interference. This
+example streams messages, counts state snapshots, and counts raw protocol
+events in parallel via `Promise.all`.
+
+```bash
+npx tsx src/parallel.ts
+```
+
+Shows: `Promise.all([run.messages, run.values, run])`, independent cursors
+
+### `human-in-the-loop.ts` — Interrupt, inspect, resume
+
+Demonstrates the `streamV2()` interrupt/resume lifecycle using a planner →
+approval → executor graph. Turn 1 runs until `interrupt()` is called; the
+example inspects `run.interrupted` and `run.interrupts`, then resumes with
+`Command({ resume })` in turn 2.
+
+```bash
+npx tsx src/human-in-the-loop.ts
+```
+
+Shows: `interrupt()`, `run.interrupted`, `run.interrupts`, `Command({ resume })`, multi-turn `streamV2()`
+
+## Agents
+
+The example agents live in `src/agents/`:
+
+| Agent | File | Description |
+|-------|------|-------------|
+| Simple tool graph | `simple-tool-graph.ts` | Single ReAct loop with search + calculator |
+| Research pipeline | `research-pipeline.ts` | Two sequential subgraphs with separate tools |
+| Approval graph | `approval-graph.ts` | Planner → human approval → executor with interrupt/resume |
+
+## API Surface
+
+All examples use the `GraphRunStream` returned by `graph.streamV2()`:
+
+```typescript
+const run = await graph.streamV2(input, options?);
+
+// Iterate all protocol events
+for await (const event of run) { ... }
+
+// Stream AI messages with text/reasoning/usage projections
+for await (const msg of run.messages) {
+  for await (const token of msg.text) { process.stdout.write(token); }
+  const fullText = await msg.text;
+  const usage = await msg.usage;
+}
+
+// Observe subgraphs recursively
+for await (const sub of run.subgraphs) {
+  console.log(sub.name, sub.path);
+  for await (const msg of sub.messages) { ... }
+}
+
+// Final output
+const state = await run.output;
+
+// State snapshots per step
+for await (const snapshot of run.values) { ... }
+
+// Messages from a specific node
+for await (const msg of run.messagesFrom("agent")) { ... }
+
+// Custom reducers
+const run = await graph.streamV2(input, { reducers: [myReducer] });
+const custom = await run.extensions.myProjection;
+
+// Human-in-the-loop
+const run1 = await graph.streamV2(input, config);
+for await (const msg of run1.messages) { ... }
+await run1.output;
+if (run1.interrupted) {
+  console.log(run1.interrupts);
+  const run2 = await graph.streamV2(
+    new Command({ resume: userDecision }),
+    config
+  );
+}
+```
+
+## Coming Soon
+
+Additional examples will be added for:
+
+- `createAgent` — `AgentRunStream` with typed `run.toolCalls`
+- `createDeepAgent` — `DeepAgentRunStream` with `run.subagents`
+- Cancellation — `run.abort()`, `AbortSignal` passthrough

--- a/examples/streaming/package.json
+++ b/examples/streaming/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@examples/streaming",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "basic": "tsx src/basic.ts",
+    "messages": "tsx src/messages.ts",
+    "subgraphs": "tsx src/subgraphs.ts",
+    "custom-reducer": "tsx src/custom-reducer.ts",
+    "parallel": "tsx src/parallel.ts",
+    "hitl": "tsx src/human-in-the-loop.ts"
+  },
+  "devDependencies": {
+    "@langchain/anthropic": "^1.3.26",
+    "@langchain/core": "^1.1.39",
+    "@langchain/langgraph": "workspace:*",
+    "langchain": "^1.3.1",
+    "tsx": "^4.21.0",
+    "zod": "^4.3.6"
+  }
+}

--- a/examples/streaming/src/agents/approval-graph.ts
+++ b/examples/streaming/src/agents/approval-graph.ts
@@ -1,0 +1,94 @@
+/**
+ * Approval graph: model proposes an action, human approves or rejects.
+ *
+ * Demonstrates the `interrupt()` / `Command({ resume })` pattern with
+ * `streamV2()`. The graph has three nodes:
+ *
+ *   1. planner — model proposes an action
+ *   2. approval — calls interrupt() with the proposed action
+ *   3. executor — runs the approved action (or reports rejection)
+ */
+
+import { AIMessage, SystemMessage } from "@langchain/core/messages";
+import {
+  END,
+  interrupt,
+  MemorySaver,
+  MessagesValue,
+  ReducedValue,
+  START,
+  StateGraph,
+  StateSchema,
+} from "@langchain/langgraph";
+import { z } from "zod/v4";
+
+import { model } from "./shared.js";
+
+const GraphState = new StateSchema({
+  messages: MessagesValue,
+  proposedAction: new ReducedValue(z.string().default(() => ""), {
+    reducer: (_: string, next: string) => next,
+  }),
+  approved: new ReducedValue(z.boolean().nullable().default(() => null), {
+    reducer: (_: boolean | null, next: boolean | null) => next,
+  }),
+});
+
+type GraphStateType = typeof GraphState.State;
+
+const planner = async (state: GraphStateType) => {
+  const response = await model.invoke([
+    new SystemMessage(
+      "You are a planner. Propose a single concrete action for the user's request. " +
+        "Respond with ONLY the action description, nothing else."
+    ),
+    ...state.messages,
+  ]);
+  const action =
+    typeof response.content === "string"
+      ? response.content
+      : JSON.stringify(response.content);
+  return {
+    messages: [response],
+    proposedAction: action,
+  };
+};
+
+const approval = (_state: GraphStateType) => {
+  const decision = interrupt({
+    question: "Do you approve this action?",
+    action: _state.proposedAction,
+  }) as { approved: boolean };
+  return { approved: decision.approved };
+};
+
+const executor = async (state: GraphStateType) => {
+  if (state.approved) {
+    const response = await model.invoke([
+      new SystemMessage(
+        "The user approved the action. Confirm it has been executed. " +
+          "Keep your response to one sentence."
+      ),
+      ...state.messages,
+      { role: "user", content: `Execute: ${state.proposedAction}` },
+    ]);
+    return { messages: [response] };
+  }
+  return {
+    messages: [
+      new AIMessage("Action was rejected by the user. No changes were made."),
+    ],
+  };
+};
+
+export const checkpointer = new MemorySaver();
+
+export const graph = new StateGraph(GraphState)
+  .addNode("planner", planner)
+  .addNode("approval", approval)
+  .addNode("executor", executor)
+  .addEdge(START, "planner")
+  .addEdge("planner", "approval")
+  .addEdge("approval", "executor")
+  .addEdge("executor", END)
+  .compile({ checkpointer });

--- a/examples/streaming/src/agents/research-pipeline.ts
+++ b/examples/streaming/src/agents/research-pipeline.ts
@@ -1,0 +1,122 @@
+/**
+ * Research pipeline: researcher subgraph → analyst subgraph.
+ *
+ * Two subgraphs with separate tool sets, wired sequentially.
+ * Demonstrates how streamV2() exposes subgraph events hierarchically.
+ */
+
+import { AIMessage, SystemMessage } from "@langchain/core/messages";
+import {
+  END,
+  MessagesAnnotation,
+  START,
+  StateGraph,
+} from "@langchain/langgraph";
+import { ToolNode } from "@langchain/langgraph/prebuilt";
+import { tool } from "langchain";
+import { z } from "zod/v4";
+
+import { model, searchWeb } from "./shared.js";
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+const summarize = tool(
+  async ({ text, format }: { text: string; format: "bullets" | "prose" }) => {
+    await sleep(200);
+    const lines =
+      format === "bullets"
+        ? text
+            .split(".")
+            .filter(Boolean)
+            .map((s) => `- ${s.trim()}`)
+        : [text];
+    return JSON.stringify({ summary: lines.join("\n") });
+  },
+  {
+    name: "summarize",
+    description: "Summarize text into bullets or prose.",
+    schema: z.object({
+      text: z.string(),
+      format: z.enum(["bullets", "prose"]),
+    }),
+  }
+);
+
+const scoreRisks = tool(
+  async ({ risks }: { risks: string[] }) => {
+    await sleep(150);
+    return JSON.stringify({
+      scored: risks.map((risk, i) => ({
+        risk,
+        severity: i % 2 === 0 ? "high" : "medium",
+      })),
+    });
+  },
+  {
+    name: "score_risks",
+    description: "Score a list of risks by severity.",
+    schema: z.object({ risks: z.array(z.string()) }),
+  }
+);
+
+const researcherModel = model.bindTools([searchWeb, summarize]);
+const researcherTools = new ToolNode([searchWeb, summarize]);
+
+const researcherGraph = new StateGraph(MessagesAnnotation)
+  .addNode("researcher", async (state) => ({
+    messages: [
+      await researcherModel.invoke([
+        new SystemMessage(
+          "You are a research agent. Search for the topic, then summarize findings as bullets."
+        ),
+        ...state.messages,
+      ]),
+    ],
+  }))
+  .addNode("tools", researcherTools)
+  .addEdge(START, "researcher")
+  .addConditionalEdges(
+    "researcher",
+    (state) => {
+      const last = state.messages.at(-1) as AIMessage;
+      return last.tool_calls?.length ? "tools" : END;
+    },
+    ["tools", END]
+  )
+  .addEdge("tools", "researcher")
+  .compile();
+
+const analystModel = model.bindTools([scoreRisks]);
+const analystTools = new ToolNode([scoreRisks]);
+
+const analystGraph = new StateGraph(MessagesAnnotation)
+  .addNode("analyst", async (state) => ({
+    messages: [
+      await analystModel.invoke([
+        new SystemMessage(
+          "You are a risk analyst. Read the research, identify 3 risks, and score them."
+        ),
+        ...state.messages,
+      ]),
+    ],
+  }))
+  .addNode("tools", analystTools)
+  .addEdge(START, "analyst")
+  .addConditionalEdges(
+    "analyst",
+    (state) => {
+      const last = state.messages.at(-1) as AIMessage;
+      return last.tool_calls?.length ? "tools" : END;
+    },
+    ["tools", END]
+  )
+  .addEdge("tools", "analyst")
+  .compile();
+
+export const graph = new StateGraph(MessagesAnnotation)
+  .addNode("researcher", researcherGraph)
+  .addNode("analyst", analystGraph)
+  .addEdge(START, "researcher")
+  .addEdge("researcher", "analyst")
+  .addEdge("analyst", END)
+  .compile();

--- a/examples/streaming/src/agents/shared.ts
+++ b/examples/streaming/src/agents/shared.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared model instance and tools used across streaming examples.
+ */
+
+import { ChatAnthropic } from "@langchain/anthropic";
+import { tool } from "langchain";
+import { z } from "zod/v4";
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+export const model = new ChatAnthropic({
+  model: process.env.ANTHROPIC_MODEL ?? "claude-haiku-4-5",
+  temperature: 0,
+});
+
+export const searchWeb = tool(
+  async ({ query }: { query: string }) => {
+    await sleep(300);
+    return JSON.stringify({
+      results: [
+        { title: `Result for: ${query}`, snippet: `Found info about ${query}.` },
+      ],
+    });
+  },
+  {
+    name: "search_web",
+    description: "Search the web for information.",
+    schema: z.object({ query: z.string().describe("Search query.") }),
+  }
+);
+
+export const calculator = tool(
+  async ({ expression }: { expression: string }) => {
+    await sleep(100);
+    try {
+      return String(Function(`"use strict"; return (${expression})`)());
+    } catch {
+      return `Error evaluating: ${expression}`;
+    }
+  },
+  {
+    name: "calculator",
+    description: "Evaluate a math expression.",
+    schema: z.object({
+      expression: z.string().describe("Math expression to evaluate."),
+    }),
+  }
+);

--- a/examples/streaming/src/agents/simple-tool-graph.ts
+++ b/examples/streaming/src/agents/simple-tool-graph.ts
@@ -1,0 +1,40 @@
+/**
+ * Simple tool-calling graph: model → tools → model (loop).
+ *
+ * A single ReAct-style loop with search and calculator tools.
+ */
+
+import { AIMessage, SystemMessage } from "@langchain/core/messages";
+import {
+  END,
+  MessagesAnnotation,
+  START,
+  StateGraph,
+} from "@langchain/langgraph";
+import { ToolNode } from "@langchain/langgraph/prebuilt";
+
+import { model, searchWeb, calculator } from "./shared.js";
+
+const modelWithTools = model.bindTools([searchWeb, calculator]);
+const toolNode = new ToolNode([searchWeb, calculator]);
+
+const systemMessage = new SystemMessage(
+  "You are a helpful assistant. Use tools when needed. Keep answers concise."
+);
+
+export const graph = new StateGraph(MessagesAnnotation)
+  .addNode("agent", async (state) => ({
+    messages: [await modelWithTools.invoke([systemMessage, ...state.messages])],
+  }))
+  .addNode("tools", toolNode)
+  .addEdge(START, "agent")
+  .addConditionalEdges(
+    "agent",
+    (state) => {
+      const last = state.messages.at(-1) as AIMessage;
+      return last.tool_calls?.length ? "tools" : END;
+    },
+    ["tools", END]
+  )
+  .addEdge("tools", "agent")
+  .compile();

--- a/examples/streaming/src/basic.ts
+++ b/examples/streaming/src/basic.ts
@@ -1,0 +1,29 @@
+/**
+ * Basic streamV2() usage — iterate protocol events and await final output.
+ *
+ * Run:
+ *   ANTHROPIC_API_KEY=sk-... npx tsx src/basic.ts
+ */
+
+import { graph } from "./agents/simple-tool-graph.js";
+
+const run = await graph.streamV2({
+  messages: [{ role: "user", content: "What is 42 * 17?" }],
+});
+
+console.log("--- All protocol events ---\n");
+
+for await (const event of run) {
+  const ns = event.params.namespace;
+  const prefix = ns.length > 0 ? `[${ns.join("/")}] ` : "";
+  console.log(`${prefix}${event.method}`, JSON.stringify(event.params.data).slice(0, 120));
+}
+
+const finalState = await run.output;
+const lastMsg = finalState?.messages?.at(-1);
+console.log("\n--- Final answer ---");
+console.log(
+  typeof lastMsg?.content === "string"
+    ? lastMsg.content
+    : JSON.stringify(lastMsg?.content)
+);

--- a/examples/streaming/src/custom-reducer.ts
+++ b/examples/streaming/src/custom-reducer.ts
@@ -1,0 +1,104 @@
+/**
+ * Custom StreamReducer — extend streamV2() with domain-specific projections.
+ *
+ * Demonstrates passing a custom reducer factory via the `reducers` option.
+ * The reducer counts tool calls and tracks total token usage, exposing
+ * the results on `run.extensions`.
+ *
+ * Run:
+ *   ANTHROPIC_API_KEY=sk-... npx tsx src/custom-reducer.ts
+ */
+
+import type {
+  ProtocolEvent,
+  StreamReducer,
+  MessagesEventData,
+  ToolsEventData,
+} from "@langchain/langgraph";
+import { graph } from "./agents/simple-tool-graph.js";
+
+/**
+ * A reducer that counts tool invocations and tracks token usage.
+ * Returned projections are merged into `run.extensions`.
+ */
+const statsReducer = (): StreamReducer<{
+  toolCallCount: Promise<number>;
+  totalTokens: Promise<number>;
+}> => {
+  let tools = 0;
+  let tokens = 0;
+
+  let resolveTools: (n: number) => void;
+  let resolveTokens: (n: number) => void;
+  const toolCallCount = new Promise<number>((r) => {
+    resolveTools = r;
+  });
+  const totalTokens = new Promise<number>((r) => {
+    resolveTokens = r;
+  });
+
+  return {
+    init: () => ({ toolCallCount, totalTokens }),
+
+    process(event: ProtocolEvent): boolean {
+      if (event.method === "tools") {
+        const data = event.params.data as ToolsEventData;
+        if (data.event === "tool-started") tools += 1;
+      }
+
+      if (event.method === "messages") {
+        const data = event.params.data as MessagesEventData;
+        if (data.event === "message-finish" && data.usage) {
+          tokens += (data.usage.inputTokens ?? 0) + (data.usage.outputTokens ?? 0);
+        }
+      }
+
+      return true;
+    },
+
+    finalize() {
+      resolveTools(tools);
+      resolveTokens(tokens);
+    },
+
+    fail() {
+      resolveTools(tools);
+      resolveTokens(tokens);
+    },
+  };
+};
+
+const run = await graph.streamV2(
+  {
+    messages: [
+      { role: "user", content: "What is the square root of 144? Then search for who discovered it." },
+    ],
+  },
+  { reducers: [statsReducer] }
+);
+
+console.log("--- Streaming ---\n");
+
+for await (const event of run) {
+  if (event.method === "messages") {
+    const data = event.params.data as MessagesEventData;
+    if (data.event === "content-block-delta") {
+      const cb = data.contentBlock as { type: string; text?: string };
+      if (cb.type === "text" && cb.text) process.stdout.write(cb.text);
+    }
+    if (data.event === "message-finish") process.stdout.write("\n");
+  }
+  if (event.method === "tools") {
+    const data = event.params.data as ToolsEventData;
+    if (data.event === "tool-started") {
+      console.log(`  [tool] ${data.toolName} started`);
+    }
+    if (data.event === "tool-finished") {
+      console.log(`  [tool] finished`);
+    }
+  }
+}
+
+console.log("\n--- Stats (from custom reducer) ---");
+console.log("Tool calls:", await run.extensions.toolCallCount);
+console.log("Total tokens:", await run.extensions.totalTokens);

--- a/examples/streaming/src/custom-reducer.ts
+++ b/examples/streaming/src/custom-reducer.ts
@@ -1,9 +1,19 @@
 /**
  * Custom StreamReducer — extend streamV2() with domain-specific projections.
  *
- * Demonstrates passing a custom reducer factory via the `reducers` option.
- * The reducer counts tool calls and tracks total token usage, exposing
- * the results on `run.extensions`.
+ * This example shows two reducer patterns:
+ *
+ *   1. Final values — promises resolved once when the run ends (e.g. total
+ *      token count).  Consumers `await` them after the stream is done.
+ *
+ *   2. Streaming updates — an AsyncIterable backed by an EventLog that
+ *      yields incremental items as events arrive.  Consumers iterate them
+ *      concurrently with the main event stream.
+ *
+ * Both patterns use the same StreamReducer interface.  The difference is
+ * what you put in the projection returned from `init()`:
+ *   - A `Promise` for final values
+ *   - An `AsyncIterable` (via `EventLog`) for streaming updates
  *
  * Run:
  *   ANTHROPIC_API_KEY=sk-... npx tsx src/custom-reducer.ts
@@ -15,11 +25,18 @@ import type {
   MessagesEventData,
   ToolsEventData,
 } from "@langchain/langgraph";
+import { EventLog } from "@langchain/langgraph";
 import { graph } from "./agents/simple-tool-graph.js";
 
+const DIM = "\x1b[2m";
+const BOLD = "\x1b[1m";
+const RESET = "\x1b[0m";
+const CYAN = "\x1b[36m";
+const YELLOW = "\x1b[33m";
+const GREEN = "\x1b[32m";
+
 /**
- * A reducer that counts tool invocations and tracks token usage.
- * Returned projections are merged into `run.extensions`.
+ * Pattern 1: Final values — resolved once at the end of the run.
  */
 const statsReducer = (): StreamReducer<{
   toolCallCount: Promise<number>;
@@ -49,7 +66,8 @@ const statsReducer = (): StreamReducer<{
       if (event.method === "messages") {
         const data = event.params.data as MessagesEventData;
         if (data.event === "message-finish" && data.usage) {
-          tokens += (data.usage.inputTokens ?? 0) + (data.usage.outputTokens ?? 0);
+          tokens +=
+            (data.usage.inputTokens ?? 0) + (data.usage.outputTokens ?? 0);
         }
       }
 
@@ -68,37 +86,80 @@ const statsReducer = (): StreamReducer<{
   };
 };
 
+/**
+ * Pattern 2: Streaming updates — yields tool activity as it happens.
+ *
+ * The EventLog acts as the async buffer: the reducer pushes items into it
+ * during `process()`, and the consumer iterates them in a concurrent
+ * `for await` loop.  The log is closed in `finalize()` / `fail()` so the
+ * iterator ends when the run ends.
+ */
+const toolActivityReducer = (): StreamReducer<{
+  toolActivity: AsyncIterable<{ name: string; status: string }>;
+}> => {
+  const log = new EventLog<{ name: string; status: string }>();
+
+  return {
+    init: () => ({ toolActivity: log.toAsyncIterable() }),
+
+    process(event: ProtocolEvent): boolean {
+      if (event.method !== "tools") return true;
+
+      const data = event.params.data as ToolsEventData;
+      if (data.event === "tool-started") {
+        log.push({ name: data.toolName, status: "started" });
+      } else if (data.event === "tool-finished") {
+        log.push({ name: data.toolCallId, status: "finished" });
+      } else if (data.event === "tool-error") {
+        log.push({ name: data.toolCallId, status: "error" });
+      }
+      return true;
+    },
+
+    finalize: () => log.close(),
+    fail: (err) => log.fail(err),
+  };
+};
+
 const run = await graph.streamV2(
   {
     messages: [
-      { role: "user", content: "What is the square root of 144? Then search for who discovered it." },
+      {
+        role: "user",
+        content:
+          "What is the square root of 144? Then search for who discovered it.",
+      },
     ],
   },
-  { reducers: [statsReducer] }
+  { reducers: [statsReducer, toolActivityReducer] }
 );
 
-console.log("--- Streaming ---\n");
+console.log(`${BOLD}--- Parallel consumers ---${RESET}\n`);
 
-for await (const event of run) {
-  if (event.method === "messages") {
-    const data = event.params.data as MessagesEventData;
-    if (data.event === "content-block-delta") {
-      const cb = data.contentBlock as { type: string; text?: string };
-      if (cb.type === "text" && cb.text) process.stdout.write(cb.text);
+await Promise.all([
+  // Consumer 1: stream text from run.messages (built-in projection)
+  (async () => {
+    let msgIndex = 0;
+    for await (const msg of run.messages) {
+      msgIndex += 1;
+      const text = await msg.text;
+      if (text.length > 0) {
+        console.log(`${CYAN}[message #${msgIndex}]${RESET} ${text}`);
+      } else {
+        console.log(`${CYAN}[message #${msgIndex}]${RESET} ${DIM}(tool call)${RESET}`);
+      }
     }
-    if (data.event === "message-finish") process.stdout.write("\n");
-  }
-  if (event.method === "tools") {
-    const data = event.params.data as ToolsEventData;
-    if (data.event === "tool-started") {
-      console.log(`  [tool] ${data.toolName} started`);
-    }
-    if (data.event === "tool-finished") {
-      console.log(`  [tool] finished`);
-    }
-  }
-}
+  })(),
 
-console.log("\n--- Stats (from custom reducer) ---");
-console.log("Tool calls:", await run.extensions.toolCallCount);
-console.log("Total tokens:", await run.extensions.totalTokens);
+  // Consumer 2: stream tool activity (custom reducer projection)
+  (async () => {
+    for await (const activity of run.extensions.toolActivity) {
+      const icon = activity.status === "started" ? YELLOW : GREEN;
+      console.log(`${icon}[tool]${RESET} ${activity.name} ${DIM}→ ${activity.status}${RESET}`);
+    }
+  })(),
+]);
+
+console.log(`\n${BOLD}--- Final stats (from statsReducer) ---${RESET}`);
+console.log(`  Tool calls:   ${await run.extensions.toolCallCount}`);
+console.log(`  Total tokens: ${await run.extensions.totalTokens}`);

--- a/examples/streaming/src/human-in-the-loop.ts
+++ b/examples/streaming/src/human-in-the-loop.ts
@@ -1,0 +1,75 @@
+/**
+ * Human-in-the-loop — interrupt, inspect, resume.
+ *
+ * Demonstrates the streamV2() interrupt/resume lifecycle:
+ *
+ *   Turn 1: graph runs until interrupt() → run.interrupted is true,
+ *           run.interrupts contains the interrupt payloads.
+ *
+ *   Turn 2: resume with Command({ resume }) → graph continues from
+ *           the interrupt point with the user's decision.
+ *
+ * Run:
+ *   ANTHROPIC_API_KEY=sk-... npx tsx src/human-in-the-loop.ts
+ */
+
+import { Command } from "@langchain/langgraph";
+import { graph } from "./agents/approval-graph.js";
+
+const threadId = `hitl-example-${Date.now()}`;
+const config = { configurable: { thread_id: threadId } };
+
+// ── Turn 1: run until interrupt ─────────────────────────────────────────────
+
+console.log("=== Turn 1: Run until interrupt ===\n");
+
+const run1 = await graph.streamV2(
+  { messages: [{ role: "user", content: "Deploy the latest build to staging." }] },
+  config
+);
+
+for await (const msg of run1.messages) {
+  const text = await msg.text;
+  if (text.length > 0) {
+    console.log(`  [planner] ${text}`);
+  }
+}
+
+// After all events are consumed, check interrupt status
+await run1.output;
+
+console.log(`\n  interrupted: ${run1.interrupted}`);
+console.log(`  interrupts:  ${JSON.stringify(run1.interrupts, null, 2)}`);
+
+if (!run1.interrupted) {
+  console.log("\n  (graph completed without interrupting — unexpected)");
+  process.exit(1);
+}
+
+// ── Simulate user decision ──────────────────────────────────────────────────
+
+const userApproves = true;
+console.log(`\n  User decision: ${userApproves ? "APPROVED" : "REJECTED"}`);
+
+// ── Turn 2: resume with decision ────────────────────────────────────────────
+
+console.log("\n=== Turn 2: Resume after approval ===\n");
+
+const run2 = await graph.streamV2(
+  new Command({ resume: { approved: userApproves } }),
+  config
+);
+
+for await (const msg of run2.messages) {
+  const text = await msg.text;
+  if (text.length > 0) {
+    console.log(`  [executor] ${text}`);
+  }
+}
+
+const finalState = await run2.output;
+console.log(`\n  interrupted: ${run2.interrupted}`);
+console.log(
+  `  final messages: ${(finalState?.messages as unknown[])?.length ?? 0}`
+);
+console.log("\nDone.");

--- a/examples/streaming/src/messages.ts
+++ b/examples/streaming/src/messages.ts
@@ -1,0 +1,53 @@
+/**
+ * Streaming messages — consume text tokens as they arrive.
+ *
+ * Demonstrates the .messages projection on GraphRunStream. Each yielded
+ * ChatModelStream represents one AI message lifecycle. The .text getter
+ * is both an AsyncIterable (for streaming) and a PromiseLike (for the
+ * full text).
+ *
+ * Run:
+ *   ANTHROPIC_API_KEY=sk-... npx tsx src/messages.ts
+ */
+
+import { graph } from "./agents/simple-tool-graph.js";
+
+const run = await graph.streamV2({
+  messages: [
+    {
+      role: "user",
+      content: "Search the web for the current population of Tokyo, then calculate what 1% of that number is.",
+    },
+  ],
+});
+
+console.log("--- Streaming messages ---\n");
+
+let messageIndex = 0;
+for await (const message of run.messages) {
+  messageIndex += 1;
+  const node = message.node ?? "unknown";
+  process.stdout.write(`[Message #${messageIndex} from "${node}"] `);
+
+  // Stream text tokens as they arrive
+  for await (const token of message.text) {
+    process.stdout.write(token);
+  }
+
+  // Usage is available after message-finish
+  const usage = await message.usage;
+  if (usage) {
+    process.stdout.write(
+      `\n  (tokens: ${usage.inputTokens ?? 0} in, ${usage.outputTokens ?? 0} out)`
+    );
+  }
+
+  process.stdout.write("\n\n");
+}
+
+console.log("--- Final output ---");
+const state = await run.output;
+const last = state?.messages?.at(-1);
+console.log(
+  typeof last?.content === "string" ? last.content : "(complex content)"
+);

--- a/examples/streaming/src/parallel.ts
+++ b/examples/streaming/src/parallel.ts
@@ -1,0 +1,71 @@
+/**
+ * Parallel consumption — messages, values, and raw events concurrently.
+ *
+ * All projections on GraphRunStream read from the same underlying EventLog.
+ * Multiple `for await` loops can run simultaneously without interfering.
+ * This example uses the simple tool graph (direct model calls at root
+ * level) so that `run.messages` captures the model output.
+ *
+ * Run:
+ *   ANTHROPIC_API_KEY=sk-... npx tsx src/parallel.ts
+ */
+
+import { graph } from "./agents/simple-tool-graph.js";
+
+const run = await graph.streamV2({
+  messages: [
+    {
+      role: "user",
+      content:
+        "Search the web for the population of Paris, then calculate 5% of that number.",
+    },
+  ],
+});
+
+console.log("--- Parallel consumption ---\n");
+
+const [messageCount, valuesCount, eventCount] = await Promise.all([
+  // Consumer 1: stream messages and count them
+  (async () => {
+    let count = 0;
+    for await (const msg of run.messages) {
+      count += 1;
+      const text = await msg.text;
+      if (text.length > 0) {
+        const preview = text.length > 60 ? `${text.slice(0, 57)}...` : text;
+        console.log(`  [msg #${count}] ${preview}`);
+      } else {
+        console.log(`  [msg #${count}] (tool call)`);
+      }
+    }
+    return count;
+  })(),
+
+  // Consumer 2: count state snapshots
+  (async () => {
+    let count = 0;
+    for await (const _snapshot of run.values) {
+      count += 1;
+    }
+    return count;
+  })(),
+
+  // Consumer 3: count raw protocol events
+  (async () => {
+    let count = 0;
+    for await (const _event of run) {
+      count += 1;
+    }
+    return count;
+  })(),
+]);
+
+const finalState = await run.output;
+
+console.log("\n--- Summary ---");
+console.log(`Messages streamed: ${messageCount}`);
+console.log(`State snapshots: ${valuesCount}`);
+console.log(`Total protocol events: ${eventCount}`);
+console.log(
+  `Final state messages: ${(finalState?.messages as unknown[] | undefined)?.length ?? 0}`
+);

--- a/examples/streaming/src/subgraphs.ts
+++ b/examples/streaming/src/subgraphs.ts
@@ -1,0 +1,108 @@
+/**
+ * Subgraph observation — recursive subgraph tree walking.
+ *
+ * The research pipeline has two sequential subgraphs (researcher → analyst).
+ * This example demonstrates two complementary approaches:
+ *
+ *   1. Subgraph-scoped messages — discover subgraphs via run.subgraphs,
+ *      then consume each subgraph's messages independently.
+ *
+ *   2. Root-level messages — consume all messages from the root run
+ *      without caring about subgraph boundaries (simpler, flat view).
+ *
+ * Run:
+ *   ANTHROPIC_API_KEY=sk-... npx tsx src/subgraphs.ts
+ */
+
+import type { SubgraphRunStream } from "@langchain/langgraph";
+import { graph } from "./agents/research-pipeline.js";
+
+const input = {
+  messages: [
+    {
+      role: "user" as const,
+      content: "Research TypeScript 5.8 features and identify risks.",
+    },
+  ],
+};
+
+/**
+ * Approach 1: Hierarchical observation.
+ *
+ * Discover subgraphs as they spawn and consume each one's messages
+ * independently. This is the right model for rendering each subgraph
+ * in its own panel/card/section.
+ */
+async function hierarchical() {
+  console.log("=== Approach 1: Hierarchical (per-subgraph messages) ===\n");
+
+  const run = await graph.streamV2(input);
+
+  async function observe(sub: SubgraphRunStream, depth = 1) {
+    const indent = "  ".repeat(depth);
+    console.log(`${indent}[${sub.name}] spawned`);
+
+    const children: Promise<void>[] = [];
+
+    await Promise.all([
+      (async () => {
+        for await (const msg of sub.messages) {
+          const text = await msg.text;
+          if (text.length > 0) {
+            const preview =
+              text.length > 80 ? `${text.slice(0, 77)}...` : text;
+            console.log(`${indent}  message: ${preview}`);
+          }
+        }
+      })(),
+      (async () => {
+        for await (const child of sub.subgraphs) {
+          children.push(observe(child, depth + 1));
+        }
+      })(),
+    ]);
+
+    await Promise.all(children);
+    console.log(`${indent}[${sub.name}] completed`);
+  }
+
+  const tasks: Promise<void>[] = [];
+  for await (const sub of run.subgraphs) {
+    tasks.push(observe(sub));
+  }
+  await Promise.all(tasks);
+
+  const state = await run.output;
+  console.log(`\nDone (${(state?.messages as unknown[])?.length ?? 0} total messages)\n`);
+}
+
+/**
+ * Approach 2: Flat observation.
+ *
+ * Consume all messages from the root run.  This is simpler and works
+ * well when you just want to render a single message feed regardless
+ * of which subgraph produced each message.
+ */
+export async function flat() {
+  console.log("=== Approach 2: Flat (all messages from root) ===\n");
+
+  const run = await graph.streamV2(input);
+
+  let count = 0;
+  for await (const msg of run.messages) {
+    count += 1;
+    const text = await msg.text;
+    if (text.length > 0) {
+      const preview = text.length > 100 ? `${text.slice(0, 97)}...` : text;
+      const node = msg.node ?? "?";
+      console.log(`  [msg #${count}, node=${node}] ${preview}`);
+    }
+  }
+
+  const state = await run.output;
+  console.log(`\nDone (${count} messages streamed, ${(state?.messages as unknown[])?.length ?? 0} in final state)\n`);
+}
+
+// Run the hierarchical approach by default; uncomment flat() instead to compare.
+await hierarchical();
+// await flat();

--- a/libs/langgraph-core/package.json
+++ b/libs/langgraph-core/package.json
@@ -32,7 +32,8 @@
     "@langchain/langgraph-checkpoint": "workspace:^",
     "@langchain/langgraph-sdk": "workspace:~",
     "@standard-schema/spec": "1.1.0",
-    "uuid": "^10.0.0"
+    "uuid": "^10.0.0",
+    "@langchain/protocol": "^0.0.5"
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.16",

--- a/libs/langgraph-core/src/graph/graph.ts
+++ b/libs/langgraph-core/src/graph/graph.ts
@@ -426,17 +426,41 @@ export class Graph<
     return this.addEdge(key, END);
   }
 
-  compile({
+  compile<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const TReducers extends ReadonlyArray<
+      () => import("../stream/types.js").StreamReducer<any>
+    > = [],
+  >({
     checkpointer,
     interruptBefore,
     interruptAfter,
     name,
+    reducers,
   }: {
     checkpointer?: BaseCheckpointSaver | false;
     interruptBefore?: N[] | All;
     interruptAfter?: N[] | All;
     name?: string;
-  } = {}): CompiledGraph<N> {
+    /**
+     * Stream reducer factories baked into the compiled graph.  These run
+     * automatically for every `streamV2()` call, before any call-site
+     * reducers.
+     */
+    reducers?: TReducers;
+  } = {}): CompiledGraph<
+    N,
+    RunInput,
+    RunOutput,
+    Record<string, any>,
+    any,
+    any,
+    unknown,
+    unknown,
+    any,
+    TReducers
+  > {
+    // eslint-disable-line @typescript-eslint/no-explicit-any
     // validate the graph
     this.validate([
       ...(Array.isArray(interruptBefore) ? interruptBefore : []),
@@ -460,6 +484,7 @@ export class Graph<
       streamChannels: [] as N[],
       streamMode: "values",
       name,
+      streamReducers: reducers,
     });
 
     // attach nodes, edges and branches
@@ -563,6 +588,9 @@ export class CompiledGraph<
   NodeReturnType = unknown,
   CommandType = unknown,
   StreamCustomType = any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  TStreamReducers extends ReadonlyArray<
+    () => import("../stream/types.js").StreamReducer<any>
+  > = [], // eslint-disable-line @typescript-eslint/no-explicit-any
 > extends Pregel<
   Record<N | typeof START, PregelNode<State, Update>>,
   Record<N | typeof START | typeof END | string, BaseChannel>,
@@ -573,7 +601,8 @@ export class CompiledGraph<
   OutputType,
   NodeReturnType,
   CommandType,
-  StreamCustomType
+  StreamCustomType,
+  TStreamReducers
 > {
   declare "~NodeType": N;
 
@@ -590,7 +619,8 @@ export class CompiledGraph<
     ...rest
   }: { builder: Graph<N, State, Update> } & PregelParams<
     Record<N | typeof START, PregelNode<State, Update>>,
-    Record<N | typeof START | typeof END | string, BaseChannel>
+    Record<N | typeof START | typeof END | string, BaseChannel>,
+    TStreamReducers
   >) {
     super(rest);
     this.builder = builder;

--- a/libs/langgraph-core/src/graph/state.ts
+++ b/libs/langgraph-core/src/graph/state.ts
@@ -1073,7 +1073,12 @@ export class StateGraph<
     >;
   }
 
-  override compile({
+  override compile<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const TReducers extends ReadonlyArray<
+      () => import("../stream/types.js").StreamReducer<any>
+    > = [],
+  >({
     checkpointer,
     store,
     cache,
@@ -1081,6 +1086,7 @@ export class StateGraph<
     interruptAfter,
     name,
     description,
+    reducers,
   }: {
     checkpointer?: BaseCheckpointSaver | boolean;
     store?: BaseStore;
@@ -1089,6 +1095,12 @@ export class StateGraph<
     interruptAfter?: N[] | All;
     name?: string;
     description?: string;
+    /**
+     * Stream reducer factories baked into the compiled graph.  These run
+     * automatically for every `streamV2()` call, before any call-site
+     * reducers.
+     */
+    reducers?: TReducers;
   } = {}): CompiledStateGraph<
     Prettify<S>,
     Prettify<U>,
@@ -1098,7 +1110,8 @@ export class StateGraph<
     C,
     NodeReturnType,
     InterruptType,
-    WriterType
+    WriterType,
+    TReducers
   > {
     // validate the graph
     this.validate([
@@ -1128,7 +1141,8 @@ export class StateGraph<
       C,
       NodeReturnType,
       InterruptType,
-      WriterType
+      WriterType,
+      TReducers
     >({
       builder: this,
       checkpointer,
@@ -1149,6 +1163,7 @@ export class StateGraph<
       name,
       description,
       userInterrupt,
+      streamReducers: reducers,
     });
 
     // attach nodes, edges and branches
@@ -1248,6 +1263,10 @@ export class CompiledStateGraph<
   NodeReturnType = unknown,
   InterruptType = unknown,
   WriterType = unknown,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TStreamReducers extends ReadonlyArray<
+    () => import("../stream/types.js").StreamReducer<any>
+  > = [],
 > extends CompiledGraph<
   N,
   S,
@@ -1257,7 +1276,8 @@ export class CompiledStateGraph<
   ExtractStateType<O>,
   NodeReturnType,
   CommandInstance<InferInterruptResumeType<InterruptType>, Prettify<U>, N>,
-  InferWriterType<WriterType>
+  InferWriterType<WriterType>,
+  TStreamReducers
 > {
   declare builder: StateGraph<unknown, S, U, N, I, O, C, NodeReturnType>;
 
@@ -1283,7 +1303,8 @@ export class CompiledStateGraph<
       ExtractStateType<O>,
       NodeReturnType,
       CommandInstance<InferInterruptResumeType<InterruptType>, Prettify<U>, N>,
-      InferWriterType<WriterType>
+      InferWriterType<WriterType>,
+      TStreamReducers
     >
   >[0]) {
     super(rest);

--- a/libs/langgraph-core/src/pregel/index.ts
+++ b/libs/langgraph-core/src/pregel/index.ts
@@ -93,6 +93,12 @@ import {
   StreamToolsHandler,
   toEventStream,
 } from "./stream.js";
+import {
+  createGraphRunStream,
+  GraphRunStream,
+  STREAM_V2_MODES,
+} from "../stream/index.js";
+import type { InferExtensions, StreamReducer } from "../stream/index.js";
 import type {
   Durability,
   GetStateOptions,
@@ -1894,6 +1900,101 @@ export class Pregel<
         ? toEventStream(stream)
         : stream,
       abortController
+    );
+  }
+
+  /**
+   * Ergonomic v2 stream API for a single graph run.
+   *
+   * `streamV2()` is the recommended way to consume graph execution when you
+   * need typed, recursive access to subgraph events, tool lifecycle, and
+   * message content-block streaming.
+   *
+   * Returns a `Promise<GraphRunStream>` that resolves immediately (no async
+   * setup needed), kept async for a uniform call pattern across graph, agent,
+   * and deep agent levels (§ 15.8).
+   *
+   * The returned `GraphRunStream` is an `AsyncIterable<ProtocolEvent>`.
+   *
+   * Built-in projections:
+   *  - `run.output`        — `Promise<OutputType>` for the final state
+   *  - `run.values`        — `AsyncIterable` of state snapshots + `PromiseLike`
+   *  - `run.subgraphs`     — `AsyncIterable<SubgraphRunStream>` for child graphs
+   *  - `run.messages`      — `AsyncIterable<ChatModelStream>` for message lifecycles
+   *  - `run.messagesFrom`  — node-filtered messages
+   *  - `run.interrupted`   — whether the run ended due to an interrupt
+   *  - `run.interrupts`    — interrupt payloads
+   *  - `run.abort()`       — programmatic cancellation
+   *  - `run.extensions`    — merged reducer projections
+   *
+   * Example:
+   * ```typescript
+   * const run = await graph.streamV2(input, { configurable: { thread_id: "t1" } });
+   *
+   * for await (const event of run) {
+   *   console.log(event.method, event.params.data);
+   * }
+   *
+   * for await (const msg of run.messages) {
+   *   for await (const token of msg.text) { process.stdout.write(token); }
+   * }
+   *
+   * for await (const sub of run.subgraphs) {
+   *   for await (const event of sub) { … }
+   * }
+   *
+   * const finalState = await run.output;
+   * ```
+   *
+   * The v1 `stream()` API remains unchanged.
+   */
+  async streamV2<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const TReducers extends ReadonlyArray<() => StreamReducer<any>> = [],
+  >(
+    input: InputType | CommandType | null,
+    options?: Partial<
+      Omit<
+        PregelOptions<Nodes, Channels, ContextType>,
+        "encoding" | "subgraphs"
+      >
+    > & {
+      /** User-supplied reducer factories for custom projections. */
+      reducers?: TReducers;
+    }
+  ): Promise<GraphRunStream<OutputType, InferExtensions<TReducers>>> {
+    const { reducers: userReducers, ...restOptions } = options ?? {};
+
+    const streamOptions = {
+      recursionLimit: this.config?.recursionLimit,
+      ...restOptions,
+      configurable: {
+        ...this.config?.configurable,
+        ...restOptions?.configurable,
+        [PROTOCOL_MESSAGES_STREAM_CONFIG_KEY]: true,
+      },
+      streamMode: STREAM_V2_MODES,
+      subgraphs: true as const,
+      encoding: undefined,
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sourcePromise = this.stream(input, streamOptions as any);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const source: AsyncIterable<any> = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      [Symbol.asyncIterator]: async function* (): AsyncGenerator<any> {
+        const src = await sourcePromise;
+        for await (const chunk of src) {
+          yield chunk;
+        }
+      },
+    };
+
+    return createGraphRunStream<OutputType, TReducers>(
+      source,
+      (userReducers ?? []) as unknown as TReducers
     );
   }
 

--- a/libs/langgraph-core/src/pregel/index.ts
+++ b/libs/langgraph-core/src/pregel/index.ts
@@ -404,6 +404,8 @@ export class Pregel<
   CommandType = CommandInstance,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   StreamCustom = any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TStreamReducers extends ReadonlyArray<() => StreamReducer<any>> = [],
 >
   extends PartialRunnable<
     InputType | CommandType | null,
@@ -519,6 +521,13 @@ export class Pregel<
   private userInterrupt?: unknown;
 
   /**
+   * Stream reducer factories registered at compile time.  These run
+   * automatically for every `streamV2()` call, before any call-site
+   * reducers passed via `streamV2(input, { reducers })`.
+   */
+  streamReducers: TStreamReducers;
+
+  /**
    * The trigger to node mapping for the graph run.
    * @internal
    */
@@ -529,7 +538,7 @@ export class Pregel<
    *
    * @internal
    */
-  constructor(fields: PregelParams<Nodes, Channels>) {
+  constructor(fields: PregelParams<Nodes, Channels, TStreamReducers>) {
     super(fields);
 
     let { streamMode } = fields;
@@ -570,6 +579,7 @@ export class Pregel<
     this.name = fields.name;
     this.triggerToNodes = fields.triggerToNodes ?? this.triggerToNodes;
     this.userInterrupt = fields.userInterrupt;
+    this.streamReducers = (fields.streamReducers ?? []) as TStreamReducers;
 
     if (this.autoValidate) {
       this.validate();
@@ -1962,7 +1972,12 @@ export class Pregel<
       /** User-supplied reducer factories for custom projections. */
       reducers?: TReducers;
     }
-  ): Promise<GraphRunStream<OutputType, InferExtensions<TReducers>>> {
+  ): Promise<
+    GraphRunStream<
+      OutputType,
+      InferExtensions<readonly [...TStreamReducers, ...TReducers]>
+    >
+  > {
     const { reducers: userReducers, ...restOptions } = options ?? {};
 
     const streamOptions = {
@@ -1992,10 +2007,13 @@ export class Pregel<
       },
     };
 
-    return createGraphRunStream<OutputType, TReducers>(
-      source,
-      (userReducers ?? []) as unknown as TReducers
-    );
+    type TMerged = readonly [...TStreamReducers, ...TReducers];
+    const mergedReducers = [
+      ...(this.streamReducers ?? []),
+      ...(userReducers ?? []),
+    ] as unknown as TMerged;
+
+    return createGraphRunStream<OutputType, TMerged>(source, mergedReducers);
   }
 
   /**

--- a/libs/langgraph-core/src/pregel/messages-v2.ts
+++ b/libs/langgraph-core/src/pregel/messages-v2.ts
@@ -164,6 +164,30 @@ const finalizeContentBlock = (
 };
 
 /**
+ * Converts LangChain's snake_case `usage_metadata` into the protocol's
+ * camelCase `UsageInfo` shape expected by `@langchain/protocol`.
+ *
+ * @param usage - LangChain-format usage metadata.
+ * @returns Protocol-compatible usage info, or `undefined` if input is nullish.
+ */
+const toProtocolUsage = (
+  usage: UsageMetadataLike | undefined
+): Record<string, unknown> | undefined => {
+  if (usage == null) return undefined;
+  return {
+    inputTokens: usage.input_tokens,
+    outputTokens: usage.output_tokens,
+    totalTokens: usage.total_tokens,
+    ...(usage.input_token_details != null
+      ? { inputTokenDetails: usage.input_token_details }
+      : {}),
+    ...(usage.output_token_details != null
+      ? { outputTokenDetails: usage.output_token_details }
+      : {}),
+  };
+};
+
+/**
  * Combines additive usage metadata emitted by chunk streams into a running
  * snapshot.
  *
@@ -488,10 +512,15 @@ export class StreamProtocolMessagesHandler extends BaseCallbackHandler {
     runId: string | undefined,
     dedupe = false
   ) {
-    const messageId = this.normalizeMessageId(message, runId);
-    if (dedupe && messageId != null && this.seen[messageId] !== message) {
-      return;
+    if (dedupe) {
+      const existingId =
+        message.id ??
+        (runId != null ? this.stableMessageIdMap[runId] : undefined);
+      if (existingId != null && existingId in this.seen) {
+        return;
+      }
     }
+    const messageId = this.normalizeMessageId(message, runId);
 
     this.emitProtocolEvent(meta, {
       event: "message-start",
@@ -549,11 +578,12 @@ export class StreamProtocolMessagesHandler extends BaseCallbackHandler {
       "usage_metadata" in message && isUsageMetadataLike(message.usage_metadata)
         ? message.usage_metadata
         : undefined;
+    const protocolUsage = toProtocolUsage(usage);
 
     this.emitProtocolEvent(meta, {
       event: "message-finish",
       reason: finishReason,
-      ...(usage != null ? { usage } : {}),
+      ...(protocolUsage != null ? { usage: protocolUsage } : {}),
       ...(responseMetadata != null ? { metadata: responseMetadata } : {}),
     });
   }
@@ -735,10 +765,11 @@ export class StreamProtocolMessagesHandler extends BaseCallbackHandler {
         });
       }
 
+      const protocolUsage = toProtocolUsage(finishUsage);
       this.emitProtocolEvent(meta!, {
         event: "message-finish",
         reason: normalizeMessageFinishReason(responseMetadata?.stop_reason),
-        ...(finishUsage != null ? { usage: finishUsage } : {}),
+        ...(protocolUsage != null ? { usage: protocolUsage } : {}),
         ...(responseMetadata != null ? { metadata: responseMetadata } : {}),
       });
     }

--- a/libs/langgraph-core/src/pregel/types.ts
+++ b/libs/langgraph-core/src/pregel/types.ts
@@ -14,6 +14,7 @@ import type { BaseMessage } from "@langchain/core/messages";
 import type { BaseChannel } from "../channels/base.js";
 import type { PregelNode } from "./read.js";
 import type { Interrupt } from "../constants.js";
+import type { StreamReducer } from "../stream/types.js";
 import { CachePolicy, RetryPolicy } from "./utils/index.js";
 import { LangGraphRunnableConfig } from "./runnable_types.js";
 
@@ -446,6 +447,8 @@ export interface PregelInterface<
 export type PregelParams<
   Nodes extends StrRecord<string, PregelNode>,
   Channels extends StrRecord<string, BaseChannel>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TStreamReducers extends ReadonlyArray<() => StreamReducer<any>> = [],
 > = {
   /**
    * The name of the graph. @see {@link Runnable.name}
@@ -550,6 +553,13 @@ export type PregelParams<
    * @internal
    */
   userInterrupt?: unknown;
+
+  /**
+   * Stream reducer factories registered at compile time.  These run
+   * automatically for every `streamV2()` call, before any call-site
+   * reducers.
+   */
+  streamReducers?: TStreamReducers;
 };
 
 export interface PregelTaskDescription {

--- a/libs/langgraph-core/src/stream/chat-model-stream.test.ts
+++ b/libs/langgraph-core/src/stream/chat-model-stream.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import { ChatModelStreamImpl } from "./chat-model-stream.js";
+import type { MessagesEventData, UsageInfo } from "./types.js";
+
+/** Test helpers */
+
+const textDelta = (text: string, index = 0): MessagesEventData => ({
+  event: "content-block-delta",
+  index,
+  contentBlock: { type: "text", text },
+});
+
+const reasoningDelta = (
+  reasoning: string,
+  index = 0
+): MessagesEventData => ({
+  event: "content-block-delta",
+  index,
+  contentBlock: { type: "reasoning", reasoning },
+});
+
+const messageStart = (): MessagesEventData => ({
+  event: "message-start",
+  role: "ai",
+});
+
+const messageFinish = (
+  usage?: UsageInfo
+): MessagesEventData & { event: "message-finish" } => ({
+  event: "message-finish",
+  reason: "stop",
+  usage,
+});
+
+const imageDelta = (index = 0): MessagesEventData => ({
+  event: "content-block-delta",
+  index,
+  contentBlock: { type: "image", url: "https://example.com/img.png" },
+});
+
+async function collectAsync<T>(iter: AsyncIterable<T>): Promise<T[]> {
+  const results: T[] = [];
+  for await (const item of iter) {
+    results.push(item);
+  }
+  return results;
+}
+
+describe("ChatModelStreamImpl", () => {
+  it("text deltas accumulate and resolve on finish", async () => {
+    const stream = new ChatModelStreamImpl(["agent"], "chatModel");
+
+    stream.pushEvent(messageStart());
+    stream.pushEvent(textDelta("Hello"));
+    stream.pushEvent(textDelta(", "));
+    stream.pushEvent(textDelta("world!"));
+    stream.finish(messageFinish());
+
+    const fullText = await stream.text;
+    expect(fullText).toBe("Hello, world!");
+  });
+
+  it("reasoning deltas accumulate and resolve on finish", async () => {
+    const stream = new ChatModelStreamImpl(["agent"], "chatModel");
+
+    stream.pushEvent(messageStart());
+    stream.pushEvent(reasoningDelta("Let me "));
+    stream.pushEvent(reasoningDelta("think..."));
+    stream.finish(messageFinish());
+
+    const fullReasoning = await stream.reasoning;
+    expect(fullReasoning).toBe("Let me think...");
+  });
+
+  it("usage is resolved from message-finish data", async () => {
+    const stream = new ChatModelStreamImpl(["agent"], "chatModel");
+    const usage: UsageInfo = {
+      inputTokens: 10,
+      outputTokens: 25,
+      totalTokens: 35,
+    };
+
+    stream.pushEvent(messageStart());
+    stream.pushEvent(textDelta("hi"));
+    stream.finish(messageFinish(usage));
+
+    const result = await stream.usage;
+    expect(result).toEqual(usage);
+  });
+
+  it("iterating raw events with [Symbol.asyncIterator]", async () => {
+    const stream = new ChatModelStreamImpl(["agent"], "chatModel");
+
+    const start = messageStart();
+    const delta = textDelta("hi");
+    const finish = messageFinish();
+
+    stream.pushEvent(start);
+    stream.pushEvent(delta);
+    stream.finish(finish);
+
+    const events = await collectAsync(stream);
+    expect(events).toHaveLength(3);
+    expect(events[0]).toEqual(start);
+    expect(events[1]).toEqual(delta);
+    expect(events[2]).toEqual(finish);
+  });
+
+  it("text getter as AsyncIterable yields deltas", async () => {
+    const stream = new ChatModelStreamImpl(["agent"], "chatModel");
+
+    stream.pushEvent(messageStart());
+    stream.pushEvent(textDelta("one"));
+    stream.pushEvent(textDelta("two"));
+    stream.pushEvent(textDelta("three"));
+    stream.finish(messageFinish());
+
+    const deltas = await collectAsync(stream.text);
+    expect(deltas).toEqual(["one", "two", "three"]);
+  });
+
+  it("text getter as PromiseLike resolves with full text", async () => {
+    const stream = new ChatModelStreamImpl(["agent"], "chatModel");
+
+    stream.pushEvent(messageStart());
+    stream.pushEvent(textDelta("a"));
+    stream.pushEvent(textDelta("b"));
+    stream.pushEvent(textDelta("c"));
+    stream.finish(messageFinish());
+
+    const result = await stream.text.then((t) => t.toUpperCase());
+    expect(result).toBe("ABC");
+  });
+
+  it("reasoning getter works same as text", async () => {
+    const stream = new ChatModelStreamImpl(["agent"], "chatModel");
+
+    stream.pushEvent(messageStart());
+    stream.pushEvent(reasoningDelta("step1"));
+    stream.pushEvent(reasoningDelta("step2"));
+    stream.finish(messageFinish());
+
+    const deltas = await collectAsync(stream.reasoning);
+    expect(deltas).toEqual(["step1", "step2"]);
+
+    const stream2 = new ChatModelStreamImpl(["agent"], "chatModel");
+    stream2.pushEvent(messageStart());
+    stream2.pushEvent(reasoningDelta("alpha"));
+    stream2.pushEvent(reasoningDelta("beta"));
+    stream2.finish(messageFinish());
+
+    const full = await stream2.reasoning;
+    expect(full).toBe("alphabeta");
+  });
+
+  it("fail() causes all promises to reject and iterators to throw", async () => {
+    const stream = new ChatModelStreamImpl(["agent"], "chatModel");
+    const error = new Error("run failed");
+
+    stream.pushEvent(messageStart());
+    stream.fail(error);
+
+    await expect(stream.text).rejects.toThrow("run failed");
+    await expect(stream.reasoning).rejects.toThrow("run failed");
+    await expect(
+      stream.usage.then(
+        (v) => v,
+        (e) => {
+          throw e;
+        }
+      )
+    ).rejects.toThrow("run failed");
+
+    await expect(collectAsync(stream)).rejects.toThrow("run failed");
+  });
+
+  it("non-text/non-reasoning content blocks don't affect accumulators", async () => {
+    const stream = new ChatModelStreamImpl(["agent"], "chatModel");
+
+    stream.pushEvent(messageStart());
+    stream.pushEvent(textDelta("hello"));
+    stream.pushEvent(imageDelta());
+    stream.pushEvent(reasoningDelta("think"));
+    stream.finish(messageFinish());
+
+    const text = await stream.text;
+    const reasoning = await stream.reasoning;
+
+    expect(text).toBe("hello");
+    expect(reasoning).toBe("think");
+  });
+
+  it("namespace and node properties are set correctly", () => {
+    const stream1 = new ChatModelStreamImpl(["agent", "inner"], "myNode");
+    expect(stream1.namespace).toEqual(["agent", "inner"]);
+    expect(stream1.node).toBe("myNode");
+
+    const stream2 = new ChatModelStreamImpl([], undefined);
+    expect(stream2.namespace).toEqual([]);
+    expect(stream2.node).toBeUndefined();
+  });
+});

--- a/libs/langgraph-core/src/stream/chat-model-stream.ts
+++ b/libs/langgraph-core/src/stream/chat-model-stream.ts
@@ -1,0 +1,200 @@
+/**
+ * ChatModelStream implementation — one instance per AI message lifecycle.
+ *
+ * Created by the MessagesReducer when a `message-start` event is observed.
+ * Tracks all content-block events and resolves projections (`.text`,
+ * `.reasoning`, `.usage`) when `message-finish` arrives.
+ */
+
+import { EventLog } from "./event-log.js";
+import type {
+  ChatModelStream,
+  MessagesEventData,
+  Namespace,
+  UsageInfo,
+} from "./types.js";
+
+/**
+ * Concrete implementation of the {@link ChatModelStream} interface.
+ *
+ * Each instance tracks a single AI message from `message-start` through
+ * `message-finish`. Content-block deltas are accumulated into text and
+ * reasoning projections that are available both as async iterables (for
+ * streaming consumption) and as promise-like values (for awaiting the
+ * final concatenated result).
+ *
+ * Instances are created by the `MessagesReducer` and should not be
+ * constructed directly by application code.
+ */
+export class ChatModelStreamImpl implements ChatModelStream {
+  /**
+   * Hierarchical namespace identifying the position in the agent tree
+   * that produced this message.
+   */
+  readonly namespace: Namespace;
+
+  /**
+   * The graph node that produced this message, if known.
+   */
+  readonly node: string | undefined;
+
+  readonly #events = new EventLog<MessagesEventData>();
+  readonly #textDeltas = new EventLog<string>();
+  readonly #reasoningDeltas = new EventLog<string>();
+
+  #accumulatedText = "";
+  #accumulatedReasoning = "";
+  #resolveText: ((v: string) => void) | undefined;
+  #resolveReasoning: ((v: string) => void) | undefined;
+  #resolveUsage: ((v: UsageInfo | undefined) => void) | undefined;
+  #rejectText: ((e: unknown) => void) | undefined;
+  #rejectReasoning: ((e: unknown) => void) | undefined;
+  #rejectUsage: ((e: unknown) => void) | undefined;
+
+  readonly #textDone: Promise<string>;
+  readonly #reasoningDone: Promise<string>;
+  readonly #usageDone: Promise<UsageInfo | undefined>;
+
+  /**
+   * @param namespace - Hierarchical path identifying where in the agent
+   *   tree this message originates.
+   * @param node - The graph node name that produced this message, or
+   *   `undefined` if not known.
+   */
+  constructor(namespace: Namespace, node: string | undefined) {
+    this.namespace = namespace;
+    this.node = node;
+
+    this.#textDone = new Promise<string>((resolve, reject) => {
+      this.#resolveText = resolve;
+      this.#rejectText = reject;
+    });
+    this.#reasoningDone = new Promise<string>((resolve, reject) => {
+      this.#resolveReasoning = resolve;
+      this.#rejectReasoning = reject;
+    });
+    this.#usageDone = new Promise<UsageInfo | undefined>((resolve, reject) => {
+      this.#resolveUsage = resolve;
+      this.#rejectUsage = reject;
+    });
+  }
+
+  /**
+   * Push a messages event into this stream.
+   *
+   * Called by the `MessagesReducer` for every event in this message's
+   * lifecycle. Text and reasoning content-block deltas are accumulated
+   * into the respective projections.
+   *
+   * @param data - The messages-channel event data to record.
+   */
+  pushEvent(data: MessagesEventData): void {
+    this.#events.push(data);
+
+    if (data.event === "content-block-delta") {
+      const cb = data.contentBlock as Record<string, unknown>;
+      if (cb.type === "text" && typeof cb.text === "string") {
+        this.#accumulatedText += cb.text;
+        this.#textDeltas.push(cb.text);
+      } else if (cb.type === "reasoning" && typeof cb.reasoning === "string") {
+        this.#accumulatedReasoning += cb.reasoning;
+        this.#reasoningDeltas.push(cb.reasoning);
+      }
+    }
+  }
+
+  /**
+   * Finalize this stream with a `message-finish` event.
+   *
+   * Closes all internal event logs and resolves the text, reasoning, and
+   * usage promises with their final values.
+   *
+   * @param data - The `message-finish` event data, which includes usage
+   *   metadata and the finish reason.
+   */
+  finish(data: MessagesEventData & { event: "message-finish" }): void {
+    this.#events.push(data);
+    this.#events.close();
+    this.#textDeltas.close();
+    this.#reasoningDeltas.close();
+    this.#resolveText?.(this.#accumulatedText);
+    this.#resolveReasoning?.(this.#accumulatedReasoning);
+    this.#resolveUsage?.(data.usage);
+  }
+
+  /**
+   * Abort this stream due to an error.
+   *
+   * Called when the run errors before a `message-finish` event is
+   * received. Propagates the error to all internal event logs and
+   * rejects all pending promises.
+   *
+   * @param err - The error to propagate to consumers.
+   */
+  fail(err: unknown): void {
+    this.#events.fail(err);
+    this.#textDeltas.fail(err);
+    this.#reasoningDeltas.fail(err);
+    this.#rejectText?.(err);
+    this.#rejectReasoning?.(err);
+    this.#rejectUsage?.(err);
+  }
+
+  /**
+   * Returns an async iterator over all raw {@link MessagesEventData}
+   * events in this message's lifecycle.
+   *
+   * @returns An async iterator that yields each event in order.
+   */
+  [Symbol.asyncIterator](): AsyncIterator<MessagesEventData> {
+    return this.#events.iterate();
+  }
+
+  /**
+   * Streaming text projection.
+   *
+   * When used as an `AsyncIterable`, yields individual text deltas as
+   * they arrive. When used as a `PromiseLike`, resolves with the full
+   * concatenated text after the message finishes.
+   *
+   * @returns A hybrid object that is both async-iterable and thenable.
+   */
+  get text(): AsyncIterable<string> & PromiseLike<string> {
+    const iterable = this.#textDeltas.toAsyncIterable();
+    const done = this.#textDone;
+    return {
+      [Symbol.asyncIterator]: () => iterable[Symbol.asyncIterator](),
+      then: done.then.bind(done),
+    };
+  }
+
+  /**
+   * Streaming reasoning projection.
+   *
+   * When used as an `AsyncIterable`, yields individual reasoning deltas
+   * as they arrive. When used as a `PromiseLike`, resolves with the
+   * full concatenated reasoning text after the message finishes.
+   *
+   * @returns A hybrid object that is both async-iterable and thenable.
+   */
+  get reasoning(): AsyncIterable<string> & PromiseLike<string> {
+    const iterable = this.#reasoningDeltas.toAsyncIterable();
+    const done = this.#reasoningDone;
+    return {
+      [Symbol.asyncIterator]: () => iterable[Symbol.asyncIterator](),
+      then: done.then.bind(done),
+    };
+  }
+
+  /**
+   * Usage metadata promise.
+   *
+   * Resolves with {@link UsageInfo} (or `undefined`) once the
+   * `message-finish` event has been processed.
+   *
+   * @returns A promise-like that resolves with usage information.
+   */
+  get usage(): PromiseLike<UsageInfo | undefined> {
+    return this.#usageDone;
+  }
+}

--- a/libs/langgraph-core/src/stream/convert.test.ts
+++ b/libs/langgraph-core/src/stream/convert.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import { convertToProtocolEvent } from "./convert.js";
+
+describe("convertToProtocolEvent", () => {
+  const ns = ["agent", "inner"];
+
+  it("converts 'messages' mode events", () => {
+    const payload = { event: "message-start", role: "assistant" };
+    const result = convertToProtocolEvent(ns, "messages", payload, 1);
+    expect(result).toMatchObject({
+      type: "event",
+      seq: 1,
+      method: "messages",
+      params: { namespace: ns, data: payload },
+    });
+    expect(result!.params.timestamp).toBeTypeOf("number");
+  });
+
+  it("converts 'values' mode events", () => {
+    const payload = { count: 42 };
+    const result = convertToProtocolEvent(ns, "values", payload, 2);
+    expect(result).toMatchObject({
+      type: "event",
+      seq: 2,
+      method: "values",
+      params: { namespace: ns, data: payload },
+    });
+  });
+
+  it("converts 'updates' mode — extracts node from {nodeName: delta} shape", () => {
+    const result = convertToProtocolEvent(
+      ns,
+      "updates",
+      { myNode: { foo: "bar" } },
+      3
+    );
+    expect(result).toMatchObject({
+      method: "updates",
+      params: {
+        data: { node: "myNode", values: { foo: "bar" } },
+      },
+    });
+  });
+
+  it("converts 'tools' mode — on_tool_start → tool-started", () => {
+    const payload = {
+      event: "on_tool_start",
+      name: "search",
+      toolCallId: "tc_1",
+      input: { q: "hello" },
+    };
+    const result = convertToProtocolEvent(ns, "tools", payload, 4);
+    expect(result!.params.data).toEqual({
+      event: "tool-started",
+      toolName: "search",
+      toolCallId: "tc_1",
+      input: { q: "hello" },
+    });
+  });
+
+  it("converts 'tools' mode — on_tool_end → tool-finished", () => {
+    const payload = {
+      event: "on_tool_end",
+      output: "result",
+      toolCallId: "tc_2",
+    };
+    const result = convertToProtocolEvent(ns, "tools", payload, 5);
+    expect(result!.params.data).toEqual({
+      event: "tool-finished",
+      output: "result",
+      toolCallId: "tc_2",
+    });
+  });
+
+  it("converts 'tools' mode — on_tool_error → tool-error with Error-like objects and plain strings", () => {
+    const withError = convertToProtocolEvent(
+      ns,
+      "tools",
+      { event: "on_tool_error", error: new Error("boom") },
+      6
+    );
+    expect(withError!.params.data).toMatchObject({
+      event: "tool-error",
+      message: "boom",
+    });
+
+    const withString = convertToProtocolEvent(
+      ns,
+      "tools",
+      { event: "on_tool_error", error: "plain failure" },
+      7
+    );
+    expect(withString!.params.data).toMatchObject({
+      event: "tool-error",
+      message: "plain failure",
+    });
+  });
+
+  it("converts 'tools' mode — on_tool_event → tool-output-delta", () => {
+    const result = convertToProtocolEvent(
+      ns,
+      "tools",
+      { event: "on_tool_event", data: "chunk", toolCallId: "tc_3" },
+      8
+    );
+    expect(result!.params.data).toEqual({
+      event: "tool-output-delta",
+      delta: "chunk",
+      toolCallId: "tc_3",
+    });
+  });
+
+  it("converts 'custom' mode events", () => {
+    const payload = { key: "value" };
+    const result = convertToProtocolEvent(ns, "custom", payload, 9);
+    expect(result).toMatchObject({
+      method: "custom",
+      params: { data: { payload } },
+    });
+  });
+
+  it("converts 'debug', 'checkpoints', 'tasks' mode events", () => {
+    for (const mode of ["debug", "checkpoints", "tasks"] as const) {
+      const payload = { info: mode };
+      const result = convertToProtocolEvent(ns, mode, payload, 10);
+      expect(result).toMatchObject({
+        method: mode,
+        params: { namespace: ns, data: payload },
+      });
+    }
+  });
+
+  it("returns null for unknown modes", () => {
+    const result = convertToProtocolEvent(
+      ns,
+      "nonexistent" as never,
+      {},
+      11
+    );
+    expect(result).toBeNull();
+  });
+
+  it("preserves namespace in params", () => {
+    const deep = ["root", "sub", "leaf"];
+    const result = convertToProtocolEvent(deep, "values", {}, 12);
+    expect(result!.params.namespace).toEqual(deep);
+  });
+
+  it("assigns correct seq numbers", () => {
+    const r1 = convertToProtocolEvent(ns, "values", {}, 100);
+    const r2 = convertToProtocolEvent(ns, "values", {}, 200);
+    expect(r1!.seq).toBe(100);
+    expect(r2!.seq).toBe(200);
+  });
+
+  it("updates payload with empty object when non-object", () => {
+    const result = convertToProtocolEvent(ns, "updates", null, 13);
+    expect(result!.params.data).toEqual({ values: {} });
+
+    const result2 = convertToProtocolEvent(ns, "updates", 42, 14);
+    expect(result2!.params.data).toEqual({ values: {} });
+  });
+
+  it("toolCallId is preserved when present, defaults to empty string when absent", () => {
+    const withId = convertToProtocolEvent(
+      ns,
+      "tools",
+      { event: "on_tool_start", name: "t", toolCallId: "id_1" },
+      15
+    );
+    expect(withId!.params.data).toHaveProperty("toolCallId", "id_1");
+
+    const withoutId = convertToProtocolEvent(
+      ns,
+      "tools",
+      { event: "on_tool_start", name: "t" },
+      16
+    );
+    expect(withoutId!.params.data).toHaveProperty("toolCallId", "");
+  });
+});

--- a/libs/langgraph-core/src/stream/convert.ts
+++ b/libs/langgraph-core/src/stream/convert.ts
@@ -1,0 +1,222 @@
+/**
+ * Protocol event conversion — maps raw `[ns, mode, payload]` stream chunks
+ * from graph.stream() to CDDL-aligned ProtocolEvents.
+ */
+
+import type { StreamMode } from "../pregel/types.js";
+import type {
+  Namespace,
+  ProtocolEvent,
+  ToolsEventData,
+  UpdatesEventData,
+} from "./types.js";
+
+/**
+ * The complete set of stream modes requested by `streamV2()`, ensuring every
+ * protocol-defined channel is captured.
+ */
+export const STREAM_V2_MODES: StreamMode[] = [
+  "values",
+  "updates",
+  "messages",
+  "tools",
+  "custom",
+  "debug",
+  "checkpoints",
+  "tasks",
+];
+
+/**
+ * Converts a raw `[ns, mode, payload]` stream chunk emitted by
+ * `graph.stream()` into a CDDL-aligned {@link ProtocolEvent}.
+ *
+ * Returns `null` for stream modes that have no protocol mapping.
+ *
+ * @param ns - Hierarchical namespace path identifying the source in the
+ *   agent tree.
+ * @param mode - The stream mode that produced this chunk (e.g. `"messages"`,
+ *   `"tools"`).
+ * @param payload - The raw payload emitted by the stream for this mode.
+ * @param seq - Monotonically increasing sequence number for ordering.
+ * @returns A {@link ProtocolEvent} ready for downstream reducers, or `null`
+ *   if the mode is unrecognised.
+ */
+export function convertToProtocolEvent(
+  ns: Namespace,
+  mode: StreamMode,
+  payload: unknown,
+  seq: number
+): ProtocolEvent | null {
+  const timestamp = Date.now();
+  const base = { type: "event" as const, seq };
+
+  switch (mode) {
+    case "messages":
+      return {
+        ...base,
+        method: "messages",
+        params: { namespace: ns, timestamp, data: payload },
+      };
+
+    case "tools":
+      return {
+        ...base,
+        method: "tools",
+        params: {
+          namespace: ns,
+          timestamp,
+          data: convertToolsPayload(payload),
+        },
+      };
+
+    case "values":
+      return {
+        ...base,
+        method: "values",
+        params: { namespace: ns, timestamp, data: payload },
+      };
+
+    case "updates":
+      return {
+        ...base,
+        method: "updates",
+        params: {
+          namespace: ns,
+          timestamp,
+          data: convertUpdatesPayload(payload),
+        },
+      };
+
+    case "custom":
+      return {
+        ...base,
+        method: "custom",
+        params: { namespace: ns, timestamp, data: { payload } },
+      };
+
+    case "debug":
+      return {
+        ...base,
+        method: "debug",
+        params: { namespace: ns, timestamp, data: payload },
+      };
+
+    case "checkpoints":
+      return {
+        ...base,
+        method: "checkpoints",
+        params: { namespace: ns, timestamp, data: payload },
+      };
+
+    case "tasks":
+      return {
+        ...base,
+        method: "tasks",
+        params: { namespace: ns, timestamp, data: payload },
+      };
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Normalises a raw tools-mode payload into a typed {@link ToolsEventData}
+ * discriminated union, mapping internal lifecycle events (`on_tool_start`,
+ * `on_tool_end`, etc.) to their protocol counterparts.
+ *
+ * @param payload - The raw payload from a `"tools"` stream chunk.
+ * @returns A {@link ToolsEventData} object with the appropriate `event`
+ *   discriminant and associated fields.
+ */
+function convertToolsPayload(payload: unknown): ToolsEventData {
+  if (typeof payload !== "object" || payload === null) {
+    return {
+      event: "tool-error",
+      toolCallId: "",
+      message: "Unexpected tools payload shape",
+    };
+  }
+
+  const p = payload as Record<string, unknown>;
+  const toolCallId = String(p.toolCallId ?? "");
+
+  switch (p.event) {
+    case "on_tool_start":
+      return {
+        event: "tool-started",
+        toolCallId,
+        toolName: String(p.name ?? "unknown"),
+        input: p.input,
+      };
+
+    case "on_tool_event": {
+      const delta =
+        typeof p.data === "string" ? p.data : JSON.stringify(p.data ?? "");
+      return {
+        event: "tool-output-delta",
+        toolCallId,
+        delta,
+      };
+    }
+
+    case "on_tool_end":
+      return {
+        event: "tool-finished",
+        toolCallId,
+        output: p.output,
+      };
+
+    case "on_tool_error": {
+      const err = p.error;
+      const errMessage =
+        typeof err === "object" &&
+        err !== null &&
+        "message" in err &&
+        typeof (err as { message: unknown }).message === "string"
+          ? (err as { message: string }).message
+          : String(err ?? "unknown error");
+      return {
+        event: "tool-error",
+        toolCallId,
+        message: errMessage,
+      };
+    }
+
+    default:
+      return {
+        event: "tool-error",
+        toolCallId: "",
+        message: `Unknown tool event: ${String(p.event)}`,
+      };
+  }
+}
+
+/**
+ * Extracts the first `{node: delta}` entry from an updates-mode payload and
+ * reshapes it into an {@link UpdatesEventData} with explicit `node` and
+ * `values` fields.  Non-object payloads are coerced to `{ values: {} }`.
+ *
+ * @param payload - The raw payload from an `"updates"` stream chunk,
+ *   expected to be a `Record<string, unknown>` keyed by node name.
+ * @returns An {@link UpdatesEventData} containing the extracted node name
+ *   and its associated delta values.
+ */
+function convertUpdatesPayload(payload: unknown): UpdatesEventData {
+  if (typeof payload !== "object" || payload === null) {
+    return { values: {} };
+  }
+
+  const entries = Object.entries(payload as Record<string, unknown>);
+  if (entries.length === 0) {
+    return { values: {} };
+  }
+
+  const [node, values] = entries[0];
+  return {
+    node,
+    values: (typeof values === "object" && values !== null
+      ? values
+      : { value: values }) as Record<string, unknown>,
+  };
+}

--- a/libs/langgraph-core/src/stream/event-log.test.ts
+++ b/libs/langgraph-core/src/stream/event-log.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import { EventLog } from "./event-log.js";
+
+async function collect<T>(iter: AsyncIterator<T>): Promise<T[]> {
+  const out: T[] = [];
+  for (;;) {
+    const r = await iter.next();
+    if (r.done) break;
+    out.push(r.value);
+  }
+  return out;
+}
+
+describe("EventLog", () => {
+  it("pushes items and iterates them in order", async () => {
+    const log = new EventLog<number>();
+    log.push(1);
+    log.push(2);
+    log.push(3);
+    log.close();
+
+    const items = await collect(log.iterate());
+    expect(items).toEqual([1, 2, 3]);
+  });
+
+  it("supports multiple independent cursors", async () => {
+    const log = new EventLog<string>();
+    log.push("a");
+    log.push("b");
+    log.close();
+
+    const items1 = await collect(log.iterate());
+    const items2 = await collect(log.iterate());
+    expect(items1).toEqual(["a", "b"]);
+    expect(items2).toEqual(["a", "b"]);
+  });
+
+  it("close() causes iterators to end with done:true", async () => {
+    const log = new EventLog<number>();
+    log.push(1);
+    log.close();
+
+    const iter = log.iterate();
+    const first = await iter.next();
+    expect(first).toEqual({ value: 1, done: false });
+
+    const second = await iter.next();
+    expect(second.done).toBe(true);
+  });
+
+  it("fail(err) causes iterators to throw that error", async () => {
+    const log = new EventLog<number>();
+    log.push(1);
+    const error = new Error("boom");
+    log.fail(error);
+
+    const iter = log.iterate();
+    await iter.next(); // consume the buffered item
+
+    await expect(iter.next()).rejects.toThrow("boom");
+  });
+
+  it("iterate(startAt) skips items before startAt", async () => {
+    const log = new EventLog<number>();
+    log.push(10);
+    log.push(20);
+    log.push(30);
+    log.close();
+
+    const items = await collect(log.iterate(2));
+    expect(items).toEqual([30]);
+  });
+
+  it("push after iterate starts delivers items to waiting cursors", async () => {
+    const log = new EventLog<number>();
+    const iter = log.iterate();
+
+    const firstPromise = iter.next();
+
+    log.push(42);
+    const first = await firstPromise;
+    expect(first).toEqual({ value: 42, done: false });
+
+    log.push(43);
+    log.close();
+
+    const rest = await collect(iter);
+    expect(rest).toEqual([43]);
+  });
+
+  it("toAsyncIterable works and returns independent iterators", async () => {
+    const log = new EventLog<number>();
+    log.push(1);
+    log.push(2);
+    log.close();
+
+    const iterable = log.toAsyncIterable();
+
+    const results1: number[] = [];
+    for await (const item of iterable) {
+      results1.push(item);
+    }
+
+    const results2: number[] = [];
+    for await (const item of iterable) {
+      results2.push(item);
+    }
+
+    expect(results1).toEqual([1, 2]);
+    expect(results2).toEqual([1, 2]);
+  });
+
+  it("size reflects the number of pushed items", () => {
+    const log = new EventLog<string>();
+    expect(log.size).toBe(0);
+    log.push("x");
+    expect(log.size).toBe(1);
+    log.push("y");
+    expect(log.size).toBe(2);
+  });
+
+  it("done is false until close/fail", () => {
+    const log = new EventLog<number>();
+    expect(log.done).toBe(false);
+    log.close();
+    expect(log.done).toBe(true);
+  });
+
+  it("done is true after fail", () => {
+    const log = new EventLog<number>();
+    expect(log.done).toBe(false);
+    log.fail(new Error("err"));
+    expect(log.done).toBe(true);
+  });
+
+  it("concurrent push and iterate", async () => {
+    const log = new EventLog<number>();
+    const iter = log.iterate();
+    const collected: number[] = [];
+
+    const consumer = (async () => {
+      for (;;) {
+        const r = await iter.next();
+        if (r.done) break;
+        collected.push(r.value);
+      }
+    })();
+
+    log.push(1);
+    // Yield to let the consumer process
+    await new Promise((r) => setTimeout(r, 0));
+    log.push(2);
+    await new Promise((r) => setTimeout(r, 0));
+    log.push(3);
+    log.close();
+
+    await consumer;
+    expect(collected).toEqual([1, 2, 3]);
+  });
+
+  it("toAsyncIterable respects startAt", async () => {
+    const log = new EventLog<string>();
+    log.push("a");
+    log.push("b");
+    log.push("c");
+    log.close();
+
+    const results: string[] = [];
+    for await (const item of log.toAsyncIterable(1)) {
+      results.push(item);
+    }
+    expect(results).toEqual(["b", "c"]);
+  });
+
+  it("multiple cursors at different positions", async () => {
+    const log = new EventLog<number>();
+    log.push(0);
+    log.push(1);
+    log.push(2);
+    log.push(3);
+    log.close();
+
+    const [from0, from2, from4] = await Promise.all([
+      collect(log.iterate(0)),
+      collect(log.iterate(2)),
+      collect(log.iterate(4)),
+    ]);
+
+    expect(from0).toEqual([0, 1, 2, 3]);
+    expect(from2).toEqual([2, 3]);
+    expect(from4).toEqual([]);
+  });
+});

--- a/libs/langgraph-core/src/stream/event-log.ts
+++ b/libs/langgraph-core/src/stream/event-log.ts
@@ -1,0 +1,119 @@
+/**
+ * EventLog — append-only log with multiple independent async cursors.
+ *
+ * All projections in the v2 streaming API are backed by EventLog instances.
+ * Multiple `for await` loops can run concurrently over the same log without
+ * interfering — each iterator maintains its own cursor position.
+ *
+ * Items are retained for the lifetime of the log (no eviction).  A
+ * bounded-buffer variant may be substituted for very long-running agents.
+ */
+
+/**
+ * An append-only, async-iterable event log that supports multiple independent
+ * cursors.  Producers {@link EventLog.push | push} items and signal completion
+ * via {@link EventLog.close | close} or {@link EventLog.fail | fail}.
+ * Consumers obtain cursors with {@link EventLog.iterate | iterate} or
+ * {@link EventLog.toAsyncIterable | toAsyncIterable}.
+ *
+ * @typeParam T - The type of items stored in the log.
+ */
+export class EventLog<T> {
+  #items: T[] = [];
+  #waiters: Array<() => void> = [];
+  #done = false;
+  #error: unknown;
+
+  /**
+   * Append an item to the log and wake any waiting cursors.
+   *
+   * @param item - The item to append.
+   */
+  push(item: T): void {
+    this.#items.push(item);
+    this.#wake();
+  }
+
+  /**
+   * Mark the log as complete.  All active and future iterators will finish
+   * after yielding any remaining items.
+   */
+  close(): void {
+    this.#done = true;
+    this.#wake();
+  }
+
+  /**
+   * Mark the log as failed.  All active and future iterators will throw
+   * {@link err} after yielding any remaining items.
+   *
+   * @param err - The error to propagate to consumers.
+   */
+  fail(err: unknown): void {
+    this.#error = err;
+    this.#done = true;
+    this.#wake();
+  }
+
+  /**
+   * Returns an async iterator starting at position {@link startAt}.
+   * Each call returns an independent cursor so multiple consumers can
+   * iterate the same log concurrently.
+   *
+   * Uses arrow functions to lexically bind `this`, giving the returned
+   * iterator object access to native `#private` fields.
+   *
+   * @param startAt - Zero-based index to begin reading from.
+   * @returns A new {@link AsyncIterator} over log items.
+   */
+  iterate(startAt = 0): AsyncIterator<T> {
+    let cursor = startAt;
+    return {
+      next: async (): Promise<IteratorResult<T>> => {
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          if (cursor < this.#items.length) {
+            return { value: this.#items[cursor++], done: false };
+          }
+          if (this.#done) {
+            if (this.#error) throw this.#error;
+            return { value: undefined as unknown as T, done: true };
+          }
+          await new Promise<void>((resolve) => this.#waiters.push(resolve));
+        }
+      },
+    };
+  }
+
+  /**
+   * Creates an {@link AsyncIterable} backed by this log, starting from
+   * {@link startAt}.  Convenience wrapper so callers can use `for await`.
+   *
+   * @param startAt - Zero-based index to begin reading from.
+   * @returns A new {@link AsyncIterable} over log items.
+   */
+  toAsyncIterable(startAt = 0): AsyncIterable<T> {
+    return {
+      [Symbol.asyncIterator]: () => this.iterate(startAt),
+    };
+  }
+
+  /**
+   * The number of items currently in the log.
+   */
+  get size(): number {
+    return this.#items.length;
+  }
+
+  /**
+   * Whether the log has been closed or failed.
+   */
+  get done(): boolean {
+    return this.#done;
+  }
+
+  #wake(): void {
+    const waiters = this.#waiters.splice(0);
+    for (const w of waiters) w();
+  }
+}

--- a/libs/langgraph-core/src/stream/index.ts
+++ b/libs/langgraph-core/src/stream/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Public re-exports for the v2 streaming interface.
+ *
+ * This barrel provides the complete public API for the in-process streaming
+ * protocol.
+ */
+
+export { EventLog } from "./event-log.js";
+export { ChatModelStreamImpl } from "./chat-model-stream.js";
+export { StreamMux, pump, nsKey, hasPrefix, STREAM_V2_MODES } from "./mux.js";
+export {
+  GraphRunStream,
+  SubgraphRunStream,
+  createGraphRunStream,
+} from "./run-stream.js";
+export { createMessagesReducer, createValuesReducer } from "./reducers.js";
+export { convertToProtocolEvent } from "./convert.js";
+export type {
+  Namespace,
+  ProtocolEvent,
+  FinishReason,
+  UsageInfo,
+  MessagesEventData,
+  ToolsEventData,
+  UpdatesEventData,
+  MessageStartData,
+  ContentBlockStartData,
+  ContentBlockDeltaData,
+  ContentBlockFinishData,
+  MessageFinishData,
+  MessageErrorData,
+  ToolStartedData,
+  ToolOutputDeltaData,
+  ToolFinishedData,
+  ToolErrorData,
+  StreamReducer,
+  InferExtensions,
+  ChatModelStream,
+  ToolCallStatus,
+  ToolCallStream,
+  InterruptPayload,
+} from "./types.js";

--- a/libs/langgraph-core/src/stream/mux.test.ts
+++ b/libs/langgraph-core/src/stream/mux.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  StreamMux,
+  pump,
+  nsKey,
+  hasPrefix,
+  setRunStreamClasses,
+} from "./mux.js";
+import type { ProtocolEvent, StreamReducer } from "./types.js";
+
+class MockSubgraphStream {
+  constructor(
+    public path: string[],
+    public mux: StreamMux,
+    public discoveryStart: number,
+    public eventStart: number
+  ) {}
+  _resolveValues(_v: unknown) {}
+  _rejectValues(_e: unknown) {}
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+setRunStreamClasses(MockSubgraphStream as any, MockSubgraphStream as any);
+
+function makeEvent(
+  method: string,
+  ns: string[] = [],
+  seq = 0
+): ProtocolEvent {
+  return {
+    type: "event",
+    seq,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    method: method as any,
+    params: { namespace: ns, timestamp: Date.now(), data: {} },
+  };
+}
+
+async function collect<T>(iter: AsyncIterator<T>): Promise<T[]> {
+  const out: T[] = [];
+  for (;;) {
+    const r = await iter.next();
+    if (r.done) break;
+    out.push(r.value);
+  }
+  return out;
+}
+
+describe("nsKey", () => {
+  it("joins segments with null byte", () => {
+    expect(nsKey(["a", "b", "c"])).toBe("a\x00b\x00c");
+  });
+
+  it("returns empty string for empty namespace", () => {
+    expect(nsKey([])).toBe("");
+  });
+
+  it("returns the segment itself for single-element namespace", () => {
+    expect(nsKey(["root"])).toBe("root");
+  });
+});
+
+describe("hasPrefix", () => {
+  it("returns true for empty prefix", () => {
+    expect(hasPrefix(["a", "b"], [])).toBe(true);
+  });
+
+  it("returns true for exact match", () => {
+    expect(hasPrefix(["a", "b"], ["a", "b"])).toBe(true);
+  });
+
+  it("returns true when ns starts with prefix", () => {
+    expect(hasPrefix(["a", "b", "c"], ["a", "b"])).toBe(true);
+  });
+
+  it("returns false when prefix is longer than ns", () => {
+    expect(hasPrefix(["a"], ["a", "b"])).toBe(false);
+  });
+
+  it("returns false when segments differ", () => {
+    expect(hasPrefix(["a", "b"], ["a", "x"])).toBe(false);
+  });
+
+  it("returns true for two empty arrays", () => {
+    expect(hasPrefix([], [])).toBe(true);
+  });
+});
+
+describe("StreamMux", () => {
+  it("push creates subgraph discoveries for new namespaces", () => {
+    const mux = new StreamMux();
+    mux.push(["agent"], makeEvent("messages", ["agent"]));
+
+    const discoveries: unknown[] = [];
+    const iter = mux._discoveries.iterate();
+
+    mux._discoveries.close();
+
+    (async () => {
+      const items = await collect(iter);
+      discoveries.push(...items);
+    })();
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(discoveries).toHaveLength(1);
+        const d = discoveries[0] as { ns: string[]; stream: MockSubgraphStream };
+        expect(d.ns).toEqual(["agent"]);
+        expect(d.stream).toBeInstanceOf(MockSubgraphStream);
+        resolve();
+      }, 10);
+    });
+  });
+
+  it("push creates discoveries only for top-level namespace segments", () => {
+    const mux = new StreamMux();
+    mux.push(
+      ["parent", "child"],
+      makeEvent("messages", ["parent", "child"])
+    );
+    mux._discoveries.close();
+
+    return collect(mux._discoveries.iterate()).then((items) => {
+      expect(items).toHaveLength(1);
+      expect(items[0].ns).toEqual(["parent"]);
+    });
+  });
+
+  it("push does not create duplicate discoveries", () => {
+    const mux = new StreamMux();
+    mux.push(["agent"], makeEvent("messages", ["agent"], 0));
+    mux.push(["agent"], makeEvent("messages", ["agent"], 1));
+    mux._discoveries.close();
+
+    return collect(mux._discoveries.iterate()).then((items) => {
+      expect(items).toHaveLength(1);
+    });
+  });
+
+  it("push runs reducer pipeline — events suppressed when reducer returns false", () => {
+    const mux = new StreamMux();
+    const reducer: StreamReducer = {
+      init: () => ({}),
+      process: (event) => event.method !== "debug",
+      finalize: () => {},
+      fail: () => {},
+    };
+    mux.addReducer(reducer);
+
+    mux.push([], makeEvent("messages", [], 0));
+    mux.push([], makeEvent("debug", [], 1));
+    mux.push([], makeEvent("updates", [], 2));
+    mux._events.close();
+
+    return collect(mux._events.iterate()).then((events) => {
+      expect(events).toHaveLength(2);
+      expect(events[0].method).toBe("messages");
+      expect(events[1].method).toBe("updates");
+    });
+  });
+
+  it("addReducer + process order", () => {
+    const mux = new StreamMux();
+    const order: number[] = [];
+
+    const makeReducer = (id: number): StreamReducer => ({
+      init: () => ({}),
+      process: () => {
+        order.push(id);
+        return true;
+      },
+      finalize: () => {},
+      fail: () => {},
+    });
+
+    mux.addReducer(makeReducer(1));
+    mux.addReducer(makeReducer(2));
+    mux.addReducer(makeReducer(3));
+
+    mux.push([], makeEvent("messages"));
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it("close finalizes reducers, closes event and discovery logs", () => {
+    const mux = new StreamMux();
+    const finalizeSpy = vi.fn();
+    const reducer: StreamReducer = {
+      init: () => ({}),
+      process: () => true,
+      finalize: finalizeSpy,
+      fail: () => {},
+    };
+    mux.addReducer(reducer);
+    mux.close();
+
+    expect(finalizeSpy).toHaveBeenCalledOnce();
+    expect(mux._events.done).toBe(true);
+    expect(mux._discoveries.done).toBe(true);
+  });
+
+  it("close resolves values on registered streams", () => {
+    const mux = new StreamMux();
+    const mockStream = new MockSubgraphStream([], mux, 0, 0);
+    const resolveSpy = vi.spyOn(mockStream, "_resolveValues");
+    mux.register([], mockStream);
+
+    const valuesEvent: ProtocolEvent = {
+      type: "event",
+      seq: 0,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      method: "values" as any,
+      params: {
+        namespace: [],
+        timestamp: Date.now(),
+        data: { count: 42 },
+      },
+    };
+    mux.push([], valuesEvent);
+    mux.close();
+
+    expect(resolveSpy).toHaveBeenCalledWith({ count: 42 });
+  });
+
+  it("fail calls fail on all reducers, events, discoveries, and streams", () => {
+    const mux = new StreamMux();
+    const failSpy = vi.fn();
+    const reducer: StreamReducer = {
+      init: () => ({}),
+      process: () => true,
+      finalize: () => {},
+      fail: failSpy,
+    };
+    mux.addReducer(reducer);
+
+    const mockStream = new MockSubgraphStream([], mux, 0, 0);
+    const rejectSpy = vi.spyOn(mockStream, "_rejectValues");
+    mux.register(["sub"], mockStream);
+
+    const error = new Error("test failure");
+    mux.fail(error);
+
+    expect(failSpy).toHaveBeenCalledWith(error);
+    expect(mux._events.done).toBe(true);
+    expect(mux._discoveries.done).toBe(true);
+    expect(rejectSpy).toHaveBeenCalledWith(error);
+  });
+
+  it("subscribeEvents filters by namespace prefix", async () => {
+    const mux = new StreamMux();
+
+    mux.push([], makeEvent("messages", [], 0));
+    mux.push(["agent"], makeEvent("messages", ["agent"], 1));
+    mux.push(["agent", "sub"], makeEvent("updates", ["agent", "sub"], 2));
+    mux.push(["other"], makeEvent("messages", ["other"], 3));
+    mux._events.close();
+
+    const filtered = await collect(mux.subscribeEvents(["agent"]));
+    expect(filtered).toHaveLength(2);
+    expect(filtered[0].params.namespace).toEqual(["agent"]);
+    expect(filtered[1].params.namespace).toEqual(["agent", "sub"]);
+  });
+
+  it("subscribeSubgraphs yields only top-level discovered subgraphs", async () => {
+    const mux = new StreamMux();
+
+    // Deep namespace — only top-level ["parent"] is announced as a discovery
+    mux.push(
+      ["parent", "child", "grandchild"],
+      makeEvent("messages", ["parent", "child", "grandchild"])
+    );
+    // Second top-level subgraph
+    mux.push(["sibling"], makeEvent("messages", ["sibling"]));
+    mux._discoveries.close();
+
+    // Root-level subscription sees both top-level subgraphs
+    const rootChildren = await collect(mux.subscribeSubgraphs([]));
+    expect(rootChildren).toHaveLength(2);
+    expect((rootChildren[0] as MockSubgraphStream).path).toEqual(["parent"]);
+    expect((rootChildren[1] as MockSubgraphStream).path).toEqual(["sibling"]);
+  });
+
+  it("markInterrupted sets interrupted flag and stores payloads", () => {
+    const mux = new StreamMux();
+    expect(mux.interrupted).toBe(false);
+    expect(mux.interrupts).toEqual([]);
+
+    const payloads = [
+      { interruptId: "int-1", payload: { question: "continue?" } },
+      { interruptId: "int-2", payload: null },
+    ];
+    mux.markInterrupted(payloads);
+
+    expect(mux.interrupted).toBe(true);
+    expect(mux.interrupts).toEqual(payloads);
+  });
+
+  it("markInterrupted accumulates across multiple calls", () => {
+    const mux = new StreamMux();
+    mux.markInterrupted([{ interruptId: "a", payload: 1 }]);
+    mux.markInterrupted([{ interruptId: "b", payload: 2 }]);
+
+    expect(mux.interrupts).toHaveLength(2);
+    expect(mux.interrupts[0].interruptId).toBe("a");
+    expect(mux.interrupts[1].interruptId).toBe("b");
+  });
+});
+
+describe("pump", () => {
+  it("converts chunks and pushes them, closes on end", async () => {
+    const mux = new StreamMux();
+
+    async function* source() {
+      yield [[], "messages", { text: "hello" }] as [string[], string, unknown];
+      yield [[], "updates", { node: "a" }] as [string[], string, unknown];
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await pump(source() as any, mux);
+
+    expect(mux._events.done).toBe(true);
+    const events = await collect(mux._events.iterate());
+    expect(events).toHaveLength(2);
+    expect(events[0].method).toBe("messages");
+    expect(events[1].method).toBe("updates");
+    expect(events[0].seq).toBe(0);
+    expect(events[1].seq).toBe(1);
+  });
+
+  it("calls fail on error", async () => {
+    const mux = new StreamMux();
+    const failError = new Error("stream broke");
+
+    async function* source() {
+      yield [[], "messages", {}] as [string[], string, unknown];
+      throw failError;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await pump(source() as any, mux);
+
+    expect(mux._events.done).toBe(true);
+
+    const iter = mux._events.iterate();
+    await iter.next(); // consume the one valid event
+    await expect(iter.next()).rejects.toThrow("stream broke");
+  });
+
+  it("skips null events from unrecognised modes", async () => {
+    const mux = new StreamMux();
+
+    async function* source() {
+      yield [[], "unknown_mode", {}] as [string[], string, unknown];
+      yield [[], "messages", { text: "hi" }] as [string[], string, unknown];
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await pump(source() as any, mux);
+
+    const events = await collect(mux._events.iterate());
+    expect(events).toHaveLength(1);
+    expect(events[0].method).toBe("messages");
+  });
+});

--- a/libs/langgraph-core/src/stream/mux.ts
+++ b/libs/langgraph-core/src/stream/mux.ts
@@ -1,0 +1,354 @@
+/**
+ * StreamMux — central dispatcher with reducer pipeline.
+ *
+ * Routes raw stream chunks through registered StreamReducers, then appends
+ * the resulting ProtocolEvents to the main EventLog.  Also tracks namespace
+ * discovery for SubgraphRunStream creation.
+ *
+ * lifecycle:
+ *   graph.streamV2(input)
+ *     ├─ StreamMux starts pumping from graph.stream(…, { subgraphs: true })
+ *     ├─ For each ProtocolEvent:
+ *     │   ├─ reducer_1.process(event)
+ *     │   ├─ reducer_2.process(event)
+ *     │   └─ event appended to _events (unless suppressed)
+ *     └─ On close: reducer_n.finalize() called in registration order
+ */
+
+import type { StreamChunk } from "../pregel/stream.js";
+import { INTERRUPT, isInterrupted, type Interrupt } from "../constants.js";
+import { EventLog } from "./event-log.js";
+import { convertToProtocolEvent, STREAM_V2_MODES } from "./convert.js";
+import type {
+  InterruptPayload,
+  Namespace,
+  ProtocolEvent,
+  StreamReducer,
+} from "./types.js";
+
+export { STREAM_V2_MODES };
+
+/**
+ * A discovered subgraph namespace paired with its run stream handle.
+ */
+export type SubgraphDiscovery = {
+  ns: Namespace;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  stream: any;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let _SubgraphRunStreamCtor: new (...args: any[]) => any;
+
+/**
+ * Registers the concrete run-stream constructors used by {@link StreamMux}
+ * to create subgraph stream handles.  Called once by `run-stream.ts` at
+ * module load to break the circular dependency.
+ *
+ * @internal
+ * @param _graphCtor - The graph-level run stream constructor (unused here,
+ *   accepted for symmetry with the registration call).
+ * @param subCtor - The subgraph run stream constructor instantiated for
+ *   each newly discovered namespace.
+ */
+export function setRunStreamClasses(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _graphCtor: new (...args: any[]) => any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  subCtor: new (...args: any[]) => any
+): void {
+  _SubgraphRunStreamCtor = subCtor;
+}
+
+/**
+ * Central event dispatcher that routes {@link ProtocolEvent}s through a
+ * pipeline of {@link StreamReducer}s, manages namespace discovery for
+ * subgraph streams, and exposes async iteration over filtered event
+ * sequences.
+ *
+ * One `StreamMux` instance exists per top-level `streamV2()` invocation.
+ */
+export class StreamMux {
+  /** @internal All protocol events in arrival order (after reducer pipeline). */
+  readonly _events = new EventLog<ProtocolEvent>();
+
+  /** @internal New-namespace discovery notifications. */
+  readonly _discoveries = new EventLog<SubgraphDiscovery>();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly #reducers: StreamReducer<any>[] = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly #streamMap = new Map<string, any>();
+  readonly #seenNs = new Set<string>();
+  readonly #latestValues = new Map<string, Record<string, unknown>>();
+  readonly #interrupts: InterruptPayload[] = [];
+  #interrupted = false;
+
+  /**
+   * Associates a pre-existing stream handle with a namespace so that
+   * {@link close} can resolve its values promise later.
+   *
+   * @param path - The namespace path to register.
+   * @param stream - The run stream handle for that namespace.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  register(path: Namespace, stream: any): void {
+    this.#streamMap.set(nsKey(path), stream);
+  }
+
+  /**
+   * Appends a reducer to the pipeline.  Reducers run in registration order
+   * for every event passed to {@link push}.
+   *
+   * @param reducer - The reducer to add.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  addReducer(reducer: StreamReducer<any>): void {
+    this.#reducers.push(reducer);
+  }
+
+  /**
+   * Distributes an event through the reducer pipeline, then appends it to
+   * the main event log.  Creates {@link SubgraphDiscovery} entries for any
+   * namespace segments not yet seen.
+   *
+   * @param ns - The namespace path that produced the event.
+   * @param event - The protocol event to process and store.
+   */
+  push(ns: Namespace, event: ProtocolEvent): void {
+    // Only announce first-level namespace segments as discoverable
+    // subgraphs.  Deeper segments (e.g. ["researcher:uuid", "tools:uuid"])
+    // are internal Pregel checkpoint namespace entries for nodes within a
+    // subgraph and should not appear as user-facing SubgraphRunStream
+    // instances.  We still track them in #seenNs / #streamMap so that
+    // values resolution and event filtering work correctly.
+    if (ns.length > 0) {
+      const topNs = ns.slice(0, 1);
+      const topKey = nsKey(topNs);
+      if (!this.#seenNs.has(topKey)) {
+        this.#seenNs.add(topKey);
+        const subStream = new _SubgraphRunStreamCtor(
+          topNs,
+          this,
+          this._discoveries.size,
+          this._events.size
+        );
+        this.#streamMap.set(topKey, subStream);
+        this._discoveries.push({ ns: topNs, stream: subStream });
+      }
+    }
+
+    if (event.method === "values") {
+      this.#latestValues.set(
+        nsKey(ns),
+        event.params.data as Record<string, unknown>
+      );
+    }
+
+    let keep = true;
+    for (const reducer of this.#reducers) {
+      if (!reducer.process(event)) {
+        keep = false;
+      }
+    }
+
+    if (keep) {
+      this._events.push(event);
+    }
+  }
+
+  /**
+   * Gracefully ends the stream: resolves values promises on all known
+   * streams, finalizes every reducer, and closes both event logs.
+   */
+  close(): void {
+    for (const [key, values] of this.#latestValues.entries()) {
+      const ns = key ? key.split("\x00") : [];
+      const stream = this.#streamMap.get(nsKey(ns));
+      stream?._resolveValues(values);
+    }
+
+    for (const reducer of this.#reducers) {
+      reducer.finalize();
+    }
+
+    this._events.close();
+    this._discoveries.close();
+
+    for (const stream of this.#streamMap.values()) {
+      stream._resolveValues(undefined);
+    }
+  }
+
+  /**
+   * Propagates a failure to all reducers, event logs, and stream handles.
+   *
+   * @param err - The error that caused the run to fail.
+   */
+  fail(err: unknown): void {
+    for (const reducer of this.#reducers) {
+      reducer.fail(err);
+    }
+    this._events.fail(err);
+    this._discoveries.fail(err);
+    for (const stream of this.#streamMap.values()) {
+      stream._rejectValues(err);
+    }
+  }
+
+  /**
+   * Records that the run was interrupted, appending the supplied payloads
+   * for later retrieval.
+   *
+   * @param interrupts - The interrupt payloads to store.
+   */
+  markInterrupted(interrupts: InterruptPayload[]): void {
+    this.#interrupted = true;
+    this.#interrupts.push(...interrupts);
+  }
+
+  /**
+   * Whether the run ended due to an interrupt.
+   *
+   * @returns `true` if {@link markInterrupted} was called.
+   */
+  get interrupted(): boolean {
+    return this.#interrupted;
+  }
+
+  /**
+   * All interrupt payloads collected during the run.
+   *
+   * @returns A readonly view of the accumulated interrupt payloads.
+   */
+  get interrupts(): readonly InterruptPayload[] {
+    return this.#interrupts;
+  }
+
+  /**
+   * Returns an async iterator that yields only events whose namespace
+   * starts with {@link path}.
+   *
+   * @param path - Namespace prefix to filter on.
+   * @param startAt - Zero-based index into the event log to begin from.
+   * @returns An async iterator over matching {@link ProtocolEvent}s.
+   */
+  subscribeEvents(path: Namespace, startAt = 0): AsyncIterator<ProtocolEvent> {
+    const base = this._events.iterate(startAt);
+    return {
+      async next(): Promise<IteratorResult<ProtocolEvent>> {
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          const result = await base.next();
+          if (result.done) return result;
+          if (hasPrefix(result.value.params.namespace, path)) {
+            return result;
+          }
+        }
+      },
+    };
+  }
+
+  /**
+   * Returns an async iterator that yields subgraph stream handles for
+   * direct children of {@link path} (i.e. namespaces exactly one level
+   * deeper).
+   *
+   * @param path - Parent namespace to watch for children.
+   * @param startAt - Zero-based index into the discovery log to begin from.
+   * @returns An async iterator over subgraph stream handles.
+   */
+  subscribeSubgraphs(
+    path: Namespace,
+    startAt = 0
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): AsyncIterator<any> {
+    const base = this._discoveries.iterate(startAt);
+    const targetDepth = path.length + 1;
+    return {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async next(): Promise<IteratorResult<any>> {
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          const result = await base.next();
+          if (result.done) {
+            return { value: undefined, done: true };
+          }
+          const { ns, stream } = result.value;
+          if (ns.length === targetDepth && hasPrefix(ns, path)) {
+            return { value: stream, done: false };
+          }
+        }
+      },
+    };
+  }
+}
+
+/**
+ * Background consumer that drains a raw `graph.stream()` source into a
+ * {@link StreamMux}.  Converts each chunk to a {@link ProtocolEvent} and
+ * pushes it; calls {@link StreamMux.close} on normal completion or
+ * {@link StreamMux.fail} on error.
+ *
+ * @param source - The async iterable of raw stream chunks from the engine.
+ * @param mux - The mux instance to feed.
+ * @returns A promise that resolves when the source is fully consumed.
+ */
+export async function pump(
+  source: AsyncIterable<StreamChunk>,
+  mux: StreamMux
+): Promise<void> {
+  let seq = 0;
+  try {
+    for await (const chunk of source) {
+      const [ns, mode, payload] = chunk;
+
+      // Detect interrupt payloads attached to values-mode chunks.
+      if (mode === "values" && isInterrupted(payload)) {
+        const interrupts = (payload as { [INTERRUPT]: Interrupt[] })[INTERRUPT];
+        mux.markInterrupted(
+          interrupts.map((i) => ({
+            interruptId: i.id ?? "",
+            payload: i.value,
+          }))
+        );
+      }
+
+      const event = convertToProtocolEvent(ns, mode, payload, seq);
+      seq += 1;
+      if (event !== null) {
+        mux.push(ns, event);
+      }
+    }
+  } catch (err) {
+    mux.fail(err);
+    return;
+  }
+  mux.close();
+}
+
+/**
+ * Serialises a {@link Namespace} array into a single string key using the
+ * null byte (`\x00`) as separator, suitable for `Map`/`Set` lookups.
+ *
+ * @param ns - The namespace segments to join.
+ * @returns A null-byte-joined string key.
+ */
+export function nsKey(ns: Namespace): string {
+  return ns.join("\x00");
+}
+
+/**
+ * Tests whether {@link ns} starts with every segment in {@link prefix}.
+ *
+ * @param ns - The full namespace to check.
+ * @param prefix - The prefix to match against.
+ * @returns `true` if `ns` begins with `prefix` segment-by-segment.
+ */
+export function hasPrefix(ns: Namespace, prefix: Namespace): boolean {
+  if (prefix.length > ns.length) return false;
+  for (let i = 0; i < prefix.length; i += 1) {
+    if (ns[i] !== prefix[i]) return false;
+  }
+  return true;
+}

--- a/libs/langgraph-core/src/stream/reducers.test.ts
+++ b/libs/langgraph-core/src/stream/reducers.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, it } from "vitest";
+import { createMessagesReducer, createValuesReducer } from "./reducers.js";
+import type { ProtocolEvent } from "./types.js";
+
+function makeEvent(
+  method: string,
+  data: unknown,
+  namespace: string[] = [],
+  node?: string,
+  seq = 0
+): ProtocolEvent {
+  return {
+    type: "event",
+    seq,
+    method: method as ProtocolEvent["method"],
+    params: {
+      namespace,
+      timestamp: Date.now(),
+      data,
+      ...(node != null ? { node } : {}),
+    },
+  };
+}
+
+async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
+  const items: T[] = [];
+  for await (const item of iter) {
+    items.push(item);
+  }
+  return items;
+}
+
+/**
+ * Root-level reducer tests use path=[] and emit events at namespace
+ * ["agent"] (depth 1), because the MessagesReducer only captures events
+ * at exactly path.length + 1 — the graph's own node namespace depth.
+ */
+describe("createMessagesReducer", () => {
+  const agentNs = ["agent"];
+
+  it("creates ChatModelStreams from message-start events", () => {
+    const reducer = createMessagesReducer([]);
+    const proj = reducer.init();
+
+    reducer.process(
+      makeEvent("messages", { event: "message-start", role: "ai" }, agentNs)
+    );
+    reducer.process(
+      makeEvent("messages", { event: "message-finish", reason: "stop" }, agentNs)
+    );
+    reducer.finalize();
+
+    const collected = collect(proj.messages);
+    return expect(collected).resolves.toHaveLength(1);
+  });
+
+  it("forwards content-block-delta to active stream", async () => {
+    const reducer = createMessagesReducer([]);
+    const proj = reducer.init();
+
+    reducer.process(
+      makeEvent("messages", { event: "message-start", role: "ai" }, agentNs)
+    );
+    reducer.process(
+      makeEvent("messages", {
+        event: "content-block-delta",
+        index: 0,
+        contentBlock: { type: "text", text: "hello" },
+      }, agentNs)
+    );
+    reducer.process(
+      makeEvent("messages", { event: "message-finish", reason: "stop" }, agentNs)
+    );
+    reducer.finalize();
+
+    const streams = await collect(proj.messages);
+    expect(streams).toHaveLength(1);
+
+    const text = await streams[0].text;
+    expect(text).toBe("hello");
+  });
+
+  it("closes stream on message-finish", async () => {
+    const reducer = createMessagesReducer([]);
+    const proj = reducer.init();
+
+    reducer.process(
+      makeEvent("messages", { event: "message-start", role: "ai" }, agentNs)
+    );
+    reducer.process(
+      makeEvent("messages", { event: "message-finish", reason: "stop" }, agentNs)
+    );
+    reducer.finalize();
+
+    const streams = await collect(proj.messages);
+    expect(streams).toHaveLength(1);
+
+    const events = await collect(streams[0]);
+    const finishEvents = events.filter((e) => e.event === "message-finish");
+    expect(finishEvents).toHaveLength(1);
+  });
+
+  it("nodeFilter only processes events from matching node", async () => {
+    const reducer = createMessagesReducer([], "agent");
+    const proj = reducer.init();
+
+    reducer.process(
+      makeEvent(
+        "messages",
+        { event: "message-start", role: "ai" },
+        ["other_node"],
+        "other"
+      )
+    );
+    reducer.process(
+      makeEvent(
+        "messages",
+        { event: "message-finish", reason: "stop" },
+        ["other_node"],
+        "other"
+      )
+    );
+
+    reducer.process(
+      makeEvent(
+        "messages",
+        { event: "message-start", role: "ai" },
+        agentNs,
+        "agent"
+      )
+    );
+    reducer.process(
+      makeEvent(
+        "messages",
+        { event: "message-finish", reason: "stop" },
+        agentNs,
+        "agent"
+      )
+    );
+    reducer.finalize();
+
+    const streams = await collect(proj.messages);
+    expect(streams).toHaveLength(1);
+    expect(streams[0].node).toBe("agent");
+  });
+
+  it("captures events only at depth + 1 (direct child nodes)", async () => {
+    const reducer = createMessagesReducer(["root"]);
+    const proj = reducer.init();
+
+    // Direct child node (depth + 1) — should be captured
+    reducer.process(
+      makeEvent("messages", { event: "message-start", role: "ai" }, [
+        "root",
+        "node",
+      ])
+    );
+    reducer.process(
+      makeEvent("messages", { event: "message-finish", reason: "stop" }, [
+        "root",
+        "node",
+      ])
+    );
+
+    // Same depth as path (chain-level replay) — should be ignored
+    reducer.process(
+      makeEvent(
+        "messages",
+        { event: "message-start", role: "ai" },
+        ["root"]
+      )
+    );
+    reducer.process(
+      makeEvent(
+        "messages",
+        { event: "message-finish", reason: "stop" },
+        ["root"]
+      )
+    );
+
+    reducer.finalize();
+
+    const streams = await collect(proj.messages);
+    expect(streams).toHaveLength(1);
+    expect(streams[0].namespace).toEqual(["root", "node"]);
+  });
+
+  it("ignores events from deeply nested namespaces (depth + 2 or more)", async () => {
+    const reducer = createMessagesReducer(["root"]);
+    const proj = reducer.init();
+
+    // Deeply nested — should be ignored (belongs to a subgraph's own nodes)
+    reducer.process(
+      makeEvent("messages", { event: "message-start", role: "ai" }, [
+        "root",
+        "sub",
+        "inner",
+      ])
+    );
+    reducer.process(
+      makeEvent("messages", { event: "message-finish", reason: "stop" }, [
+        "root",
+        "sub",
+        "inner",
+      ])
+    );
+
+    // Direct child — should be captured
+    reducer.process(
+      makeEvent("messages", { event: "message-start", role: "ai" }, [
+        "root",
+        "node",
+      ])
+    );
+    reducer.process(
+      makeEvent("messages", { event: "message-finish", reason: "stop" }, [
+        "root",
+        "node",
+      ])
+    );
+
+    reducer.finalize();
+
+    const streams = await collect(proj.messages);
+    expect(streams).toHaveLength(1);
+    expect(streams[0].namespace).toEqual(["root", "node"]);
+  });
+
+  it("ignores events from unrelated namespaces", async () => {
+    const reducer = createMessagesReducer(["root"]);
+    const proj = reducer.init();
+
+    // Unrelated namespace — should be ignored
+    reducer.process(
+      makeEvent("messages", { event: "message-start", role: "ai" }, ["other", "node"])
+    );
+    reducer.process(
+      makeEvent("messages", { event: "message-finish", reason: "stop" }, ["other", "node"])
+    );
+
+    // Correct namespace at depth+1 — should be captured
+    reducer.process(
+      makeEvent("messages", { event: "message-start", role: "ai" }, ["root", "node"])
+    );
+    reducer.process(
+      makeEvent("messages", { event: "message-finish", reason: "stop" }, ["root", "node"])
+    );
+    reducer.finalize();
+
+    const streams = await collect(proj.messages);
+    expect(streams).toHaveLength(1);
+    expect(streams[0].namespace).toEqual(["root", "node"]);
+  });
+
+  it("finalize closes the log", async () => {
+    const reducer = createMessagesReducer([]);
+    const proj = reducer.init();
+    reducer.finalize();
+
+    const streams = await collect(proj.messages);
+    expect(streams).toHaveLength(0);
+  });
+
+  it("fail propagates error to active stream and log", async () => {
+    const reducer = createMessagesReducer([]);
+    const proj = reducer.init();
+    const error = new Error("boom");
+
+    reducer.process(
+      makeEvent("messages", { event: "message-start", role: "ai" }, agentNs)
+    );
+
+    const iter = proj.messages[Symbol.asyncIterator]();
+    const first = await iter.next();
+    expect(first.done).toBe(false);
+
+    const stream = first.value;
+    // Suppress unhandled rejections on internal promises before fail() rejects them.
+    stream.text.then(() => {}, () => {});
+    stream.reasoning.then(() => {}, () => {});
+    stream.usage.then(() => {}, () => {});
+
+    reducer.fail(error);
+
+    await expect(iter.next()).rejects.toThrow("boom");
+  });
+
+  it("multiple message lifecycles create separate ChatModelStreams", async () => {
+    const reducer = createMessagesReducer([]);
+    const proj = reducer.init();
+
+    reducer.process(
+      makeEvent("messages", { event: "message-start", role: "ai" }, agentNs)
+    );
+    reducer.process(
+      makeEvent("messages", {
+        event: "content-block-delta",
+        index: 0,
+        contentBlock: { type: "text", text: "first" },
+      }, agentNs)
+    );
+    reducer.process(
+      makeEvent("messages", { event: "message-finish", reason: "stop" }, agentNs)
+    );
+
+    reducer.process(
+      makeEvent("messages", { event: "message-start", role: "ai" }, agentNs)
+    );
+    reducer.process(
+      makeEvent("messages", {
+        event: "content-block-delta",
+        index: 0,
+        contentBlock: { type: "text", text: "second" },
+      }, agentNs)
+    );
+    reducer.process(
+      makeEvent("messages", { event: "message-finish", reason: "stop" }, agentNs)
+    );
+    reducer.finalize();
+
+    const streams = await collect(proj.messages);
+    expect(streams).toHaveLength(2);
+
+    const text0 = await streams[0].text;
+    const text1 = await streams[1].text;
+    expect(text0).toBe("first");
+    expect(text1).toBe("second");
+  });
+});
+
+describe("createValuesReducer", () => {
+  it("captures values events at the target namespace depth", async () => {
+    const reducer = createValuesReducer(["root"]);
+    const proj = reducer.init();
+
+    reducer.process(
+      makeEvent("values", { count: 1 }, ["root"])
+    );
+    reducer.process(
+      makeEvent("values", { count: 2 }, ["root"])
+    );
+    reducer.finalize();
+
+    const items = await collect(proj._valuesLog.toAsyncIterable());
+    expect(items).toEqual([{ count: 1 }, { count: 2 }]);
+  });
+
+  it("ignores events from different namespaces", async () => {
+    const reducer = createValuesReducer(["root"]);
+    const proj = reducer.init();
+
+    reducer.process(
+      makeEvent("values", { x: 1 }, ["other"])
+    );
+    reducer.process(
+      makeEvent("values", { x: 2 }, ["root", "child"])
+    );
+    reducer.finalize();
+
+    const items = await collect(proj._valuesLog.toAsyncIterable());
+    expect(items).toHaveLength(0);
+  });
+
+  it("ignores non-values events", async () => {
+    const reducer = createValuesReducer(["root"]);
+    const proj = reducer.init();
+
+    reducer.process(
+      makeEvent("messages", { event: "message-start" }, ["root"])
+    );
+    reducer.finalize();
+
+    const items = await collect(proj._valuesLog.toAsyncIterable());
+    expect(items).toHaveLength(0);
+  });
+
+  it("finalize closes the log", async () => {
+    const reducer = createValuesReducer([]);
+    const proj = reducer.init();
+    reducer.finalize();
+
+    const items = await collect(proj._valuesLog.toAsyncIterable());
+    expect(items).toHaveLength(0);
+  });
+
+  it("fail propagates error", async () => {
+    const reducer = createValuesReducer([]);
+    const proj = reducer.init();
+    const error = new Error("fail");
+
+    reducer.process(makeEvent("values", { a: 1 }, []));
+    reducer.fail(error);
+
+    await expect(
+      collect(proj._valuesLog.toAsyncIterable())
+    ).rejects.toThrow("fail");
+  });
+});

--- a/libs/langgraph-core/src/stream/reducers.ts
+++ b/libs/langgraph-core/src/stream/reducers.ts
@@ -1,0 +1,173 @@
+/**
+ * Built-in graph-level reducers.
+ *
+ * These reducers are registered automatically for every graph run:
+ *
+ *   ValuesReducer   — captures values events and resolves run.output.
+ *   MessagesReducer — groups messages events into ChatModelStream lifecycles.
+ *
+ * They run in a fixed order: ValuesReducer first, then MessagesReducer.
+ */
+
+import { EventLog } from "./event-log.js";
+import { ChatModelStreamImpl } from "./chat-model-stream.js";
+import type {
+  ChatModelStream,
+  MessagesEventData,
+  Namespace,
+  ProtocolEvent,
+  StreamReducer,
+} from "./types.js";
+import { hasPrefix } from "./mux.js";
+
+/**
+ * The projection shape merged into a run stream by the messages reducer.
+ * Exposes a `messages` async iterable that yields one {@link ChatModelStream}
+ * per AI message lifecycle observed during the run.
+ */
+export interface MessagesReducerProjection {
+  messages: AsyncIterable<ChatModelStream>;
+}
+
+/**
+ * Creates a {@link StreamReducer} that groups `messages` channel events into
+ * per-message {@link ChatModelStream} instances.
+ *
+ * A new `ChatModelStream` is created on `message-start` and closed on
+ * `message-finish`.  Content-block events in between are forwarded to the
+ * active stream.  Only events whose namespace exactly matches {@link path}
+ * are processed; child namespaces are ignored.
+ *
+ * @param path - Namespace prefix to match against incoming events.
+ * @param nodeFilter - If provided, only events emitted by this graph node
+ *   are processed; all others are skipped.
+ * @returns A `StreamReducer` whose projection contains the `messages`
+ *   async iterable.
+ */
+export function createMessagesReducer(
+  path: Namespace,
+  nodeFilter?: string
+): StreamReducer<MessagesReducerProjection> {
+  const log = new EventLog<ChatModelStream>();
+  let active: ChatModelStreamImpl | undefined;
+
+  return {
+    init: () => ({
+      messages: log.toAsyncIterable(),
+    }),
+
+    process(event: ProtocolEvent): boolean {
+      if (event.method !== "messages") return true;
+      if (!hasPrefix(event.params.namespace, path)) return true;
+
+      // Only capture messages from this graph's own node executions,
+      // which sit exactly one namespace level deeper than `path`.
+      // Events at `path` itself are chain-level replays from the
+      // callback system (handleChainEnd re-emits finalized messages)
+      // and would duplicate the streamed content already captured
+      // at depth+1.
+      const depth = event.params.namespace.length;
+      if (depth !== path.length + 1) return true;
+
+      if (nodeFilter !== undefined && event.params.node !== nodeFilter) {
+        return true;
+      }
+
+      const data = event.params.data as MessagesEventData;
+
+      switch (data.event) {
+        case "message-start":
+          active = new ChatModelStreamImpl(
+            event.params.namespace,
+            event.params.node
+          );
+          log.push(active);
+          break;
+
+        case "content-block-start":
+        case "content-block-delta":
+        case "content-block-finish":
+          active?.pushEvent(data);
+          break;
+
+        case "message-finish":
+          if (active) {
+            active.finish(data);
+            active = undefined;
+          }
+          break;
+
+        case "error":
+          active?.pushEvent(data);
+          break;
+      }
+
+      return true;
+    },
+
+    finalize(): void {
+      if (active) {
+        active.finish({
+          event: "message-finish",
+          reason: "stop",
+        });
+        active = undefined;
+      }
+      log.close();
+    },
+
+    fail(err: unknown): void {
+      active?.fail(err);
+      active = undefined;
+      log.fail(err);
+    },
+  };
+}
+
+/**
+ * The projection shape merged into a run stream by the values reducer.
+ * Exposes the underlying {@link EventLog} so that `StreamMux` can resolve
+ * the final output value on close.
+ */
+export interface ValuesReducerProjection {
+  _valuesLog: EventLog<Record<string, unknown>>;
+}
+
+/**
+ * Creates a {@link StreamReducer} that captures `values` channel events
+ * into an {@link EventLog}.  Only events whose namespace exactly matches
+ * {@link path} are recorded; events from child or sibling namespaces are
+ * ignored.
+ *
+ * The final snapshot is resolved by {@link StreamMux.close} directly;
+ * this reducer only accumulates intermediate values.
+ *
+ * @param path - Namespace prefix to match against incoming events.
+ * @returns A `StreamReducer` whose projection contains the internal
+ *   `_valuesLog` event log.
+ */
+export function createValuesReducer(
+  path: Namespace
+): StreamReducer<ValuesReducerProjection> {
+  const valuesLog = new EventLog<Record<string, unknown>>();
+
+  return {
+    init: () => ({ _valuesLog: valuesLog }),
+
+    process(event: ProtocolEvent): boolean {
+      if (event.method !== "values") return true;
+      if (event.params.namespace.length !== path.length) return true;
+      if (!hasPrefix(event.params.namespace, path)) return true;
+      valuesLog.push(event.params.data as Record<string, unknown>);
+      return true;
+    },
+
+    finalize(): void {
+      valuesLog.close();
+    },
+
+    fail(err: unknown): void {
+      valuesLog.fail(err);
+    },
+  };
+}

--- a/libs/langgraph-core/src/stream/run-stream.test.ts
+++ b/libs/langgraph-core/src/stream/run-stream.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it } from "vitest";
+import {
+  GraphRunStream,
+  SubgraphRunStream,
+  createGraphRunStream,
+} from "./run-stream.js";
+import { StreamMux, setRunStreamClasses } from "./mux.js";
+import type { ProtocolEvent, StreamReducer } from "./types.js";
+
+setRunStreamClasses(GraphRunStream, SubgraphRunStream);
+
+function makeEvent(
+  method: string,
+  ns: string[] = [],
+  data: unknown = {},
+  seq = 0
+): ProtocolEvent {
+  return {
+    type: "event",
+    seq,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    method: method as any,
+    params: { namespace: ns, timestamp: Date.now(), data },
+  };
+}
+
+async function collect<T>(iter: AsyncIterator<T>): Promise<T[]> {
+  const out: T[] = [];
+  for (;;) {
+    const r = await iter.next();
+    if (r.done) break;
+    out.push(r.value);
+  }
+  return out;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function* makeSource(
+  chunks: [string[], string, unknown][]
+): AsyncGenerator<any> {
+  for (const chunk of chunks) yield chunk;
+}
+
+describe("GraphRunStream", () => {
+  it("iterates protocol events via [Symbol.asyncIterator]", async () => {
+    const mux = new StreamMux();
+    const stream = new GraphRunStream([], mux);
+    mux.register([], stream);
+
+    const e1 = makeEvent("values", [], { count: 1 }, 0);
+    const e2 = makeEvent("updates", [], { count: 2 }, 1);
+
+    mux.push([], e1);
+    mux.push([], e2);
+    mux.close();
+
+    const events = await collect(stream[Symbol.asyncIterator]());
+    expect(events).toHaveLength(2);
+    expect(events[0].method).toBe("values");
+    expect(events[1].method).toBe("updates");
+  });
+
+  it("subgraphs getter yields SubgraphRunStream on discovery", async () => {
+    const mux = new StreamMux();
+    const root = new GraphRunStream([], mux);
+    mux.register([], root);
+
+    const childEvent = makeEvent("values", ["child:0"], { x: 1 }, 0);
+    mux.push(["child:0"], childEvent);
+    mux.close();
+
+    const subs: SubgraphRunStream[] = [];
+    for await (const sub of root.subgraphs) {
+      subs.push(sub);
+    }
+
+    expect(subs).toHaveLength(1);
+    expect(subs[0]).toBeInstanceOf(SubgraphRunStream);
+    expect(subs[0].name).toBe("child");
+    expect(subs[0].index).toBe(0);
+  });
+
+  it("values getter provides both AsyncIterable and PromiseLike", async () => {
+    const mux = new StreamMux();
+    const root = new GraphRunStream([], mux);
+    mux.register([], root);
+
+    const v1 = makeEvent("values", [], { step: 1 }, 0);
+    const v2 = makeEvent("values", [], { step: 2 }, 1);
+
+    mux.push([], v1);
+    mux.push([], v2);
+    mux.close();
+
+    const vals = root.values;
+
+    expect(typeof vals.then).toBe("function");
+    expect(typeof vals[Symbol.asyncIterator]).toBe("function");
+
+    const collected: unknown[] = [];
+    for await (const v of vals) {
+      collected.push(v);
+    }
+    expect(collected).toEqual([{ step: 1 }, { step: 2 }]);
+  });
+
+  it("output resolves when _resolveValues is called", async () => {
+    const mux = new StreamMux();
+    const root = new GraphRunStream<{ answer: number }>([], mux);
+
+    const outputPromise = root.output;
+    root._resolveValues({ answer: 42 });
+
+    const result = await outputPromise;
+    expect(result).toEqual({ answer: 42 });
+  });
+
+  it("output rejects when _rejectValues is called", async () => {
+    const mux = new StreamMux();
+    const root = new GraphRunStream([], mux);
+
+    const outputPromise = root.output;
+    root._rejectValues(new Error("run failed"));
+
+    await expect(outputPromise).rejects.toThrow("run failed");
+  });
+
+  it("messages getter returns fallback iterable when not set", () => {
+    const mux = new StreamMux();
+    const root = new GraphRunStream([], mux);
+
+    const iterable = root.messages;
+    expect(typeof iterable[Symbol.asyncIterator]).toBe("function");
+  });
+
+  it("messages getter returns provided iterable when set", async () => {
+    const mux = new StreamMux();
+    const root = new GraphRunStream([], mux);
+
+    const items = [{ fake: "message" }];
+    const custom: AsyncIterable<any> = {
+      async *[Symbol.asyncIterator]() {
+        for (const item of items) yield item;
+      },
+    };
+
+    root._setMessagesIterable(custom);
+    const collected: unknown[] = [];
+    for await (const msg of root.messages) {
+      collected.push(msg);
+    }
+    expect(collected).toEqual([{ fake: "message" }]);
+  });
+
+  it("interrupted and interrupts delegate to mux", () => {
+    const mux = new StreamMux();
+    const root = new GraphRunStream([], mux);
+
+    expect(root.interrupted).toBe(false);
+    expect(root.interrupts).toEqual([]);
+
+    mux.markInterrupted([
+      { interruptId: "int-1", payload: { question: "continue?" } },
+    ]);
+
+    expect(root.interrupted).toBe(true);
+    expect(root.interrupts).toHaveLength(1);
+    expect(root.interrupts[0].interruptId).toBe("int-1");
+  });
+
+  it("abort() triggers the signal", () => {
+    const mux = new StreamMux();
+    const root = new GraphRunStream([], mux);
+
+    expect(root.signal.aborted).toBe(false);
+    root.abort("cancelled");
+    expect(root.signal.aborted).toBe(true);
+    expect(root.signal.reason).toBe("cancelled");
+  });
+
+  it("signal getter returns abort signal", () => {
+    const controller = new AbortController();
+    const mux = new StreamMux();
+    const root = new GraphRunStream([], mux, 0, 0, undefined, controller);
+
+    expect(root.signal).toBe(controller.signal);
+  });
+});
+
+describe("SubgraphRunStream", () => {
+  it("parses name from last path segment", () => {
+    const mux = new StreamMux();
+    const sub = new SubgraphRunStream(["agent"], mux);
+    expect(sub.name).toBe("agent");
+  });
+
+  it("parses index from 'name:N' suffix", () => {
+    const mux = new StreamMux();
+    const sub = new SubgraphRunStream(["parent", "child:3"], mux);
+    expect(sub.name).toBe("child");
+    expect(sub.index).toBe(3);
+  });
+
+  it("defaults index to 0 when no numeric suffix", () => {
+    const mux = new StreamMux();
+
+    const noColon = new SubgraphRunStream(["nodeName"], mux);
+    expect(noColon.name).toBe("nodeName");
+    expect(noColon.index).toBe(0);
+
+    const nonNumeric = new SubgraphRunStream(["node:abc"], mux);
+    expect(nonNumeric.name).toBe("node");
+    expect(nonNumeric.index).toBe(0);
+  });
+
+  it("inherits GraphRunStream functionality", async () => {
+    const mux = new StreamMux();
+    const sub = new SubgraphRunStream<{ v: number }>(["sub:0"], mux);
+    mux.register(["sub:0"], sub);
+
+    const e = makeEvent("values", ["sub:0"], { v: 10 }, 0);
+    mux.push(["sub:0"], e);
+    mux.close();
+
+    const events = await collect(sub[Symbol.asyncIterator]());
+    expect(events).toHaveLength(1);
+    expect(events[0].params.data).toEqual({ v: 10 });
+
+    expect(sub.interrupted).toBe(false);
+    expect(sub.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe("createGraphRunStream", () => {
+  it("creates a stream that iterates events from source", async () => {
+    const source = makeSource([
+      [[], "values", { a: 1 }],
+      [[], "updates", { node: "n", values: {} }],
+    ]);
+
+    const stream = createGraphRunStream(source);
+    const events: ProtocolEvent[] = [];
+    for await (const e of stream) {
+      events.push(e);
+    }
+
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    const methods = events.map((e) => e.method);
+    expect(methods).toContain("values");
+  });
+
+  it("output resolves with final values from source", async () => {
+    const source = makeSource([
+      [[], "values", { step: 1 }],
+      [[], "values", { step: 2 }],
+    ]);
+
+    const stream = createGraphRunStream<{ step: number }>(source);
+    const result = await stream.output;
+    expect(result).toEqual({ step: 2 });
+  });
+
+  it("custom reducers receive events and produce extensions", async () => {
+    let processedCount = 0;
+
+    const customReducerFactory = (): StreamReducer<{ counter: number }> => ({
+      init: () => ({ counter: 0 }),
+      process(_event: ProtocolEvent): boolean {
+        processedCount += 1;
+        return true;
+      },
+      finalize(): void {},
+      fail(): void {},
+    });
+
+    const source = makeSource([
+      [[], "values", { x: 1 }],
+      [[], "values", { x: 2 }],
+    ]);
+
+    const stream = createGraphRunStream(source, [customReducerFactory]);
+    await stream.output;
+
+    expect(processedCount).toBeGreaterThan(0);
+    expect(stream.extensions).toHaveProperty("counter");
+  });
+
+  it("processes values mode events through ValuesReducer", async () => {
+    const source = makeSource([
+      [[], "values", { count: 10 }],
+      [[], "values", { count: 20 }],
+      [[], "values", { count: 30 }],
+    ]);
+
+    const stream = createGraphRunStream<{ count: number }>(source);
+
+    const collected: Array<{ count: number }> = [];
+    for await (const v of stream.values) {
+      collected.push(v);
+    }
+
+    expect(collected).toEqual([
+      { count: 10 },
+      { count: 20 },
+      { count: 30 },
+    ]);
+  });
+});

--- a/libs/langgraph-core/src/stream/run-stream.ts
+++ b/libs/langgraph-core/src/stream/run-stream.ts
@@ -1,0 +1,427 @@
+/**
+ * GraphRunStream and SubgraphRunStream — the public run stream classes.
+ *
+ * Built-in projections:
+ *   .subgraphs     — recursive child subgraph discovery
+ *   .values        — state snapshots (AsyncIterable & PromiseLike)
+ *   .messages      — per-message ChatModelStream lifecycle
+ *   .messagesFrom  — node-filtered messages
+ *   .output        — final state Promise
+ *   .interrupted   — whether the run ended due to an interrupt
+ *   .interrupts    — interrupt payloads
+ *   .abort()       — programmatic cancellation
+ *   .extensions    — merged reducer projections
+ */
+
+import type { StreamChunk } from "../pregel/stream.js";
+import { EventLog } from "./event-log.js";
+import { StreamMux, setRunStreamClasses, pump } from "./mux.js";
+import { createMessagesReducer, createValuesReducer } from "./reducers.js";
+import type {
+  ChatModelStream,
+  InferExtensions,
+  InterruptPayload,
+  Namespace,
+  ProtocolEvent,
+  StreamReducer,
+} from "./types.js";
+
+/**
+ * Primary run stream for a LangGraph execution.
+ *
+ * Implements {@link AsyncIterable} over {@link ProtocolEvent} and exposes
+ * ergonomic projections for values, messages, subgraphs, output, and
+ * interrupts. Created by {@link createGraphRunStream}.
+ *
+ * @typeParam TValues - Shape of the graph's state values.
+ * @typeParam TExtensions - Shape of additional reducer projections merged
+ *   into {@link GraphRunStream.extensions}.
+ */
+export class GraphRunStream<
+  TValues = Record<string, unknown>,
+  TExtensions extends Record<string, unknown> = Record<string, unknown>,
+> implements AsyncIterable<ProtocolEvent> {
+  /**
+   * Namespace path identifying this stream's position in the agent tree.
+   * An empty array for the root stream.
+   */
+  readonly path: Namespace;
+
+  /**
+   * Merged projections from user-supplied {@link StreamReducer} factories.
+   * Each reducer's `init()` return value is spread into this object.
+   */
+  readonly extensions: TExtensions;
+
+  /**
+   * The central stream multiplexer that drives event dispatch and reducer
+   * pipelines. Accessible to subclasses for direct event subscription.
+   *
+   * @internal
+   */
+  protected readonly _mux: StreamMux;
+
+  #eventStart: number;
+  #discoveryStart: number;
+  #abortController: AbortController;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  #resolveValuesFn?: (v: any) => void;
+  #rejectValuesFn?: (e: unknown) => void;
+  readonly #valuesDone: Promise<TValues>;
+
+  #valuesLog?: EventLog<Record<string, unknown>>;
+  #messagesIterable?: AsyncIterable<ChatModelStream>;
+
+  /**
+   * @param path - Namespace path for this stream (empty array for root).
+   * @param mux - The {@link StreamMux} driving this run.
+   * @param discoveryStart - Cursor offset into the mux discovery log.
+   * @param eventStart - Cursor offset into the mux event log.
+   * @param extensions - Pre-initialized reducer projections.
+   * @param abortController - Controller for programmatic cancellation.
+   */
+  constructor(
+    path: Namespace,
+    mux: StreamMux,
+    discoveryStart = 0,
+    eventStart = 0,
+    extensions?: TExtensions,
+    abortController?: AbortController
+  ) {
+    this.path = path;
+    this._mux = mux;
+    this.#discoveryStart = discoveryStart;
+    this.#eventStart = eventStart;
+    this.extensions = extensions ?? ({} as TExtensions);
+    this.#abortController = abortController ?? new AbortController();
+    this.#valuesDone = new Promise<TValues>((resolve, reject) => {
+      this.#resolveValuesFn = resolve;
+      this.#rejectValuesFn = reject;
+    });
+  }
+
+  /**
+   * Async iterator over all {@link ProtocolEvent}s at or below this
+   * stream's namespace, starting from the configured event offset.
+   *
+   * @returns An async iterator yielding protocol events in arrival order.
+   */
+  [Symbol.asyncIterator](): AsyncIterator<ProtocolEvent> {
+    return this._mux.subscribeEvents(this.path, this.#eventStart);
+  }
+
+  /**
+   * Async iterable of child {@link SubgraphRunStream} instances discovered
+   * during the run. Each yielded stream represents a direct child namespace.
+   *
+   * @returns An async iterable of subgraph run streams.
+   */
+  get subgraphs(): AsyncIterable<SubgraphRunStream> {
+    const iter = this._mux.subscribeSubgraphs(this.path, this.#discoveryStart);
+    return { [Symbol.asyncIterator]: () => iter };
+  }
+
+  /**
+   * Dual-interface accessor for graph state snapshots.
+   *
+   * As an {@link AsyncIterable}, yields each intermediate state snapshot
+   * as it arrives. As a {@link PromiseLike}, resolves with the final
+   * state value when the run completes.
+   *
+   * @returns A combined async iterable and promise-like for state values.
+   */
+  get values(): AsyncIterable<TValues> & PromiseLike<TValues> {
+    const log = this.#valuesLog;
+    const done = this.#valuesDone;
+    const mux = this._mux;
+    const eventStart = this.#eventStart;
+    const path = this.path;
+
+    const iterable: AsyncIterable<TValues> = log
+      ? (log.toAsyncIterable() as AsyncIterable<TValues>)
+      : {
+          [Symbol.asyncIterator]: () => {
+            const base = mux.subscribeEvents(path, eventStart);
+            return {
+              async next(): Promise<IteratorResult<TValues>> {
+                // eslint-disable-next-line no-constant-condition
+                while (true) {
+                  const result = await base.next();
+                  if (result.done) {
+                    return {
+                      value: undefined as unknown as TValues,
+                      done: true,
+                    };
+                  }
+                  if (
+                    result.value.method === "values" &&
+                    result.value.params.namespace.length === path.length
+                  ) {
+                    return {
+                      value: result.value.params.data as TValues,
+                      done: false,
+                    };
+                  }
+                }
+              },
+            };
+          },
+        };
+
+    return {
+      [Symbol.asyncIterator]: () => iterable[Symbol.asyncIterator](),
+      then: done.then.bind(done),
+    };
+  }
+
+  /**
+   * All AI message lifecycles observed at this namespace level, in order.
+   * Each yielded {@link ChatModelStream} represents one message-start →
+   * message-finish lifecycle with streaming `.text`, `.reasoning`, and
+   * `.usage` projections.
+   *
+   * @returns An async iterable of chat model streams.
+   */
+  get messages(): AsyncIterable<ChatModelStream> {
+    if (this.#messagesIterable) return this.#messagesIterable;
+    // Lazily create a MessagesReducer scoped to this stream's path.
+    // This handles SubgraphRunStream instances that are created
+    // dynamically by StreamMux and don't have a reducer pre-wired.
+    const reducer = createMessagesReducer(this.path);
+    this._mux.addReducer(reducer);
+    const projection = reducer.init();
+    this.#messagesIterable = projection.messages;
+    return this.#messagesIterable;
+  }
+
+  /**
+   * Messages produced by a specific graph node. Use when the run has
+   * multiple model-calling nodes and you only want messages from one.
+   *
+   * @param node - The graph node name to filter messages by.
+   * @returns An async iterable of chat model streams from the given node.
+   */
+  messagesFrom(node: string): AsyncIterable<ChatModelStream> {
+    const reducer = createMessagesReducer(this.path, node);
+    this._mux.addReducer(reducer);
+    const projection = reducer.init();
+    return projection.messages;
+  }
+
+  /**
+   * Promise that resolves with the final graph state when the run completes,
+   * or rejects if the run fails.
+   *
+   * @returns A promise resolving to the final state values.
+   */
+  get output(): Promise<TValues> {
+    return this.#valuesDone;
+  }
+
+  /**
+   * Whether the run ended due to a human-in-the-loop interrupt.
+   *
+   * @returns `true` if the run was interrupted.
+   */
+  get interrupted(): boolean {
+    return this._mux.interrupted;
+  }
+
+  /**
+   * Interrupt payloads collected during the run, if any.
+   *
+   * @returns A readonly array of interrupt payloads.
+   */
+  get interrupts(): readonly InterruptPayload[] {
+    return this._mux.interrupts;
+  }
+
+  /**
+   * Programmatically abort this run. Equivalent to calling
+   * `signal.abort(reason)`.
+   *
+   * @param reason - Optional abort reason passed to the signal.
+   */
+  abort(reason?: unknown): void {
+    this.#abortController.abort(reason);
+  }
+
+  /**
+   * The {@link AbortSignal} wired into this run for cancellation support.
+   *
+   * @returns The abort signal for this stream.
+   */
+  get signal(): AbortSignal {
+    return this.#abortController.signal;
+  }
+
+  /**
+   * Resolve the output/values promise with the final state snapshot.
+   * Called by {@link StreamMux.close}.
+   *
+   * @param values - The final state values, or `undefined` if none.
+   * @internal
+   */
+  _resolveValues(values: TValues | undefined): void {
+    this.#resolveValuesFn?.(values as TValues);
+    this.#resolveValuesFn = undefined;
+  }
+
+  /**
+   * Reject the output/values promise with a run error.
+   * Called by {@link StreamMux.fail}.
+   *
+   * @param err - The error that caused the run to fail.
+   * @internal
+   */
+  _rejectValues(err: unknown): void {
+    this.#rejectValuesFn?.(err);
+    this.#rejectValuesFn = undefined;
+  }
+
+  /**
+   * Attach the reducer-populated event log backing the `.values` iterable.
+   * Called during stream setup in {@link createGraphRunStream}.
+   *
+   * @param log - The event log from the values reducer projection.
+   * @internal
+   */
+  _setValuesLog(log: EventLog<Record<string, unknown>>): void {
+    this.#valuesLog = log;
+  }
+
+  /**
+   * Attach the reducer-populated async iterable backing the `.messages`
+   * accessor. Called during stream setup in {@link createGraphRunStream}.
+   *
+   * @param iterable - The async iterable from the messages reducer projection.
+   * @internal
+   */
+  _setMessagesIterable(iterable: AsyncIterable<ChatModelStream>): void {
+    this.#messagesIterable = iterable;
+  }
+}
+
+/**
+ * A run stream for a child subgraph within a parent graph execution.
+ *
+ * Extends {@link GraphRunStream} with a parsed {@link name} and
+ * {@link index} extracted from the last segment of the namespace path.
+ * The segment is expected to follow the `"name:index"` convention;
+ * when no numeric suffix is present, {@link index} defaults to `0`.
+ *
+ * @typeParam TValues - Shape of the subgraph's state values.
+ * @typeParam TExtensions - Shape of additional reducer projections.
+ */
+export class SubgraphRunStream<
+  TValues = Record<string, unknown>,
+  TExtensions extends Record<string, unknown> = Record<string, unknown>,
+> extends GraphRunStream<TValues, TExtensions> {
+  /**
+   * The node name extracted from the last segment of the namespace path
+   * (everything before the final colon, or the full segment if no colon).
+   */
+  readonly name: string;
+
+  /**
+   * The invocation index parsed from the `"name:N"` suffix of the last
+   * namespace segment. Defaults to `0` when no numeric suffix is present.
+   */
+  readonly index: number;
+
+  /**
+   * @param path - Namespace path for this subgraph stream.
+   * @param mux - The {@link StreamMux} driving this run.
+   * @param discoveryStart - Cursor offset into the mux discovery log.
+   * @param eventStart - Cursor offset into the mux event log.
+   * @param extensions - Pre-initialized reducer projections.
+   * @param abortController - Controller for programmatic cancellation.
+   */
+  constructor(
+    path: Namespace,
+    mux: StreamMux,
+    discoveryStart = 0,
+    eventStart = 0,
+    extensions?: TExtensions,
+    abortController?: AbortController
+  ) {
+    super(path, mux, discoveryStart, eventStart, extensions, abortController);
+    const lastSegment = path[path.length - 1] ?? "";
+    const colonIdx = lastSegment.lastIndexOf(":");
+    if (colonIdx >= 0) {
+      this.name = lastSegment.slice(0, colonIdx);
+      const suffix = lastSegment.slice(colonIdx + 1);
+      this.index = /^\d+$/.test(suffix) ? Number(suffix) : 0;
+    } else {
+      this.name = lastSegment;
+      this.index = 0;
+    }
+  }
+}
+
+// Register constructors with StreamMux to break the circular dependency.
+setRunStreamClasses(GraphRunStream, SubgraphRunStream);
+
+/**
+ * Creates a {@link GraphRunStream} with built-in reducers and kicks off the
+ * background pump that feeds raw stream chunks through the reducer pipeline.
+ *
+ * Built-in reducers (values and messages) are registered first, followed by
+ * any user-supplied reducer factories. The root stream is registered with the
+ * mux and the pump is started in the background.
+ *
+ * @typeParam TValues - Shape of the graph's state values.
+ * @param source - Raw async iterable from `graph.stream(…, { subgraphs: true })`.
+ * @param reducers - User-supplied reducer factories.
+ * @param abortController - Optional controller for cancellation.
+ * @returns A {@link GraphRunStream} for the root namespace.
+ */
+export function createGraphRunStream<
+  TValues = Record<string, unknown>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const TReducers extends ReadonlyArray<() => StreamReducer<any>> = [],
+>(
+  source: AsyncIterable<StreamChunk>,
+  reducers: TReducers = [] as unknown as TReducers,
+  abortController?: AbortController
+): GraphRunStream<TValues, InferExtensions<TReducers>> {
+  const mux = new StreamMux();
+
+  const valuesReducer = createValuesReducer([]);
+  const messagesReducer = createMessagesReducer([]);
+  mux.addReducer(valuesReducer);
+  mux.addReducer(messagesReducer);
+
+  const extensions: Record<string, unknown> = {};
+  for (const factory of reducers) {
+    const reducer = factory();
+    mux.addReducer(reducer);
+    Object.assign(extensions, reducer.init());
+  }
+
+  const root = new GraphRunStream<TValues, InferExtensions<TReducers>>(
+    [],
+    mux,
+    0,
+    0,
+    extensions as InferExtensions<TReducers>,
+    abortController
+  );
+
+  // Wire reducer projections into the root stream.
+  const valuesProjection = valuesReducer.init();
+  root._setValuesLog(valuesProjection._valuesLog);
+
+  const messagesProjection = messagesReducer.init();
+  root._setMessagesIterable(messagesProjection.messages);
+
+  mux.register([], root);
+
+  // Start background pump.
+  pump(source, mux).catch((err) => {
+    void err;
+  });
+
+  return root;
+}

--- a/libs/langgraph-core/src/stream/types.test-d.ts
+++ b/libs/langgraph-core/src/stream/types.test-d.ts
@@ -137,7 +137,49 @@ describe("streamV2 with MessagesValue state", () => {
   });
 });
 
-describe("streamV2 with custom reducers", () => {
+describe("streamV2 with compile-time reducers", () => {
+  const eventCounter = (): StreamReducer<{
+    eventCount: Promise<number>;
+  }> => ({
+    init: () => ({ eventCount: Promise.resolve(0) }),
+    process: () => true,
+    finalize: () => {},
+    fail: () => {},
+  });
+
+  const CompileState = new StateSchema({
+    value: new ReducedValue(z.string().default(() => ""), {
+      reducer: (_: string, b: string) => b,
+    }),
+  });
+
+  it("merges compile-time and call-site reducer projections", async () => {
+    const graph = new StateGraph(CompileState)
+      .addNode("echo", (s) => ({ value: s.value }))
+      .addEdge(START, "echo")
+      .addEdge("echo", END)
+      .compile({ reducers: [eventCounter] });
+
+    const callSiteReducer = (): StreamReducer<{
+      flag: boolean;
+    }> => ({
+      init: () => ({ flag: true }),
+      process: () => true,
+      finalize: () => {},
+      fail: () => {},
+    });
+
+    const run = await graph.streamV2(
+      { value: "test" },
+      { reducers: [callSiteReducer] }
+    );
+
+    expectTypeOf(run.extensions.eventCount).toEqualTypeOf<Promise<number>>();
+    expectTypeOf(run.extensions.flag).toBeBoolean();
+  });
+});
+
+describe("streamV2 with call-site reducers", () => {
   const ValueState = new StateSchema({
     value: new ReducedValue(z.string().default(() => ""), {
       reducer: (_: string, b: string) => b,

--- a/libs/langgraph-core/src/stream/types.test-d.ts
+++ b/libs/langgraph-core/src/stream/types.test-d.ts
@@ -1,0 +1,321 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expectTypeOf, it, describe } from "vitest";
+import { z } from "zod/v4";
+
+import { StateGraph } from "../graph/state.js";
+import { StateSchema } from "../state/schema.js";
+import { ReducedValue } from "../state/values/reduced.js";
+import { MessagesValue } from "../state/prebuilt/messages.js";
+import { END, START } from "../constants.js";
+import type {
+  ProtocolEvent,
+  StreamReducer,
+  ChatModelStream,
+  InferExtensions,
+  ToolCallStream,
+  ToolCallStatus,
+  InterruptPayload,
+} from "./types.js";
+import type { GraphRunStream, SubgraphRunStream } from "./run-stream.js";
+
+describe("streamV2 on a simple StateGraph", () => {
+  const CounterState = new StateSchema({
+    count: new ReducedValue(z.number().default(() => 0), {
+      reducer: (a: number, b: number) => a + b,
+    }),
+    label: new ReducedValue(z.string().default(() => ""), {
+      reducer: (_: string, b: string) => b,
+    }),
+  });
+
+  const graph = new StateGraph(CounterState)
+    .addNode("increment", () => ({ count: 1 }))
+    .addNode("name", () => ({ label: "done" }))
+    .addEdge(START, "increment")
+    .addEdge("increment", "name")
+    .addEdge("name", END)
+    .compile();
+
+  it("returns a Promise<GraphRunStream>", async () => {
+    const run = await graph.streamV2({ count: 0 });
+    expectTypeOf(run).toExtend<GraphRunStream>();
+  });
+
+  it("output resolves with the graph state type", async () => {
+    const run = await graph.streamV2({ count: 0 });
+    const output = await run.output;
+    expectTypeOf(output).toHaveProperty("count").toBeNumber();
+    expectTypeOf(output).toHaveProperty("label").toBeString();
+  });
+
+  it("values is both AsyncIterable and PromiseLike of state type", async () => {
+    const run = await graph.streamV2({ count: 0 });
+    expectTypeOf(run.values).toExtend<
+      AsyncIterable<{ count: number; label: string }>
+    >();
+    expectTypeOf(run.values).toExtend<
+      PromiseLike<{ count: number; label: string }>
+    >();
+  });
+
+  it("iterates ProtocolEvent", async () => {
+    const run = await graph.streamV2({ count: 0 });
+    for await (const event of run) {
+      expectTypeOf(event).toExtend<ProtocolEvent>();
+      expectTypeOf(event.type).toEqualTypeOf<"event">();
+      expectTypeOf(event.seq).toBeNumber();
+      expectTypeOf(event.params.namespace).toEqualTypeOf<string[]>();
+    }
+  });
+
+  it("messages yields ChatModelStream", async () => {
+    const run = await graph.streamV2({ count: 0 });
+    for await (const msg of run.messages) {
+      expectTypeOf(msg).toExtend<ChatModelStream>();
+      expectTypeOf(msg.text).toExtend<AsyncIterable<string>>();
+      expectTypeOf(msg.text).toExtend<PromiseLike<string>>();
+      expectTypeOf(msg.reasoning).toExtend<AsyncIterable<string>>();
+      expectTypeOf(msg.reasoning).toExtend<PromiseLike<string>>();
+    }
+  });
+
+  it("messagesFrom returns AsyncIterable<ChatModelStream>", async () => {
+    const run = await graph.streamV2({ count: 0 });
+    expectTypeOf(run.messagesFrom("increment")).toExtend<
+      AsyncIterable<ChatModelStream>
+    >();
+  });
+
+  it("subgraphs yields SubgraphRunStream", async () => {
+    const run = await graph.streamV2({ count: 0 });
+    for await (const sub of run.subgraphs) {
+      expectTypeOf(sub).toExtend<SubgraphRunStream>();
+      expectTypeOf(sub.name).toBeString();
+      expectTypeOf(sub.index).toBeNumber();
+      expectTypeOf(sub.path).toEqualTypeOf<string[]>();
+    }
+  });
+
+  it("interrupted and interrupts are typed", async () => {
+    const run = await graph.streamV2({ count: 0 });
+    expectTypeOf(run.interrupted).toBeBoolean();
+    expectTypeOf(run.interrupts).toExtend<readonly InterruptPayload[]>();
+  });
+
+  it("abort and signal are typed", async () => {
+    const run = await graph.streamV2({ count: 0 });
+    expectTypeOf(run.abort).toBeCallableWith();
+    expectTypeOf(run.abort).toBeCallableWith("reason");
+    expectTypeOf(run.signal).toEqualTypeOf<AbortSignal>();
+  });
+
+  it("extensions defaults to empty record when no reducers", async () => {
+    const run = await graph.streamV2({ count: 0 });
+    expectTypeOf(run.extensions).toEqualTypeOf<Record<string, never>>();
+  });
+});
+
+describe("streamV2 with MessagesValue state", () => {
+  const ChatState = new StateSchema({
+    messages: MessagesValue,
+    topic: new ReducedValue(z.string().default(() => ""), {
+      reducer: (_: string, b: string) => b,
+    }),
+  });
+
+  const graph = new StateGraph(ChatState)
+    .addNode("respond", () => ({ topic: "answered" }))
+    .addEdge(START, "respond")
+    .addEdge("respond", END)
+    .compile();
+
+  it("output includes messages and topic", async () => {
+    const run = await graph.streamV2({ topic: "test" });
+    const output = await run.output;
+    expectTypeOf(output).toHaveProperty("topic").toBeString();
+    expectTypeOf(output).toHaveProperty("messages");
+  });
+});
+
+describe("streamV2 with custom reducers", () => {
+  const ValueState = new StateSchema({
+    value: new ReducedValue(z.string().default(() => ""), {
+      reducer: (_: string, b: string) => b,
+    }),
+  });
+
+  const graph = new StateGraph(ValueState)
+    .addNode("echo", (s) => ({ value: s.value }))
+    .addEdge(START, "echo")
+    .addEdge("echo", END)
+    .compile();
+
+  it("infers single reducer projection type on extensions", async () => {
+    const tokenReducer = (): StreamReducer<{
+      totalTokens: Promise<number>;
+    }> => ({
+      init: () => ({ totalTokens: Promise.resolve(0) }),
+      process: () => true,
+      finalize: () => {},
+      fail: () => {},
+    });
+
+    const run = await graph.streamV2(
+      { value: "test" },
+      { reducers: [tokenReducer] }
+    );
+
+    expectTypeOf(run.extensions.totalTokens).toEqualTypeOf<Promise<number>>();
+  });
+
+  it("intersects projections from multiple reducers", async () => {
+    const countReducer = (): StreamReducer<{
+      eventCount: Promise<number>;
+    }> => ({
+      init: () => ({ eventCount: Promise.resolve(0) }),
+      process: () => true,
+      finalize: () => {},
+      fail: () => {},
+    });
+
+    const labelReducer = (): StreamReducer<{
+      lastNode: Promise<string>;
+    }> => ({
+      init: () => ({ lastNode: Promise.resolve("") }),
+      process: () => true,
+      finalize: () => {},
+      fail: () => {},
+    });
+
+    const run = await graph.streamV2(
+      { value: "test" },
+      { reducers: [countReducer, labelReducer] }
+    );
+
+    expectTypeOf(run.extensions.eventCount).toEqualTypeOf<Promise<number>>();
+    expectTypeOf(run.extensions.lastNode).toEqualTypeOf<Promise<string>>();
+  });
+
+  it("output type is preserved alongside custom extensions", async () => {
+    const reducer = (): StreamReducer<{ flag: boolean }> => ({
+      init: () => ({ flag: true }),
+      process: () => true,
+      finalize: () => {},
+      fail: () => {},
+    });
+
+    const run = await graph.streamV2(
+      { value: "test" },
+      { reducers: [reducer] }
+    );
+
+    const output = await run.output;
+    expectTypeOf(output).toHaveProperty("value").toBeString();
+    expectTypeOf(run.extensions.flag).toBeBoolean();
+  });
+});
+
+describe("streamV2 with subgraph nodes", () => {
+  const ItemsState = new StateSchema({
+    items: new ReducedValue(
+      z.array(z.string()).default(() => []),
+      { reducer: (a: string[], b: string[]) => [...a, ...b] }
+    ),
+  });
+
+  const childGraph = new StateGraph(ItemsState)
+    .addNode("worker", () => ({ items: ["processed"] }))
+    .addEdge(START, "worker")
+    .addEdge("worker", END)
+    .compile();
+
+  const graph = new StateGraph(ItemsState)
+    .addNode("child", childGraph)
+    .addEdge(START, "child")
+    .addEdge("child", END)
+    .compile();
+
+  it("subgraphs yield SubgraphRunStream with correct types", async () => {
+    const run = await graph.streamV2({ items: [] });
+
+    for await (const sub of run.subgraphs) {
+      expectTypeOf(sub).toExtend<SubgraphRunStream>();
+      expectTypeOf(sub.name).toBeString();
+      expectTypeOf(sub.index).toBeNumber();
+
+      for await (const msg of sub.messages) {
+        expectTypeOf(msg).toExtend<ChatModelStream>();
+      }
+
+      const subOutput = await sub.output;
+      expectTypeOf(subOutput).toExtend<Record<string, unknown>>();
+    }
+  });
+
+  it("recursive subgraphs are also SubgraphRunStream", async () => {
+    const run = await graph.streamV2({ items: [] });
+
+    for await (const sub of run.subgraphs) {
+      for await (const nested of sub.subgraphs) {
+        expectTypeOf(nested).toExtend<SubgraphRunStream>();
+        expectTypeOf(nested.name).toBeString();
+      }
+    }
+  });
+});
+
+describe("InferExtensions utility type", () => {
+  it("produces Record<string, never> for empty tuple", () => {
+    expectTypeOf<InferExtensions<[]>>().toEqualTypeOf<
+      Record<string, never>
+    >();
+  });
+
+  it("infers a single projection", () => {
+    type Factories = [() => StreamReducer<{ count: number }>];
+    expectTypeOf<InferExtensions<Factories>>().toExtend<{
+      count: number;
+    }>();
+  });
+
+  it("intersects multiple projections", () => {
+    type Factories = [
+      () => StreamReducer<{ a: number }>,
+      () => StreamReducer<{ b: string }>,
+      () => StreamReducer<{ c: boolean }>,
+    ];
+    type Result = InferExtensions<Factories>;
+    expectTypeOf<Result>().toExtend<{ a: number }>();
+    expectTypeOf<Result>().toExtend<{ b: string }>();
+    expectTypeOf<Result>().toExtend<{ c: boolean }>();
+  });
+
+  it("falls back to Record<string, unknown> for widened arrays", () => {
+    type Widened = InferExtensions<Array<() => StreamReducer<any>>>;
+    expectTypeOf<Widened>().toEqualTypeOf<Record<string, unknown>>();
+  });
+});
+
+describe("ToolCallStream discriminated union", () => {
+  it("narrows input and output by name", () => {
+    type Union =
+      | ToolCallStream<"search", { query: string }, string[]>
+      | ToolCallStream<"calc", { expr: string }, number>;
+
+    const call = {} as Union;
+    if (call.name === "search") {
+      expectTypeOf(call.input).toEqualTypeOf<{ query: string }>();
+      expectTypeOf(call.output).toEqualTypeOf<Promise<string[]>>();
+    }
+    if (call.name === "calc") {
+      expectTypeOf(call.input).toEqualTypeOf<{ expr: string }>();
+      expectTypeOf(call.output).toEqualTypeOf<Promise<number>>();
+    }
+  });
+
+  it("status and error types are always available", () => {
+    const call = {} as ToolCallStream<"test", unknown, unknown>;
+    expectTypeOf(call.status).toEqualTypeOf<Promise<ToolCallStatus>>();
+    expectTypeOf(call.error).toEqualTypeOf<Promise<string | undefined>>();
+  });
+});

--- a/libs/langgraph-core/src/stream/types.ts
+++ b/libs/langgraph-core/src/stream/types.ts
@@ -1,0 +1,253 @@
+/**
+ * Core type definitions for the v2 streaming interface.
+ *
+ * Channel event data types (`MessagesEventData`, `ToolsEventData`,
+ * `UpdatesEventData`, `UsageInfo`, `FinishReason`) are re-exported from
+ * `@langchain/protocol` — the generated TypeScript bindings for the
+ * canonical CDDL schema.  Stream-specific types (`StreamReducer`,
+ * `ChatModelStream`, `ToolCallStream`, `InterruptPayload`) are defined here.
+ */
+
+import type { StreamMode } from "../pregel/types.js";
+
+/**
+ * Re-exports from `@langchain/protocol`.
+ *
+ * These are the canonical wire-format types generated from `protocol.cddl`.
+ * They are re-exported with local aliases so that consumers of this module
+ * do not need a direct dependency on `@langchain/protocol`.
+ */
+export type {
+  MessagesData as MessagesEventData,
+  ToolsData as ToolsEventData,
+  UpdatesData as UpdatesEventData,
+  UsageInfo,
+  FinishReason,
+  MessageStartData,
+  ContentBlockStartData,
+  ContentBlockDeltaData,
+  ContentBlockFinishData,
+  MessageFinishData,
+  MessageErrorData,
+  ToolStartedData,
+  ToolOutputDeltaData,
+  ToolFinishedData,
+  ToolErrorData,
+} from "@langchain/protocol";
+
+/**
+ * Hierarchical path identifying a position in the agent tree.
+ *
+ * Each element is one segment; longer arrays mean deeper nesting (e.g.
+ * subgraph or multi-agent scopes).
+ */
+export type Namespace = string[];
+
+/**
+ * Single envelope for a streaming protocol emission: sequence, channel
+ * (`method`), and payload (`params`).
+ */
+export interface ProtocolEvent {
+  /** Discriminator; always `"event"` for this shape. */
+  readonly type: "event";
+
+  /** Monotonic sequence number for ordering and deduplication within a run. */
+  readonly seq: number;
+
+  /**
+   * Logical stream channel; matches {@link StreamMode} (e.g. messages, updates).
+   */
+  readonly method: StreamMode;
+
+  /** Channel-specific payload and routing metadata. */
+  readonly params: {
+    /** Namespace of the node or scope that emitted this event. */
+    readonly namespace: Namespace;
+
+    /** Wall-clock or logical timestamp for the emission (milliseconds). */
+    readonly timestamp: number;
+
+    /**
+     * Graph node id when the engine can attribute the event to a single node;
+     * omitted for run-level or ambiguous emissions.
+     */
+    readonly node?: string;
+
+    /** Opaque channel payload; shape depends on `method`. */
+    readonly data: unknown;
+  };
+}
+
+/**
+ * Observes protocol events and builds typed derived projections as secondary
+ * event logs.
+ *
+ * @remarks
+ * `TProjection` is merged into the run stream's public `.extensions` object.
+ */
+/**
+ * Infers the merged extensions type from a tuple of reducer factory functions.
+ *
+ * Given `[() => StreamReducer<{ a: number }>, () => StreamReducer<{ b: string }>]`,
+ * produces `{ a: number } & { b: string }`.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type InferExtensions<T extends ReadonlyArray<() => StreamReducer<any>>> =
+  T extends readonly []
+    ? Record<string, never>
+    : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      T extends readonly [
+          () => StreamReducer<infer P>,
+          ...infer Rest extends ReadonlyArray<() => StreamReducer<any>>,
+        ]
+      ? P & InferExtensions<Rest>
+      : Record<string, unknown>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface StreamReducer<TProjection = any> {
+  /**
+   * Called once before the run starts.
+   *
+   * @returns Initial projection merged into `GraphRunStream.extensions`.
+   */
+  init(): TProjection;
+
+  /**
+   * Called for each {@link ProtocolEvent} before it is appended to the main log.
+   *
+   * @param event - Next protocol envelope for this run.
+   * @returns `false` to drop the event from the main log (use sparingly;
+   *   prefer keeping events visible and adding derived data alongside).
+   */
+  process(event: ProtocolEvent): boolean;
+
+  /**
+   * Called once when the underlying Pregel run completes without throwing.
+   */
+  finalize(): void;
+
+  /**
+   * Called once when the run fails; `err` is the rejection or error value.
+   *
+   * @param err - Failure reason from the engine or user code.
+   */
+  fail(err: unknown): void;
+}
+
+import type { MessagesData as MessagesEventDataImport } from "@langchain/protocol";
+import type { UsageInfo as UsageInfoImport } from "@langchain/protocol";
+
+/**
+ * Async view of one assistant message lifecycle
+ * (`message-start` → content blocks → `message-finish`).
+ *
+ * Provides raw event iteration plus ergonomic accessors for text,
+ * reasoning, and usage.
+ */
+export interface ChatModelStream extends AsyncIterable<MessagesEventDataImport> {
+  /**
+   * Text content for this message.
+   *
+   * @remarks
+   * Use as an `AsyncIterable<string>` to consume streaming deltas; `await` the
+   * same value (or use `.then`) to obtain the full concatenated string after
+   * the message completes.
+   */
+  get text(): AsyncIterable<string> & PromiseLike<string>;
+
+  /**
+   * Reasoning / thinking trace for this message, when the model exposes it.
+   *
+   * @remarks
+   * Same dual pattern as {@link ChatModelStream.text}: iterate for deltas,
+   * await for the full reasoning string.
+   */
+  get reasoning(): AsyncIterable<string> & PromiseLike<string>;
+
+  /**
+   * Token usage after `message-finish`, when present.
+   *
+   * @remarks
+   * Promise-like only; resolves when usage is known or `undefined` if omitted.
+   */
+  get usage(): PromiseLike<UsageInfoImport | undefined>;
+
+  /** Namespace of the graph node that produced this stream. */
+  readonly namespace: Namespace;
+
+  /** Graph node id for this stream, if the runtime attributed it. */
+  readonly node: string | undefined;
+
+  /**
+   * Low-level async iteration over message lifecycle events.
+   *
+   * @returns Iterator yielding events in order.
+   */
+  [Symbol.asyncIterator](): AsyncIterator<MessagesEventDataImport>;
+}
+
+/**
+ * High-level outcome of a single tool call for UI or aggregators.
+ */
+export type ToolCallStatus =
+  /** Invocation in flight or output still streaming. */
+  | "running"
+  /** Completed without error. */
+  | "finished"
+  /** Failed or aborted; see {@link ToolCallStream.error}. */
+  | "error";
+
+/**
+ * Stable handle for one tool call: name, arguments, and async results.
+ *
+ * Emitted when `content-block-finish` delivers a finalized `tool_call` block.
+ *
+ * @typeParam TName - Registered tool name.
+ * @typeParam TInput - Parsed or raw input type for the call.
+ * @typeParam TOutput - Successful result type after the tool returns.
+ */
+export interface ToolCallStream<
+  TName extends string = string,
+  TInput = unknown,
+  TOutput = unknown,
+> {
+  /** Tool identifier as registered on the graph or model schema. */
+  readonly name: TName;
+
+  /** Correlates with protocol `toolCallId` when the runtime provides one. */
+  readonly callId: string;
+
+  /** Arguments passed to the tool (finalized when the call is observable). */
+  readonly input: TInput;
+
+  /**
+   * Resolves to the tool return value on success.
+   *
+   * @remarks
+   * Rejection or hang semantics depend on the runner; pairing with
+   * {@link ToolCallStream.status} and {@link ToolCallStream.error} is recommended.
+   */
+  readonly output: Promise<TOutput>;
+
+  /**
+   * Resolves to {@link ToolCallStatus} when the call leaves the running state.
+   */
+  readonly status: Promise<ToolCallStatus>;
+
+  /**
+   * Resolves to an error message string if {@link ToolCallStream.status} is
+   * `"error"`, otherwise `undefined`.
+   */
+  readonly error: Promise<string | undefined>;
+}
+
+/**
+ * Human-in-the-loop interrupt: stable id plus opaque payload for resume UIs.
+ */
+export interface InterruptPayload {
+  /** Idempotent key for this interrupt instance within the run. */
+  interruptId: string;
+
+  /** Arbitrary data supplied by the graph (e.g. questions, draft state). */
+  payload: unknown;
+}

--- a/libs/langgraph-core/src/web.ts
+++ b/libs/langgraph-core/src/web.ts
@@ -39,6 +39,30 @@ export type {
 } from "./pregel/types.js";
 export type { PregelNode } from "./pregel/read.js";
 export type { Pregel } from "./pregel/index.js";
+export {
+  EventLog,
+  GraphRunStream,
+  SubgraphRunStream,
+  ChatModelStreamImpl,
+  STREAM_V2_MODES,
+  createGraphRunStream,
+  createMessagesReducer,
+  createValuesReducer,
+} from "./stream/index.js";
+export type {
+  ProtocolEvent,
+  Namespace,
+  FinishReason,
+  UsageInfo,
+  MessagesEventData,
+  ToolsEventData,
+  UpdatesEventData,
+  StreamReducer,
+  ChatModelStream,
+  ToolCallStatus,
+  ToolCallStream,
+  InterruptPayload,
+} from "./stream/index.js";
 export * from "./errors.js";
 export {
   BaseChannel,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -986,6 +986,27 @@ importers:
         specifier: ^4.3.5
         version: 4.3.6
 
+  examples/streaming:
+    devDependencies:
+      '@langchain/anthropic':
+        specifier: ^1.3.26
+        version: 1.3.26(@langchain/core@1.1.39(@opentelemetry/api@1.9.0)(openai@6.33.0(ws@8.19.0)(zod@4.3.6))(ws@8.19.0))
+      '@langchain/core':
+        specifier: '>=1.1.38'
+        version: 1.1.39(@opentelemetry/api@1.9.0)(openai@6.33.0(ws@8.19.0)(zod@4.3.6))(ws@8.19.0)
+      '@langchain/langgraph':
+        specifier: workspace:*
+        version: link:../../libs/langgraph-core
+      langchain:
+        specifier: '>=1.3.0'
+        version: 1.3.1(@langchain/core@1.1.39(@opentelemetry/api@1.9.0)(openai@6.33.0(ws@8.19.0)(zod@4.3.6))(ws@8.19.0))(@opentelemetry/api@1.9.0)(openai@6.33.0(ws@8.19.0)(zod@4.3.6))(ws@8.19.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      zod:
+        specifier: ^4.3.5
+        version: 4.3.6
+
   examples/ui-angular:
     dependencies:
       '@angular/common':
@@ -1956,6 +1977,9 @@ importers:
       '@langchain/langgraph-sdk':
         specifier: workspace:*
         version: link:../sdk
+      '@langchain/protocol':
+        specifier: ^0.0.5
+        version: 0.0.5
       '@standard-schema/spec':
         specifier: 1.1.0
         version: 1.1.0
@@ -22593,7 +22617,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 25.4.0
-      '@vitest/browser-webdriverio': 4.0.18(msw@2.12.10(@types/node@25.4.0)(typescript@5.9.3))(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.18)(webdriverio@9.25.0)
+      '@vitest/browser-webdriverio': 4.0.18(msw@2.12.10(@types/node@25.4.0)(typescript@5.9.3))(vite@8.0.7(@types/node@25.4.0)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.0.18)(webdriverio@9.25.0)
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
## Summary

- Adds `graph.streamV2()` — a new ergonomic in-process streaming API that replaces manual `[namespace, mode, payload]` tuple routing with typed, named projections
- Introduces the `StreamReducer` pipeline for extensible event processing
- Adds `ChatModelStream` for per-message text/reasoning/usage streaming
- Includes 6 runnable examples and 92 unit tests across 6 test files

## Motivation

The current `graph.stream()` API requires callers to know Pregel internals — stream mode names, checkpoint namespace formats, and manual event routing by namespace arrays. `streamV2()` hides all of that behind named, typed accessors:

```typescript
// Before — manual routing by mode and namespace
for await (const chunk of await graph.stream(input, {
  streamMode: ["updates", "messages"],
  subgraphs: true,
})) {
  const [ns, mode, data] = chunk;
  if (mode === "messages" && ns.length === 0) { /* ... */ }
}

// After — typed projections, no internals
const run = await graph.streamV2(input);
for await (const msg of run.messages) {
  for await (const token of msg.text) { process.stdout.write(token); }
}
for await (const sub of run.subgraphs) { /* ... */ }
const state = await run.output;
```
