### PR TITLE
fix(sdk): Backfill truncated history for regenerate branching

### DIFF
--- a/libs/sdk-angular/src/tests/stream.test.ts
+++ b/libs/sdk-angular/src/tests/stream.test.ts
@@ -601,6 +601,37 @@ it("branching", async () => {
     .toHaveTextContent("1 / 2");
 });
 
+it("branching: regenerating the first ai message after a long chat resets to that checkpoint", async () => {
+  const screen = await render(BranchingComponent);
+
+  for (let i = 0; i < 7; i += 1) {
+    await screen.getByTestId("submit").click();
+    await expect
+      .element(screen.getByTestId(`content-${i * 2}`), { timeout: 10_000 })
+      .toHaveTextContent("Hello");
+    await expect
+      .element(screen.getByTestId(`content-${i * 2 + 1}`), { timeout: 10_000 })
+      .toHaveTextContent("Hey");
+  }
+
+  await expect
+    .element(screen.getByTestId("message-13"), { timeout: 10_000 })
+    .toHaveTextContent("Hey");
+
+  await screen.getByTestId("regenerate-1").click();
+
+  await expect
+    .element(screen.getByTestId("message-0"), { timeout: 10_000 })
+    .toHaveTextContent("Hello");
+  await expect
+    .element(screen.getByTestId("message-1"), { timeout: 10_000 })
+    .toHaveTextContent("Hey");
+  await expect
+    .element(screen.getByTestId("branch-info-1"), { timeout: 10_000 })
+    .toHaveTextContent("2 / 2");
+  await expect.element(screen.getByTestId("message-2")).not.toBeInTheDocument();
+});
+
 it("fetchStateHistory: { limit: 2 }", async () => {
   const requests: Array<{ url: string; body?: Record<string, unknown> }> = [];
   const client = new Client({

--- a/libs/sdk-react/src/stream.lgp.tsx
+++ b/libs/sdk-react/src/stream.lgp.tsx
@@ -25,6 +25,7 @@ import type {
 import { Client, getClientConfigHash } from "@langchain/langgraph-sdk/client";
 import {
   filterStream,
+  fetchHistory,
   unique,
   StreamError,
   getBranchContext,
@@ -62,46 +63,6 @@ function getFetchHistoryKey(
   limit: boolean | number
 ) {
   return [getClientConfigHash(client), threadId, limit].join(":");
-}
-
-function fetchHistory<StateType extends Record<string, unknown>>(
-  client: Client,
-  threadId: string,
-  options?: { limit?: boolean | number }
-) {
-  if (options?.limit === false) {
-    return client.threads.getState<StateType>(threadId).then((state) => {
-      if (state.checkpoint == null) return [];
-      return [state];
-    });
-  }
-
-  const limit = typeof options?.limit === "number" ? options.limit : 10;
-  return client.threads
-    .getHistory<StateType>(threadId, { limit })
-    .then(async (history) => {
-      if (history.length < limit) return history;
-
-      const result = [...history];
-      let before = history.at(-1)?.checkpoint?.checkpoint_id;
-
-      while (before != null) {
-        const page = await client.threads.getHistory<StateType>(threadId, {
-          limit,
-          before: before as any,
-        });
-        if (page.length === 0) break;
-
-        result.push(...page);
-        if (page.length < limit) break;
-
-        const nextBefore = page.at(-1)?.checkpoint?.checkpoint_id;
-        if (nextBefore == null || nextBefore === before) break;
-        before = nextBefore;
-      }
-
-      return result;
-    });
 }
 
 function useThreadHistory<StateType extends Record<string, unknown>>(

--- a/libs/sdk-react/src/stream.lgp.tsx
+++ b/libs/sdk-react/src/stream.lgp.tsx
@@ -77,7 +77,31 @@ function fetchHistory<StateType extends Record<string, unknown>>(
   }
 
   const limit = typeof options?.limit === "number" ? options.limit : 10;
-  return client.threads.getHistory<StateType>(threadId, { limit });
+  return client.threads
+    .getHistory<StateType>(threadId, { limit })
+    .then(async (history) => {
+      if (history.length < limit) return history;
+
+      const result = [...history];
+      let before = history.at(-1)?.checkpoint?.checkpoint_id;
+
+      while (before != null) {
+        const page = await client.threads.getHistory<StateType>(threadId, {
+          limit,
+          before: before as any,
+        });
+        if (page.length === 0) break;
+
+        result.push(...page);
+        if (page.length < limit) break;
+
+        const nextBefore = page.at(-1)?.checkpoint?.checkpoint_id;
+        if (nextBefore == null || nextBefore === before) break;
+        before = nextBefore;
+      }
+
+      return result;
+    });
 }
 
 function useThreadHistory<StateType extends Record<string, unknown>>(

--- a/libs/sdk-react/src/tests/stream.test.tsx
+++ b/libs/sdk-react/src/tests/stream.test.tsx
@@ -582,6 +582,37 @@ it("branching", async () => {
     .toHaveTextContent("1 / 2");
 });
 
+it("branching: regenerating the first ai message after a long chat resets to that checkpoint", async () => {
+  const screen = await render(<Branching apiUrl={serverUrl} />);
+
+  for (let i = 0; i < 7; i += 1) {
+    await screen.getByTestId("submit").click();
+    await expect
+      .element(screen.getByTestId(`content-${i * 2}`), { timeout: 10_000 })
+      .toHaveTextContent("Hello");
+    await expect
+      .element(screen.getByTestId(`content-${i * 2 + 1}`), { timeout: 10_000 })
+      .toHaveTextContent("Hey");
+  }
+
+  await expect
+    .element(screen.getByTestId("message-13"), { timeout: 10_000 })
+    .toHaveTextContent("Hey");
+
+  await screen.getByTestId("regenerate-1").click();
+
+  await expect
+    .element(screen.getByTestId("message-0"), { timeout: 10_000 })
+    .toHaveTextContent("Hello");
+  await expect
+    .element(screen.getByTestId("message-1"), { timeout: 10_000 })
+    .toHaveTextContent("Hey");
+  await expect
+    .element(screen.getByTestId("branch-info-1"), { timeout: 10_000 })
+    .toHaveTextContent("2 / 2");
+  await expect.element(screen.getByTestId("message-2")).not.toBeInTheDocument();
+});
+
 it("fetchStateHistory: { limit: 2 }", async () => {
   const onRequestCallback = vi.fn();
   const client = new Client({

--- a/libs/sdk-svelte/src/tests/stream.test.ts
+++ b/libs/sdk-svelte/src/tests/stream.test.ts
@@ -575,6 +575,39 @@ it("branching", async () => {
     .toHaveTextContent("1 / 2");
 });
 
+it("branching: regenerating the first ai message after a long chat resets to that checkpoint", async () => {
+  const screen = render(Branching, {
+    apiUrl: serverUrl,
+  });
+
+  for (let i = 0; i < 7; i += 1) {
+    await screen.getByTestId("submit").click();
+    await expect
+      .element(screen.getByTestId(`content-${i * 2}`), { timeout: 10_000 })
+      .toHaveTextContent("Hello");
+    await expect
+      .element(screen.getByTestId(`content-${i * 2 + 1}`), { timeout: 10_000 })
+      .toHaveTextContent("Hey");
+  }
+
+  await expect
+    .element(screen.getByTestId("message-13"), { timeout: 10_000 })
+    .toHaveTextContent("Hey");
+
+  await screen.getByTestId("regenerate-1").click();
+
+  await expect
+    .element(screen.getByTestId("message-0"), { timeout: 10_000 })
+    .toHaveTextContent("Hello");
+  await expect
+    .element(screen.getByTestId("message-1"), { timeout: 10_000 })
+    .toHaveTextContent("Hey");
+  await expect
+    .element(screen.getByTestId("branch-info-1"), { timeout: 10_000 })
+    .toHaveTextContent("2 / 2");
+  await expect.element(screen.getByTestId("message-2")).not.toBeInTheDocument();
+});
+
 it("fetchStateHistory: { limit: 2 }", async () => {
   const onRequestCalls: Array<{ url: string; body?: Record<string, unknown> }> = [];
   const client = new Client({

--- a/libs/sdk-vue/src/tests/stream.test.tsx
+++ b/libs/sdk-vue/src/tests/stream.test.tsx
@@ -1206,6 +1206,138 @@ it("branching", async () => {
     .toHaveTextContent("1 / 2");
 });
 
+it("branching: regenerating the first ai message after a long chat resets to that checkpoint", async () => {
+  const TestComponent = defineComponent({
+    setup() {
+      const { submit, messages, getMessagesMetadata, setBranch } = useStream({
+        assistantId: "agent",
+        apiUrl: serverUrl,
+        fetchStateHistory: true,
+      });
+
+      return () => (
+        <div>
+          <div data-testid="messages">
+            {messages.value.map((msg, i: number) => {
+              const metadata = getMessagesMetadata(msg, i);
+              const checkpoint =
+                metadata?.firstSeenState?.parent_checkpoint ?? undefined;
+              const text =
+                typeof msg.content === "string"
+                  ? msg.content
+                  : JSON.stringify(msg.content);
+              const branchOptions = metadata?.branchOptions;
+              const branch = metadata?.branch;
+              const branchIndex =
+                branchOptions && branch ? branchOptions.indexOf(branch) : -1;
+
+              return (
+                <div key={msg.id ?? i} data-testid={`message-${i}`}>
+                  <div data-testid={`content-${i}`}>{text}</div>
+
+                  {branchOptions && branch && (
+                    <div data-testid={`branch-nav-${i}`}>
+                      <button
+                        data-testid={`prev-${i}`}
+                        onClick={() => {
+                          const prevBranch = branchOptions[branchIndex - 1];
+                          if (prevBranch) setBranch(prevBranch);
+                        }}
+                      >
+                        Previous
+                      </button>
+                      <span data-testid={`branch-info-${i}`}>
+                        {branchIndex + 1} / {branchOptions.length}
+                      </span>
+                      <button
+                        data-testid={`next-${i}`}
+                        onClick={() => {
+                          const nextBranch = branchOptions[branchIndex + 1];
+                          if (nextBranch) setBranch(nextBranch);
+                        }}
+                      >
+                        Next
+                      </button>
+                    </div>
+                  )}
+
+                  {msg.type === "human" && (
+                    <button
+                      data-testid={`fork-${i}`}
+                      onClick={() =>
+                        void submit(
+                          {
+                            messages: [
+                              { type: "human", content: `Fork: ${text}` },
+                            ],
+                          } as any,
+                          { checkpoint },
+                        )
+                      }
+                    >
+                      Fork
+                    </button>
+                  )}
+
+                  {msg.type === "ai" && (
+                    <button
+                      data-testid={`regenerate-${i}`}
+                      onClick={() =>
+                        void submit(undefined as any, { checkpoint })
+                      }
+                    >
+                      Regenerate
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          <button
+            data-testid="submit"
+            onClick={() =>
+              void submit({
+                messages: [{ content: "Hello", type: "human" }],
+              } as any)
+            }
+          >
+            Send
+          </button>
+        </div>
+      );
+    },
+  });
+
+  const screen = render(TestComponent);
+
+  for (let i = 0; i < 7; i += 1) {
+    await screen.getByTestId("submit").click();
+    await expect
+      .element(screen.getByTestId(`content-${i * 2}`), { timeout: 10_000 })
+      .toHaveTextContent("Hello");
+    await expect
+      .element(screen.getByTestId(`content-${i * 2 + 1}`), { timeout: 10_000 })
+      .toHaveTextContent("Hey");
+  }
+
+  await expect
+    .element(screen.getByTestId("message-13"), { timeout: 10_000 })
+    .toHaveTextContent("Hey");
+
+  await screen.getByTestId("regenerate-1").click();
+
+  await expect
+    .element(screen.getByTestId("message-0"), { timeout: 10_000 })
+    .toHaveTextContent("Hello");
+  await expect
+    .element(screen.getByTestId("message-1"), { timeout: 10_000 })
+    .toHaveTextContent("Hey");
+  await expect
+    .element(screen.getByTestId("branch-info-1"), { timeout: 10_000 })
+    .toHaveTextContent("2 / 2");
+  await expect.element(screen.getByTestId("message-2")).not.toBeInTheDocument();
+});
+
 it("fetchStateHistory: { limit: 2 }", async () => {
   const onRequestCallback = vi.fn();
   const client = new Client({

--- a/libs/sdk/src/react/stream.lgp.tsx
+++ b/libs/sdk/src/react/stream.lgp.tsx
@@ -73,7 +73,31 @@ function fetchHistory<StateType extends Record<string, unknown>>(
   }
 
   const limit = typeof options?.limit === "number" ? options.limit : 10;
-  return client.threads.getHistory<StateType>(threadId, { limit });
+  return client.threads
+    .getHistory<StateType>(threadId, { limit })
+    .then(async (history) => {
+      if (history.length < limit) return history;
+
+      const result = [...history];
+      let before = history.at(-1)?.checkpoint?.checkpoint_id;
+
+      while (before != null) {
+        const page = await client.threads.getHistory<StateType>(threadId, {
+          limit,
+          before: before as any,
+        });
+        if (page.length === 0) break;
+
+        result.push(...page);
+        if (page.length < limit) break;
+
+        const nextBefore = page.at(-1)?.checkpoint?.checkpoint_id;
+        if (nextBefore == null || nextBefore === before) break;
+        before = nextBefore;
+      }
+
+      return result;
+    });
 }
 
 function useThreadHistory<StateType extends Record<string, unknown>>(

--- a/libs/sdk/src/react/stream.lgp.tsx
+++ b/libs/sdk/src/react/stream.lgp.tsx
@@ -14,6 +14,7 @@ import {
 import {
   filterStream,
   findLast,
+  fetchHistory,
   onFinishRequiresThreadState,
   unique,
 } from "../ui/utils.js";
@@ -58,46 +59,6 @@ function getFetchHistoryKey(
   limit: boolean | number
 ) {
   return [getClientConfigHash(client), threadId, limit].join(":");
-}
-
-function fetchHistory<StateType extends Record<string, unknown>>(
-  client: Client,
-  threadId: string,
-  options?: { limit?: boolean | number }
-) {
-  if (options?.limit === false) {
-    return client.threads.getState<StateType>(threadId).then((state) => {
-      if (state.checkpoint == null) return [];
-      return [state];
-    });
-  }
-
-  const limit = typeof options?.limit === "number" ? options.limit : 10;
-  return client.threads
-    .getHistory<StateType>(threadId, { limit })
-    .then(async (history) => {
-      if (history.length < limit) return history;
-
-      const result = [...history];
-      let before = history.at(-1)?.checkpoint?.checkpoint_id;
-
-      while (before != null) {
-        const page = await client.threads.getHistory<StateType>(threadId, {
-          limit,
-          before: before as any,
-        });
-        if (page.length === 0) break;
-
-        result.push(...page);
-        if (page.length < limit) break;
-
-        const nextBefore = page.at(-1)?.checkpoint?.checkpoint_id;
-        if (nextBefore == null || nextBefore === before) break;
-        before = nextBefore;
-      }
-
-      return result;
-    });
 }
 
 function useThreadHistory<StateType extends Record<string, unknown>>(

--- a/libs/sdk/src/ui/index.ts
+++ b/libs/sdk/src/ui/index.ts
@@ -30,6 +30,7 @@ export {
   unique,
   findLast,
   filterStream,
+  fetchHistory,
   onFinishRequiresThreadState,
 } from "./utils.js";
 export {

--- a/libs/sdk/src/ui/orchestrator.ts
+++ b/libs/sdk/src/ui/orchestrator.ts
@@ -21,7 +21,12 @@ import {
   userFacingInterruptsFromThreadTasks,
   userFacingInterruptsFromValuesArray,
 } from "./interrupts.js";
-import { unique, filterStream, onFinishRequiresThreadState } from "./utils.js";
+import {
+  unique,
+  filterStream,
+  onFinishRequiresThreadState,
+  fetchHistory,
+} from "./utils.js";
 import { getToolCallsWithResults } from "../utils/tools.js";
 import { flushPendingHeadlessToolInterrupts } from "../headless-tools.js";
 import type {
@@ -41,53 +46,6 @@ interface RunMetadataStorage {
   getItem(key: `lg:stream:${string}`): string | null;
   setItem(key: `lg:stream:${string}`, value: string): void;
   removeItem(key: `lg:stream:${string}`): void;
-}
-
-/**
- * Fetch the history of a thread.
- * @param client - The client to use.
- * @param threadId - The ID of the thread to fetch the history of.
- * @param options - The options to use.
- * @returns The history of the thread.
- */
-function fetchHistory<StateType extends Record<string, unknown>>(
-  client: Client,
-  threadId: string,
-  options?: { limit?: boolean | number }
-) {
-  if (options?.limit === false) {
-    return client.threads.getState<StateType>(threadId).then((state) => {
-      if (state.checkpoint == null) return [];
-      return [state];
-    });
-  }
-
-  const limit = typeof options?.limit === "number" ? options.limit : 10;
-  return client.threads
-    .getHistory<StateType>(threadId, { limit })
-    .then(async (history) => {
-      if (history.length < limit) return history;
-
-      const result = [...history];
-      let before = history.at(-1)?.checkpoint?.checkpoint_id;
-
-      while (before != null) {
-        const page = await client.threads.getHistory<StateType>(threadId, {
-          limit,
-          before: before as any,
-        });
-        if (page.length === 0) break;
-
-        result.push(...page);
-        if (page.length < limit) break;
-
-        const nextBefore = page.at(-1)?.checkpoint?.checkpoint_id;
-        if (nextBefore == null || nextBefore === before) break;
-        before = nextBefore;
-      }
-
-      return result;
-    });
 }
 
 /**

--- a/libs/sdk/src/ui/orchestrator.ts
+++ b/libs/sdk/src/ui/orchestrator.ts
@@ -63,7 +63,31 @@ function fetchHistory<StateType extends Record<string, unknown>>(
   }
 
   const limit = typeof options?.limit === "number" ? options.limit : 10;
-  return client.threads.getHistory<StateType>(threadId, { limit });
+  return client.threads
+    .getHistory<StateType>(threadId, { limit })
+    .then(async (history) => {
+      if (history.length < limit) return history;
+
+      const result = [...history];
+      let before = history.at(-1)?.checkpoint?.checkpoint_id;
+
+      while (before != null) {
+        const page = await client.threads.getHistory<StateType>(threadId, {
+          limit,
+          before: before as any,
+        });
+        if (page.length === 0) break;
+
+        result.push(...page);
+        if (page.length < limit) break;
+
+        const nextBefore = page.at(-1)?.checkpoint?.checkpoint_id;
+        if (nextBefore == null || nextBefore === before) break;
+        before = nextBefore;
+      }
+
+      return result;
+    });
 }
 
 /**

--- a/libs/sdk/src/ui/utils.ts
+++ b/libs/sdk/src/ui/utils.ts
@@ -1,3 +1,6 @@
+import type { Client } from "../client.js";
+import type { ThreadState } from "../schema.js";
+
 /**
  * Returns true when `onFinish` declares at least one parameter and therefore
  * needs the server-fetched thread head. A zero-arity `onFinish` is treated as
@@ -33,4 +36,44 @@ export async function* filterStream<T, TReturn>(
     if (done) return value as TReturn;
     if (filter(value)) yield value as T;
   }
+}
+
+export function fetchHistory<StateType extends Record<string, unknown>>(
+  client: Client,
+  threadId: string,
+  options?: { limit?: boolean | number }
+): Promise<ThreadState<StateType>[]> {
+  if (options?.limit === false) {
+    return client.threads.getState<StateType>(threadId).then((state) => {
+      if (state.checkpoint == null) return [];
+      return [state];
+    });
+  }
+
+  const limit = typeof options?.limit === "number" ? options.limit : 10;
+  return client.threads
+    .getHistory<StateType>(threadId, { limit })
+    .then(async (history) => {
+      if (history.length < limit) return history;
+
+      const result = [...history];
+      let before = history.at(-1)?.checkpoint?.checkpoint_id;
+
+      while (before != null) {
+        const page = await client.threads.getHistory<StateType>(threadId, {
+          limit,
+          before: before as any,
+        });
+        if (page.length === 0) break;
+
+        result.push(...page);
+        if (page.length < limit) break;
+
+        const nextBefore = page.at(-1)?.checkpoint?.checkpoint_id;
+        if (nextBefore == null || nextBefore === before) break;
+        before = nextBefore;
+      }
+
+      return result;
+    });
 }


### PR DESCRIPTION
## Summary

This fixes incorrect regenerate branching in `useStream` when `fetchStateHistory`
is enabled with the default bounded history window.

In longer chats, the initial history fetch can exclude the earliest checkpoint
for older visible messages. When that happens, `getMessagesMetadata()` can
resolve an incorrect `firstSeenState`, which causes regenerate to branch from a
later checkpoint instead of the selected message's actual parent checkpoint.

This change backfills older history pages when the initial history response is
truncated, so message metadata can resolve against the full checkpoint chain.
The fix is applied in both:

- `libs/sdk-react/src/stream.lgp.tsx`
- `libs/sdk/src/react/stream.lgp.tsx`

## Testing

- Added a regression test covering a 7-turn conversation and regenerating the
  first AI message in `libs/sdk-react/src/tests/stream.test.tsx`
- Ran `pnpm format:check`
- Ran `pnpm build`
- Ran `pnpm --filter @langchain/react run test`

## Notes

This is a correctness-first fix for truncated history. Any optimization to avoid
eagerly backfilling older history pages can be handled separately.

Related: #2304

`#2304` addresses repeated forks / intermediate fork checkpoints. This PR is
still needed for `#2306` because it fixes incorrect regenerate behavior when
older checkpoints fall outside the initial history window in long chats.

Fixes #2306
