### PR TITLE
ci: add PR title lint workflow

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -1,0 +1,86 @@
+# PR title linting.
+#
+# Enforces Conventional Commits format for pull request titles.
+name: "PR Title Lint"
+
+permissions:
+  pull-requests: read
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  lint-pr-title:
+    name: "validate format"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Reject empty scope"
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ "$PR_TITLE" =~ ^[a-z]+\(\)[!]?: ]]; then
+            echo "::error::PR title has empty scope parentheses: '$PR_TITLE'"
+            echo "Either remove the parentheses or provide a scope (e.g., 'fix(langgraph): ...')."
+            exit 1
+          fi
+
+      - name: "Validate Conventional Commits format"
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+            release
+            hotfix
+          scopes: |
+            langgraph
+            langgraph-api
+            langgraph-cli
+            langgraph-ui
+            langgraph-cua
+            langgraph-supervisor
+            langgraph-swarm
+            langgraph-sdk
+            langgraph-checkpoint
+            langgraph-checkpoint-validation
+            langgraph-checkpoint-postgres
+            langgraph-checkpoint-sqlite
+            langgraph-checkpoint-mongodb
+            langgraph-checkpoint-redis
+            create-langgraph
+            checkpoint
+            sdk
+            core
+            api
+            cli
+            ui
+            cua
+            supervisor
+            swarm
+            angular
+            react
+            svelte
+            vue
+            docs
+            examples
+            internal
+            infra
+            deps
+          requireScope: false
+          disallowScopes: |
+            release
+            [A-Z]+
+          ignoreLabels: |
+            ignore-lint-pr-title


### PR DESCRIPTION
## Summary
Adds pull request title linting to enforce Conventional Commit style titles in this repository.

## Changes
- Add .github/workflows/pr_lint.yml
- Reject empty scopes in PR titles (for example, fix(): ...)
- Validate title format via amannn/action-semantic-pull-request
- Allow langgraphjs package/area scopes and ignore label override