### PR TITLE
fix(sdk): pin framework SDKs to langgraph-sdk version

### DIFF
--- a/.changeset/hip-jokes-hide.md
+++ b/.changeset/hip-jokes-hide.md
@@ -1,0 +1,8 @@
+---
+"@langchain/angular": patch
+"@langchain/react": patch
+"@langchain/svelte": patch
+"@langchain/vue": patch
+---
+
+fix(sdk): pin framework SDKs to langgraph-sdk version

--- a/libs/sdk-angular/package.json
+++ b/libs/sdk-angular/package.json
@@ -18,7 +18,7 @@
     "directory": "libs/sdk-angular"
   },
   "dependencies": {
-    "@langchain/langgraph-sdk": "workspace:^"
+    "@langchain/langgraph-sdk": "workspace:*"
   },
   "devDependencies": {
     "@analogjs/vite-plugin-angular": "^2.4.0",

--- a/libs/sdk-react/package.json
+++ b/libs/sdk-react/package.json
@@ -18,7 +18,7 @@
     "directory": "libs/sdk-react"
   },
   "dependencies": {
-    "@langchain/langgraph-sdk": "workspace:^"
+    "@langchain/langgraph-sdk": "workspace:*"
   },
   "devDependencies": {
     "@hono/node-server": "^1.19.13",

--- a/libs/sdk-svelte/package.json
+++ b/libs/sdk-svelte/package.json
@@ -18,7 +18,7 @@
     "directory": "libs/sdk-svelte"
   },
   "dependencies": {
-    "@langchain/langgraph-sdk": "workspace:^"
+    "@langchain/langgraph-sdk": "workspace:*"
   },
   "devDependencies": {
     "@hono/node-server": "^1.19.13",

--- a/libs/sdk-vue/package.json
+++ b/libs/sdk-vue/package.json
@@ -18,7 +18,7 @@
     "directory": "libs/sdk-vue"
   },
   "dependencies": {
-    "@langchain/langgraph-sdk": "workspace:^"
+    "@langchain/langgraph-sdk": "workspace:*"
   },
   "devDependencies": {
     "@hono/node-server": "^1.19.13",


### PR DESCRIPTION
As a safe guard for the upcoming major release of the framework SDK packages we pin the 0.x packages to whatever the latest langgraph-sdk was at the time.