### PR TITLE
feat(sdk): add returnMinimal to threads update

### DIFF
--- a/.changeset/threads-update-return-minimal.md
+++ b/.changeset/threads-update-return-minimal.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+Add a `returnMinimal` option to `threads.update`.

--- a/libs/sdk/src/client.ts
+++ b/libs/sdk/src/client.ts
@@ -1174,7 +1174,7 @@ export class ThreadsClient<
         ? { ttl: payload.ttl, strategy: "delete" as const }
         : payload?.ttl;
 
-    return this.fetch<Thread>(`/threads/${threadId}`, {
+    return this.fetch<Thread | void>(`/threads/${threadId}`, {
       method: "PATCH",
       headers: payload?.returnMinimal
         ? { Prefer: "return=minimal" }

--- a/libs/sdk/src/client.ts
+++ b/libs/sdk/src/client.ts
@@ -1091,11 +1091,84 @@ export class ThreadsClient<
        */
       ttl?: number | { ttl: number; strategy?: "delete" };
       /**
+       * If true, request a 204 response with no body.
+       */
+      returnMinimal?: false;
+      /**
        * Signal to abort the request.
        */
       signal?: AbortSignal;
     }
-  ): Promise<Thread> {
+  ): Promise<Thread>;
+  async update(
+    threadId: string,
+    payload: {
+      /**
+       * Metadata for the thread.
+       */
+      metadata?: Metadata;
+      /**
+       * Optional time-to-live in minutes for the thread.
+       * If a number is provided, it is treated as minutes and defaults to strategy "delete".
+       * You may also provide an object { ttl: number, strategy?: "delete" }.
+       */
+      ttl?: number | { ttl: number; strategy?: "delete" };
+      /**
+       * If true, request a 204 response with no body.
+       */
+      returnMinimal: true;
+      /**
+       * Signal to abort the request.
+       */
+      signal?: AbortSignal;
+    }
+  ): Promise<void>;
+  async update(
+    threadId: string,
+    payload: {
+      /**
+       * Metadata for the thread.
+       */
+      metadata?: Metadata;
+      /**
+       * Optional time-to-live in minutes for the thread.
+       * If a number is provided, it is treated as minutes and defaults to strategy "delete".
+       * You may also provide an object { ttl: number, strategy?: "delete" }.
+       */
+      ttl?: number | { ttl: number; strategy?: "delete" };
+      /**
+       * If true, request a 204 response with no body.
+       */
+      returnMinimal: boolean;
+      /**
+       * Signal to abort the request.
+       */
+      signal?: AbortSignal;
+    }
+  ): Promise<Thread | void>;
+  async update(
+    threadId: string,
+    payload?: {
+      /**
+       * Metadata for the thread.
+       */
+      metadata?: Metadata;
+      /**
+       * Optional time-to-live in minutes for the thread.
+       * If a number is provided, it is treated as minutes and defaults to strategy "delete".
+       * You may also provide an object { ttl: number, strategy?: "delete" }.
+       */
+      ttl?: number | { ttl: number; strategy?: "delete" };
+      /**
+       * If true, request a 204 response with no body.
+       */
+      returnMinimal?: boolean;
+      /**
+       * Signal to abort the request.
+       */
+      signal?: AbortSignal;
+    }
+  ): Promise<Thread | void> {
     const ttlPayload =
       typeof payload?.ttl === "number"
         ? { ttl: payload.ttl, strategy: "delete" as const }
@@ -1103,6 +1176,9 @@ export class ThreadsClient<
 
     return this.fetch<Thread>(`/threads/${threadId}`, {
       method: "PATCH",
+      headers: payload?.returnMinimal
+        ? { Prefer: "return=minimal" }
+        : undefined,
       json: { metadata: payload?.metadata, ttl: ttlPayload },
       signal: payload?.signal,
     });

--- a/libs/sdk/src/tests/fetch.test.ts
+++ b/libs/sdk/src/tests/fetch.test.ts
@@ -76,6 +76,39 @@ describe.each([["global"], ["mocked"]])(
       });
     });
 
+    describe("threads.update", () => {
+      it("should request a minimal response when returnMinimal is true", async () => {
+        expectedFetchMock.mockResolvedValueOnce({
+          ok: true,
+          status: 204,
+          json: () => Promise.resolve({}),
+          text: () => Promise.resolve(""),
+          headers: new Headers({}),
+        });
+
+        const client = new Client({ apiKey: "test-api-key" });
+        const result = await client.threads.update("thread_123", {
+          metadata: { foo: "bar" },
+          returnMinimal: true,
+        });
+
+        expect(result).toBeUndefined();
+        expect(expectedFetchMock).toHaveBeenCalledWith(
+          expect.stringContaining("/threads/thread_123"),
+          expect.objectContaining({
+            method: "PATCH",
+            headers: expect.objectContaining({
+              prefer: "return=minimal",
+            }),
+          })
+        );
+        expect(
+          JSON.parse((expectedFetchMock.mock.calls[0][1] as RequestInit).body as string)
+        ).toEqual({ metadata: { foo: "bar" } });
+        expect(unexpectedFetchMock).not.toHaveBeenCalled();
+      });
+    });
+
     describe("header coalescing", () => {
       it("should properly merge headers with conflicting name casing", async () => {
         const client = new Client({ apiKey: "test-api-key" });


### PR DESCRIPTION
Adds a first-class `returnMinimal` option to JS SDK `threads.update`. When enabled, the SDK sends `Prefer: return=minimal` and resolves with `undefined` for the 204 response. Includes a patch changeset and focused fetch test coverage. 