### PR TITLE
fix(sdk): route subagent messages by stream event namespace

### DIFF
--- a/.changeset/bright-subagents-stream.md
+++ b/.changeset/bright-subagents-stream.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+Fix subagent message routing to prefer the stream event namespace over checkpoint metadata when filtering subagent messages.

--- a/libs/sdk/src/ui/manager.test.ts
+++ b/libs/sdk/src/ui/manager.test.ts
@@ -216,6 +216,94 @@ describe("StreamManager", () => {
     });
   });
 
+  describe("subagent message namespace routing", () => {
+    it("prefers the stream event namespace over checkpoint metadata", async () => {
+      const manager = new StreamManager<TestState>(new MessageTupleManager(), {
+        throttle: false,
+        filterSubagentMessages: true,
+        subagentToolNames: ["task"],
+      });
+      const onError = vi.fn();
+
+      const events = [
+        {
+          event: "messages" as const,
+          data: [
+            {
+              id: "ai-1",
+              type: "ai",
+              content: "",
+              tool_calls: [
+                {
+                  id: "call_1",
+                  name: "task",
+                  args: {
+                    subagent_type: "researcher",
+                    description: "Research AI trends",
+                  },
+                },
+              ],
+            },
+            {},
+          ],
+        },
+        {
+          event: "values|tools:stream-task-id" as const,
+          data: {
+            messages: [
+              {
+                id: "sub-human-1",
+                type: "human",
+                content: "Research AI trends",
+              },
+            ],
+          },
+        },
+        {
+          event: "messages|tools:stream-task-id" as const,
+          data: [
+            {
+              id: "sub-ai-1",
+              type: "ai",
+              content: "",
+              tool_calls: [
+                {
+                  id: "search-1",
+                  name: "search_web",
+                  args: { query: "AI trends" },
+                },
+              ],
+            },
+            { checkpoint_ns: "tools:metadata-task-id" },
+          ],
+        },
+      ];
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (manager as any).enqueue(async () => createMockStream(events), {
+        getMessages: (values: TestState) => values.messages ?? [],
+        setMessages: (current: TestState, messages: TestState["messages"]) => ({
+          ...current,
+          messages,
+        }),
+        initialValues: { messages: [] },
+        callbacks: {},
+        onSuccess: () => undefined,
+        onError,
+      });
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(manager.values?.messages).toHaveLength(1);
+      expect(manager.values?.messages[0]?.id).toBe("ai-1");
+
+      const subagent = manager.getSubagentsByMessage("ai-1")[0];
+      expect(subagent).toBeDefined();
+      expect(subagent?.messages).toHaveLength(1);
+      expect(subagent?.toolCalls).toHaveLength(1);
+      expect(subagent?.toolCalls[0]?.call.name).toBe("search_web");
+    });
+  });
+
   describe("tools stream events", () => {
     it("calls onToolEvent when tools event is received", async () => {
       const onToolEvent = vi.fn();

--- a/libs/sdk/src/ui/manager.ts
+++ b/libs/sdk/src/ui/manager.ts
@@ -984,14 +984,19 @@ export class StreamManager<
           const [serialized, metadata] = data;
 
           // Check if this message is from a subagent namespace
+          const eventCheckpointNs =
+            namespace && isSubagentNamespace(namespace) ? namespace : undefined;
           const rawCheckpointNs =
             (metadata?.langgraph_checkpoint_ns as string | undefined) ||
             (metadata?.checkpoint_ns as string | undefined);
-          const checkpointNs: string | undefined =
-            typeof rawCheckpointNs === "string" ? rawCheckpointNs : undefined;
+          const checkpointNs: string[] | undefined =
+            eventCheckpointNs ??
+            (typeof rawCheckpointNs === "string"
+              ? rawCheckpointNs.split("|")
+              : undefined);
           const isFromSubagent = isSubagentNamespace(checkpointNs);
           const toolCallId = isFromSubagent
-            ? extractToolCallIdFromNamespace(checkpointNs?.split("|"))
+            ? extractToolCallIdFromNamespace(checkpointNs)
             : undefined;
 
           // If filtering is enabled and this is a subagent message,


### PR DESCRIPTION
## Summary

Fix `StreamManager` subagent message routing so `messages|...` stream events prefer the SSE event namespace when it identifies a subagent, falling back to `metadata.langgraph_checkpoint_ns` / `metadata.checkpoint_ns` only when there is no subagent event namespace.

This prevents subagent message chunks from being buffered under the wrong namespace when the event name and message metadata disagree.

## Motivation

When streaming DeepAgent subgraphs from a deployed LangGraph server, the stream can contain events shaped like:

```text
event: messages|tools:<stream-task-id>
data: [{...}, { checkpoint_ns: "tools:<metadata-task-id>" }]
```

`updates|tools:<stream-task-id>` and `values|tools:<stream-task-id>` establish the visible subagent using the event namespace, but the `messages` handler currently derives the subagent id from metadata. If the metadata namespace differs, the subagent's internal AI/tool messages are queued under a namespace that never maps to the visible subagent, so `getSubagentsByMessage(...)` returns the subagent without its tool-call history.

The stream event namespace is already parsed and passed to other subagent event handlers, so message events should use it when available.

## Tests

```bash
pnpm --filter @langchain/langgraph-sdk test -- src/ui/manager.test.ts
```

Result: 37 files passed, 512 tests passed, no type errors.
