### PR TITLE
fix(sdk): avoid reusing history message array references during submit

### DIFF
--- a/libs/sdk/src/ui/orchestrator-custom.test.ts
+++ b/libs/sdk/src/ui/orchestrator-custom.test.ts
@@ -363,6 +363,28 @@ describe("CustomStreamOrchestrator", () => {
 
       orch.dispose();
     });
+
+    it("does not reuse the initial messages array for stream values", async () => {
+      const historyMessage = { id: "m1", content: "hello", type: "human" };
+      const initialMessages = [historyMessage];
+      const transport = createMockTransport([]);
+
+      const orch = new CustomStreamOrchestrator<TestState>(
+        createOptions({
+          transport,
+          threadId: "t1",
+          initialValues: { messages: initialMessages },
+        })
+      );
+
+      await orch.submit({ messages: [] });
+
+      expect(orch.values.messages).toEqual(initialMessages);
+      expect(orch.values.messages).not.toBe(initialMessages);
+      expect(orch.values.messages[0]).toBe(historyMessage);
+
+      orch.dispose();
+    });
   });
 
   describe("subagents", () => {

--- a/libs/sdk/src/ui/orchestrator-custom.ts
+++ b/libs/sdk/src/ui/orchestrator-custom.ts
@@ -186,6 +186,15 @@ export class CustomStreamOrchestrator<
     return { ...current, [messagesKey]: messages };
   };
 
+  #copyMessagesArray = (value: StateType): StateType => {
+    const messagesKey = this.#options.messagesKey ?? "messages";
+    const messages = (value as Record<string, unknown>)[messagesKey];
+
+    if (!Array.isArray(messages)) return value;
+
+    return { ...value, [messagesKey]: messages.slice() };
+  };
+
   /**
    * The current stream state values, falling back to an empty object
    * when no stream values are available.
@@ -421,17 +430,19 @@ export class CustomStreamOrchestrator<
 
     let usableThreadId = this.#threadId ?? submitOptions?.threadId;
 
+    const initialValues = this.#copyMessagesArray(this.#historyValues);
+
     this.stream.setStreamValues(() => {
       if (submitOptions?.optimisticValues != null) {
         return {
-          ...this.#historyValues,
+          ...initialValues,
           ...(typeof submitOptions.optimisticValues === "function"
-            ? submitOptions.optimisticValues(this.#historyValues)
+            ? submitOptions.optimisticValues(initialValues)
             : submitOptions.optimisticValues),
         };
       }
 
-      return { ...this.#historyValues };
+      return initialValues;
     });
 
     await this.stream.start(

--- a/libs/sdk/src/ui/orchestrator.test.ts
+++ b/libs/sdk/src/ui/orchestrator.test.ts
@@ -366,6 +366,52 @@ describe("StreamOrchestrator", () => {
 
       orch.dispose();
     });
+
+    it("does not reuse the history messages array for submit stream values", async () => {
+      const historyMessage = { id: "m1", content: "hello", type: "human" };
+      const historyMessages = [historyMessage];
+      const historyState = {
+        values: { messages: historyMessages },
+        checkpoint: {
+          thread_id: "t1",
+          checkpoint_id: "cp1",
+          checkpoint_ns: "",
+          checkpoint_map: null,
+        },
+        next: [],
+        tasks: [],
+        metadata: undefined,
+        created_at: null,
+        parent_checkpoint: null,
+      };
+      (client.threads.getState as ReturnType<typeof vi.fn>).mockResolvedValue(
+        historyState
+      );
+      (client.runs.stream as ReturnType<typeof vi.fn>).mockReturnValue({
+        async *[Symbol.asyncIterator]() {
+          yield { event: "updates" as const, data: {} };
+        },
+      });
+
+      const orch = new StreamOrchestrator<TestState>(
+        createOptions({ fetchStateHistory: false }),
+        accessors
+      );
+
+      orch.initThreadId("t1");
+
+      await vi.waitFor(() => {
+        expect(orch.historyData.data).toEqual([historyState]);
+      });
+
+      await orch.submit({ messages: [] });
+
+      expect(orch.values.messages).toEqual(historyMessages);
+      expect(orch.values.messages).not.toBe(historyMessages);
+      expect(orch.values.messages[0]).toBe(historyMessage);
+
+      orch.dispose();
+    });
   });
 
   describe("branch management", () => {

--- a/libs/sdk/src/ui/orchestrator.ts
+++ b/libs/sdk/src/ui/orchestrator.ts
@@ -419,6 +419,15 @@ export class StreamOrchestrator<
     return { ...current, [messagesKey]: messages };
   }
 
+  #copyMessagesArray(value: StateType): StateType {
+    const messagesKey = this.#accessors.getMessagesKey();
+    const messages = (value as Record<string, unknown>)[messagesKey];
+
+    if (!Array.isArray(messages)) return value;
+
+    return { ...value, [messagesKey]: messages.slice() };
+  }
+
   /**
    * The state values from the thread head of the current branch history,
    * falling back to {@link AnyStreamOptions.initialValues | initialValues}
@@ -953,6 +962,7 @@ export class StreamOrchestrator<
 
     const client = this.#accessors.getClient();
     const assistantId = this.#accessors.getAssistantId();
+    const initialValues = this.#copyMessagesArray(this.historyValues);
 
     return this.stream.start(
       async (signal) => {
@@ -983,7 +993,10 @@ export class StreamOrchestrator<
         ]);
 
         this.stream.setStreamValues(() => {
-          const prev = { ...this.historyValues, ...this.stream.values };
+          const prev = this.#copyMessagesArray({
+            ...initialValues,
+            ...this.stream.values,
+          });
 
           if (submitOptions?.optimisticValues != null) {
             return {
@@ -1043,7 +1056,7 @@ export class StreamOrchestrator<
         getMessages: (value: StateType) => this.#getMessages(value),
         setMessages: (current: StateType, messages: Message[]) =>
           this.#setMessages(current, messages),
-        initialValues: this.historyValues,
+        initialValues,
         callbacks: this.#options,
 
         onSuccess: async () => {


### PR DESCRIPTION
Closes #2341

### Summary

When a new run is started, the SDK UI layer seeds stream state from history or initial values using a shallow object copy, but it keeps the same `messages` array reference.

This can make consumers observe historical messages as part of the new active stream state.

### Current behavior

During `submit()`, stream state is initialized from history/initial values.

The state object itself is copied, but `messages` still points to the same array reference from history.

As a result, consumers that derive UI state from `values/messages` can treat historical messages as if they were part of the new in-flight run.

In our case, a historical assistant message could appear updated during submit, even though no new assistant message had been produced yet.

### Expected behavior

Starting a new run should not reuse the same history `messages` array reference in stream state.

Historical messages should remain stable, and only messages produced by the new run should be reflected as stream-time updates.

### Root cause

The shared UI orchestrator initializes stream values from history with a shallow copy of the state object, but not of the `messages` array.

So the container object changes, while the `messages` array reference is still shared.

### Proposed fix

When seeding stream state from history/initial values, copy the `messages` array for the configured `messagesKey` before passing it into stream state.

A shallow array copy is enough here; the main problem is the shared array reference.

### Implementation

This patch:

- adds a small helper to copy the `messages` array for the configured `messagesKey`
- applies it in `StreamOrchestrator`
- applies the same protection in `CustomStreamOrchestrator`
- adds regression tests for both code paths

### Why this matters

Framework consumers often use `values/messages` as the source of truth for rendering streaming state.

If history and active stream state share the same `messages` array reference, UI layers can produce false positive updates on historical messages.
