### PR TITLE
fix(langgraph): source serverInfo ids from configurable first

### DIFF
--- a/.changeset/server-info-configurable.md
+++ b/.changeset/server-info-configurable.md
@@ -1,0 +1,10 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(langgraph): prefer configurable assistant and graph IDs for runtime server info
+
+Update runtime `serverInfo` construction to read `assistant_id` and `graph_id` from
+`config.configurable` first, with fallback to `config.metadata` for compatibility.
+Also expands `execution_info` tests to cover configurable sourcing, precedence,
+and metadata fallback behavior.

--- a/libs/langgraph-core/src/pregel/index.ts
+++ b/libs/langgraph-core/src/pregel/index.ts
@@ -2616,8 +2616,12 @@ function _buildServerInfo(
 ): ServerInfo | undefined {
   const metadata = config.metadata ?? {};
   const configurable = config.configurable ?? {};
-  const assistantId = metadata.assistant_id as string | undefined;
-  const graphId = metadata.graph_id as string | undefined;
+  const assistantId =
+    (configurable.assistant_id as string | undefined) ??
+    (metadata.assistant_id as string | undefined);
+  const graphId =
+    (configurable.graph_id as string | undefined) ??
+    (metadata.graph_id as string | undefined);
 
   const authUserData = configurable.langgraph_auth_user as
     | Record<string, any>

--- a/libs/langgraph-core/src/tests/execution_info.test.ts
+++ b/libs/langgraph-core/src/tests/execution_info.test.ts
@@ -157,7 +157,7 @@ describe("ExecutionInfo", () => {
 });
 
 describe("ServerInfo", () => {
-  it("should build serverInfo from assistant_id/graph_id in config metadata", async () => {
+  it("should build serverInfo from assistant_id/graph_id in config configurable", async () => {
     let captured: ServerInfo | undefined;
 
     const graph = new StateGraph(State)
@@ -171,7 +171,7 @@ describe("ServerInfo", () => {
 
     await graph.invoke(
       { message: "hi" },
-      { metadata: { assistant_id: "asst-abc", graph_id: "my-graph" } }
+      { configurable: { assistant_id: "asst-abc", graph_id: "my-graph" } }
     );
 
     expect(captured).toBeDefined();
@@ -180,7 +180,54 @@ describe("ServerInfo", () => {
     expect(captured!.user).toBeUndefined();
   });
 
-  it("should return undefined serverInfo when no metadata present", async () => {
+  it("should use configurable values when metadata and configurable both provide ids", async () => {
+    let captured: ServerInfo | undefined;
+
+    const graph = new StateGraph(State)
+      .addNode("capture", (_state: any, runtime: Runtime) => {
+        captured = runtime.serverInfo;
+        return { message: "done" };
+      })
+      .addEdge(START, "capture")
+      .addEdge("capture", END)
+      .compile();
+
+    await graph.invoke(
+      { message: "hi" },
+      {
+        configurable: { assistant_id: "asst-config", graph_id: "graph-config" },
+        metadata: { assistant_id: "asst-meta", graph_id: "graph-meta" },
+      }
+    );
+
+    expect(captured).toBeDefined();
+    expect(captured!.assistantId).toBe("asst-config");
+    expect(captured!.graphId).toBe("graph-config");
+  });
+
+  it("should fall back to metadata ids when configurable ids are absent", async () => {
+    let captured: ServerInfo | undefined;
+
+    const graph = new StateGraph(State)
+      .addNode("capture", (_state: any, runtime: Runtime) => {
+        captured = runtime.serverInfo;
+        return { message: "done" };
+      })
+      .addEdge(START, "capture")
+      .addEdge("capture", END)
+      .compile();
+
+    await graph.invoke(
+      { message: "hi" },
+      { metadata: { assistant_id: "asst-meta", graph_id: "graph-meta" } }
+    );
+
+    expect(captured).toBeDefined();
+    expect(captured!.assistantId).toBe("asst-meta");
+    expect(captured!.graphId).toBe("graph-meta");
+  });
+
+  it("should return undefined serverInfo when no ids or auth user are present", async () => {
     let captured: ServerInfo | undefined;
 
     const graph = new StateGraph(State)
@@ -219,8 +266,11 @@ describe("ServerInfo", () => {
     await graph.invoke(
       { message: "hi" },
       {
-        configurable: { langgraph_auth_user: proxyUser },
-        metadata: { assistant_id: "asst-proxy", graph_id: "graph-proxy" },
+        configurable: {
+          langgraph_auth_user: proxyUser,
+          assistant_id: "asst-proxy",
+          graph_id: "graph-proxy",
+        },
       }
     );
 


### PR DESCRIPTION
## Summary

Runtime now prefers `assistant_id` and `graph_id` from `config.configurable`, which aligns with server-provided config, while preserving metadata fallback for compatibility.

## Changes

### `@langchain/langgraph`
- Updated `libs/langgraph-core/src/pregel/index.ts` `_buildServerInfo` to resolve `assistant_id` and `graph_id` from `config.configurable` first, then fall back to `config.metadata`.
- Kept `langgraph_auth_user` sourcing unchanged from `config.configurable`.
- Expanded `libs/langgraph-core/src/tests/execution_info.test.ts` to cover:
  - configurable-based ID sourcing,
  - configurable-over-metadata precedence,
  - metadata fallback behavior,
  - existing auth-user serverInfo behavior with configurable IDs.
