### PR TITLE
fix(langgraph-checkpoint-mongodb): reject non-primitive thread_id/checkpoint_ns/checkpoint_id

### DIFF
--- a/.changeset/mongodb-saver-operator-injection.md
+++ b/.changeset/mongodb-saver-operator-injection.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint-mongodb": patch
+---
+
+fix: validate `thread_id`, `checkpoint_ns`, and `checkpoint_id` in `MongoDBSaver` to prevent NoSQL operator injection. Object/function values for these fields are now rejected before they reach a MongoDB query, mirroring the existing guard on the `filter` argument of `list()`. Applies to `getTuple`, `list`, `put`, and `putWrites`.

--- a/libs/checkpoint-mongodb/src/checkpoint.ts
+++ b/libs/checkpoint-mongodb/src/checkpoint.ts
@@ -43,6 +43,29 @@ export class MongoDBSaver extends BaseCheckpointSaver {
       : {};
   }
 
+  /**
+   * Reject non-primitive values for `thread_id`, `checkpoint_ns`, and
+   * `checkpoint_id` before they reach a MongoDB query. Mongo treats nested
+   * objects as operator expressions (e.g. `{ $gt: "" }`), so allowing
+   * caller-shaped objects here would let an attacker bypass thread scoping
+   * and read other tenants' checkpoints. Mirrors the existing guard in
+   * `list()` for the `filter` argument.
+   */
+  private static assertConfigurableScalars(values: {
+    thread_id?: unknown;
+    checkpoint_ns?: unknown;
+    checkpoint_id?: unknown;
+  }): void {
+    for (const [name, value] of Object.entries(values)) {
+      if (value === undefined || value === null) continue;
+      if (typeof value === "object" || typeof value === "function") {
+        throw new Error(
+          `Invalid configurable.${name}: must be a primitive (string, number, or boolean), got ${typeof value}.`
+        );
+      }
+    }
+  }
+
   constructor(
     {
       client,
@@ -78,6 +101,11 @@ export class MongoDBSaver extends BaseCheckpointSaver {
       checkpoint_ns = "",
       checkpoint_id,
     } = config.configurable ?? {};
+    MongoDBSaver.assertConfigurableScalars({
+      thread_id,
+      checkpoint_ns,
+      checkpoint_id,
+    });
     let query;
     if (checkpoint_id) {
       query = {
@@ -154,6 +182,11 @@ export class MongoDBSaver extends BaseCheckpointSaver {
     options?: CheckpointListOptions
   ): AsyncGenerator<CheckpointTuple> {
     const { limit, before, filter } = options ?? {};
+    MongoDBSaver.assertConfigurableScalars({
+      thread_id: config?.configurable?.thread_id,
+      checkpoint_ns: config?.configurable?.checkpoint_ns,
+      checkpoint_id: before?.configurable?.checkpoint_id,
+    });
     const query: Record<string, unknown> = {};
 
     if (config?.configurable?.thread_id) {
@@ -242,6 +275,11 @@ export class MongoDBSaver extends BaseCheckpointSaver {
         `The provided config must contain a configurable field with a "thread_id" field.`
       );
     }
+    MongoDBSaver.assertConfigurableScalars({
+      thread_id,
+      checkpoint_ns,
+      checkpoint_id: config.configurable?.checkpoint_id,
+    });
     const [
       [checkpointType, serializedCheckpoint],
       [metadataType, serializedMetadata],
@@ -301,6 +339,11 @@ export class MongoDBSaver extends BaseCheckpointSaver {
         `The provided config must contain a configurable field with "thread_id", "checkpoint_ns" and "checkpoint_id" fields.`
       );
     }
+    MongoDBSaver.assertConfigurableScalars({
+      thread_id,
+      checkpoint_ns,
+      checkpoint_id,
+    });
 
     const operations = await Promise.all(
       writes.map(async ([channel, value], idx) => {

--- a/libs/checkpoint-mongodb/src/tests/checkpoints.test.ts
+++ b/libs/checkpoint-mongodb/src/tests/checkpoints.test.ts
@@ -121,4 +121,141 @@ describe("MongoDBSaver", () => {
       expect(result.done).toBe(true);
     });
   });
+
+  describe("configurable scalar validation", () => {
+    it("should reject MongoDB operator object as thread_id in getTuple", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const maliciousConfig = {
+        configurable: {
+          thread_id: { $gt: "" },
+          checkpoint_ns: { $ne: null },
+        },
+      };
+
+      await expect(saver.getTuple(maliciousConfig)).rejects.toThrow(
+        "Invalid configurable.thread_id: must be a primitive"
+      );
+    });
+
+    it("should reject object checkpoint_id in getTuple", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const maliciousConfig = {
+        configurable: {
+          thread_id: "user-A",
+          checkpoint_id: { $gt: "" },
+        },
+      };
+
+      await expect(saver.getTuple(maliciousConfig)).rejects.toThrow(
+        "Invalid configurable.checkpoint_id: must be a primitive"
+      );
+    });
+
+    it("should accept primitive thread_id in getTuple", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const config = { configurable: { thread_id: "test-thread" } };
+
+      const result = await saver.getTuple(config);
+      // Mock returns no results, so undefined is expected
+      expect(result).toBeUndefined();
+    });
+
+    it("should reject object thread_id in list", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const maliciousConfig = {
+        configurable: { thread_id: { $gt: "" } },
+      };
+
+      const generator = saver.list(maliciousConfig);
+
+      await expect(generator.next()).rejects.toThrow(
+        "Invalid configurable.thread_id: must be a primitive"
+      );
+    });
+
+    it("should reject object checkpoint_id in before option of list", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const config = { configurable: { thread_id: "test-thread" } };
+      const before = {
+        configurable: { checkpoint_id: { $gt: "" } },
+      };
+
+      const generator = saver.list(config, { before });
+
+      await expect(generator.next()).rejects.toThrow(
+        "Invalid configurable.checkpoint_id: must be a primitive"
+      );
+    });
+
+    it("should reject object thread_id in put", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const maliciousConfig = {
+        configurable: { thread_id: { $gt: "" } },
+      };
+
+      await expect(
+        saver.put(
+          maliciousConfig,
+          {
+            v: 1,
+            id: "checkpoint-1",
+            ts: new Date().toISOString(),
+            channel_values: {},
+            channel_versions: {},
+            versions_seen: {},
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          {} as any
+        )
+      ).rejects.toThrow(
+        "Invalid configurable.thread_id: must be a primitive"
+      );
+    });
+
+    it("should reject object thread_id in putWrites", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const maliciousConfig = {
+        configurable: {
+          thread_id: { $gt: "" },
+          checkpoint_ns: "",
+          checkpoint_id: "checkpoint-1",
+        },
+      };
+
+      await expect(
+        saver.putWrites(maliciousConfig, [["channel", "value"]], "task-1")
+      ).rejects.toThrow(
+        "Invalid configurable.thread_id: must be a primitive"
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Description

`MongoDBSaver.getTuple`, `list`, `put`, and `putWrites` forwarded `thread_id`, `checkpoint_ns`, and `checkpoint_id` from `config.configurable` straight into MongoDB queries with no type validation. A caller able to shape those values (for example, by passing an HTTP request body's `thread_id` straight into config without coercion) could submit Mongo operator objects (`{ $gt: "" }`, `{ $ne: null }`) to bypass thread scoping and read other tenants' checkpoints.

`getTuple` was the most exposed entry point because it's invoked automatically by `app.invoke()` whenever a saver is configured, so any chat handler that takes `thread_id` from a request body without `String(...)` / `z.string()` coercion was reachable.

## Fix

Adds a private `MongoDBSaver.assertConfigurableScalars` helper that rejects object/function values for these fields, mirroring the existing guard in `list()` for the `filter` argument:

```ts
private static assertConfigurableScalars(values: {
  thread_id?: unknown;
  checkpoint_ns?: unknown;
  checkpoint_id?: unknown;
}): void {
  for (const [name, value] of Object.entries(values)) {
    if (value === undefined || value === null) continue;
    if (typeof value === "object" || typeof value === "function") {
      throw new Error(
        `Invalid configurable.${name}: must be a primitive (string, number, or boolean), got ${typeof value}.`
      );
    }
  }
}
```

It is called at the top of every method that consumes those fields:

- `getTuple` — guards both the initial `find()` and the follow-up `find(configurableValues)` against `checkpoint_writes`.
- `list` — also guards `before.configurable.checkpoint_id` (which previously fed `{ $lt: ... }` unchecked).
- `put` and `putWrites` — guard the upsert filters.

## Tests

Adds 7 unit tests in `libs/checkpoint-mongodb/src/tests/checkpoints.test.ts` covering each entry point with a Mongo-operator payload, plus a happy-path assertion that primitive values still pass. All 13 unit tests in the suite pass:

```
✓ |unit| src/tests/checkpoints.test.ts (13 tests)
```

## Backward compatibility

Strictly additive validation — primitive `thread_id` / `checkpoint_ns` / `checkpoint_id` (the only documented and intended shape) keep working. Callers that were relying on undocumented object-shaped identifiers will get a clear error pointing at the offending field.

## Notes

- Same class of guard is already present (and tested) in `list()` for the `filter` argument; this PR extends it to the configurable identifiers.
- Sister injection issues likely exist in `@langchain/langgraph-checkpoint-redis` (key/glob/RediSearch query injection); separate report on the way.

Fixes #2351
