### PR TITLE
fix(checkpoint-redis): preserve all channel_values in multi-node graphs

### DIFF
--- a/libs/checkpoint-redis/src/index.ts
+++ b/libs/checkpoint-redis/src/index.ts
@@ -189,29 +189,7 @@ export class RedisSaver extends BaseCheckpointSaver {
     const checkpointId = checkpoint.id || uuid6(0);
     const key = `checkpoint:${threadId}:${checkpointNs}:${checkpointId}`;
 
-    // Copy checkpoint and filter channel_values to only include changed channels
     const storedCheckpoint = copyCheckpoint(checkpoint);
-
-    // If newVersions is provided and has keys, only store those channels that changed
-    // If newVersions is empty {}, store no channel values
-    // If newVersions is not provided (undefined), keep all channel_values as-is
-    if (storedCheckpoint.channel_values && newVersions !== undefined) {
-      if (Object.keys(newVersions).length === 0) {
-        // Empty newVersions means no channels changed - store empty channel_values
-        storedCheckpoint.channel_values = {};
-      } else {
-        // Only store the channels that are in newVersions
-        const filteredChannelValues: Record<string, any> = {};
-        for (const channel of Object.keys(newVersions)) {
-          if (channel in storedCheckpoint.channel_values) {
-            filteredChannelValues[channel] =
-              storedCheckpoint.channel_values[channel];
-          }
-        }
-        storedCheckpoint.channel_values = filteredChannelValues;
-      }
-    }
-    // If newVersions is undefined, keep all channel_values as-is (for backward compatibility)
 
     // Check if writes already exist for this checkpoint (handles putWrites-before-put ordering)
     const zsetKey = `${WRITE_KEYS_ZSET_PREFIX}:${threadId}:${checkpointNs}:${checkpointId}`;

--- a/libs/checkpoint-redis/src/tests/checkpoint.int.test.ts
+++ b/libs/checkpoint-redis/src/tests/checkpoint.int.test.ts
@@ -1098,6 +1098,82 @@ describe("test_sync_redis_checkpointer", () => {
       resumable: true,
     });
   });
+
+  it("should preserve all channel_values when newVersions contains a subset of channels", async () => {
+    const saver = await RedisSaver.fromUrl(redisUrl);
+
+    const config: RunnableConfig = {
+      configurable: {
+        thread_id: "multi-channel-thread",
+        checkpoint_ns: "",
+      },
+    };
+
+    // Simulate node A writing messages channel
+    const checkpoint1: Checkpoint = {
+      v: 1,
+      id: uuid6(0),
+      ts: new Date().toISOString(),
+      channel_values: {
+        messages: [
+          { type: "human", content: "Hi there" },
+          { type: "ai", content: "Hello!" },
+        ],
+        status: "idle",
+        category: "",
+      },
+      channel_versions: { messages: "1", status: "1", category: "1" },
+      versions_seen: {},
+    };
+
+    await saver.put(
+      config,
+      checkpoint1,
+      { source: "loop", step: 1, parents: {} },
+      { messages: "1", status: "1", category: "1" }
+    );
+
+    // Simulate node B (post-process) writing only status and category.
+    // The Pregel loop passes ALL channel_values in the checkpoint object,
+    // but newVersions only contains the channels written by the current node.
+    const checkpoint2: Checkpoint = {
+      v: 1,
+      id: uuid6(1),
+      ts: new Date().toISOString(),
+      channel_values: {
+        messages: [
+          { type: "human", content: "Hi there" },
+          { type: "ai", content: "Hello!" },
+        ],
+        status: "completed",
+        category: "greeting",
+      },
+      channel_versions: { messages: "1", status: "2", category: "2" },
+      versions_seen: {},
+    };
+
+    await saver.put(
+      {
+        ...config,
+        configurable: { ...config.configurable, checkpoint_id: checkpoint1.id },
+      },
+      checkpoint2,
+      { source: "loop", step: 2, parents: {} },
+      { status: "2", category: "2" }
+    );
+
+    // Retrieve the latest checkpoint — messages must still be present
+    const latest = await saver.getTuple(config);
+    expect(latest).toBeDefined();
+    expect(latest?.checkpoint.channel_values.messages).toEqual([
+      { type: "human", content: "Hi there" },
+      { type: "ai", content: "Hello!" },
+    ]);
+    expect(latest?.checkpoint.channel_values.status).toBe("completed");
+    expect(latest?.checkpoint.channel_values.category).toBe("greeting");
+
+    await saver.end();
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Old Fixes for 2334

`RedisSaver.put()` delta-filters `channel_values` based on `newVersions`, keeping only channels written by the current node. This causes **silent data loss** in any multi-node graph where the last node writes a subset of channels.

### Root cause

The delta-filter mirrors `PostgresSaver.put()` behavior, which only persists changed channel blobs. In PostgresSaver this works because blobs are stored in a **separate `checkpoint_blobs` table** keyed by `(thread_id, channel, version)`, and `getTuple()` reconstructs full state via a SQL JOIN across all blob versions.

`RedisSaver` stores the entire checkpoint (including `channel_values`) in a **single JSON document**. There is no separate blob storage and no reconstruction logic in `getTuple()`. When the final node writes its checkpoint, the delta filter strips channels not written by that node. Those channels are permanently lost.

### Fix

Remove the delta-filter block entirely. The `checkpoint` object passed to `put()` by the Pregel loop already contains the **complete** `channel_values` for all channels. The delta filter was discarding data that was correctly assembled upstream.

This is consistent with `MemorySaver` and `ShallowRedisSaver`, neither of which filter `channel_values`.

### Trade-off

Each checkpoint JSON document will be slightly larger (it includes unchanged channel data). For Redis's single-document model this is correct behavior.

### Test

Added integration test: multi-channel state where node B writes only `{status, category}` (not `messages`), verifying that `messages` survives in the stored checkpoint.

### Reproduction

```typescript
// 3-channel state: messages (reducer), status (last-write), category (last-write)
// Node A writes { messages }
// Node B writes { status, category }
// getState() → messages: [] ← BUG (should be the accumulated messages)
```

See #2334 for full reproduction code and root cause analysis.