### PR TITLE
fix(sdk): clear MessageTupleManager on joinStream full replay

### DIFF
--- a/.changeset/joinstream-replay-doubles-messages.md
+++ b/.changeset/joinstream-replay-doubles-messages.md
@@ -1,0 +1,24 @@
+---
+"@langchain/langgraph-sdk": patch
+"@langchain/react": patch
+---
+
+fix(sdk, sdk-react): clear `MessageTupleManager` on `joinStream` full replay
+
+When a network error interrupted a stream and `joinStream` reconnected
+without a `lastEventId`, the server replayed events from the beginning
+and `MessageTupleManager.add()` concatenated the replay onto the chunks
+still held from the pre-disconnect stream — doubling the assistant's
+message content (`"Hello"` → `"HelloHello"`) and corrupting streamed
+tool_call args. The same doubling affected per-subagent chunk managers.
+
+`StreamManager` now exposes `resetChunkAccumulator(existingMessages?)`
+which drops chunk state (plus per-subagent chunks) without touching
+`state.values`, the abort controller, or the subagent registry. When
+`existingMessages` is supplied, each id is seeded with its current
+index so the replay overwrites messages at their original positions
+instead of appending duplicates. Both the orchestrator and the React
+hook's `joinStream` now call this before `stream.start(...)` when
+`lastEventId === "-1"`.
+
+Closes https://github.com/langchain-ai/langgraphjs/issues/2028.

--- a/libs/sdk-react/src/stream.lgp.tsx
+++ b/libs/sdk-react/src/stream.lgp.tsx
@@ -762,6 +762,15 @@ export function useStreamLGP<
     lastEventId ??= "-1";
     if (!threadId) return;
 
+    // See libs/sdk/src/ui/orchestrator.ts joinStream() and issue #2028:
+    // on a full replay the MessageTupleManager would concat the replay
+    // onto the chunks from the pre-disconnect stream, doubling content.
+    // Seed current messages' indexes so the replay overwrites them in
+    // place rather than appending duplicates.
+    if (lastEventId === "-1") {
+      stream.resetChunkAccumulator(getMessages(stream.values ?? historyValues));
+    }
+
     const callbackMeta: RunCallbackMeta = {
       thread_id: threadId,
       run_id: runId,

--- a/libs/sdk/src/ui/manager.test.ts
+++ b/libs/sdk/src/ui/manager.test.ts
@@ -1260,6 +1260,51 @@ describe("StreamManager", () => {
       expect(subagents[0]?.status).toBe("pending");
     });
 
+    it("resetChunkAccumulator drops per-subagent chunks without losing the registry (issue #2028)", () => {
+      const mgr = new SubagentManager({
+        subagentToolNames: ["task"],
+      });
+
+      mgr.registerFromToolCalls(toolCalls, "msg-1");
+
+      // Partial subagent output from before a disconnect.
+      mgr.addMessageToSubagent(
+        "call_1",
+        { id: "sub-ai-1", type: "ai", content: "par" },
+        undefined
+      );
+      mgr.addMessageToSubagent(
+        "call_1",
+        { id: "sub-ai-1", type: "ai", content: "tial" },
+        undefined
+      );
+
+      expect(mgr.getSubagent("call_1")?.messages[0]?.content).toBe("partial");
+
+      // Reconnect → full replay: drop chunk state, keep registration.
+      mgr.resetChunkAccumulator();
+
+      expect(mgr.getSubagent("call_1")).toBeDefined();
+      expect(mgr.getSubagent("call_1")?.messages).toEqual([]);
+
+      // Replay delivers the same two chunks again.
+      mgr.addMessageToSubagent(
+        "call_1",
+        { id: "sub-ai-1", type: "ai", content: "par" },
+        undefined
+      );
+      mgr.addMessageToSubagent(
+        "call_1",
+        { id: "sub-ai-1", type: "ai", content: "tial" },
+        undefined
+      );
+
+      // Without the reset, concat would produce "partialpartial" /
+      // "parparttialial"; after the reset it's back to "partial".
+      expect(mgr.getSubagent("call_1")?.messages).toHaveLength(1);
+      expect(mgr.getSubagent("call_1")?.messages[0]?.content).toBe("partial");
+    });
+
     it("replays buffered subagent messages after namespace matching", () => {
       const mgr = new SubagentManager({
         subagentToolNames: ["task"],

--- a/libs/sdk/src/ui/manager.ts
+++ b/libs/sdk/src/ui/manager.ts
@@ -1180,4 +1180,29 @@ export class StreamManager<
     // Clear subagent state
     this.subagentManager.clear();
   };
+
+  // Drop the MessageTupleManager's per-run chunk accumulator (plus the
+  // per-subagent chunk accumulators) without touching state.values, the
+  // abort controller, or the subagent registry.
+  //
+  // Called by joinStream when a reconnect is about to replay events from
+  // the beginning (lastEventId === "-1"): otherwise the replayed chunks
+  // concatenate onto the chunk still held from the pre-disconnect stream
+  // and the assistant message doubles. See
+  // https://github.com/langchain-ai/langgraphjs/issues/2028.
+  //
+  // If `existingMessages` is supplied, each id in the list is seeded with
+  // its current index but no chunk, so the replay overwrites the message
+  // at its original position instead of appending a duplicate.
+  resetChunkAccumulator = (existingMessages?: Message[]) => {
+    this.messages.clear();
+    this.subagentManager.resetChunkAccumulator();
+    if (!existingMessages) return;
+    for (let i = 0; i < existingMessages.length; i += 1) {
+      const id = existingMessages[i]?.id;
+      if (typeof id === "string" && id.length > 0) {
+        this.messages.chunks[id] = { index: i };
+      }
+    }
+  };
 }

--- a/libs/sdk/src/ui/orchestrator.test.ts
+++ b/libs/sdk/src/ui/orchestrator.test.ts
@@ -831,4 +831,162 @@ describe("StreamOrchestrator", () => {
       orch.dispose();
     });
   });
+
+  // Regression coverage for https://github.com/langchain-ai/langgraphjs/issues/2028
+  describe("joinStream replay (issue #2028)", () => {
+    // Emits an AIMessageChunk "messages" event for a streamed assistant reply.
+    // Two chunks with the same id concatenate to form the final content, which
+    // is how real servers deliver token-by-token output.
+    const streamedChunks = () => [
+      {
+        event: "messages" as const,
+        data: [
+          { type: "ai", id: "m1", content: "Hel" },
+          {},
+        ] as unknown as [unknown, Record<string, unknown>],
+      },
+      {
+        event: "messages" as const,
+        data: [
+          { type: "ai", id: "m1", content: "lo" },
+          {},
+        ] as unknown as [unknown, Record<string, unknown>],
+      },
+    ];
+
+    it("does not double message content when the server replays from the beginning", async () => {
+      // Initial run: server delivers "Hel" + "lo" → content = "Hello".
+      (client.runs.stream as ReturnType<typeof vi.fn>).mockImplementation(
+        (
+          _threadId: string,
+          _assistantId: string,
+          opts: { onRunCreated?: (p: { run_id: string }) => void }
+        ) => {
+          opts.onRunCreated?.({ run_id: "run-1" });
+          const events = streamedChunks();
+          return (async function* () {
+            for (const ev of events) yield ev;
+          })();
+        }
+      );
+
+      const orch = new StreamOrchestrator<TestState>(
+        createOptions(),
+        accessors
+      );
+      orch.initThreadId("t1");
+
+      await orch.submit({ messages: [] });
+
+      expect(orch.values.messages).toHaveLength(1);
+      expect(orch.values.messages[0].id).toBe("m1");
+      expect(orch.values.messages[0].content).toBe("Hello");
+
+      // Reconnect: the server has no Location header, so lastEventId defaults
+      // to "-1" and the replay delivers the same two chunks. Before the fix,
+      // MessageTupleManager kept the already-concatenated "Hello" chunk and
+      // appended "Hel" + "lo" onto it, producing "HelHellolo" / "HelloHello".
+      (client.runs.joinStream as ReturnType<typeof vi.fn>).mockImplementation(
+        () => {
+          const events = streamedChunks();
+          return (async function* () {
+            for (const ev of events) yield ev;
+          })();
+        }
+      );
+
+      await orch.joinStream("run-1");
+
+      expect(orch.values.messages).toHaveLength(1);
+      expect(orch.values.messages[0].id).toBe("m1");
+      expect(orch.values.messages[0].content).toBe("Hello");
+
+      orch.dispose();
+    });
+
+    it("does not double tool_call args when the server replays a streamed tool call", async () => {
+      // Tool-call streaming is the practical impact of the same bug: without
+      // a reset, the replay concatenates the args JSON and AIMessageChunk
+      // reducer has to recover from "{}\"path\":\"/\"}{\"path\":\"/\"}".
+      const toolChunks = () => [
+        {
+          event: "messages" as const,
+          data: [
+            {
+              type: "ai",
+              id: "m2",
+              content: "",
+              tool_call_chunks: [
+                { id: "call-1", index: 0, name: "ls", args: '{"pa' },
+              ],
+            },
+            {},
+          ] as unknown as [unknown, Record<string, unknown>],
+        },
+        {
+          event: "messages" as const,
+          data: [
+            {
+              type: "ai",
+              id: "m2",
+              content: "",
+              tool_call_chunks: [{ index: 0, args: 'th":"/"}' }],
+            },
+            {},
+          ] as unknown as [unknown, Record<string, unknown>],
+        },
+      ];
+
+      (client.runs.stream as ReturnType<typeof vi.fn>).mockImplementation(
+        (
+          _threadId: string,
+          _assistantId: string,
+          opts: { onRunCreated?: (p: { run_id: string }) => void }
+        ) => {
+          opts.onRunCreated?.({ run_id: "run-2" });
+          const events = toolChunks();
+          return (async function* () {
+            for (const ev of events) yield ev;
+          })();
+        }
+      );
+
+      const orch = new StreamOrchestrator<TestState>(
+        createOptions(),
+        accessors
+      );
+      orch.initThreadId("t1");
+
+      await orch.submit({ messages: [] });
+
+      const afterSubmit = orch.values.messages[0] as unknown as {
+        tool_calls?: Array<{ args: Record<string, unknown> }>;
+      };
+      expect(afterSubmit.tool_calls).toEqual([
+        expect.objectContaining({ args: { path: "/" } }),
+      ]);
+
+      (client.runs.joinStream as ReturnType<typeof vi.fn>).mockImplementation(
+        () => {
+          const events = toolChunks();
+          return (async function* () {
+            for (const ev of events) yield ev;
+          })();
+        }
+      );
+
+      await orch.joinStream("run-2");
+
+      const afterJoin = orch.values.messages[0] as unknown as {
+        tool_calls?: Array<{ args: Record<string, unknown> }>;
+      };
+      // Without the fix, the tool_call args JSON doubles
+      // ('{"path":"/"}{"path":"/"}') and tool_calls parses empty.
+      expect(afterJoin.tool_calls).toEqual([
+        expect.objectContaining({ args: { path: "/" } }),
+      ]);
+
+      orch.dispose();
+    });
+  });
 });

--- a/libs/sdk/src/ui/orchestrator.ts
+++ b/libs/sdk/src/ui/orchestrator.ts
@@ -842,6 +842,22 @@ export class StreamOrchestrator<
     if (!tid) return;
     this.#threadIdStreaming = tid;
 
+    // A full replay (lastEventId === "-1") re-sends every chunk the server
+    // has produced so far. The MessageTupleManager still holds the chunks
+    // from the pre-disconnect stream, and MessageTupleManager.add() would
+    // concat the replay onto them, doubling the message content
+    // (issue #2028). Drop the chunk accumulator — not state.values — and
+    // seed each visible message's index so the replay overwrites at the
+    // original position instead of appending a duplicate.
+    //
+    // TODO: track last-seen event id inside StreamManager.enqueue and
+    // thread it through here so the server resumes at the correct cursor
+    // instead of replaying from zero — same pattern streamWithRetry uses
+    // at libs/sdk/src/utils/stream.ts around lastEventId tracking.
+    if (lastEventId === "-1") {
+      this.stream.resetChunkAccumulator(this.#getMessages(this.values));
+    }
+
     const callbackMeta: RunCallbackMeta = {
       thread_id: tid,
       run_id: runId,

--- a/libs/sdk/src/ui/subagents.ts
+++ b/libs/sdk/src/ui/subagents.ts
@@ -867,6 +867,21 @@ export class SubagentManager<ToolCall = DefaultToolCall> {
     this.onSubagentChange?.();
   }
 
+  // Drop per-subagent chunk accumulators and any un-flushed buffered
+  // messages, while keeping the subagent registry (keyed by tool_call_id)
+  // and the namespace-to-tool-call mapping intact. Those are idempotent
+  // on re-registration, the chunk state is not — see #2028 and the
+  // companion fix in StreamManager.resetChunkAccumulator().
+  resetChunkAccumulator(): void {
+    this.messageManagers.clear();
+    this.pendingMessages.clear();
+    for (const [toolCallId, existing] of this.subagents) {
+      if (existing.messages.length > 0) {
+        this.subagents.set(toolCallId, { ...existing, messages: [] });
+      }
+    }
+  }
+
   /**
    * Process a tool message to complete a subagent.
    *


### PR DESCRIPTION
## What

When a network error interrupted an SSE stream and `useStream`'s `onError` handler called `joinStream(runId)` to reconnect, the server replayed all events from the beginning (default `lastEventId = "-1"`) and `MessageTupleManager.add()` concatenated the replay onto the chunks still held from the pre-disconnect stream - doubling assistant message content (`"Hello"` → `"HelloHello"`) and corrupting streamed `tool_call` args into unparseable JSON. The same bug affected per-subagent chunk managers inside `SubagentManager`, so subagent output doubled too on replay.

## Root cause

`StreamManager.enqueue()` had no reset of `MessageTupleManager.chunks` between runs. `joinStream` defaulted `lastEventId` to `"-1"` in both the orchestrator and the React hook, so every reconnect against servers without the SSE `Location` header (e.g. LangGraph Platform ≤ 0.4.46) re-delivered every chunk and collided with stale state. `streamWithRetry` did not catch this because it requires the server to advertise a reconnect path via `Location`.

## Fix

- Added `StreamManager.resetChunkAccumulator(existingMessages?)` in `libs/sdk/src/ui/manager.ts`. It clears `MessageTupleManager.chunks` and the per-subagent chunk managers, without touching `state.values`, the abort controller, or the subagent registry. When `existingMessages` is supplied, each id is seeded with its current index so the replay overwrites the visible message in place instead of appending a duplicate.
- Added `SubagentManager.resetChunkAccumulator()` in `libs/sdk/src/ui/subagents.ts`. Drops `messageManagers` + `pendingMessages` and zeroes each subagent's `messages` array, preserving the idempotent registry and namespace mapping.
- `StreamOrchestrator.joinStream` (`libs/sdk/src/ui/orchestrator.ts`) and the parallel React hook `joinStream` (`libs/sdk-react/src/stream.lgp.tsx`) call the reset before `stream.start(...)` when `lastEventId === "-1"`, passing the currently visible messages for index seeding.
- Left a `TODO` in the orchestrator pointing at the longer-term follow-up: have `StreamManager.enqueue` remember the last seen event id (the same approach `streamWithRetry` already uses at `libs/sdk/src/utils/stream.ts`) and thread it into `joinStream` automatically, so servers resume at the correct cursor instead of replaying from zero.

## Scope decisions

- The reporter suggested unconditionally calling `this.messages.clear()` at the top of every `enqueue()`. I did not take that approach - it also runs on normal `submit()` calls and hides the intent. Gating on `lastEventId === "-1"` inside `joinStream` is smaller, explicit about when it fires, and leaves the normal submit path untouched.
- `StreamManager.clear()` was intentionally not reused: it also aborts the in-flight controller and nulls `state.values`, which would produce a visible UI blink on reconnect.
- Subagent coverage is included in this PR because it is the same root cause and the symmetrically-named method keeps the semantics obvious. Subagent registrations remain idempotent by `tool_call_id`.
- Issue #1969 (`joinStream`'s `onSuccess` not clearing stream values) is related but independent and out of scope here.

## Testing

- `pnpm test` in `libs/sdk`: 310 tests pass (up from 307). New tests added:
  - `libs/sdk/src/ui/orchestrator.test.ts` - `joinStream replay (issue #2028)`: asserts the main stream's message content is not doubled after a full replay, and that streamed `tool_call` args survive the replay (they previously concatenated into invalid JSON, producing an empty `tool_calls` array).
  - `libs/sdk/src/ui/manager.test.ts` - `SubagentManager.resetChunkAccumulator drops per-subagent chunks without losing the registry (issue #2028)`: asserts per-subagent replay does not double subagent messages and that the subagent registry survives the reset.
- All three new tests fail on `main` (verified before the fix was wired in) and pass with the fix.
- `pnpm build:internal` passes clean for both `@langchain/langgraph-sdk` and `@langchain/react`; `attw` and `publint` report no problems; TypeScript type-check passes.
- Repo-level `pnpm lint` and `pnpm format:check` were not exercised locally because the environment used for this change did not have `oxlint` / `oxfmt` on `PATH`; those will run in CI.

## Changeset

`.changeset/joinstream-replay-doubles-messages.md` - patch bump for `@langchain/langgraph-sdk` and `@langchain/react`.


Fixes #2028