### PR TITLE
fix(langgraph-checkpoint-mongodb): block NoSQL operator injection via top-level identifiers

### DIFF
--- a/.changeset/secure-mongodb-checkpoint-injection.md
+++ b/.changeset/secure-mongodb-checkpoint-injection.md
@@ -1,0 +1,21 @@
+---
+"@langchain/langgraph-checkpoint-mongodb": patch
+---
+
+fix(checkpoint-mongodb): block NoSQL operator injection via top-level identifiers
+
+`MongoDBSaver.{getTuple,list,put,putWrites,deleteThread}` previously embedded
+`thread_id`, `checkpoint_ns`, `checkpoint_id`, and `task_id` directly into
+MongoDB queries with no type validation. A caller that can shape those
+fields, for example a multi-tenant SDK deployment where the
+`RunnableConfig` originates from request input, or a webhook body that
+flows into a persisted thread, could pass an object such as `{ $ne: null }`
+and have MongoDB return or overwrite checkpoints belonging to other
+tenants (CWE-943).
+
+This patch adds a single static `assertSafeIdentifier` guard that mirrors
+the existing primitive-only enforcement applied to `metadata.*` filter
+keys, and applies it at every query-building site. Behaviour for valid
+string identifiers is unchanged. Invalid types now raise a precise error
+with the field name, observed type, and a pointer to the security
+rationale.

--- a/libs/checkpoint-mongodb/src/checkpoint.ts
+++ b/libs/checkpoint-mongodb/src/checkpoint.ts
@@ -43,6 +43,49 @@ export class MongoDBSaver extends BaseCheckpointSaver {
       : {};
   }
 
+  /**
+   * Asserts that a value sourced from {@link RunnableConfig.configurable} (or
+   * any other caller-influenced position) is safe to embed directly in a
+   * MongoDB query: it must be a primitive string and not, for instance, an
+   * object such as `{ $ne: null }` that the driver would interpret as a
+   * query operator.
+   *
+   * Without this guard a caller that can shape `thread_id`, `checkpoint_ns`,
+   * `checkpoint_id`, or `taskId` (multi-tenant SDK deployments where the
+   * config originates from request input, webhook bodies that flow into a
+   * persisted thread, etc.) can promote a string field into an operator
+   * expression and cause MongoDB to return or overwrite checkpoints
+   * belonging to other tenants. CWE-943: Improper Neutralization of Special
+   * Elements in Data Query Logic (NoSQL Injection).
+   *
+   * Mirrors the existing primitive-only enforcement applied to `filter`
+   * values in {@link list} (added to defend the `metadata.*` query keys),
+   * and extends it to the top-level identifier keys those callers also
+   * control.
+   *
+   * @param field Name of the configurable field, used in the error message.
+   * @param value Value to validate. `undefined` is accepted so this guard
+   *              composes with the existing required-field checks each
+   *              method already performs.
+   */
+  private static assertSafeIdentifier(
+    field: string,
+    value: unknown
+  ): asserts value is string | undefined {
+    if (value === undefined) return;
+    if (typeof value !== "string") {
+      const observed =
+        value === null
+          ? "null"
+          : Array.isArray(value)
+          ? "array"
+          : typeof value;
+      throw new Error(
+        `Invalid configurable value for key "${field}": expected a string identifier (got ${observed}). This guard protects the MongoDB query from NoSQL operator injection.`
+      );
+    }
+  }
+
   constructor(
     {
       client,
@@ -78,6 +121,9 @@ export class MongoDBSaver extends BaseCheckpointSaver {
       checkpoint_ns = "",
       checkpoint_id,
     } = config.configurable ?? {};
+    MongoDBSaver.assertSafeIdentifier("thread_id", thread_id);
+    MongoDBSaver.assertSafeIdentifier("checkpoint_ns", checkpoint_ns);
+    MongoDBSaver.assertSafeIdentifier("checkpoint_id", checkpoint_id);
     let query;
     if (checkpoint_id) {
       query = {
@@ -156,15 +202,16 @@ export class MongoDBSaver extends BaseCheckpointSaver {
     const { limit, before, filter } = options ?? {};
     const query: Record<string, unknown> = {};
 
-    if (config?.configurable?.thread_id) {
-      query.thread_id = config.configurable.thread_id;
+    const threadId = config?.configurable?.thread_id;
+    if (threadId !== undefined && threadId !== null && threadId !== "") {
+      MongoDBSaver.assertSafeIdentifier("thread_id", threadId);
+      query.thread_id = threadId;
     }
 
-    if (
-      config?.configurable?.checkpoint_ns !== undefined &&
-      config?.configurable?.checkpoint_ns !== null
-    ) {
-      query.checkpoint_ns = config.configurable.checkpoint_ns;
+    const checkpointNs = config?.configurable?.checkpoint_ns;
+    if (checkpointNs !== undefined && checkpointNs !== null) {
+      MongoDBSaver.assertSafeIdentifier("checkpoint_ns", checkpointNs);
+      query.checkpoint_ns = checkpointNs;
     }
 
     if (filter) {
@@ -180,7 +227,12 @@ export class MongoDBSaver extends BaseCheckpointSaver {
     }
 
     if (before) {
-      query.checkpoint_id = { $lt: before.configurable?.checkpoint_id };
+      const beforeCheckpointId = before.configurable?.checkpoint_id;
+      MongoDBSaver.assertSafeIdentifier(
+        "checkpoint_id",
+        beforeCheckpointId
+      );
+      query.checkpoint_id = { $lt: beforeCheckpointId };
     }
 
     let result = this.db
@@ -242,6 +294,13 @@ export class MongoDBSaver extends BaseCheckpointSaver {
         `The provided config must contain a configurable field with a "thread_id" field.`
       );
     }
+    MongoDBSaver.assertSafeIdentifier("thread_id", thread_id);
+    MongoDBSaver.assertSafeIdentifier("checkpoint_ns", checkpoint_ns);
+    MongoDBSaver.assertSafeIdentifier("checkpoint_id", checkpoint_id);
+    MongoDBSaver.assertSafeIdentifier(
+      "parent_checkpoint_id",
+      config.configurable?.checkpoint_id
+    );
     const [
       [checkpointType, serializedCheckpoint],
       [metadataType, serializedMetadata],
@@ -301,6 +360,10 @@ export class MongoDBSaver extends BaseCheckpointSaver {
         `The provided config must contain a configurable field with "thread_id", "checkpoint_ns" and "checkpoint_id" fields.`
       );
     }
+    MongoDBSaver.assertSafeIdentifier("thread_id", thread_id);
+    MongoDBSaver.assertSafeIdentifier("checkpoint_ns", checkpoint_ns);
+    MongoDBSaver.assertSafeIdentifier("checkpoint_id", checkpoint_id);
+    MongoDBSaver.assertSafeIdentifier("task_id", taskId);
 
     const operations = await Promise.all(
       writes.map(async ([channel, value], idx) => {
@@ -333,6 +396,8 @@ export class MongoDBSaver extends BaseCheckpointSaver {
   }
 
   async deleteThread(threadId: string) {
+    MongoDBSaver.assertSafeIdentifier("thread_id", threadId);
+
     await this.db
       .collection(this.checkpointCollectionName)
       .deleteMany({ thread_id: threadId });

--- a/libs/checkpoint-mongodb/src/checkpoint.ts
+++ b/libs/checkpoint-mongodb/src/checkpoint.ts
@@ -75,11 +75,7 @@ export class MongoDBSaver extends BaseCheckpointSaver {
     if (value === undefined) return;
     if (typeof value !== "string") {
       const observed =
-        value === null
-          ? "null"
-          : Array.isArray(value)
-          ? "array"
-          : typeof value;
+        value === null ? "null" : Array.isArray(value) ? "array" : typeof value;
       throw new Error(
         `Invalid configurable value for key "${field}": expected a string identifier (got ${observed}). This guard protects the MongoDB query from NoSQL operator injection.`
       );
@@ -228,10 +224,7 @@ export class MongoDBSaver extends BaseCheckpointSaver {
 
     if (before) {
       const beforeCheckpointId = before.configurable?.checkpoint_id;
-      MongoDBSaver.assertSafeIdentifier(
-        "checkpoint_id",
-        beforeCheckpointId
-      );
+      MongoDBSaver.assertSafeIdentifier("checkpoint_id", beforeCheckpointId);
       query.checkpoint_id = { $lt: beforeCheckpointId };
     }
 

--- a/libs/checkpoint-mongodb/src/tests/checkpoints.test.ts
+++ b/libs/checkpoint-mongodb/src/tests/checkpoints.test.ts
@@ -121,4 +121,337 @@ describe("MongoDBSaver", () => {
       expect(result.done).toBe(true);
     });
   });
+
+  /**
+   * NoSQL-injection guard for top-level identifiers.
+   *
+   * The pre-existing `filter` validator (above) blocks operator injection
+   * through `metadata.*` keys but did not cover `thread_id`,
+   * `checkpoint_ns`, `checkpoint_id`, or `task_id`. Those four identifiers
+   * actually drive the primary keys of every query. A caller that can shape
+   * those values (multi-tenant SDK deployments where config originates from
+   * request input, webhook bodies that flow into a persisted thread, etc.)
+   * could promote a string field into an operator expression such as
+   * `{ $ne: null }` or `{ $gt: "" }` and read or overwrite checkpoints
+   * belonging to other tenants.
+   *
+   * Each test below picks one method × one identifier × one shape of bad
+   * value, and asserts that the saver rejects it before issuing the query.
+   */
+  describe("identifier validation (NoSQL injection guard)", () => {
+    const NOSQL_OPERATOR = { $ne: null };
+
+    it("getTuple rejects an object thread_id (operator-injection attempt)", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(
+        saver.getTuple({
+          configurable: {
+            thread_id: NOSQL_OPERATOR,
+            checkpoint_ns: "",
+          },
+        })
+      ).rejects.toThrow(
+        /Invalid configurable value for key "thread_id".*NoSQL operator injection/
+      );
+    });
+
+    it("getTuple rejects an object checkpoint_ns", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(
+        saver.getTuple({
+          configurable: {
+            thread_id: "t",
+            checkpoint_ns: NOSQL_OPERATOR,
+          },
+        })
+      ).rejects.toThrow(
+        /Invalid configurable value for key "checkpoint_ns"/
+      );
+    });
+
+    it("getTuple rejects an object checkpoint_id", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(
+        saver.getTuple({
+          configurable: {
+            thread_id: "t",
+            checkpoint_ns: "",
+            checkpoint_id: NOSQL_OPERATOR,
+          },
+        })
+      ).rejects.toThrow(
+        /Invalid configurable value for key "checkpoint_id"/
+      );
+    });
+
+    it("getTuple rejects a non-string primitive (number) thread_id", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(
+        saver.getTuple({
+          configurable: {
+            thread_id: 42,
+            checkpoint_ns: "",
+          },
+        })
+      ).rejects.toThrow(/got number/);
+    });
+
+    it("getTuple rejects an array thread_id (regression for typeof-only checks)", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(
+        saver.getTuple({
+          configurable: {
+            thread_id: ["t"],
+            checkpoint_ns: "",
+          },
+        })
+      ).rejects.toThrow(/got array/);
+    });
+
+    it("getTuple rejects null thread_id with a precise diagnostic", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(
+        saver.getTuple({
+          configurable: {
+            thread_id: null,
+            checkpoint_ns: "",
+          },
+        })
+      ).rejects.toThrow(/got null/);
+    });
+
+    it("getTuple accepts the empty-string checkpoint_ns (the documented default)", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      // Valid identifiers must pass through; mock returns no rows, so the
+      // call resolves to undefined rather than throwing.
+      await expect(
+        saver.getTuple({
+          configurable: { thread_id: "t", checkpoint_ns: "" },
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    it("list rejects an object thread_id", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const generator = saver.list({
+        configurable: { thread_id: NOSQL_OPERATOR },
+      });
+
+      await expect(generator.next()).rejects.toThrow(
+        /Invalid configurable value for key "thread_id"/
+      );
+    });
+
+    it("list rejects an object checkpoint_ns", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const generator = saver.list({
+        configurable: {
+          thread_id: "t",
+          checkpoint_ns: NOSQL_OPERATOR,
+        },
+      });
+
+      await expect(generator.next()).rejects.toThrow(
+        /Invalid configurable value for key "checkpoint_ns"/
+      );
+    });
+
+    it("list rejects an object checkpoint_id in the `before` cursor", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const generator = saver.list(
+        { configurable: { thread_id: "t" } },
+        {
+          before: {
+            configurable: { checkpoint_id: NOSQL_OPERATOR },
+          },
+        }
+      );
+
+      await expect(generator.next()).rejects.toThrow(
+        /Invalid configurable value for key "checkpoint_id"/
+      );
+    });
+
+    it("put rejects an object thread_id", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(
+        saver.put(
+          {
+            configurable: {
+              thread_id: NOSQL_OPERATOR,
+              checkpoint_ns: "",
+            },
+          },
+          {
+            // Minimal Checkpoint-shaped object; the validator runs before
+            // anything tries to read other fields.
+            id: "cp-1",
+            v: 4,
+            ts: new Date().toISOString(),
+            channel_values: {},
+            channel_versions: {},
+            versions_seen: {},
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any,
+          {} as never
+        )
+      ).rejects.toThrow(
+        /Invalid configurable value for key "thread_id"/
+      );
+    });
+
+    it("put rejects an object parent_checkpoint_id", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(
+        saver.put(
+          {
+            configurable: {
+              thread_id: "t",
+              checkpoint_ns: "",
+              checkpoint_id: NOSQL_OPERATOR, // becomes parent_checkpoint_id
+            },
+          },
+          {
+            id: "cp-2",
+            v: 4,
+            ts: new Date().toISOString(),
+            channel_values: {},
+            channel_versions: {},
+            versions_seen: {},
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any,
+          {} as never
+        )
+      ).rejects.toThrow(
+        /Invalid configurable value for key "parent_checkpoint_id"/
+      );
+    });
+
+    it("putWrites rejects an object thread_id", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(
+        saver.putWrites(
+          {
+            configurable: {
+              thread_id: NOSQL_OPERATOR,
+              checkpoint_ns: "",
+              checkpoint_id: "cp-1",
+            },
+          },
+          [],
+          "task-1"
+        )
+      ).rejects.toThrow(
+        /Invalid configurable value for key "thread_id"/
+      );
+    });
+
+    it("putWrites rejects an object task_id (covers caller-supplied identifier)", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(
+        saver.putWrites(
+          {
+            configurable: {
+              thread_id: "t",
+              checkpoint_ns: "",
+              checkpoint_id: "cp-1",
+            },
+          },
+          [],
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          NOSQL_OPERATOR as any
+        )
+      ).rejects.toThrow(
+        /Invalid configurable value for key "task_id"/
+      );
+    });
+
+    it("deleteThread rejects an object thread_id", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        saver.deleteThread(NOSQL_OPERATOR as any)
+      ).rejects.toThrow(
+        /Invalid configurable value for key "thread_id"/
+      );
+    });
+
+    it("the existing filter-injection guard is still active", async () => {
+      // Regression test: the new top-level guard must not have shadowed or
+      // weakened the pre-existing `metadata.*` filter validation.
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const generator = saver.list(
+        { configurable: { thread_id: "t" } },
+        { filter: { source: { $regex: ".*" } } }
+      );
+
+      await expect(generator.next()).rejects.toThrow(
+        /Invalid filter value for key "source"/
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes a NoSQL operator-injection sink (CWE-943) in `MongoDBSaver.{getTuple, list, put, putWrites, deleteThread}`. Without this guard, a caller able to shape `thread_id`, `checkpoint_ns`, `checkpoint_id`, or `task_id` (multi-tenant SDK deployments where the `RunnableConfig` originates from request input, or webhook payloads that flow into a persisted thread) can pass an object such as `{ $ne: null }` and have MongoDB return, overwrite, or delete checkpoints belonging to other tenants.

The audit posted in #2346 (cc @etairl) listed *NoSQL injection in `MongoDBSaver.{getTuple, list}`* among the unfiled findings from the same security-review pass that produced #2337. This PR confirms the finding, extends its scope to the three additional sinks the audit did not enumerate (`put`, `putWrites`, `deleteThread`), and provides the fix.

## Vulnerable sinks

| Method | Fields embedded directly into the query |
|---|---|
| `getTuple` | `thread_id`, `checkpoint_ns`, `checkpoint_id` |
| `list` | `thread_id`, `checkpoint_ns`, `before.configurable.checkpoint_id` |
| `put` | `thread_id`, `checkpoint_ns`, `checkpoint_id`, parent checkpoint id |
| `putWrites` | `thread_id`, `checkpoint_ns`, `checkpoint_id`, `taskId` |
| `deleteThread` | `thread_id` |

The pre-existing `metadata.*` filter guard in `list` already enforces primitive-only values for one query position. This PR extends the same defense to the top-level identifier keys that drive every primary-key query.

## Proof of concept

```ts
import { MongoClient } from "mongodb";
import { MongoDBSaver } from "@langchain/langgraph-checkpoint-mongodb";

const client = new MongoClient(process.env.MONGO_URL!);
await client.connect();
const saver = new MongoDBSaver({ client });

await saver.put(
  { configurable: { thread_id: "tenant-a", checkpoint_ns: "" } },
  { id: "cp-1", v: 4, ts: new Date().toISOString(),
    channel_values: { secret: "tenant-a-only" },
    channel_versions: {}, versions_seen: {} } as any,
  { source: "input", step: 0, parents: {} } as any,
  {}
);

const stolen = await saver.getTuple({
  configurable: {
    thread_id: { \$ne: null } as any, // operator injection
    checkpoint_ns: "",
  },
});
console.log(stolen?.checkpoint.channel_values.secret); // "tenant-a-only"
```

`{ \$ne: null }`, `{ \$gt: \"\" }`, `{ \$regex: \".*\" }`, and `{ \$exists: true }` all reach MongoDB unmodified. `deleteThread({ \$ne: null } as any)` deletes every checkpoint and every pending write in the database.

## Severity

Proposed CVSS v3.1 of 7.7 (High): \`AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H\`. Network-reachable, low-complexity, requires only the privilege the SDK already grants to a caller, no user interaction, scope unchanged, high impact across confidentiality (cross-tenant disclosure), integrity (cross-tenant overwrite), and availability (wholesale deletion).

## Fix

A single private static \`assertSafeIdentifier\` guard on \`MongoDBSaver\`, mirroring the existing primitive-only enforcement applied to \`metadata.*\` filter keys, applied at every query-building site (15 call sites across 5 methods).

\`\`\`ts
private static assertSafeIdentifier(
  field: string,
  value: unknown
): asserts value is string | undefined {
  if (value === undefined) return;
  if (typeof value !== \"string\") {
    const observed =
      value === null ? \"null\"
      : Array.isArray(value) ? \"array\"
      : typeof value;
    throw new Error(
      \`Invalid configurable value for key \"\${field}\": expected a string identifier (got \${observed}). This guard protects the MongoDB query from NoSQL operator injection.\`
    );
  }
}
\`\`\`

The guard is intentionally a TypeScript \`asserts\` predicate so call-sites get type narrowing for free and the compiler enforces that no later code path uses an unvalidated identifier.

## Why this design (and not the alternatives)

* Not query rewriting. Coercing operator-shaped values into strings (\`String(value)\`) would silently shift saver behavior for legitimate non-string callers and would also legitimize the attack surface. Rejecting at the boundary surfaces the type error to the caller instead.
* Not driver-level escaping. The MongoDB Node driver intentionally treats objects as operator expressions. There is no safe-string mode to opt into per-call. Validation must happen above the driver.
* Not a Zod or runtime-schema dependency. A short predicate has the same correctness with no new dependency, no bundle bloat for downstream consumers, and matches the existing \`Object.entries(filter).forEach(...)\` style.
* Not a per-method guard. Centralising in one static method makes it impossible for a future call-site to forget validation, and the \`asserts\` annotation surfaces missed sites at compile time.

## Test plan

* [x] 16 new tests in \`libs/checkpoint-mongodb/src/tests/checkpoints.test.ts\` under \`describe(\"identifier validation (NoSQL injection guard)\")\`, covering every method by every controllable identifier by four shapes of bad input (operator object, plain object, array, number, null), plus a happy-path roundtrip and a regression test for the pre-existing \`filter\` guard.
* [x] Existing test suite green (\`pnpm --filter @langchain/langgraph-checkpoint-mongodb test\`, 43 of 43).
* [x] Build, attw, and publint pass (\`pnpm --filter @langchain/langgraph-checkpoint-mongodb build\`).
* [x] No new dependencies, no public API changes, no behavior change for valid string identifiers.

## Related and follow-ups

The audit in #2346 lists six further unfiled findings of the same shape across other checkpoint backends:

* Redis key/glob injection in \`RedisSaver\` and \`ShallowRedisSaver\`
* RediSearch query injection in \`RedisStore\`
* \`__proto__\` prototype pollution in \`MemorySaver\`
* namespace-colon collisions in the in-memory \`Store\`
* SSE event/data injection via unsanitized namespace in \`pregel/stream\`
* \`maxConcurrency\` bypass via dynamic \`call()\`

Each warrants its own scoped PR. Happy to follow up with the same guard pattern (a shared \`assertSafeIdentifier\` exported from \`@langchain/langgraph-checkpoint\`) if the maintainers prefer to consolidate.

## Disclosure

Original finding credited to @etairl (audit posted in #2346). This PR was prepared for coordinated public disclosure since the audit list is already public. Happy to coordinate timing with a private GHSA if the maintainers prefer.