### PR TITLE
fix: forward streamSubgraphs in runs.joinStream and threads.joinStream

### DIFF
--- a/.changeset/joinstream-subgraphs.md
+++ b/.changeset/joinstream-subgraphs.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+Add `streamSubgraphs` option to `client.runs.joinStream` and `client.threads.joinStream`.
+
+The server reads `stream_subgraphs` from the request params of the open stream, so reconnecting via `joinStream` without it silently drops all subgraph-namespaced events (e.g. `tasks|my_subgraph:…`) — even if the run was originally created with `streamSubgraphs: true` via `runs.create` / `runs.stream`. Forwarding the flag on `joinStream` matches the behavior of `runs.stream` and lets resumable bridges (the typical production pattern of `runs.create` → `runs.joinStream`) observe subgraph events.

--- a/libs/sdk/src/client.ts
+++ b/libs/sdk/src/client.ts
@@ -1389,6 +1389,12 @@ export class ThreadsClient<
     options?: {
       lastEventId?: string;
       streamMode?: ThreadStreamMode | ThreadStreamMode[];
+      /**
+       * Stream output from subgraphs. By default, streams only the top graph.
+       * Must be set on this call (not only on the original run creation) —
+       * the server reads it from the request params on every stream open.
+       */
+      streamSubgraphs?: boolean;
       signal?: AbortSignal;
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1400,9 +1406,12 @@ export class ThreadsClient<
       headers: options?.lastEventId
         ? { "Last-Event-ID": options.lastEventId }
         : undefined,
-      params: options?.streamMode
-        ? { stream_mode: options.streamMode }
-        : undefined,
+      params: {
+        ...(options?.streamMode ? { stream_mode: options.streamMode } : {}),
+        ...(options?.streamSubgraphs !== undefined
+          ? { stream_subgraphs: options.streamSubgraphs }
+          : {}),
+      },
     });
   }
 }
@@ -1827,6 +1836,14 @@ export class RunsClient<
           cancelOnDisconnect?: boolean;
           lastEventId?: string;
           streamMode?: StreamMode | StreamMode[];
+          /**
+           * Stream output from subgraphs. By default, streams only the top
+           * graph. Must be set on this call (not only on the original
+           * `runs.create` / `runs.stream` invocation) — the server reads it
+           * from the request params each time the stream is opened, so
+           * reconnecting via `joinStream` without it drops subgraph events.
+           */
+          streamSubgraphs?: boolean;
         }
       | AbortSignal
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1852,6 +1869,9 @@ export class RunsClient<
       params: {
         cancel_on_disconnect: opts?.cancelOnDisconnect ? "1" : "0",
         stream_mode: opts?.streamMode,
+        ...(opts?.streamSubgraphs !== undefined
+          ? { stream_subgraphs: opts.streamSubgraphs }
+          : {}),
       },
     });
   }


### PR DESCRIPTION
## Summary

`client.runs.joinStream` (and `client.threads.joinStream`) silently drop every subgraph-namespaced event (e.g. `tasks|my_subgraph:…`, `updates|my_subgraph:…`) on reconnect, even when the run was originally created with `streamSubgraphs: true` via `runs.create` / `runs.stream`.

Root cause: the LangGraph Platform reads `stream_subgraphs` from the *request params of each stream-open*, not from run state. `runs.stream` sends it (`stream_subgraphs: payload?.streamSubgraphs` in the POST body), but both `joinStream` overloads only forward `stream_mode` + `cancel_on_disconnect`. That's fine for the `stream()` one-shot flow, but it breaks the "resumable bridge" pattern (`runs.create` → `runs.joinStream`) that long-running agents use when they outlive any single client connection — every reconnect resets to top-graph-only.

This PR adds an optional `streamSubgraphs?: boolean` to the options object of both overloads and forwards it as the `stream_subgraphs` query param when set. Behavior is unchanged for callers that don't opt in.

### Repro (before)

```ts
const run = await client.runs.create(threadId, "deep_research_agent", {
  input,
  streamMode: ["updates", "tasks", "values"],
  streamSubgraphs: true,
  streamResumable: true,
  onDisconnect: "continue",
});
for await (const ev of client.runs.joinStream(threadId, run.run_id, {
  streamMode: ["updates", "tasks", "values"],
})) {
  // Only top-graph `tasks` / `updates` / `values` arrive.
  // Zero `tasks|<subgraph>:…` / `updates|<subgraph>:…` events, ever.
}
```

Contrast with `client.runs.stream(...)` using the same payload, which does emit the full `*|<subgraph>:…` event stream — because `runs.stream` POSTs `stream_subgraphs` on the body.

### After

```ts
for await (const ev of client.runs.joinStream(threadId, run.run_id, {
  streamMode: ["updates", "tasks", "values"],
  streamSubgraphs: true, // new
})) {
  // Subgraph-namespaced events now arrive as expected.
}
```

## Changes

- `libs/sdk/src/client.ts`:
  - `RunsClient.joinStream`: accept `streamSubgraphs?: boolean`, forward as `stream_subgraphs` param when defined.
  - `ThreadsClient.joinStream`: same.
- `.changeset/joinstream-subgraphs.md`: patch-level changeset for `@langchain/langgraph-sdk`.

Default is `undefined` (no query param), so no behavior change for existing callers.

## Test 

- [x] `pnpm --filter @langchain/langgraph-sdk... install` + `tsc --noEmit` on `libs/sdk` passes.
- [x] Manually verified against a local LangGraph Platform (`@langchain/langgraph-api` 127.0.0.1:2024) that `runs.joinStream` with `streamSubgraphs: true` produces `tasks|<subgraph>:…` / `updates|<subgraph>:…` / `values|<subgraph>:…` events, matching what `runs.stream` already produces. Without the flag, only top-graph events arrive.