### PR TITLE
fix(checkpoint): restrict load() to allowlisted LangChain id namespaces

### DIFF
--- a/.changeset/secure-jsonplus-load.md
+++ b/.changeset/secure-jsonplus-load.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint": patch
+---
+
+fix: restrict JsonPlusSerializer's load() call to an allowlist of safe LangChain id namespaces (messages, documents, prompt_values, outputs) to close an insecure-deserialization sink in checkpoint restore. Other namespaces pass through as plain objects; apps can extend the allowlist via the new `JsonPlusSerializerOptions.loadableLangChainPrefixes` option.

--- a/libs/checkpoint/src/serde/jsonplus.ts
+++ b/libs/checkpoint/src/serde/jsonplus.ts
@@ -14,6 +14,44 @@ function isLangChainSerializedObject(value: Record<string, unknown>) {
 }
 
 /**
+ * Default LangChain `id` namespace prefixes whose classes are pure data
+ * containers (no I/O, no network, no env access in their constructors) and
+ * are therefore safe to instantiate when reviving a checkpoint.
+ *
+ * Other LangChain namespaces (tools, retrievers, vectorstores, language
+ * models, document loaders, agents, callbacks, etc.) can have construction
+ * side effects — instantiating them from a checkpoint payload that an
+ * attacker can influence is an insecure-deserialization sink. Those classes
+ * are intentionally not loaded; their envelopes pass through as plain
+ * objects unless the embedding application opts in via
+ * `JsonPlusSerializerOptions.loadableLangChainPrefixes`.
+ */
+const DEFAULT_LOADABLE_LC_PREFIXES: readonly (readonly string[])[] = [
+  ["langchain_core", "messages"],
+  ["langchain_core", "documents"],
+  ["langchain_core", "prompt_values"],
+  ["langchain_core", "outputs"],
+];
+
+function idMatchesPrefix(
+  id: readonly unknown[],
+  prefix: readonly string[]
+): boolean {
+  if (id.length < prefix.length) return false;
+  for (let i = 0; i < prefix.length; i += 1) {
+    if (id[i] !== prefix[i]) return false;
+  }
+  return true;
+}
+
+function isLoadableLangChainId(
+  id: readonly unknown[],
+  allowedPrefixes: readonly (readonly string[])[]
+): boolean {
+  return allowedPrefixes.some((prefix) => idMatchesPrefix(id, prefix));
+}
+
+/**
  * The replacer in stringify does not allow delegation to built-in LangChain
  * serialization methods, and instead immediately calls `.toJSON()` and
  * continues to stringify subfields.
@@ -21,17 +59,20 @@ function isLangChainSerializedObject(value: Record<string, unknown>) {
  * We therefore must start from the most nested elements in the input and
  * deserialize upwards rather than top-down.
  */
-async function _reviver(value: any): Promise<any> {
+async function _reviver(
+  value: any,
+  loadableLangChainPrefixes: readonly (readonly string[])[]
+): Promise<any> {
   if (value && typeof value === "object") {
     if (Array.isArray(value)) {
       const revivedArray = await Promise.all(
-        value.map((item) => _reviver(item))
+        value.map((item) => _reviver(item, loadableLangChainPrefixes))
       );
       return revivedArray;
     } else {
       const revivedObj: any = {};
       for (const [k, v] of Object.entries(value)) {
-        revivedObj[k] = await _reviver(v);
+        revivedObj[k] = await _reviver(v, loadableLangChainPrefixes);
       }
 
       if (revivedObj.lc === 2 && revivedObj.type === "undefined") {
@@ -75,6 +116,14 @@ async function _reviver(value: any): Promise<any> {
           return revivedObj;
         }
       } else if (isLangChainSerializedObject(revivedObj)) {
+        if (
+          !isLoadableLangChainId(
+            revivedObj.id as unknown[],
+            loadableLangChainPrefixes
+          )
+        ) {
+          return revivedObj;
+        }
         return load(JSON.stringify(revivedObj));
       }
 
@@ -128,7 +177,33 @@ function _default(obj: any): any {
   }
 }
 
+export interface JsonPlusSerializerOptions {
+  /**
+   * Additional LangChain `id` namespace prefixes that may be passed to
+   * `@langchain/core/load` during deserialization, on top of the built-in
+   * defaults (messages, documents, prompt_values, outputs).
+   *
+   * Each prefix is an array of namespace path segments; an envelope is
+   * considered loadable if its `id` starts with any allowed prefix.
+   *
+   * **Security:** only add namespaces whose classes have side-effect-free
+   * constructors. Adding tool, retriever, loader, vector store, or language
+   * model namespaces widens the deserialization attack surface — never
+   * derive these values from user input.
+   */
+  loadableLangChainPrefixes?: readonly (readonly string[])[];
+}
+
 export class JsonPlusSerializer implements SerializerProtocol {
+  private readonly loadableLangChainPrefixes: readonly (readonly string[])[];
+
+  constructor(options?: JsonPlusSerializerOptions) {
+    this.loadableLangChainPrefixes = [
+      ...DEFAULT_LOADABLE_LC_PREFIXES,
+      ...(options?.loadableLangChainPrefixes ?? []),
+    ];
+  }
+
   protected _dumps(obj: any): Uint8Array {
     const encoder = new TextEncoder();
     return encoder.encode(
@@ -148,7 +223,7 @@ export class JsonPlusSerializer implements SerializerProtocol {
 
   protected async _loads(data: string): Promise<any> {
     const parsed = JSON.parse(data);
-    return _reviver(parsed);
+    return _reviver(parsed, this.loadableLangChainPrefixes);
   }
 
   async loadsTyped(type: string, data: Uint8Array | string): Promise<any> {

--- a/libs/checkpoint/src/serde/tests/jsonplus.test.ts
+++ b/libs/checkpoint/src/serde/tests/jsonplus.test.ts
@@ -151,3 +151,64 @@ it("Should replace circular JSON inputs", async () => {
     `{"a":{"b":{"a":"[Circular]"}},"b":{"a":"[Circular]"}}`
   );
 });
+
+it("does not call load() for non-allowlisted LangChain ids", async () => {
+  // A LangChain serialization envelope outside the default allowlist must not
+  // be passed to `@langchain/core/load`, even if it would otherwise resolve
+  // to a registered class. The envelope is preserved as a plain object so
+  // legitimate data is not lost, but no constructor is invoked.
+  const maliciousEnvelope = {
+    lc: 1,
+    type: "constructor",
+    id: ["langchain_core", "tools", "AttackerTool"],
+    kwargs: { url: "http://attacker.example/exfil" },
+  };
+  const wrapper = { state: { tool: maliciousEnvelope } };
+
+  const serde = new JsonPlusSerializer();
+  const [type, serialized] = await serde.dumpsTyped(wrapper);
+  const deserialized = await serde.loadsTyped(type, serialized);
+
+  expect(deserialized).toEqual(wrapper);
+  // It is still a plain object, not an instance.
+  expect(Object.getPrototypeOf(deserialized.state.tool)).toBe(
+    Object.prototype
+  );
+});
+
+it("does not call load() for invalid namespaces that load() would reject", async () => {
+  // Even an envelope that load() itself would reject must not reach load(),
+  // since reaching it implies an exception being thrown during checkpoint
+  // restore. The reviver should pass it through as plain data instead.
+  const envelope = {
+    lc: 1,
+    type: "constructor",
+    id: ["totally", "unknown", "Class"],
+    kwargs: {},
+  };
+
+  const serde = new JsonPlusSerializer();
+  const [type, serialized] = await serde.dumpsTyped({ envelope });
+  const deserialized = await serde.loadsTyped(type, serialized);
+
+  expect(deserialized).toEqual({ envelope });
+});
+
+it("can opt in to additional loadable LangChain prefixes", async () => {
+  // Embedding apps that explicitly trust their checkpoint store can extend
+  // the allowlist. Once a prefix is allowed, matching envelopes flow through
+  // load() (and surface load()'s own validation errors).
+  const envelope = {
+    lc: 1,
+    type: "constructor",
+    id: ["langchain_core", "tools", "FakeClassThatDoesNotExist"],
+    kwargs: {},
+  };
+
+  const serde = new JsonPlusSerializer({
+    loadableLangChainPrefixes: [["langchain_core", "tools"]],
+  });
+  const [type, serialized] = await serde.dumpsTyped({ envelope });
+
+  await expect(serde.loadsTyped(type, serialized)).rejects.toThrow();
+});


### PR DESCRIPTION
## Summary

`JsonPlusSerializer._loads` walks every parsed checkpoint object and calls `@langchain/core/load` on anything matching the LangChain serialization envelope `{lc:1, type:"constructor", id:[...]}` with no allowlist of acceptable class IDs. Because graph state can contain attacker-influenced fields (a message body, a tool payload, anything that survives JSON serialization), a crafted envelope nested inside state causes `load()` to instantiate an arbitrary registered LangChain class with attacker-chosen `kwargs` on the next checkpoint restore — a classic insecure-deserialization sink usable as a stepping stone to RCE / SSRF / credential exfiltration via tool, retriever, loader, or LLM constructors with side effects.

This affects every checkpoint backend (Memory, SQLite, Postgres, Redis, MongoDB) because `JsonPlusSerializer` is the default serde set on `BaseCheckpointSaver`.

## Fix

Gate the `load()` call with a default allowlist of LangChain `id` namespace prefixes whose classes are pure data containers — no I/O, no env access, no network in their constructors:

- `["langchain_core", "messages"]` — AIMessage, HumanMessage, ToolMessage, SystemMessage, etc.
- `["langchain_core", "documents"]`
- `["langchain_core", "prompt_values"]`
- `["langchain_core", "outputs"]`

Envelopes outside the allowlist (e.g. `langchain_core/tools/*`, `langchain_core/retrievers/*`, `langchain_core/language_models/*`, `langchain/document_loaders/*`, `langchain/vectorstores/*`, etc.) pass through as plain objects rather than being instantiated. Apps that explicitly trust their checkpoint store and need to rehydrate additional namespaces can extend the allowlist via a new `JsonPlusSerializerOptions.loadableLangChainPrefixes` constructor option.

## Test plan

- [x] Existing AIMessage / HumanMessage / complex-nested-state roundtrip tests still pass (`pnpm test src/serde/tests/jsonplus.test.ts`).
- [x] New test: a `langchain_core.tools.AttackerTool` envelope nested inside graph state is preserved as a plain object on deserialization and never reaches `load()`.
- [x] New test: an unknown-namespace envelope is preserved as plain data instead of crashing the restore.
- [x] New test: opting in via `loadableLangChainPrefixes` makes `load()` reachable again, proving the gate (not the registry) is what blocks the call.
- [x] Full `@langchain/langgraph-checkpoint` package suite green (74 tests).
- [x] Package builds (`pnpm --filter @langchain/langgraph-checkpoint build`).

> Scanned automatically with https://github.com/etairl/Probus