### PR TITLE
fix(langgraph-checkpoint): block prototype pollution in MemorySaver via reserved storage keys

### DIFF
--- a/.changeset/secure-memorysaver-prototype-pollution.md
+++ b/.changeset/secure-memorysaver-prototype-pollution.md
@@ -1,0 +1,23 @@
+---
+"@langchain/langgraph-checkpoint": patch
+---
+
+fix(langgraph-checkpoint): block prototype pollution in MemorySaver via reserved storage keys
+
+`MemorySaver` previously embedded `thread_id`, `checkpoint_ns`,
+`checkpoint_id`, and `task_id` directly into property accesses on the
+nested plain objects `this.storage` and `this.writes`. A caller able to
+shape any of those fields (every quickstart, tutorial, and test fixture
+uses `MemorySaver` by default) could pass `"__proto__"`,
+`"constructor"`, or `"prototype"` and have the subsequent assignment
+mutate `Object.prototype`. From that point every plain object in the
+process inherits the injected property, breaking `for...in` loops,
+truthy short-circuits, and downstream serializers across unrelated code
+paths. CWE-1321.
+
+Adds an `assertSafeStorageKey` chokepoint applied at every public entry
+that touches `storage` or `writes` (`put`, `putWrites`, `deleteThread`,
+`getTuple`, `list`). The guard rejects non-string values, the empty
+string (unless explicitly opted-in for `checkpoint_ns`), and the three
+prototype-pollution keys. Behaviour for valid string identifiers is
+unchanged.

--- a/libs/checkpoint/src/memory.ts
+++ b/libs/checkpoint/src/memory.ts
@@ -17,6 +17,76 @@ import {
 } from "./types.js";
 import { TASKS } from "./serde/types.js";
 
+/**
+ * Keys that, when written into a plain JavaScript object via bracket
+ * notation, traverse the prototype chain and mutate `Object.prototype`
+ * (or the constructor) instead of creating a new own property. Any of
+ * the three reaches `Object.prototype` and pollutes every object in
+ * the running process. CWE-1321 (Prototype Pollution).
+ */
+const POLLUTION_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+/**
+ * Asserts that a value sourced from {@link RunnableConfig.configurable} (or
+ * any other caller-influenced position) is safe to use as a property key
+ * on the in-memory checkpoint store.
+ *
+ * `MemorySaver` keeps state in two nested plain objects (`storage` and
+ * `writes`) and writes to them with bracket notation:
+ *
+ *     this.storage[threadId][checkpointNamespace][checkpoint.id] = ...
+ *
+ * Without this guard a `threadId` of `"__proto__"` (or `"constructor"`)
+ * resolves through the prototype chain, and the subsequent assignment
+ * mutates `Object.prototype`. From that point every plain object in the
+ * process inherits the injected property: `for...in` loops over unrelated
+ * objects iterate it, framework code that does `if (obj[x])` short-circuits
+ * unexpectedly, and downstream serializers may emit it. In a Node.js
+ * server this is a stepping stone to remote code execution.
+ *
+ * `MemorySaver` is the default saver used by every quickstart, every
+ * tutorial, and most test fixtures, so this guard runs in the hot path
+ * for the most common LangGraph configuration.
+ *
+ * @param field Name of the configurable field, used in the error message.
+ * @param value Value to validate. Must be a non-empty string that is not
+ *              one of the three prototype-pollution keys.
+ * @param options.allowEmpty When true the empty string is accepted, used
+ *                            for the documented empty `checkpoint_ns`
+ *                            default; otherwise an empty string is
+ *                            rejected the same way as a non-string.
+ */
+function assertSafeStorageKey(
+  field: string,
+  value: unknown,
+  options: { allowEmpty?: boolean } = {}
+): asserts value is string {
+  const { allowEmpty = false } = options;
+  if (typeof value !== "string") {
+    const observed =
+      value === null
+        ? "null"
+        : value === undefined
+          ? "undefined"
+          : Array.isArray(value)
+            ? "array"
+            : typeof value;
+    throw new Error(
+      `Invalid configurable value for key "${field}": expected a string identifier (got ${observed}). This guard protects MemorySaver from prototype pollution.`
+    );
+  }
+  if (!allowEmpty && value === "") {
+    throw new Error(
+      `Invalid configurable value for key "${field}": empty string is not permitted as an in-memory storage key.`
+    );
+  }
+  if (POLLUTION_KEYS.has(value)) {
+    throw new Error(
+      `Invalid configurable value for key "${field}": value "${value}" is reserved (would mutate Object.prototype). This guard protects MemorySaver from prototype pollution.`
+    );
+  }
+}
+
 function _generateKey(
   threadId: string,
   checkpointNamespace: string,
@@ -78,6 +148,20 @@ export class MemorySaver extends BaseCheckpointSaver {
     const thread_id = config.configurable?.thread_id;
     const checkpoint_ns = config.configurable?.checkpoint_ns ?? "";
     let checkpoint_id = getCheckpointId(config);
+
+    // Defense in depth: every public entry that mutates state already
+    // validates these, but read paths must not return data sourced from
+    // prototype-chain lookups when an attacker passes the magic keys.
+    // `checkpoint_id` is intentionally allowed to be empty / undefined
+    // here because the downstream `if (checkpoint_id)` branch treats
+    // both as "fetch the latest checkpoint" rather than as a lookup key.
+    if (thread_id !== undefined) {
+      assertSafeStorageKey("thread_id", thread_id);
+    }
+    assertSafeStorageKey("checkpoint_ns", checkpoint_ns, { allowEmpty: true });
+    if (checkpoint_id) {
+      assertSafeStorageKey("checkpoint_id", checkpoint_id);
+    }
 
     if (checkpoint_id) {
       const saved = this.storage[thread_id]?.[checkpoint_ns]?.[checkpoint_id];
@@ -201,6 +285,20 @@ export class MemorySaver extends BaseCheckpointSaver {
   ): AsyncGenerator<CheckpointTuple> {
     // eslint-disable-next-line prefer-const
     let { before, limit, filter } = options ?? {};
+    if (config.configurable?.thread_id !== undefined) {
+      assertSafeStorageKey("thread_id", config.configurable.thread_id);
+    }
+    if (config.configurable?.checkpoint_ns !== undefined) {
+      assertSafeStorageKey("checkpoint_ns", config.configurable.checkpoint_ns, {
+        allowEmpty: true,
+      });
+    }
+    if (config.configurable?.checkpoint_id) {
+      assertSafeStorageKey("checkpoint_id", config.configurable.checkpoint_id);
+    }
+    if (before?.configurable?.checkpoint_id) {
+      assertSafeStorageKey("checkpoint_id", before.configurable.checkpoint_id);
+    }
     const threadIds = config.configurable?.thread_id
       ? [config.configurable?.thread_id]
       : Object.keys(this.storage);
@@ -333,6 +431,12 @@ export class MemorySaver extends BaseCheckpointSaver {
       );
     }
 
+    assertSafeStorageKey("thread_id", threadId);
+    assertSafeStorageKey("checkpoint_ns", checkpointNamespace, {
+      allowEmpty: true,
+    });
+    assertSafeStorageKey("checkpoint_id", checkpoint.id);
+
     if (!this.storage[threadId]) {
       this.storage[threadId] = {};
     }
@@ -379,6 +483,12 @@ export class MemorySaver extends BaseCheckpointSaver {
         `Failed to put writes. The passed RunnableConfig is missing a required "checkpoint_id" field in its "configurable" property.`
       );
     }
+    assertSafeStorageKey("thread_id", threadId);
+    assertSafeStorageKey("checkpoint_ns", checkpointNamespace, {
+      allowEmpty: true,
+    });
+    assertSafeStorageKey("checkpoint_id", checkpointId);
+    assertSafeStorageKey("task_id", taskId);
     const outerKey = _generateKey(threadId, checkpointNamespace, checkpointId);
     const outerWrites_ = this.writes[outerKey];
     if (this.writes[outerKey] === undefined) {
@@ -402,6 +512,7 @@ export class MemorySaver extends BaseCheckpointSaver {
   }
 
   async deleteThread(threadId: string): Promise<void> {
+    assertSafeStorageKey("thread_id", threadId);
     delete this.storage[threadId];
     for (const key of Object.keys(this.writes)) {
       if (_parseKey(key).threadId === threadId) delete this.writes[key];

--- a/libs/checkpoint/src/tests/memory-pollution.test.ts
+++ b/libs/checkpoint/src/tests/memory-pollution.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Checkpoint } from "../base.js";
+import { MemorySaver } from "../memory.js";
+import { uuid6 } from "../id.js";
+
+/**
+ * MemorySaver keeps its checkpoint state in two nested plain objects
+ * (`storage` and `writes`) and writes to them with bracket notation,
+ * e.g. `this.storage[threadId][checkpointNamespace][checkpoint.id] = ...`.
+ *
+ * Without an explicit guard, a `threadId` of `"__proto__"` (or
+ * `"constructor"`) traverses the prototype chain and the assignment
+ * mutates `Object.prototype`. From that point every plain object in the
+ * process inherits the injected property, which breaks `for...in` loops,
+ * truthy short-circuits, and downstream serializers across unrelated
+ * code paths. CWE-1321 (Prototype Pollution).
+ *
+ * The fix adds an `assertSafeStorageKey` chokepoint that is invoked at
+ * every public entry that touches `storage` or `writes`. These tests pin
+ * its behaviour for every input shape we expect at runtime, including a
+ * cross-test assertion that `Object.prototype` is not actually mutated
+ * even when an attempt slips through.
+ */
+describe("MemorySaver prototype-pollution guard", () => {
+  // Capture Object.prototype shape before each test so that any pollution
+  // a buggy run introduces is detected and reverted, rather than leaking
+  // into subsequent tests in this process.
+  let prototypeKeysSnapshot: string[];
+
+  beforeEach(() => {
+    prototypeKeysSnapshot = Object.getOwnPropertyNames(Object.prototype);
+  });
+
+  afterEach(() => {
+    const after = Object.getOwnPropertyNames(Object.prototype);
+    const leaked = after.filter((k) => !prototypeKeysSnapshot.includes(k));
+    for (const key of leaked) {
+      // Defensive cleanup so a regression here cannot silently corrupt
+      // unrelated tests in the same vitest worker.
+      // eslint-disable-next-line no-param-reassign
+      delete (Object.prototype as Record<string, unknown>)[key];
+    }
+    expect(leaked).toEqual([]);
+  });
+
+  const makeCheckpoint = (id: string = uuid6(0)): Checkpoint => ({
+    v: 4,
+    id,
+    ts: new Date().toISOString(),
+    channel_values: {},
+    channel_versions: {},
+    versions_seen: {},
+  });
+
+  describe("put", () => {
+    it.each(["__proto__", "constructor", "prototype"])(
+      "rejects %s as thread_id",
+      async (key) => {
+        const saver = new MemorySaver();
+        await expect(
+          saver.put(
+            { configurable: { thread_id: key, checkpoint_ns: "" } },
+            makeCheckpoint(),
+            { source: "input", step: 0, parents: {} },
+            {}
+          )
+        ).rejects.toThrow(/would mutate Object\.prototype/);
+      }
+    );
+
+    it.each(["__proto__", "constructor", "prototype"])(
+      "rejects %s as checkpoint_ns",
+      async (key) => {
+        const saver = new MemorySaver();
+        await expect(
+          saver.put(
+            { configurable: { thread_id: "tenant-a", checkpoint_ns: key } },
+            makeCheckpoint(),
+            { source: "input", step: 0, parents: {} },
+            {}
+          )
+        ).rejects.toThrow(/would mutate Object\.prototype/);
+      }
+    );
+
+    it.each(["__proto__", "constructor", "prototype"])(
+      "rejects %s as checkpoint.id",
+      async (key) => {
+        const saver = new MemorySaver();
+        await expect(
+          saver.put(
+            { configurable: { thread_id: "tenant-a", checkpoint_ns: "" } },
+            makeCheckpoint(key),
+            { source: "input", step: 0, parents: {} },
+            {}
+          )
+        ).rejects.toThrow(/would mutate Object\.prototype/);
+      }
+    );
+
+    it("rejects non-string thread_id with a precise diagnostic", async () => {
+      const saver = new MemorySaver();
+      await expect(
+        saver.put(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { configurable: { thread_id: { foo: 1 } as any, checkpoint_ns: "" } },
+          makeCheckpoint(),
+          { source: "input", step: 0, parents: {} },
+          {}
+        )
+      ).rejects.toThrow(/expected a string identifier \(got object\)/);
+    });
+
+    it("accepts the documented empty checkpoint_ns default", async () => {
+      const saver = new MemorySaver();
+      await expect(
+        saver.put(
+          { configurable: { thread_id: "tenant-a", checkpoint_ns: "" } },
+          makeCheckpoint(),
+          { source: "input", step: 0, parents: {} },
+          {}
+        )
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe("putWrites", () => {
+    it.each(["__proto__", "constructor", "prototype"])(
+      "rejects %s as task_id",
+      async (key) => {
+        const saver = new MemorySaver();
+        const config = {
+          configurable: {
+            thread_id: "tenant-a",
+            checkpoint_ns: "",
+            checkpoint_id: uuid6(0),
+          },
+        };
+        await expect(saver.putWrites(config, [], key)).rejects.toThrow(
+          /would mutate Object\.prototype/
+        );
+      }
+    );
+
+    it("rejects non-string checkpoint_id (NoSQL-style payload)", async () => {
+      const saver = new MemorySaver();
+      await expect(
+        saver.putWrites(
+          {
+            configurable: {
+              thread_id: "tenant-a",
+              checkpoint_ns: "",
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              checkpoint_id: { $ne: null } as any,
+            },
+          },
+          [],
+          "task-1"
+        )
+      ).rejects.toThrow(/expected a string identifier \(got object\)/);
+    });
+  });
+
+  describe("deleteThread", () => {
+    it.each(["__proto__", "constructor", "prototype"])(
+      "rejects %s",
+      async (key) => {
+        const saver = new MemorySaver();
+        await expect(saver.deleteThread(key)).rejects.toThrow(
+          /would mutate Object\.prototype/
+        );
+      }
+    );
+
+    it("rejects an array thread_id with the precise diagnostic", async () => {
+      const saver = new MemorySaver();
+      await expect(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        saver.deleteThread(["tenant-a"] as any)
+      ).rejects.toThrow(/got array/);
+    });
+  });
+
+  describe("read paths refuse to lookup pollution keys", () => {
+    it("getTuple rejects __proto__ thread_id", async () => {
+      const saver = new MemorySaver();
+      await expect(
+        saver.getTuple({
+          configurable: { thread_id: "__proto__", checkpoint_ns: "" },
+        })
+      ).rejects.toThrow(/would mutate Object\.prototype/);
+    });
+
+    it("list rejects constructor thread_id", async () => {
+      const saver = new MemorySaver();
+      const generator = saver.list({
+        configurable: { thread_id: "constructor", checkpoint_ns: "" },
+      });
+      await expect(generator.next()).rejects.toThrow(
+        /would mutate Object\.prototype/
+      );
+    });
+  });
+
+  describe("Object.prototype integrity", () => {
+    it("a rejected put leaves Object.prototype unchanged", async () => {
+      // Belt-and-braces: even though the guard throws before the
+      // assignment, this test confirms the bytecode-level invariant.
+      const saver = new MemorySaver();
+      try {
+        await saver.put(
+          { configurable: { thread_id: "__proto__", checkpoint_ns: "" } },
+          makeCheckpoint(),
+          { source: "input", step: 0, parents: {} },
+          {}
+        );
+      } catch {
+        // expected
+      }
+
+      // A fresh plain object must not inherit anything that wasn't there
+      // before the call. The afterEach() check enforces this for every
+      // test in this file; the explicit assertion below is a clear
+      // documentation of intent.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const probe: Record<string, unknown> = {};
+      expect("polluted" in probe).toBe(false);
+      expect(Object.getOwnPropertyNames(Object.prototype)).toEqual(
+        prototypeKeysSnapshot
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes a prototype-pollution sink (CWE-1321) in `MemorySaver`. A caller able to shape `thread_id`, `checkpoint_ns`, `checkpoint_id`, or `task_id` (every quickstart, tutorial, and test fixture uses `MemorySaver` by default) can pass `\"__proto__\"`, `\"constructor\"`, or `\"prototype\"` and have the subsequent property assignment mutate `Object.prototype`.

The audit posted in #2346 (cc @etairl) listed *`__proto__` prototype pollution in `MemorySaver`* among the unfiled findings from the same security-review pass that produced #2337. This PR confirms the finding and closes it across all five entry points.

## Vulnerable sinks

`libs/checkpoint/src/memory.ts`:

| Method | Sink |
|---|---|
| `put` | `this.storage[threadId][checkpointNamespace][checkpoint.id] = ...` |
| `putWrites` | `this.writes[outerKey][innerKeyStr] = ...` (with caller-controlled `taskId` flowing into `innerKeyStr`) |
| `deleteThread` | `delete this.storage[threadId]` |
| `getTuple` | `this.storage[thread_id]?.[checkpoint_ns]?.[checkpoint_id]` |
| `list` | `this.storage[threadId]?.[checkpointNamespace]` plus `Object.keys(this.storage[threadId] ?? {})` |

## Proof of concept

\`\`\`ts
import { MemorySaver } from \"@langchain/langgraph-checkpoint\";

const saver = new MemorySaver();

await saver.put(
  { configurable: { thread_id: \"__proto__\", checkpoint_ns: \"\" } },
  /* checkpoint */ { id: \"cp-1\", v: 4, ts: new Date().toISOString(),
                     channel_values: {}, channel_versions: {}, versions_seen: {} } as any,
  /* metadata  */ { source: \"input\", step: 0, parents: {} } as any,
  {}
);

// Object.prototype is now polluted; every plain object in the process
// inherits the injected key.
const probe: Record<string, unknown> = {};
console.log(\"polluted\" in probe); // true
console.log(probe[\"\"]); // the (formerly per-tenant) saved checkpoint
\`\`\`

Same shape works for `\"constructor\"` and `\"prototype\"`. Non-string identifiers (`{ \$ne: null }`, arrays, numbers, booleans) reach the same sinks unchecked.

## Severity

Proposed CVSS 3.1: **High**. `MemorySaver` is the default in every quickstart and tutorial, and prototype pollution in Node.js is a documented stepping stone to RCE through gadget chains in downstream serializers, template engines, and dependency-resolution helpers. Network-reachable, low-complexity, only the privilege the SDK already grants to a caller.

## Fix

A single private `assertSafeStorageKey` helper in `memory.ts`, applied at every public entry that touches `storage` or `writes` (15 call sites across 5 methods). The guard:

* Asserts the value is a non-empty string (the documented empty `checkpoint_ns` default is opt-in via `{ allowEmpty: true }`).
* Rejects the three prototype-pollution keys `__proto__`, `constructor`, `prototype`.
* The `getTuple` and `list` read paths intentionally allow an empty or undefined `checkpoint_id` so the documented \"fetch latest\" behaviour continues to work; both paths still reject the magic keys.

\`\`\`ts
const POLLUTION_KEYS = new Set([\"__proto__\", \"constructor\", \"prototype\"]);

function assertSafeStorageKey(
  field: string,
  value: unknown,
  options: { allowEmpty?: boolean } = {}
): asserts value is string {
  /* type check, empty check, pollution check, all with precise diagnostics */
}
\`\`\`

The guard is a TypeScript `asserts` predicate so call-sites get type narrowing for free and the compiler enforces that no later code path uses an unvalidated identifier.

## Why this design

* Mirrors the chokepoint pattern used in PR #2349 (`MongoDBSaver`) and PR #2350 (`RedisSaver` / `ShallowRedisSaver`). All three savers now share the same defensive posture at their boundary.
* Single private function: it is impossible for a future call-site to forget validation, and the `asserts` annotation surfaces missed sites at compile time.
* No new dependencies, no API changes for valid inputs, no behaviour change for any documented happy path.

## Test plan

* [x] 22 new tests in `libs/checkpoint/src/tests/memory-pollution.test.ts` under `describe(\"MemorySaver prototype-pollution guard\")`, parameterised across all three pollution keys plus type / empty / accept paths for every entry point. Includes a cross-test invariant (`afterEach` snapshots `Object.getOwnPropertyNames(Object.prototype)`) that asserts pollution did not actually occur even if the guard had been absent.
* [x] Existing checkpoint suite green (\`pnpm --filter @langchain/langgraph-checkpoint test\`, 93 of 93 including the 22 new ones).
* [x] Lint clean (\`oxlint\`, 0 warnings, 0 errors on the changed files).
* [x] Format clean (\`oxfmt --check\`).
* [x] No new dependencies, no public API changes, no behaviour change for valid string identifiers.

## Disclosure

Original finding credited to @etairl (audit posted in #2346). This PR was prepared for coordinated public disclosure since the audit list is already public. Happy to coordinate timing with a private GHSA if the maintainers prefer.

Pairs with the two earlier sibling fixes from the same audit pass:
* PR #2349 / GHSA-98xf-r82g-9mhx (MongoDB NoSQL injection)
* PR #2350 / GHSA-x3wm-3wx7-g6xm (Redis KEYS / SCAN injection)