### PR TITLE
fix(sdk): update endpoints

### DIFF
--- a/.changeset/quick-breads-hang.md
+++ b/.changeset/quick-breads-hang.md
@@ -1,0 +1,6 @@
+---
+"@langchain/langgraph-api": patch
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): update endpoints

--- a/examples/streaming/src/api/_shared.ts
+++ b/examples/streaming/src/api/_shared.ts
@@ -16,10 +16,10 @@
  *
  *     LANGGRAPH_API_URL=http://localhost:8080 npx tsx src/api/basic.ts
  *
- * These scripts exercise the protocol-v2 endpoints shipped in the
- * Python API: `POST /v2/threads/{thread_id}/commands`,
- * `POST /v2/threads/{thread_id}/events`, and the WebSocket at
- * `/v2/threads/{thread_id}`.
+ * These scripts exercise the protocol endpoints shipped in the Python API:
+ * `POST /threads/{thread_id}/commands`,
+ * `POST /threads/{thread_id}/stream/events`, and the WebSocket at
+ * `/threads/{thread_id}/stream/events`.
  */
 
 export const DEFAULT_API_URL = "http://localhost:9123";

--- a/examples/streaming/src/api/basic.ts
+++ b/examples/streaming/src/api/basic.ts
@@ -6,8 +6,8 @@
  * core channels until the run completes.
  *
  * This exercises:
- *   - `POST /v2/threads/{thread_id}/commands` for `run.start`
- *   - `POST /v2/threads/{thread_id}/events` SSE stream
+ *   - `POST /threads/{thread_id}/commands` for `run.start`
+ *   - `POST /threads/{thread_id}/stream/events` SSE stream
  *   - CDDL envelope shape (`type`, `seq`, `event_id`, `method`, `params`)
  *   - Lifecycle events (`running`, `completed`)
  *   - Messages content-block lifecycle (`message-start` →

--- a/examples/streaming/src/api/channels.ts
+++ b/examples/streaming/src/api/channels.ts
@@ -122,7 +122,7 @@ async function main() {
   });
 
   // Open each subscription sequentially (each ``thread.subscribe`` is
-  // ``await``-ed before moving on) so 8 concurrent ``POST /events``
+  // ``await``-ed before moving on) so 8 concurrent ``POST /stream/events``
   // requests don't race undici's connection pool before the run even
   // starts. Drains run in parallel after every handle is established.
   const drains: Record<Channel, Promise<CollectedEvent[]>> = {} as Record<

--- a/examples/streaming/src/api/commands.ts
+++ b/examples/streaming/src/api/commands.ts
@@ -10,7 +10,7 @@
  *   - Malformed envelope — confirm the route's `invalid_argument` path.
  *
  * Unlike the other api/ scripts, this one talks directly to the
- * `POST /v2/threads/{thread_id}/commands` endpoint via `fetch` so we
+ * `POST /threads/{thread_id}/commands` endpoint via `fetch` so we
  * can assert on the raw `ProtocolError` / `ProtocolSuccess` shapes
  * the server returns.
  *
@@ -38,7 +38,7 @@ async function send(
   threadId: string,
   payload: Record<string, unknown>
 ): Promise<ProtocolResponse> {
-  const res = await fetch(`${url}/v2/threads/${threadId}/commands`, {
+  const res = await fetch(`${url}/threads/${threadId}/commands`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(payload),
@@ -115,7 +115,7 @@ async function main() {
 
   // 7. Malformed envelope — missing method
   const malformed = await fetch(
-    `${url}/v2/threads/${threadId}/commands`,
+    `${url}/threads/${threadId}/commands`,
     {
       method: "POST",
       headers: { "content-type": "application/json" },

--- a/examples/streaming/src/api/multimodal_stream_websocket.ts
+++ b/examples/streaming/src/api/multimodal_stream_websocket.ts
@@ -3,7 +3,7 @@
  *
  * Same ``agent_multimodal_stream`` graph, same ``AudioBlock`` /
  * ``ImageBlock`` content-block shapes — just routed through the
- * ``ws://<host>/v2/threads/{id}`` transport instead of SSE. Proves
+ * ``ws://<host>/threads/{id}/stream/events`` transport instead of SSE. Proves
  * the SDK's media handles work identically on both transports.
  *
  * Node 22+ required: the SDK's WebSocket transport uses the global

--- a/examples/streaming/src/api/reconnect.ts
+++ b/examples/streaming/src/api/reconnect.ts
@@ -1,7 +1,7 @@
 /**
  * SSE reconnect / replay verification for the Python `langgraph-api`.
  *
- * Opens a raw `POST /v2/threads/{thread_id}/events` SSE stream, starts a
+ * Opens a raw `POST /threads/{thread_id}/stream/events` SSE stream, starts a
  * run, reads events until some point in the middle, drops the
  * connection, then reopens it with a `Last-Event-ID: <seq>` header and
  * asserts every event after that point is replayed in order with no
@@ -50,7 +50,7 @@ function parseFrame(rawFrame: string): SseField | null {
  *
  * We deliberately use `node:http` instead of `fetch` here: Node's fetch
  * (undici) default pool holds keep-alive slots on the origin and the
- * second POST to `/events` stalls waiting for a free slot after the
+ * second POST to `/stream/events` stalls waiting for a free slot after the
  * first connection is aborted. `http.request` with `Connection: close`
  * forces a fresh socket per call and destroys cleanly on abort.
  */
@@ -60,7 +60,7 @@ function openSseStream(
   filter: Record<string, unknown>
 ): Promise<{ res: http.IncomingMessage; req: http.ClientRequest }> {
   return new Promise((resolve, reject) => {
-    const target = new NodeURL(`/v2/threads/${threadId}/events`, url);
+    const target = new NodeURL(`/threads/${threadId}/stream/events`, url);
     const body = JSON.stringify(filter);
     const headers: Record<string, string> = {
       "content-type": "application/json",
@@ -177,14 +177,14 @@ async function main() {
   // raw streams below, not the SDK wrapper). Use ``node:http`` here as
   // well so the entire test sticks to one transport — mixing undici's
   // fetch with follow-up ``http.request`` streams on the same origin
-  // has proven to stall the second POST to ``/events``.
+  // has proven to stall the second POST to ``/stream/events``.
   const commandBody = await new Promise<{
     type: string;
     result?: { run_id?: string };
     error?: string;
     message?: string;
   }>((resolve, reject) => {
-    const target = new NodeURL(`/v2/threads/${threadId}/commands`, url);
+    const target = new NodeURL(`/threads/${threadId}/commands`, url);
     const payload = JSON.stringify({
       id: 1,
       method: "run.start",

--- a/examples/streaming/src/api/unsupported-channel.ts
+++ b/examples/streaming/src/api/unsupported-channel.ts
@@ -2,7 +2,7 @@
  * Malformed / unsupported subscribe-envelope validation against the
  * Python `langgraph-api` server.
  *
- * Goes at the raw HTTP layer (``fetch`` → ``POST /events``) so we can
+ * Goes at the raw HTTP layer (``fetch`` → ``POST /stream/events``) so we can
  * assert on the ``invalid_argument`` / HTTP 4xx shapes the server
  * returns. The SDK sanitizes most of these before they reach the
  * wire; this script hits the validator directly.
@@ -94,7 +94,7 @@ const PROBES: readonly Probe[] = [
 ];
 
 async function probe(url: string, threadId: string, p: Probe) {
-  const res = await fetch(`${url}/v2/threads/${threadId}/events`, {
+  const res = await fetch(`${url}/threads/${threadId}/stream/events`, {
     method: "POST",
     headers: {
       "content-type": "application/json",

--- a/examples/streaming/src/api/websocket.ts
+++ b/examples/streaming/src/api/websocket.ts
@@ -4,7 +4,7 @@
  * The SDK defaults to SSE+HTTP; passing `transport: "websocket"` (or
  * setting `streamProtocol: "v2-websocket"` on the client) routes every
  * command and event over a single full-duplex WebSocket on
- * `ws://<host>/v2/threads/{thread_id}`.
+ * `ws://<host>/threads/{thread_id}/stream/events`.
  *
  * This script verifies:
  *   - The WS route accepts `subscription.subscribe`,

--- a/libs/langgraph-api/src/api/protocol.mts
+++ b/libs/langgraph-api/src/api/protocol.mts
@@ -58,7 +58,7 @@ export default function createProtocolApi(
   });
 
   api.get(
-    "/v2/threads/:thread_id/stream",
+    "/threads/:thread_id/stream/events",
     zValidator("param", ThreadIdSchema),
     upgradeWebSocket((c: any) => {
       const { thread_id } = c.req.valid("param");
@@ -134,7 +134,7 @@ export default function createProtocolApi(
   );
 
   api.post(
-    "/v2/threads/:thread_id/commands",
+    "/threads/:thread_id/commands",
     zValidator("param", ThreadIdSchema),
     zValidator("json", ProtocolCommandSchema),
     async (c) => {
@@ -153,7 +153,7 @@ export default function createProtocolApi(
   );
 
   api.post(
-    "/v2/threads/:thread_id/stream",
+    "/threads/:thread_id/stream/events",
     zValidator("param", ThreadIdSchema),
     zValidator("json", EventsFilterSchema),
     async (c) => {

--- a/libs/langgraph-api/src/experimental/embed.mts
+++ b/libs/langgraph-api/src/experimental/embed.mts
@@ -15,7 +15,7 @@ export type { ThreadSaver } from "./embed/types.mjs";
  * Create a Hono server with a subset of LangGraph Platform routes.
  *
  * Pass `upgradeWebSocket` to enable the WebSocket protocol transport
- * on `GET /v2/threads/:thread_id/stream`. Create it with `@hono/node-ws`'s
+ * on `GET /threads/:thread_id/stream/events`. Create it with `@hono/node-ws`'s
  * `createNodeWebSocket({ app })` and make sure to call `injectWebSocket`
  * on the underlying HTTP server.
  *

--- a/libs/langgraph-api/src/experimental/embed/protocol.mts
+++ b/libs/langgraph-api/src/experimental/embed/protocol.mts
@@ -369,7 +369,7 @@ export function registerProtocolRoutes(
   }
 
   api.post(
-    "/v2/threads/:thread_id/commands",
+    "/threads/:thread_id/commands",
     zValidator("param", ThreadIdSchema),
     zValidator("json", ProtocolCommandSchema),
     async (c) => {
@@ -381,7 +381,7 @@ export function registerProtocolRoutes(
   );
 
   api.post(
-    "/v2/threads/:thread_id/stream",
+    "/threads/:thread_id/stream/events",
     zValidator("param", ThreadIdSchema),
     zValidator("json", EventsFilterSchema),
     async (c) => {
@@ -451,7 +451,7 @@ export function registerProtocolRoutes(
 
   if (upgradeWebSocket != null) {
     api.get(
-      "/v2/threads/:thread_id/stream",
+      "/threads/:thread_id/stream/events",
       zValidator("param", ThreadIdSchema),
       upgradeWebSocket((c: any) => {
         const { thread_id } = c.req.valid("param");

--- a/libs/langgraph-api/tests/protocol-transport.test.mts
+++ b/libs/langgraph-api/tests/protocol-transport.test.mts
@@ -97,7 +97,7 @@ describe("protocol transport", () => {
       const thread = await client.threads.create();
 
       const socket = new WebSocket(
-        `${API_URL.replace("http", "ws")}/v2/threads/${thread.thread_id}/stream`
+        `${API_URL.replace("http", "ws")}/threads/${thread.thread_id}/stream/events`
       );
       const collector = createSocketCollector(socket);
 

--- a/libs/sdk/src/client/index.test.ts
+++ b/libs/sdk/src/client/index.test.ts
@@ -65,7 +65,7 @@ describe("Client", () => {
 
     await expect(thread.subscribe(["values"])).rejects.toBe(sentinel);
     expect(calls).toHaveLength(1);
-    expect(calls[0]).toContain("/v2/threads/my-thread/stream");
+    expect(calls[0]).toContain("/threads/my-thread/stream/events");
   });
 
   it("threads.stream forwards fetch to the sse adapter", async () => {
@@ -94,10 +94,10 @@ describe("Client", () => {
 
     await expect(thread.subscribe(["values"])).rejects.toBe(sentinel);
     expect(calls).toHaveLength(1);
-    expect(calls[0].pathname).toContain("/v2/threads/my-thread/stream");
+    expect(calls[0].pathname).toContain("/threads/my-thread/stream/events");
   });
 
-  it("uses the v2 protocol commands path for sse commands", async () => {
+  it("uses the protocol commands path for sse commands", async () => {
     const calls: URL[] = [];
     const customFetch = ((input: URL | RequestInfo) => {
       calls.push(
@@ -127,6 +127,6 @@ describe("Client", () => {
     await transport.send({ id: 1, method: "state.get", params: { namespace: [] } });
 
     expect(calls).toHaveLength(1);
-    expect(calls[0].pathname).toBe("/v2/threads/my-thread/commands");
+    expect(calls[0].pathname).toBe("/threads/my-thread/commands");
   });
 });

--- a/libs/sdk/src/client/stream/transport/agent-server.ts
+++ b/libs/sdk/src/client/stream/transport/agent-server.ts
@@ -42,7 +42,7 @@ export interface HttpAgentServerAdapterOptions {
   defaultHeaders?: Record<string, HeaderValue>;
   /** Per-request hook for last-mile header mutation. */
   onRequest?: ProtocolRequestHook;
-  /** Override the default `/v2/threads/:threadId/...` protocol paths. */
+  /** Override the default `/threads/:threadId/...` protocol paths. */
   paths?: ProtocolTransportPaths;
   /**
    * Optional `fetch` override, forwarded to the SSE transport. Useful

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -27,7 +27,7 @@ import { IterableReadableStream } from "./stream.js";
  * Transport adapter that speaks the thread-centric protocol over HTTP
  * commands plus SSE event streams. Bound to a specific `threadId`
  * at construction. Each {@link openEventStream} call opens an independent
- * filtered SSE connection via `POST /v2/threads/:thread_id/stream`.
+ * filtered SSE connection via `POST /threads/:thread_id/stream/events`.
  */
 export class ProtocolSseTransportAdapter implements TransportAdapter {
   readonly threadId: string;
@@ -62,9 +62,9 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
     this.fetchFactory = options.fetchFactory;
     this.threadId = options.threadId;
     this.commandsUrl =
-      options.paths?.commands ?? `/v2/threads/${this.threadId}/commands`;
+      options.paths?.commands ?? `/threads/${this.threadId}/commands`;
     this.streamUrl =
-      options.paths?.stream ?? `/v2/threads/${this.threadId}/stream`;
+      options.paths?.stream ?? `/threads/${this.threadId}/stream/events`;
   }
 
   private async resolveFetch(): Promise<typeof fetch> {

--- a/libs/sdk/src/client/stream/transport/websocket.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.ts
@@ -18,7 +18,7 @@ import type { TransportAdapter } from "../transport.js";
 /**
  * Transport adapter that speaks the thread-centric protocol over a
  * bidirectional WebSocket. Bound to a specific `threadId` — the socket
- * connects to `ws://.../v2/threads/:thread_id/stream`.
+ * connects to `ws://.../threads/:thread_id/stream/events`.
  */
 export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
   readonly threadId: string;
@@ -51,7 +51,7 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
     this.webSocketFactory =
       options.webSocketFactory ?? ((url) => new WebSocket(url));
     this.streamUrl =
-      options.paths?.stream ?? `/v2/threads/${this.threadId}/stream`;
+      options.paths?.stream ?? `/threads/${this.threadId}/stream/events`;
   }
 
   async open(): Promise<void> {


### PR DESCRIPTION
Aligning with latest Python changes updating endpoints to be:

POST /threads/{thread_id}/stream/events — SSE event stream
POST /threads/{thread_id}/commands — JSON command
WS /threads/{thread_id}/stream/events

for new streaming features.