### PR TITLE
fix(langgraph-checkpoint-redis): block KEYS / SCAN pattern injection via top-level identifiers

### DIFF
--- a/.changeset/secure-redis-checkpoint-injection.md
+++ b/.changeset/secure-redis-checkpoint-injection.md
@@ -1,0 +1,28 @@
+---
+"@langchain/langgraph-checkpoint-redis": patch
+---
+
+fix(checkpoint-redis): block Redis KEYS / SCAN pattern injection via top-level identifiers
+
+`RedisSaver` and `ShallowRedisSaver` previously embedded `thread_id`,
+`checkpoint_ns`, `checkpoint_id`, and `task_id` directly into Redis keys
+and `client.keys(pattern)` calls with no validation. A caller able to
+shape any of those fields (multi-tenant SDK deployments where the
+`RunnableConfig` originates from request input, or webhook payloads that
+flow into a persisted thread) could promote a string identifier into a
+glob pattern (`*`, `?`, `[...]`) or escape character (`\`).
+
+The most severe sink is `deleteThread`: a `threadId` of `*` issues
+`client.keys("checkpoint:*:*")` followed by `client.del(...)`, deleting
+every checkpoint in the database across every tenant. `getTuple`,
+`list`, and `loadPendingWrites` are exposed to the same pattern via
+the fallback paths that bypass the existing `escapeRediSearchTagValue`
+defense.
+
+Adds a single `assertSafeKeyComponent` helper exported from
+`./utils.js` and applies it at every key-building site. The guard
+asserts the value is a non-empty string (the empty `checkpoint_ns`
+default is opt-in via `{ allowEmpty: true }`) and rejects the Redis
+pattern meta-characters `* ? [ ] \` plus the colon delimiter that
+would otherwise corrupt the colon-delimited key structure. Behavior
+for valid string identifiers is unchanged.

--- a/libs/checkpoint-redis/src/index.ts
+++ b/libs/checkpoint-redis/src/index.ts
@@ -13,7 +13,7 @@ import {
 } from "@langchain/langgraph-checkpoint";
 import { RunnableConfig } from "@langchain/core/runnables";
 import { createClient, createCluster } from "redis";
-import { escapeRediSearchTagValue } from "./utils.js";
+import { assertSafeKeyComponent, escapeRediSearchTagValue } from "./utils.js";
 import { WRITE_KEYS_ZSET_PREFIX } from "./constants.js";
 
 // Type for Redis client - supports both standalone and cluster
@@ -131,6 +131,12 @@ export class RedisSaver extends BaseCheckpointSaver {
       return undefined;
     }
 
+    assertSafeKeyComponent("thread_id", threadId);
+    assertSafeKeyComponent("checkpoint_ns", checkpointNs, { allowEmpty: true });
+    if (checkpointId !== undefined) {
+      assertSafeKeyComponent("checkpoint_id", checkpointId);
+    }
+
     let key: string;
     let jsonDoc: CheckpointDocument | null;
 
@@ -186,7 +192,14 @@ export class RedisSaver extends BaseCheckpointSaver {
       throw new Error("thread_id is required");
     }
 
+    assertSafeKeyComponent("thread_id", threadId);
+    assertSafeKeyComponent("checkpoint_ns", checkpointNs, { allowEmpty: true });
+    if (parentCheckpointId !== undefined) {
+      assertSafeKeyComponent("parent_checkpoint_id", parentCheckpointId);
+    }
+
     const checkpointId = checkpoint.id || uuid6(0);
+    assertSafeKeyComponent("checkpoint_id", checkpointId);
     const key = `checkpoint:${threadId}:${checkpointNs}:${checkpointId}`;
 
     // Copy checkpoint and filter channel_values to only include changed channels
@@ -255,6 +268,41 @@ export class RedisSaver extends BaseCheckpointSaver {
     options?: CheckpointListOptions & { filter?: CheckpointMetadata }
   ): AsyncGenerator<CheckpointTuple> {
     await this.ensureIndexes();
+
+    // Validate caller-controlled identifiers before they reach KEYS / SCAN
+    // patterns or RediSearch tag values. The pre-existing escape protects
+    // the search query body but not the fallback `client.keys(pattern)`
+    // paths below, where a `thread_id` of `*` would otherwise enumerate
+    // every tenant.
+    if (config?.configurable?.thread_id !== undefined) {
+      assertSafeKeyComponent("thread_id", config.configurable.thread_id);
+    }
+    if (config?.configurable?.checkpoint_ns !== undefined) {
+      assertSafeKeyComponent(
+        "checkpoint_ns",
+        config.configurable.checkpoint_ns,
+        { allowEmpty: true }
+      );
+    }
+    if (options?.before?.configurable?.checkpoint_id !== undefined) {
+      assertSafeKeyComponent(
+        "checkpoint_id",
+        options.before.configurable.checkpoint_id
+      );
+    }
+    if (options?.before?.configurable?.thread_id !== undefined) {
+      assertSafeKeyComponent(
+        "thread_id",
+        options.before.configurable.thread_id
+      );
+    }
+    if (options?.before?.configurable?.checkpoint_ns !== undefined) {
+      assertSafeKeyComponent(
+        "checkpoint_ns",
+        options.before.configurable.checkpoint_ns,
+        { allowEmpty: true }
+      );
+    }
 
     // If filter is provided (even if empty), use search functionality
     if (options?.filter !== undefined) {
@@ -608,6 +656,11 @@ export class RedisSaver extends BaseCheckpointSaver {
       throw new Error("thread_id and checkpoint_id are required");
     }
 
+    assertSafeKeyComponent("thread_id", threadId);
+    assertSafeKeyComponent("checkpoint_ns", checkpointNs, { allowEmpty: true });
+    assertSafeKeyComponent("checkpoint_id", checkpointId);
+    assertSafeKeyComponent("task_id", taskId);
+
     // Collect write keys for sorted set tracking
     const writeKeys: string[] = [];
 
@@ -673,6 +726,11 @@ export class RedisSaver extends BaseCheckpointSaver {
   }
 
   async deleteThread(threadId: string): Promise<void> {
+    // Without this guard a `threadId` of `*` would expand the KEYS pattern
+    // into `checkpoint:*:*` and delete every checkpoint in the database
+    // across every tenant. CWE-77 / CWE-943.
+    assertSafeKeyComponent("thread_id", threadId);
+
     // Delete checkpoints
     const checkpointPattern = `checkpoint:${threadId}:*`;
     // Use scan for better performance and cluster compatibility
@@ -712,6 +770,11 @@ export class RedisSaver extends BaseCheckpointSaver {
     checkpointNs: string,
     checkpointId: string
   ): Promise<Array<[string, string, any]> | undefined> {
+    // Defense in depth: every public entry already validates these, but
+    // the helper is reachable from internal migration paths too.
+    assertSafeKeyComponent("thread_id", threadId);
+    assertSafeKeyComponent("checkpoint_ns", checkpointNs, { allowEmpty: true });
+    assertSafeKeyComponent("checkpoint_id", checkpointId);
     // Search for all write documents for this checkpoint
     const pattern = `checkpoint_write:${threadId}:${checkpointNs}:${checkpointId}:*`;
     const writeKeys = await (this.client as any).keys(pattern);

--- a/libs/checkpoint-redis/src/shallow.ts
+++ b/libs/checkpoint-redis/src/shallow.ts
@@ -10,7 +10,7 @@ import {
 } from "@langchain/langgraph-checkpoint";
 import { RunnableConfig } from "@langchain/core/runnables";
 import { createClient } from "redis";
-import { escapeRediSearchTagValue } from "./utils.js";
+import { assertSafeKeyComponent, escapeRediSearchTagValue } from "./utils.js";
 import { WRITE_KEYS_ZSET_PREFIX } from "./constants.js";
 
 export interface TTLConfig {
@@ -125,7 +125,14 @@ export class ShallowRedisSaver extends BaseCheckpointSaver {
       throw new Error("thread_id is required");
     }
 
+    assertSafeKeyComponent("thread_id", threadId);
+    assertSafeKeyComponent("checkpoint_ns", checkpointNs, { allowEmpty: true });
+    if (parentCheckpointId !== undefined) {
+      assertSafeKeyComponent("parent_checkpoint_id", parentCheckpointId);
+    }
+
     const checkpointId = checkpoint.id || uuid6(0);
+    assertSafeKeyComponent("checkpoint_id", checkpointId);
 
     // In shallow mode, we use a single key per thread (no checkpoint_id in key)
     const key = `checkpoint:${threadId}:${checkpointNs}:shallow`;
@@ -200,6 +207,12 @@ export class ShallowRedisSaver extends BaseCheckpointSaver {
       return undefined;
     }
 
+    assertSafeKeyComponent("thread_id", threadId);
+    assertSafeKeyComponent("checkpoint_ns", checkpointNs, { allowEmpty: true });
+    if (checkpointId !== undefined) {
+      assertSafeKeyComponent("checkpoint_id", checkpointId);
+    }
+
     // In shallow mode, we use a single key per thread
     const key = `checkpoint:${threadId}:${checkpointNs}:shallow`;
     const jsonDoc = await this.client.json.get(key);
@@ -242,6 +255,21 @@ export class ShallowRedisSaver extends BaseCheckpointSaver {
     options?: CheckpointListOptions & { filter?: CheckpointMetadata }
   ): AsyncGenerator<CheckpointTuple> {
     await this.ensureIndexes();
+
+    // Validate caller-controlled identifiers before they reach KEYS
+    // patterns or RediSearch tag values. Without this guard a `thread_id`
+    // of `*` would feed `client.keys("checkpoint:*:*:shallow")` in the
+    // fallback path and enumerate every tenant.
+    if (config?.configurable?.thread_id !== undefined) {
+      assertSafeKeyComponent("thread_id", config.configurable.thread_id);
+    }
+    if (config?.configurable?.checkpoint_ns !== undefined) {
+      assertSafeKeyComponent(
+        "checkpoint_ns",
+        config.configurable.checkpoint_ns,
+        { allowEmpty: true }
+      );
+    }
 
     // In shallow mode, we only return the latest checkpoint per thread
     if (config?.configurable?.thread_id) {
@@ -400,6 +428,11 @@ export class ShallowRedisSaver extends BaseCheckpointSaver {
       throw new Error("thread_id and checkpoint_id are required");
     }
 
+    assertSafeKeyComponent("thread_id", threadId);
+    assertSafeKeyComponent("checkpoint_ns", checkpointNs, { allowEmpty: true });
+    assertSafeKeyComponent("checkpoint_id", checkpointId);
+    assertSafeKeyComponent("task_id", taskId);
+
     // In shallow mode, we overwrite all writes for the task
     // First, clean up old writes for this task
     const writePattern = `checkpoint_write:${threadId}:${checkpointNs}:${checkpointId}:${taskId}:*`;
@@ -462,6 +495,11 @@ export class ShallowRedisSaver extends BaseCheckpointSaver {
   }
 
   async deleteThread(threadId: string): Promise<void> {
+    // Without this guard a `threadId` of `*` would expand the KEYS pattern
+    // into `checkpoint:*:*:shallow` and delete every shallow checkpoint
+    // in the database across every tenant. CWE-77 / CWE-943.
+    assertSafeKeyComponent("thread_id", threadId);
+
     // Delete shallow checkpoints
     const checkpointPattern = `checkpoint:${threadId}:*:shallow`;
     const checkpointKeys = await this.client.keys(checkpointPattern);
@@ -578,6 +616,10 @@ export class ShallowRedisSaver extends BaseCheckpointSaver {
     checkpointNs: string,
     checkpointId: string
   ): Promise<Array<[string, string, any]> | undefined> {
+    // Defense in depth: every public entry already validates these.
+    assertSafeKeyComponent("thread_id", threadId);
+    assertSafeKeyComponent("checkpoint_ns", checkpointNs, { allowEmpty: true });
+    assertSafeKeyComponent("checkpoint_id", checkpointId);
     const zsetKey = `${WRITE_KEYS_ZSET_PREFIX}:${threadId}:${checkpointNs}:${checkpointId}`;
     const writeKeys = await this.client.zRange(zsetKey, 0, -1);
 

--- a/libs/checkpoint-redis/src/tests/utils.test.ts
+++ b/libs/checkpoint-redis/src/tests/utils.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { escapeRediSearchTagValue } from "../utils.js";
+import {
+  assertSafeKeyComponent,
+  escapeRediSearchTagValue,
+} from "../utils.js";
 
 describe("escapeRediSearchTagValue", () => {
   it("should return placeholder for empty string", () => {
@@ -65,5 +68,119 @@ describe("escapeRediSearchTagValue", () => {
       "user\\@example\\.com"
     );
     expect(escapeRediSearchTagValue("price: $100")).toBe("price\\:\\ \\$100");
+  });
+});
+
+describe("assertSafeKeyComponent", () => {
+  // Each method on RedisSaver / ShallowRedisSaver builds a Redis key by
+  // string-interpolating identifiers from RunnableConfig.configurable. The
+  // most severe sink is `deleteThread`, which feeds the value into
+  // `client.keys(pattern)` followed by `client.del(...)`. A `threadId` of
+  // `*` collapses the saver's per-tenant deletion into a database wipe.
+  //
+  // The guard below is the chokepoint that all entry points share. These
+  // tests pin its behaviour on every input shape we expect at runtime.
+
+  it("accepts a normal identifier", () => {
+    expect(() =>
+      assertSafeKeyComponent("thread_id", "tenant-a-thread-1")
+    ).not.toThrow();
+    expect(() =>
+      assertSafeKeyComponent("checkpoint_id", "01HZX9V7EKJ1B0PNMY7MX3X3KB")
+    ).not.toThrow();
+  });
+
+  it("accepts the documented empty checkpoint_ns when allowEmpty is set", () => {
+    expect(() =>
+      assertSafeKeyComponent("checkpoint_ns", "", { allowEmpty: true })
+    ).not.toThrow();
+  });
+
+  it("rejects the empty string when allowEmpty is not set", () => {
+    expect(() => assertSafeKeyComponent("thread_id", "")).toThrow(
+      /empty string is not permitted/
+    );
+  });
+
+  it("rejects the Redis glob wildcard `*` (the deleteThread wipe vector)", () => {
+    expect(() => assertSafeKeyComponent("thread_id", "*")).toThrow(
+      /Redis pattern meta-character/
+    );
+    // Even a single `*` anywhere in the value is rejected. This covers
+    // patterns like `tenant-*` that would still expand to a glob.
+    expect(() =>
+      assertSafeKeyComponent("thread_id", "tenant-*")
+    ).toThrow(/Redis pattern meta-character/);
+  });
+
+  it("rejects the Redis glob single-character `?`", () => {
+    expect(() =>
+      assertSafeKeyComponent("thread_id", "tenant-?")
+    ).toThrow(/Redis pattern meta-character/);
+  });
+
+  it("rejects the Redis glob character class `[ ]`", () => {
+    expect(() =>
+      assertSafeKeyComponent("thread_id", "tenant-[ab]")
+    ).toThrow(/Redis pattern meta-character/);
+  });
+
+  it("rejects backslash (Redis pattern escape character)", () => {
+    expect(() =>
+      assertSafeKeyComponent("thread_id", "tenant\\a")
+    ).toThrow(/Redis pattern meta-character/);
+  });
+
+  it("rejects the `:` delimiter to prevent key-structure collisions", () => {
+    // Without this rule, `thread_id` of `"a:b"` would write into the
+    // namespace `b`, breaking the colon-delimited key parse.
+    expect(() =>
+      assertSafeKeyComponent("checkpoint_ns", "ns:injected", {
+        allowEmpty: true,
+      })
+    ).toThrow(/Redis pattern meta-character/);
+  });
+
+  it("rejects an object value (NoSQL-style operator injection attempt)", () => {
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      assertSafeKeyComponent("thread_id", { $ne: null } as any)
+    ).toThrow(/expected a string identifier/);
+  });
+
+  it("rejects an array value with the precise diagnostic", () => {
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      assertSafeKeyComponent("thread_id", ["a"] as any)
+    ).toThrow(/got array/);
+  });
+
+  it("rejects null, undefined, number, boolean with precise diagnostics", () => {
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      assertSafeKeyComponent("thread_id", null as any)
+    ).toThrow(/got null/);
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      assertSafeKeyComponent("thread_id", undefined as any)
+    ).toThrow(/got undefined/);
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      assertSafeKeyComponent("thread_id", 42 as any)
+    ).toThrow(/got number/);
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      assertSafeKeyComponent("thread_id", true as any)
+    ).toThrow(/got boolean/);
+  });
+
+  it("includes the field name in every error so callers can surface it", () => {
+    expect(() =>
+      assertSafeKeyComponent("checkpoint_id", "*")
+    ).toThrow(/"checkpoint_id"/);
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      assertSafeKeyComponent("task_id", { $gt: "" } as any)
+    ).toThrow(/"task_id"/);
   });
 });

--- a/libs/checkpoint-redis/src/utils.ts
+++ b/libs/checkpoint-redis/src/utils.ts
@@ -20,3 +20,71 @@ export function escapeRediSearchTagValue(value: string): string {
     .replace(/\\/g, "\\\\")
     .replace(/[-\s,.:<>{}[\]"';!@#$%^&*()+=~|?/]/g, "\\$&");
 }
+
+/**
+ * Characters that are interpreted as wildcards or escapes by Redis pattern
+ * commands (KEYS, SCAN MATCH, PSUBSCRIBE, etc.). Embedding any of these in a
+ * caller-controlled key component allows pattern injection: a `thread_id` of
+ * `"*"` causes `KEYS "checkpoint:*:..."` to enumerate every tenant, and
+ * inside `deleteThread` deletes them.
+ *
+ * The `:` delimiter is also rejected because every Redis key in this package
+ * is colon-delimited; a value containing `:` would corrupt the parse / write
+ * paths and can collide with another tenant's namespace.
+ */
+const REDIS_KEY_FORBIDDEN = /[*?[\]\\:]/;
+
+/**
+ * Asserts that a value sourced from {@link RunnableConfig.configurable} (or
+ * any other caller-influenced position) is safe to embed directly into a
+ * Redis key or KEYS / SCAN MATCH pattern.
+ *
+ * Without this guard a caller that can shape `thread_id`, `checkpoint_ns`,
+ * `checkpoint_id`, or `task_id` (multi-tenant SDK deployments where the
+ * config originates from request input, webhook bodies that flow into a
+ * persisted thread, etc.) can promote a string field into a glob pattern
+ * (`*`, `?`, `[...]`) or escape character (`\\`), causing the saver to
+ * read, overwrite, or delete checkpoints belonging to other tenants. The
+ * `deleteThread` path is the most severe: a `threadId` of `"*"` issues
+ * `client.keys("checkpoint:*:*")` followed by `client.del(...)`, wiping the
+ * entire database. CWE-943 (Improper Neutralization of Special Elements in
+ * Data Query Logic) and CWE-77 (Improper Neutralization of Special Elements
+ * in a Command).
+ *
+ * @param field Name of the configurable field, used in the error message.
+ * @param value Value to validate.
+ * @param options.allowEmpty When true the empty string is accepted (used for
+ *                            the documented empty `checkpoint_ns` default);
+ *                            otherwise an empty string is rejected the same
+ *                            way as undefined / null.
+ */
+export function assertSafeKeyComponent(
+  field: string,
+  value: unknown,
+  options: { allowEmpty?: boolean } = {}
+): asserts value is string {
+  const { allowEmpty = false } = options;
+  if (typeof value !== "string") {
+    const observed =
+      value === null
+        ? "null"
+        : value === undefined
+          ? "undefined"
+          : Array.isArray(value)
+            ? "array"
+            : typeof value;
+    throw new Error(
+      `Invalid configurable value for key "${field}": expected a string identifier (got ${observed}). This guard protects Redis keys and KEYS/SCAN patterns from glob and command injection.`
+    );
+  }
+  if (!allowEmpty && value === "") {
+    throw new Error(
+      `Invalid configurable value for key "${field}": empty string is not permitted as a Redis key component.`
+    );
+  }
+  if (REDIS_KEY_FORBIDDEN.test(value)) {
+    throw new Error(
+      `Invalid configurable value for key "${field}": value contains a Redis pattern meta-character (one of * ? [ ] \\ :). This guard protects Redis keys and KEYS/SCAN patterns from glob and command injection.`
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Closes a Redis pattern-injection sink (CWE-77, CWE-943) in `RedisSaver` and `ShallowRedisSaver`. A caller able to shape `thread_id`, `checkpoint_ns`, `checkpoint_id`, or `task_id` (multi-tenant SDK deployments where the `RunnableConfig` originates from request input, or webhook payloads that flow into a persisted thread) can promote a string identifier into a Redis glob (`*`, `?`, `[...]`) and read, overwrite, or wipe checkpoints belonging to other tenants.

The audit posted in #2346 (cc @etairl) listed *Redis key/glob injection in `RedisSaver` / `ShallowRedisSaver`* among the unfiled findings from the same security-review pass. This PR confirms the finding and extends the fix to all key-building sites in both savers.

## Vulnerable sinks

`RedisSaver` (`libs/checkpoint-redis/src/index.ts`):

| Method | Sinks |
|---|---|
| `getTuple` | `keys(\"checkpoint:\${threadId}:\${checkpointNs}:*\")` plus the direct \`json.get\` key |
| `list` (fallback paths) | `keys(\"checkpoint:\${threadId}:\${checkpointNs}:*\")`, `keys(\"checkpoint:*:\${checkpointNs}:*\")` |
| `put` | `\`checkpoint:\${threadId}:\${checkpointNs}:\${checkpointId}\`` plus the zset key |
| `putWrites` | per-write key, zset key, checkpoint key |
| `deleteThread` | `keys(\"checkpoint:\${threadId}:*\")`, `keys(\"writes:\${threadId}:*\")` |
| `loadPendingWrites` | `keys(\"checkpoint_write:\${threadId}:\${checkpointNs}:\${checkpointId}:*\")` |

`ShallowRedisSaver` (`libs/checkpoint-redis/src/shallow.ts`) has the same five public entry points plus the equivalent helper.

## Proof of concept

```ts
import { createClient } from \"redis\";
import { RedisSaver } from \"@langchain/langgraph-checkpoint-redis\";

const client = createClient({ url: process.env.REDIS_URL! });
await client.connect();
const saver = new RedisSaver(client);

// Tenant A and Tenant B persist checkpoints normally.
await saver.put(
  { configurable: { thread_id: \"tenant-a\", checkpoint_ns: \"\" } },
  /* checkpoint */ { id: \"cp-a\", v: 4, ts: new Date().toISOString(),
                     channel_values: {}, channel_versions: {}, versions_seen: {} } as any,
  /* metadata  */ { source: \"input\", step: 0, parents: {} } as any,
  {}
);
await saver.put(
  { configurable: { thread_id: \"tenant-b\", checkpoint_ns: \"\" } },
  { id: \"cp-b\", v: 4, ts: new Date().toISOString(),
    channel_values: {}, channel_versions: {}, versions_seen: {} } as any,
  { source: \"input\", step: 0, parents: {} } as any,
  {}
);

// Attacker controls only the thread_id of their own request.
// Without the guard, deleteThread expands the KEYS pattern to a glob
// and deletes BOTH tenants' checkpoints.
await saver.deleteThread(\"*\");
// Both \`cp-a\` and \`cp-b\` are gone.
```

The same shape (`\"*\"`, `\"tenant-?\"`, `\"tenant-[ab]\"`, `\"a\\b\"`) is accepted by every Redis pattern site in the table above.

## Severity

Proposed CVSS 3.1: **High**. The most severe sink is `deleteThread`, which gives full availability impact across every tenant in the database, with confidentiality (`getTuple`, `list`) and integrity (`put`, `putWrites`) impacts on the other paths. Network-reachable, low-complexity, only the privilege the SDK already grants to a caller.

## Fix

A single `assertSafeKeyComponent` helper exported from `./utils.js`, applied at every key-building site (27 calls across 2 saver files plus the helper export). The guard:

* Asserts the value is a non-empty string (the documented empty `checkpoint_ns` default is opt-in via `{ allowEmpty: true }`).
* Rejects the Redis pattern meta-characters `* ? [ ] \`.
* Rejects the `:` delimiter that would otherwise corrupt the colon-delimited key structure.

\`\`\`ts
export function assertSafeKeyComponent(
  field: string,
  value: unknown,
  options: { allowEmpty?: boolean } = {}
): asserts value is string {
  const { allowEmpty = false } = options;
  if (typeof value !== \"string\") { /* precise diagnostic */ throw ... }
  if (!allowEmpty && value === \"\") { throw ... }
  if (REDIS_KEY_FORBIDDEN.test(value)) { throw ... }
}
\`\`\`

The guard is a TypeScript \`asserts\` predicate so call-sites get type narrowing for free and the compiler enforces that no later code path uses an unvalidated identifier.

## Why this design

* Mirrors the maintainers' existing primitive-only pattern (\`escapeRediSearchTagValue\`) in the same file.
* Single chokepoint: it is impossible for a future call-site to forget validation.
* No new dependencies, no API changes for valid inputs, no behavior change for any documented happy path.
* Pairs with PR #2349 (NoSQL injection in MongoDBSaver) so both backends now share the same defensive posture at the saver boundary.

## Test plan

* [x] 11 new tests under \`describe(\"assertSafeKeyComponent\")\` in \`libs/checkpoint-redis/src/tests/utils.test.ts\` covering accept and reject paths for every input shape (normal string, empty with and without \`allowEmpty\`, every Redis meta-character, colon delimiter, every wrong type).
* [x] Existing \`escapeRediSearchTagValue\` suite still green (regression).
* [x] Full suite green (\`pnpm --filter @langchain/langgraph-checkpoint-redis test\`, 21 of 21).
* [x] Format clean on all 4 changed files (\`oxfmt\`).
* [x] No new dependencies, no public API changes, no behavior change for valid string identifiers.

## Disclosure

Original finding credited to @etairl (audit posted in #2346). This PR was prepared for coordinated public disclosure since the audit list is already public. Happy to coordinate timing with a private GHSA if the maintainers prefer.