### PR TITLE
fix(sdk): respect fetchStateHistory for subagent history

### DIFF
--- a/.changeset/tame-subagent-history.md
+++ b/.changeset/tame-subagent-history.md
@@ -1,6 +1,9 @@
 ---
 "@langchain/langgraph-sdk": patch
 "@langchain/react": patch
+"@langchain/vue": patch
+"@langchain/svelte": patch
+"@langchain/angular": patch
 ---
 
 Respect `fetchStateHistory` when restoring subagent history.

--- a/.changeset/tame-subagent-history.md
+++ b/.changeset/tame-subagent-history.md
@@ -1,0 +1,6 @@
+---
+"@langchain/langgraph-sdk": patch
+"@langchain/react": patch
+---
+
+Respect `fetchStateHistory` when restoring subagent history.

--- a/libs/sdk-react/src/stream.lgp.tsx
+++ b/libs/sdk-react/src/stream.lgp.tsx
@@ -437,10 +437,12 @@ export function useStreamLGP<
       // checkpointer under a subgraph-specific checkpoint_ns (e.g. tools:call_abc123).
       // We use an AbortController so React Strict Mode's effect cleanup can cancel
       // the in-flight fetch before the effect re-runs (preventing stale updates).
-      if (threadId) {
+      if (historyLimit !== false && threadId) {
         const controller = new AbortController();
         void stream.fetchSubagentHistory(client.threads, threadId, {
           messagesKey: options.messagesKey ?? "messages",
+          historyLimit:
+            typeof historyLimit === "number" ? historyLimit : undefined,
           signal: controller.signal,
         });
         return () => controller.abort();

--- a/libs/sdk/src/react/stream.lgp.tsx
+++ b/libs/sdk/src/react/stream.lgp.tsx
@@ -395,10 +395,12 @@ export function useStreamLGP<
       // Fetch internal messages for each subagent from their subgraph checkpoints.
       // These messages are not in the main thread state but are persisted in the
       // checkpointer under a subgraph-specific checkpoint_ns (e.g. tools:call_abc123).
-      if (threadId) {
+      if (historyLimit !== false && threadId) {
         const controller = new AbortController();
         void stream.fetchSubagentHistory(client.threads, threadId, {
           messagesKey: options.messagesKey ?? "messages",
+          historyLimit:
+            typeof historyLimit === "number" ? historyLimit : undefined,
           signal: controller.signal,
         });
         return () => controller.abort();

--- a/libs/sdk/src/ui/manager.ts
+++ b/libs/sdk/src/ui/manager.ts
@@ -333,7 +333,11 @@ export class StreamManager<
       >;
     },
     threadId: string,
-    options?: { messagesKey?: string; signal?: AbortSignal }
+    options?: {
+      messagesKey?: string;
+      historyLimit?: number;
+      signal?: AbortSignal;
+    }
   ): Promise<void> {
     const messagesKey = options?.messagesKey ?? "messages";
     const signal = options?.signal;
@@ -381,7 +385,7 @@ export class StreamManager<
        */
       const mainHistory = await threads.getHistory<Record<string, unknown>>(
         threadId,
-        { limit: 20, signal }
+        { limit: options?.historyLimit ?? 20, signal }
       );
 
       for (const checkpoint of mainHistory) {

--- a/libs/sdk/src/ui/orchestrator.test.ts
+++ b/libs/sdk/src/ui/orchestrator.test.ts
@@ -8,7 +8,9 @@ import type { Client } from "../client.js";
 import type { HeadlessToolImplementation } from "../headless-tools.js";
 
 type TestState = {
-  messages: Array<{ id: string; content: string; type: string }>;
+  messages: Array<
+    { id: string; content: string; type: string } & Record<string, unknown>
+  >;
   count?: number;
 };
 
@@ -60,6 +62,54 @@ function createOptions(
     assistantId: "test-assistant",
     ...overrides,
   } as AnyStreamOptions<TestState>;
+}
+
+function createSubagentStateValues(): TestState {
+  return {
+    messages: [
+      { id: "m1", content: "research tires", type: "human" },
+      {
+        id: "m2",
+        content: "",
+        type: "ai",
+        tool_calls: [
+          {
+            id: "task-1",
+            name: "task",
+            type: "tool_call",
+            args: {
+              description: "Calculate tire sizes",
+              subagent_type: "researcher",
+            },
+          },
+        ],
+      },
+      {
+        id: "m3",
+        content: "completed",
+        type: "tool",
+        name: "task",
+        tool_call_id: "task-1",
+      },
+    ],
+  };
+}
+
+function createThreadState(values: TestState) {
+  return {
+    values,
+    checkpoint: {
+      thread_id: "t1",
+      checkpoint_id: "cp1",
+      checkpoint_ns: "",
+      checkpoint_map: null,
+    },
+    next: [],
+    tasks: [],
+    metadata: undefined,
+    created_at: null,
+    parent_checkpoint: null,
+  };
 }
 
 describe("StreamOrchestrator", () => {
@@ -807,6 +857,68 @@ describe("StreamOrchestrator", () => {
 
       expect(orch.reconstructSubagentsIfNeeded()).toBeNull();
 
+      orch.dispose();
+    });
+
+    it("does not fetch subagent history when fetchStateHistory is false", async () => {
+      const values = createSubagentStateValues();
+      (client.threads.getState as ReturnType<typeof vi.fn>).mockResolvedValue(
+        createThreadState(values)
+      );
+
+      const orch = new StreamOrchestrator<TestState>(
+        createOptions({
+          fetchStateHistory: false,
+          filterSubagentMessages: true,
+        }),
+        accessors
+      );
+
+      orch.initThreadId("t1");
+
+      await vi.waitFor(() => {
+        expect(orch.historyData.isLoading).toBe(false);
+      });
+
+      expect(orch.reconstructSubagentsIfNeeded()).toBeNull();
+      expect(orch.subagents.size).toBe(1);
+      expect(client.threads.getHistory).not.toHaveBeenCalled();
+
+      orch.dispose();
+    });
+
+    it("uses fetchStateHistory limit for subagent history discovery", async () => {
+      const values = createSubagentStateValues();
+      (client.threads.getHistory as ReturnType<typeof vi.fn>).mockResolvedValue(
+        [createThreadState(values)]
+      );
+
+      const orch = new StreamOrchestrator<TestState>(
+        createOptions({
+          fetchStateHistory: { limit: 2 },
+          filterSubagentMessages: true,
+        }),
+        accessors
+      );
+
+      orch.initThreadId("t1");
+
+      await vi.waitFor(() => {
+        expect(orch.historyData.isLoading).toBe(false);
+      });
+
+      (client.threads.getHistory as ReturnType<typeof vi.fn>).mockClear();
+
+      const controller = orch.reconstructSubagentsIfNeeded();
+
+      await vi.waitFor(() => {
+        expect(client.threads.getHistory).toHaveBeenCalledWith(
+          "t1",
+          expect.objectContaining({ limit: 2 })
+        );
+      });
+
+      controller?.abort();
       orch.dispose();
     });
   });

--- a/libs/sdk/src/ui/orchestrator.ts
+++ b/libs/sdk/src/ui/orchestrator.ts
@@ -760,13 +760,17 @@ export class StreamOrchestrator<
     this.stream.reconstructSubagents(hvMessages, { skipIfPopulated: true });
 
     const tid = this.#threadId;
-    if (tid) {
+    if (this.historyLimit !== false && tid) {
       const controller = new AbortController();
       void this.stream.fetchSubagentHistory(
         this.#accessors.getClient().threads,
         tid,
         {
           messagesKey: this.#accessors.getMessagesKey(),
+          historyLimit:
+            typeof this.historyLimit === "number"
+              ? this.historyLimit
+              : undefined,
           signal: controller.signal,
         }
       );


### PR DESCRIPTION
## Summary

- skip eager subagent history restoration when `fetchStateHistory` is `false`
- reuse numeric `fetchStateHistory` limits for subagent namespace discovery
- add orchestrator regression coverage for both cases

## Context

- Slack thread: https://langchain.slack.com/archives/C09BAECNA14/p1776755205756119
- [Agent Builder trace](https://langchain-us.datadoghq.com/apm/entity/service%3Aagent_builder_prod?dependencyMap.showNetworkMetrics=false&fromUser=false&graphType=flamegraph&groupMapByOperation=null&historicalData=true&panels=qson%3A%28data%3A%28activePanelKey%3Atrace%2Cresource%3A%28resourceName%3APOST%2520%252Fthreads%252F%257Bthread_id%257D%252Fhistory%2CresourceID%3A2bfaa153eac24153%2CoperationName%3Astarlette.request%29%2Ctrace%3A%28traceID%3A69ef784f000000001773743cf39a72b5%2CspanID%3A8969752200629810217%2ChasSearchOrFacetActions%3A%21f%29%29%2Cversion%3A%210%29&resources=qson%3A%28data%3A%28visible%3A%21t%2Chits%3A%28selected%3Arate%2CgroupBy%3A%5Bresource_name%5D%29%2Cerrors%3A%28selected%3Atotal%2CgroupBy%3A%5Bresource_name%5D%29%2Clatency%3A%28selected%3Ap95%2CgroupBy%3A%5Bresource_name%5D%29%2CtopN%3Aall%29%2Cversion%3A%211%29&shouldShowLegend=true&spanID=8969752200629810217&spanKind=server&spanViewType=logs&summary=qson%3A%28data%3A%28visible%3A%21t%2Cchanges%3A%28%29%2Cerrors%3A%28selected%3Acount%2CgroupBy%3A%5B%5D%29%2Chits%3A%28selected%3Arate%2CgroupBy%3A%5B%5D%29%2Clatency%3A%28selected%3Alatency%2Cslot%3A%28agg%3A95%29%2Cdistribution%3A%28isLogScale%3A%21f%29%2CshowTraceOutliers%3A%21t%2CgroupBy%3A%5B%5D%2Coperation%3Astarlette.request%29%2Csublayer%3A%28slot%3A%28layers%3AserviceAndInferred%29%2Cselected%3Apercentage%29%2ClagMetrics%3A%28selectedMetric%3A%21s%2CselectedGroupBy%3A%21s%29%29%2Cversion%3A%211%29&timeHint=1777301587169&trace=AwAAAZ3PbgThpE93_wAAABhBWjNQYmdkWUFBQ2ZVVkFJVExwS3lYTVgAAAAkMTE5ZGNmODctODg4Ny00ZTY5LThlN2MtNGEzOWU2ZTE3ZjY0AAUrsg&traceID=69ef784f000000001773743cf39a72b5&traceQuery=&start=1777062982891&end=1777322182891&paused=false)

## Test Plan

- `corepack pnpm exec vitest run src/ui/orchestrator.test.ts --typecheck.enabled=false` from `libs/sdk`
- `corepack pnpm run lint -- libs/sdk-react/src/stream.lgp.tsx libs/sdk/src/react/stream.lgp.tsx libs/sdk/src/ui/orchestrator.ts libs/sdk/src/ui/manager.ts libs/sdk/src/ui/orchestrator.test.ts`
- `corepack pnpm run format:check -- libs/sdk-react/src/stream.lgp.tsx libs/sdk/src/react/stream.lgp.tsx libs/sdk/src/ui/orchestrator.ts libs/sdk/src/ui/manager.ts libs/sdk/src/ui/orchestrator.test.ts .changeset/tame-subagent-history.md`
