### PR TITLE
fix(sdk): preserve AI content blocks during message projection

### DIFF
--- a/.changeset/two-bobcats-switch.md
+++ b/.changeset/two-bobcats-switch.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): preserve AI content blocks during message projection

--- a/libs/sdk-svelte/src/tests/stream.test.ts
+++ b/libs/sdk-svelte/src/tests/stream.test.ts
@@ -117,6 +117,12 @@ it("make sure to pass metadata to the thread", async () => {
 
 it("handle message removal", async () => {
   const messagesValues = new Set<string>();
+  const keptStep2 = `ai: ${JSON.stringify([
+    { type: "text", text: "Step 2: To Keep" },
+  ])}`;
+  const keptStep3 = `ai: ${JSON.stringify([
+    { type: "text", text: "Step 3: To Keep" },
+  ])}`;
 
   const screen = render(MessageRemoval, {
     apiUrl: serverUrl,
@@ -135,17 +141,15 @@ it("handle message removal", async () => {
     .toHaveTextContent("human: Hello");
   await expect
     .element(screen.getByTestId("message-1"))
-    .toHaveTextContent("ai: Step 2: To Keep");
+    .toHaveTextContent(keptStep2);
   await expect
     .element(screen.getByTestId("message-2"))
-    .toHaveTextContent("ai: Step 3: To Keep");
+    .toHaveTextContent(keptStep3);
 
   const observed = [...messagesValues.values()];
   expect(observed).toContain("");
   const finalState = observed[observed.length - 1];
-  expect(finalState).toBe(
-    ["human: Hello", "ai: Step 2: To Keep", "ai: Step 3: To Keep"].join("\n"),
-  );
+  expect(finalState).toBe(["human: Hello", keptStep2, keptStep3].join("\n"));
   expect(finalState).not.toContain("Step 1: To Remove");
 });
 

--- a/libs/sdk-vue/src/tests/stream.initial-values.test.tsx
+++ b/libs/sdk-vue/src/tests/stream.initial-values.test.tsx
@@ -63,7 +63,9 @@ it("replaces initialValues with server state once a run starts", async () => {
       .toHaveTextContent("Hey");
     await expect
       .element(screen.getByTestId("values"))
-      .toHaveTextContent(/^Fresh request\|Hey/);
+      .toHaveTextContent(
+        `Fresh request|${JSON.stringify([{ type: "text", text: "Hey" }])}`,
+      );
   } finally {
     await screen.unmount();
   }

--- a/libs/sdk/src/client/stream/messages.test.ts
+++ b/libs/sdk/src/client/stream/messages.test.ts
@@ -203,6 +203,77 @@ describe("MessageAssembler", () => {
     expect(finished?.message.blocks[0]).toEqual({ type: "text", text: "Hello" });
   });
 
+  it("keeps reasoning and text deltas separate when they reuse the same protocol index", () => {
+    const assembler = new MessageAssembler();
+
+    assembler.consume(
+      eventOf("messages", { event: "message-start", id: "msg_reason" }, {
+        namespace: [],
+        node: "bot",
+      }) as Extract<Event, { method: "messages" }>
+    );
+    assembler.consume(
+      eventOf(
+        "messages",
+        {
+          event: "content-block-start",
+          index: 0,
+          content: { type: "reasoning", reasoning: "think" },
+        },
+        { namespace: [], node: "bot" }
+      ) as Extract<Event, { method: "messages" }>
+    );
+    assembler.consume(
+      eventOf(
+        "messages",
+        {
+          event: "content-block-delta",
+          index: 0,
+          delta: { type: "reasoning-delta", reasoning: " more" },
+        },
+        { namespace: [], node: "bot" }
+      ) as Extract<Event, { method: "messages" }>
+    );
+    assembler.consume(
+      eventOf(
+        "messages",
+        {
+          event: "content-block-delta",
+          index: 0,
+          delta: { type: "text-delta", text: "answer" },
+        },
+        { namespace: [], node: "bot" }
+      ) as Extract<Event, { method: "messages" }>
+    );
+    assembler.consume(
+      eventOf(
+        "messages",
+        {
+          event: "content-block-delta",
+          index: 0,
+          delta: { type: "text-delta", text: " text" },
+        },
+        { namespace: [], node: "bot" }
+      ) as Extract<Event, { method: "messages" }>
+    );
+    const finishedReasoning = assembler.consume(
+      eventOf(
+        "messages",
+        {
+          event: "content-block-finish",
+          index: 0,
+          content: { type: "reasoning", reasoning: "think more" },
+        },
+        { namespace: [], node: "bot" }
+      ) as Extract<Event, { method: "messages" }>
+    );
+
+    expect(finishedReasoning?.message.blocks).toEqual([
+      { type: "reasoning", reasoning: "think more" },
+      { type: "text", text: "answer text" },
+    ]);
+  });
+
   it("preserves message id when converting assembled messages to BaseMessage", () => {
     const message = assembledMessageToBaseMessage(
       {

--- a/libs/sdk/src/client/stream/messages.test.ts
+++ b/libs/sdk/src/client/stream/messages.test.ts
@@ -217,6 +217,27 @@ describe("MessageAssembler", () => {
     expect(message.text).toBe("Hello");
   });
 
+  it("preserves reasoning blocks when converting assembled AI messages", () => {
+    const message = assembledMessageToBaseMessage(
+      {
+        id: "msg_reasoning",
+        namespace: [],
+        blocks: [
+          { type: "reasoning", reasoning: "Thinking through it." },
+          { type: "text", text: "Final answer." },
+        ],
+      },
+      "ai"
+    );
+
+    expect(message.id).toBe("msg_reasoning");
+    expect(message.text).toBe("Final answer.");
+    expect(message.contentBlocks).toEqual([
+      { type: "reasoning", reasoning: "Thinking through it." },
+      { type: "text", text: "Final answer." },
+    ]);
+  });
+
   it("keeps usage events from terminating message projection", () => {
     const assembler = new MessageAssembler();
 

--- a/libs/sdk/src/client/stream/messages.ts
+++ b/libs/sdk/src/client/stream/messages.ts
@@ -872,7 +872,8 @@ export class MessageAssembler {
   private clearBlockIndexAliases(activeKey: string): void {
     const prefix = `${activeKey}::`;
     for (const key of this.blockIndexByProtocolIndexAndType.keys()) {
-      if (key.startsWith(prefix)) this.blockIndexByProtocolIndexAndType.delete(key);
+      if (key.startsWith(prefix))
+        this.blockIndexByProtocolIndexAndType.delete(key);
     }
   }
 }
@@ -885,7 +886,10 @@ function blockIndexKey(
   return `${activeKey}::${protocolIndex}::${blockType}`;
 }
 
-function areCompatibleBlockTypes(currentType: string, nextType: string): boolean {
+function areCompatibleBlockTypes(
+  currentType: string,
+  nextType: string
+): boolean {
   const toolCallTypes = new Set([
     "tool_call",
     "tool_call_chunk",

--- a/libs/sdk/src/client/stream/messages.ts
+++ b/libs/sdk/src/client/stream/messages.ts
@@ -586,17 +586,6 @@ function cloneBlock<T extends ContentBlock>(block: T): T {
   return structuredClone(block);
 }
 
-function ensureBlockIndex(
-  blocks: ContentBlock[],
-  index: number,
-  fallback: ContentBlock
-): ContentBlock {
-  while (blocks.length <= index) {
-    blocks.push(cloneBlock(fallback));
-  }
-  return blocks[index] ?? (blocks[index] = cloneBlock(fallback));
-}
-
 function blockFromDelta(
   delta: CoreContentBlockDelta,
   current?: ContentBlock
@@ -678,6 +667,7 @@ function toChatModelStreamEvent(event: MessagesEvent): ChatModelStreamEvent {
 export class MessageAssembler {
   private readonly activeMessages = new Map<string, AssembledMessage>();
   private readonly activeByNamespaceNode = new Map<string, string>();
+  private readonly blockIndexByProtocolIndexAndType = new Map<string, number>();
 
   /**
    * Applies a single message event and returns the resulting assembly update.
@@ -740,6 +730,10 @@ export class MessageAssembler {
     switch (data.event) {
       case "content-block-start": {
         message.blocks[data.index] = cloneBlock(data.content);
+        this.blockIndexByProtocolIndexAndType.set(
+          blockIndexKey(activeKey, data.index, data.content.type),
+          data.index
+        );
         return {
           kind: "content-block-start",
           key: activeKey,
@@ -762,16 +756,20 @@ export class MessageAssembler {
         if (deltaBlock == null) {
           throw new Error("Received content-block-delta without content");
         }
-        const current = ensureBlockIndex(
+        const targetIndex = this.resolveBlockIndex(
+          activeKey,
           message.blocks,
           data.index,
-          deltaBlock
+          deltaBlock.type
         );
-        message.blocks[data.index] =
+        const current = message.blocks[targetIndex];
+        message.blocks[targetIndex] =
           deltaEvent.content != null
-            ? applyContentDelta(current, deltaEvent.content)
+            ? current == null
+              ? cloneBlock(deltaEvent.content)
+              : applyContentDelta(current, deltaEvent.content)
             : (applyCoreEventDelta(
-                current as unknown as CoreContentBlock,
+                current as CoreContentBlock | undefined,
                 data as unknown as Extract<
                   ChatModelStreamEvent,
                   { event: "content-block-delta" }
@@ -781,18 +779,23 @@ export class MessageAssembler {
           kind: "content-block-delta",
           key: activeKey,
           message,
-          index: data.index,
+          index: targetIndex,
           block: deltaBlock,
           event,
         };
       }
       case "content-block-finish": {
-        message.blocks[data.index] = cloneBlock(data.content);
+        const targetIndex = this.resolveFinishBlockIndex(
+          activeKey,
+          data.index,
+          data.content.type
+        );
+        message.blocks[targetIndex] = cloneBlock(data.content);
         return {
           kind: "content-block-finish",
           key: activeKey,
           message,
-          index: data.index,
+          index: targetIndex,
           block: data.content,
           event,
         };
@@ -802,6 +805,7 @@ export class MessageAssembler {
         message.finishMetadata = data.responseMetadata;
         this.activeMessages.delete(activeKey);
         this.activeByNamespaceNode.delete(namespaceNodeKey);
+        this.clearBlockIndexAliases(activeKey);
         return {
           kind: "message-finish",
           key: activeKey,
@@ -813,6 +817,7 @@ export class MessageAssembler {
         message.error = { message: data.message, code: data.code };
         this.activeMessages.delete(activeKey);
         this.activeByNamespaceNode.delete(namespaceNodeKey);
+        this.clearBlockIndexAliases(activeKey);
         return {
           kind: "message-error",
           key: activeKey,
@@ -822,6 +827,80 @@ export class MessageAssembler {
       }
     }
   }
+
+  private resolveBlockIndex(
+    activeKey: string,
+    blocks: ContentBlock[],
+    protocolIndex: number,
+    blockType: string
+  ): number {
+    const current = blocks[protocolIndex];
+    if (
+      current == null ||
+      current.type === blockType ||
+      areCompatibleBlockTypes(current.type, blockType)
+    ) {
+      this.blockIndexByProtocolIndexAndType.set(
+        blockIndexKey(activeKey, protocolIndex, blockType),
+        protocolIndex
+      );
+      return protocolIndex;
+    }
+
+    const key = blockIndexKey(activeKey, protocolIndex, blockType);
+    const existing = this.blockIndexByProtocolIndexAndType.get(key);
+    if (existing != null) return existing;
+
+    const nextIndex = blocks.length;
+    this.blockIndexByProtocolIndexAndType.set(key, nextIndex);
+    return nextIndex;
+  }
+
+  private resolveFinishBlockIndex(
+    activeKey: string,
+    protocolIndex: number,
+    blockType: string
+  ): number {
+    const key = blockIndexKey(activeKey, protocolIndex, blockType);
+    const existing = this.blockIndexByProtocolIndexAndType.get(key);
+    if (existing != null) return existing;
+
+    this.blockIndexByProtocolIndexAndType.set(key, protocolIndex);
+    return protocolIndex;
+  }
+
+  private clearBlockIndexAliases(activeKey: string): void {
+    const prefix = `${activeKey}::`;
+    for (const key of this.blockIndexByProtocolIndexAndType.keys()) {
+      if (key.startsWith(prefix)) this.blockIndexByProtocolIndexAndType.delete(key);
+    }
+  }
+}
+
+function blockIndexKey(
+  activeKey: string,
+  protocolIndex: number,
+  blockType: string
+): string {
+  return `${activeKey}::${protocolIndex}::${blockType}`;
+}
+
+function areCompatibleBlockTypes(currentType: string, nextType: string): boolean {
+  const toolCallTypes = new Set([
+    "tool_call",
+    "tool_call_chunk",
+    "tool_use",
+    "input_json_delta",
+  ]);
+  const serverToolCallTypes = new Set([
+    "server_tool_call",
+    "server_tool_call_chunk",
+  ]);
+
+  return (
+    (toolCallTypes.has(currentType) && toolCallTypes.has(nextType)) ||
+    (serverToolCallTypes.has(currentType) && serverToolCallTypes.has(nextType))
+  );
 }
 
 /**

--- a/libs/sdk/src/stream/assembled-to-message.ts
+++ b/libs/sdk/src/stream/assembled-to-message.ts
@@ -105,8 +105,8 @@ export function assembledToBaseMessage(
       };
       return toolCallChunks.length > 0
         ? new AIMessageChunk(
-          payload as ConstructorParameters<typeof AIMessageChunk>[0]
-        )
+            payload as ConstructorParameters<typeof AIMessageChunk>[0]
+          )
         : new AIMessage(payload as ConstructorParameters<typeof AIMessage>[0]);
     }
   }

--- a/libs/sdk/src/stream/assembled-to-message.ts
+++ b/libs/sdk/src/stream/assembled-to-message.ts
@@ -52,7 +52,7 @@ export function assembledToBaseMessage(
   input: AssembledToMessageInput
 ): BaseMessage {
   const { id, role, blocks, toolCallId, usage } = input;
-  const content = extractContentString(blocks);
+  const textContent = extractContentString(blocks);
   const toolCalls = extractToolCalls(blocks);
   const toolCallChunks = extractToolCallChunks(blocks);
   const additionalKwargs =
@@ -62,7 +62,7 @@ export function assembledToBaseMessage(
     case "human":
       return new HumanMessage({
         ...(id != null ? { id } : {}),
-        content,
+        content: textContent,
         ...(additionalKwargs != null
           ? { additional_kwargs: additionalKwargs }
           : {}),
@@ -70,7 +70,7 @@ export function assembledToBaseMessage(
     case "system":
       return new SystemMessage({
         ...(id != null ? { id } : {}),
-        content,
+        content: textContent,
         ...(additionalKwargs != null
           ? { additional_kwargs: additionalKwargs }
           : {}),
@@ -78,7 +78,7 @@ export function assembledToBaseMessage(
     case "tool":
       return new ToolMessage({
         ...(id != null ? { id } : {}),
-        content,
+        content: textContent,
         tool_call_id: toolCallId ?? "",
       });
     case "ai":
@@ -93,7 +93,7 @@ export function assembledToBaseMessage(
       // with `BaseMessage` and round-trips through the merge logic.
       const payload = {
         ...(id != null ? { id } : {}),
-        content,
+        content: cloneContentBlocks(blocks),
         ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
         ...(toolCallChunks.length > 0
           ? { tool_call_chunks: toolCallChunks }
@@ -101,10 +101,13 @@ export function assembledToBaseMessage(
         ...(additionalKwargs != null
           ? { additional_kwargs: additionalKwargs }
           : {}),
+        response_metadata: { output_version: "v1" as const },
       };
       return toolCallChunks.length > 0
-        ? new AIMessageChunk(payload)
-        : new AIMessage(payload);
+        ? new AIMessageChunk(
+          payload as ConstructorParameters<typeof AIMessageChunk>[0]
+        )
+        : new AIMessage(payload as ConstructorParameters<typeof AIMessage>[0]);
     }
   }
 }
@@ -140,6 +143,10 @@ function extractContentString(blocks: ContentBlock[]): string {
     }
   }
   return out;
+}
+
+function cloneContentBlocks(blocks: ContentBlock[]): ContentBlock[] {
+  return blocks.map((block) => structuredClone(block));
 }
 
 interface LooseToolCall {

--- a/libs/sdk/src/stream/message-reconciliation.ts
+++ b/libs/sdk/src/stream/message-reconciliation.ts
@@ -138,9 +138,36 @@ export function shouldPreferValuesMessageForToolCalls(
       .map((toolCall) => toolCall.id)
       .filter((id): id is string => typeof id === "string" && id.length > 0)
   );
-  return valuesToolCalls.some((toolCall) => {
-    return typeof toolCall.id === "string" && !streamedIds.has(toolCall.id);
+  if (
+    valuesToolCalls.some((toolCall) => {
+      return typeof toolCall.id === "string" && !streamedIds.has(toolCall.id);
+    })
+  ) {
+    return true;
+  }
+
+  // Values snapshots carry the finalized tool-call args. Prefer them only when
+  // they add meaningful data, so empty placeholder args do not replace an
+  // otherwise useful streamed message.
+  return valuesToolCalls.some((valuesToolCall) => {
+    const streamedToolCall = streamedToolCalls.find(
+      (candidate) =>
+        typeof valuesToolCall.id === "string" &&
+        candidate.id === valuesToolCall.id
+    );
+    return (
+      streamedToolCall != null &&
+      hasMeaningfulArgs(valuesToolCall.args) &&
+      !jsonishEqual(valuesToolCall.args, streamedToolCall.args)
+    );
   });
+}
+
+function hasMeaningfulArgs(args: unknown): boolean {
+  if (args == null) return false;
+  if (typeof args === "string") return args.length > 0;
+  if (typeof args === "object") return Object.keys(args).length > 0;
+  return true;
 }
 
 export function messagesEqualList(
@@ -201,11 +228,11 @@ function normalizedMessageId(message: BaseMessage): string | undefined {
 
 function getMessageToolCalls(
   message: BaseMessage
-): Array<{ id?: string; name?: string }> {
+): Array<{ id?: string; name?: string; args?: unknown }> {
   const raw = (message as unknown as { tool_calls?: unknown }).tool_calls;
   if (!Array.isArray(raw)) return [];
   return raw.filter(
-    (toolCall): toolCall is { id?: string; name?: string } =>
+    (toolCall): toolCall is { id?: string; name?: string; args?: unknown } =>
       toolCall != null && typeof toolCall === "object"
   );
 }

--- a/libs/sdk/src/stream/root-message-projection.test.ts
+++ b/libs/sdk/src/stream/root-message-projection.test.ts
@@ -192,13 +192,15 @@ function summarizeContent(content: unknown): unknown {
     return content.map((block) => {
       if (block == null || typeof block !== "object") return block;
       const record = block as Record<string, unknown>;
-      return {
+      const summary: Record<string, unknown> = {
         type: record.type,
         id: record.id,
         name: record.name,
         args: record.args,
         text: record.text,
       };
+      if ("reasoning" in record) summary.reasoning = record.reasoning;
+      return summary;
     });
   }
   return content;
@@ -238,7 +240,7 @@ describe("RootMessageProjection", () => {
       const snap = store.getSnapshot();
       expect(snap.messages).toHaveLength(1);
       expect(snap.messages[0].id).toBe("m1");
-      expect(snap.messages[0].content).toBe("Hi there");
+      expect(snap.messages[0].text).toBe("Hi there");
     });
 
     it("updates the same message index in place across deltas", () => {
@@ -253,7 +255,7 @@ describe("RootMessageProjection", () => {
       const after2 = store.getSnapshot().messages;
 
       expect(after2).toHaveLength(1);
-      expect(after2[0].content).toBe("ab");
+      expect(after2[0].text).toBe("ab");
       // The array is replaced so React's identity check fires.
       expect(after2).not.toBe(after1);
     });
@@ -272,7 +274,7 @@ describe("RootMessageProjection", () => {
 
       const snap = store.getSnapshot();
       expect(snap.messages).toHaveLength(1);
-      expect(snap.messages[0].content).toBe("Hi there");
+      expect(snap.messages[0].text).toBe("Hi there");
     });
 
     it("mirrors messages into values[messagesKey]", () => {
@@ -433,7 +435,7 @@ describe("RootMessageProjection", () => {
       expect(snap.messages).toHaveLength(2);
       expect(snap.messages[0]).toBe(human);
       // Streamed AIMessage retained for its in-flight content.
-      expect(snap.messages[1].content).toBe("streamed");
+      expect(snap.messages[1].text).toBe("streamed");
     });
 
     it("prefers the values version when it carries finalized tool-call data the stream lacks", () => {
@@ -555,7 +557,12 @@ describe("RootMessageProjection", () => {
             "type": "tool",
           },
           {
-            "content": "The result is **80,235**.
+            "content": [
+              {
+                "args": undefined,
+                "id": undefined,
+                "name": undefined,
+                "text": "The result is **80,235**.
 
         ## When You'd Use This in Code
 
@@ -577,7 +584,100 @@ describe("RootMessageProjection", () => {
         \`\`\`
 
         This makes it reusable and dynamic based on real data from users, databases, or APIs.",
+                "type": "text",
+              },
+            ],
             "id": "msg_01M6YsZj7Wn3ivDWCFZFrmt7",
+            "status": undefined,
+            "tool_call_id": undefined,
+            "tool_calls": [],
+            "type": "ai",
+          },
+        ]
+      `);
+    });
+
+    it("replays the reasoning token stream fixture without collapsing reasoning blocks", () => {
+      const events = parseSseFixture(
+        new URL("../tests/fixtures/reasoning-token-events.sse", import.meta.url)
+      );
+      const textDeltaSnapshot = replayRootProjection(
+        events.filter((event) => event.seq != null && event.seq <= 201)
+      );
+      const textDeltaAiMessage = textDeltaSnapshot.messages.find(
+        AIMessage.isInstance
+      );
+
+      expect(summarizeMessage(textDeltaAiMessage!)).toMatchInlineSnapshot(`
+        {
+          "content": [
+            {
+              "args": undefined,
+              "id": undefined,
+              "name": undefined,
+              "text": "Two quick mental approaches:
+
+        ",
+              "type": "text",
+            },
+            {
+              "args": undefined,
+              "id": undefined,
+              "name": undefined,
+              "reasoning": "**Estimating multiplication methods**
+
+        To",
+              "text": undefined,
+              "type": "reasoning",
+            },
+          ],
+          "id": "run-019e15fb-934e-7029-94f8-87176a5ffc6a",
+          "status": undefined,
+          "tool_call_id": undefined,
+          "tool_calls": [],
+          "type": "ai",
+        }
+      `);
+
+      const snapshot = replayRootProjection(events);
+
+      expect(snapshot.messages).toHaveLength(2);
+      expect(snapshot.messages.map(summarizeMessage)).toMatchInlineSnapshot(`
+        [
+          {
+            "content": "Walk me through how you would estimate 17 × 24 mentally, then give the final number.",
+            "id": "766e0564-a666-4fc9-8e78-e00a476eb9cd",
+            "status": undefined,
+            "tool_call_id": undefined,
+            "tool_calls": undefined,
+            "type": "human",
+          },
+          {
+            "content": [
+              {
+                "args": undefined,
+                "id": undefined,
+                "name": undefined,
+                "reasoning": "**Estimating multiplication mentally**
+
+        The user wants to estimate 17 × 24 and then provide the final answer. I’ll start by showing techniques like rounding: I could round 17 to 20 and 24 to 25 to initially estimate 20 × 25, which equals 500, then adjust that down. 
+
+        Using the distributive property, I could express it as 17 × (20 + 4), leading to 340 + 68, giving the actual final answer of 408. So, I’ll clearly walk through those two methods!",
+                "text": undefined,
+                "type": "reasoning",
+              },
+              {
+                "args": undefined,
+                "id": undefined,
+                "name": undefined,
+                "reasoning": "**Estimating multiplication methods**
+
+        To estimate 17 × 24, I can round 17 to 20, which gives 20 × 24 = 480—an overestimate. Alternatively, rounding 24 to 25 gives 17 × 25 = 425, which is close; if I subtract 17 from that, it leads me to 408. I could also round both numbers together, resulting in 20 × 25 = 500, but that's even bigger. So, using the distributive property, the final answer is 408. I'll keep this clear and concise!",
+                "text": undefined,
+                "type": "reasoning",
+              },
+            ],
+            "id": "run-019e15fb-934e-7029-94f8-87176a5ffc6a",
             "status": undefined,
             "tool_call_id": undefined,
             "tool_calls": [],
@@ -664,7 +764,7 @@ describe("RootMessageProjection", () => {
       expect(snap.messages).toHaveLength(2);
       expect(snap.messages[0]).toBe(human);
       expect(snap.messages[1].id).toBe("a1");
-      expect(String(snap.messages[1].content)).toContain("more");
+      expect(snap.messages[1].text).toContain("more");
     });
   });
 

--- a/libs/sdk/src/stream/root-message-projection.test.ts
+++ b/libs/sdk/src/stream/root-message-projection.test.ts
@@ -615,10 +615,11 @@ describe("RootMessageProjection", () => {
               "args": undefined,
               "id": undefined,
               "name": undefined,
-              "text": "Two quick mental approaches:
+              "reasoning": "**Estimating multiplication mentally**
 
-        ",
-              "type": "text",
+        The user",
+              "text": undefined,
+              "type": "reasoning",
             },
             {
               "args": undefined,
@@ -629,6 +630,15 @@ describe("RootMessageProjection", () => {
         To",
               "text": undefined,
               "type": "reasoning",
+            },
+            {
+              "args": undefined,
+              "id": undefined,
+              "name": undefined,
+              "text": "Two quick mental approaches:
+
+        ",
+              "type": "text",
             },
           ],
           "id": "run-019e15fb-934e-7029-94f8-87176a5ffc6a",
@@ -675,6 +685,15 @@ describe("RootMessageProjection", () => {
         To estimate 17 × 24, I can round 17 to 20, which gives 20 × 24 = 480—an overestimate. Alternatively, rounding 24 to 25 gives 17 × 25 = 425, which is close; if I subtract 17 from that, it leads me to 408. I could also round both numbers together, resulting in 20 × 25 = 500, but that's even bigger. So, using the distributive property, the final answer is 408. I'll keep this clear and concise!",
                 "text": undefined,
                 "type": "reasoning",
+              },
+              {
+                "args": undefined,
+                "id": undefined,
+                "name": undefined,
+                "text": "Two quick mental approaches:
+
+        ",
+                "type": "text",
               },
             ],
             "id": "run-019e15fb-934e-7029-94f8-87176a5ffc6a",

--- a/libs/sdk/src/tests/fixtures/reasoning-token-events.sse
+++ b/libs/sdk/src/tests/fixtures/reasoning-token-events.sse
@@ -1,0 +1,63 @@
+event: lifecycle
+data: {"type":"event","event_id":"1","seq":1,"method":"lifecycle","params":{"namespace":[],"timestamp":1778485269262,"data":{"event":"running","graph_name":"reasoning"}}}
+id: 1
+
+event: values
+data: {"type":"event","event_id":"3","seq":3,"method":"values","params":{"namespace":[],"timestamp":1778485269330,"data":{"messages":[{"type":"human","content":"Walk me through how you would estimate 17 × 24 mentally, then give the final number.","id":"766e0564-a666-4fc9-8e78-e00a476eb9cd"}]}}}
+id: 3
+
+event: lifecycle
+data: {"type":"event","event_id":"5","seq":5,"method":"lifecycle","params":{"namespace":["model_request:d39b63be-39c2-56bf-b6df-42f99c534457"],"timestamp":1778485271449,"data":{"event":"started","graph_name":"model_request"}}}
+id: 5
+
+event: messages
+data: {"type":"event","event_id":"6","seq":6,"method":"messages","params":{"namespace":["model_request:d39b63be-39c2-56bf-b6df-42f99c534457"],"timestamp":1778485271450,"data":{"event":"message-start","id":"run-019e15fb-934e-7029-94f8-87176a5ffc6a","run_id":"019e15fb-934e-7029-94f8-87176a5ffc6a"}}}
+id: 6
+
+event: messages
+data: {"type":"event","event_id":"7","seq":7,"method":"messages","params":{"namespace":["model_request:d39b63be-39c2-56bf-b6df-42f99c534457"],"timestamp":1778485274743,"data":{"event":"content-block-start","index":0,"content":{"type":"reasoning","reasoning":"**Estimating multiplication mentally**\n\nThe","index":0},"run_id":"019e15fb-934e-7029-94f8-87176a5ffc6a"}}}
+id: 7
+
+event: messages
+data: {"type":"event","event_id":"8","seq":8,"method":"messages","params":{"namespace":["model_request:d39b63be-39c2-56bf-b6df-42f99c534457"],"timestamp":1778485274875,"data":{"event":"content-block-delta","index":0,"delta":{"type":"reasoning-delta","reasoning":" user"},"run_id":"019e15fb-934e-7029-94f8-87176a5ffc6a"}}}
+id: 8
+
+event: messages
+data: {"type":"event","event_id":"100","seq":100,"method":"messages","params":{"namespace":["model_request:d39b63be-39c2-56bf-b6df-42f99c534457"],"timestamp":1778485278393,"data":{"event":"content-block-start","index":1,"content":{"type":"reasoning","reasoning":"**Estimating multiplication methods**\n\nTo","index":1},"run_id":"019e15fb-934e-7029-94f8-87176a5ffc6a"}}}
+id: 100
+
+event: messages
+data: {"type":"event","event_id":"197","seq":197,"method":"messages","params":{"namespace":["model_request:d39b63be-39c2-56bf-b6df-42f99c534457"],"timestamp":1778485281835,"data":{"event":"content-block-delta","index":0,"delta":{"type":"text-delta","text":"Two"},"run_id":"019e15fb-934e-7029-94f8-87176a5ffc6a"}}}
+id: 197
+
+event: messages
+data: {"type":"event","event_id":"198","seq":198,"method":"messages","params":{"namespace":["model_request:d39b63be-39c2-56bf-b6df-42f99c534457"],"timestamp":1778485281837,"data":{"event":"content-block-delta","index":0,"delta":{"type":"text-delta","text":" quick"},"run_id":"019e15fb-934e-7029-94f8-87176a5ffc6a"}}}
+id: 198
+
+event: messages
+data: {"type":"event","event_id":"199","seq":199,"method":"messages","params":{"namespace":["model_request:d39b63be-39c2-56bf-b6df-42f99c534457"],"timestamp":1778485281850,"data":{"event":"content-block-delta","index":0,"delta":{"type":"text-delta","text":" mental"},"run_id":"019e15fb-934e-7029-94f8-87176a5ffc6a"}}}
+id: 199
+
+event: messages
+data: {"type":"event","event_id":"200","seq":200,"method":"messages","params":{"namespace":["model_request:d39b63be-39c2-56bf-b6df-42f99c534457"],"timestamp":1778485281851,"data":{"event":"content-block-delta","index":0,"delta":{"type":"text-delta","text":" approaches"},"run_id":"019e15fb-934e-7029-94f8-87176a5ffc6a"}}}
+id: 200
+
+event: messages
+data: {"type":"event","event_id":"201","seq":201,"method":"messages","params":{"namespace":["model_request:d39b63be-39c2-56bf-b6df-42f99c534457"],"timestamp":1778485281852,"data":{"event":"content-block-delta","index":0,"delta":{"type":"text-delta","text":":\n\n"},"run_id":"019e15fb-934e-7029-94f8-87176a5ffc6a"}}}
+id: 201
+
+event: messages
+data: {"type":"event","event_id":"323","seq":323,"method":"messages","params":{"namespace":["model_request:d39b63be-39c2-56bf-b6df-42f99c534457"],"timestamp":1778485285649,"data":{"event":"content-block-finish","index":0,"content":{"type":"reasoning","reasoning":"**Estimating multiplication mentally**\n\nThe user wants to estimate 17 × 24 and then provide the final answer. I’ll start by showing techniques like rounding: I could round 17 to 20 and 24 to 25 to initially estimate 20 × 25, which equals 500, then adjust that down. \n\nUsing the distributive property, I could express it as 17 × (20 + 4), leading to 340 + 68, giving the actual final answer of 408. So, I’ll clearly walk through those two methods!","index":0},"run_id":"019e15fb-934e-7029-94f8-87176a5ffc6a"}}}
+id: 323
+
+event: messages
+data: {"type":"event","event_id":"324","seq":324,"method":"messages","params":{"namespace":["model_request:d39b63be-39c2-56bf-b6df-42f99c534457"],"timestamp":1778485285650,"data":{"event":"content-block-finish","index":1,"content":{"type":"reasoning","reasoning":"**Estimating multiplication methods**\n\nTo estimate 17 × 24, I can round 17 to 20, which gives 20 × 24 = 480—an overestimate. Alternatively, rounding 24 to 25 gives 17 × 25 = 425, which is close; if I subtract 17 from that, it leads me to 408. I could also round both numbers together, resulting in 20 × 25 = 500, but that's even bigger. So, using the distributive property, the final answer is 408. I'll keep this clear and concise!","index":1},"run_id":"019e15fb-934e-7029-94f8-87176a5ffc6a"}}}
+id: 324
+
+event: messages
+data: {"type":"event","event_id":"325","seq":325,"method":"messages","params":{"namespace":["model_request:d39b63be-39c2-56bf-b6df-42f99c534457"],"timestamp":1778485285651,"data":{"event":"message-finish","reason":"stop","usage":{"input_tokens":26,"output_tokens":536,"total_tokens":562,"input_token_details":{"cache_read":0},"output_token_details":{"reasoning":384}},"run_id":"019e15fb-934e-7029-94f8-87176a5ffc6a"}}}
+id: 325
+
+event: values
+data: {"type":"event","event_id":"330","seq":330,"method":"values","params":{"namespace":[],"timestamp":1778485285651,"data":{"messages":[{"type":"human","content":"Walk me through how you would estimate 17 × 24 mentally, then give the final number.","id":"766e0564-a666-4fc9-8e78-e00a476eb9cd"},{"type":"ai","content":[{"type":"reasoning","reasoning":"**Estimating multiplication mentally**\n\nThe user wants to estimate 17 × 24 and then provide the final answer. I’ll start by showing techniques like rounding: I could round 17 to 20 and 24 to 25 to initially estimate 20 × 25, which equals 500, then adjust that down. \n\nUsing the distributive property, I could express it as 17 × (20 + 4), leading to 340 + 68, giving the actual final answer of 408. So, I’ll clearly walk through those two methods!","index":0},{"type":"reasoning","reasoning":"**Estimating multiplication methods**\n\nTo estimate 17 × 24, I can round 17 to 20, which gives 20 × 24 = 480—an overestimate. Alternatively, rounding 24 to 25 gives 17 × 25 = 425, which is close; if I subtract 17 from that, it leads me to 408. I could also round both numbers together, resulting in 20 × 25 = 500, but that's even bigger. So, using the distributive property, the final answer is 408. I'll keep this clear and concise!","index":1}],"id":"run-019e15fb-934e-7029-94f8-87176a5ffc6a","name":"model"}]}}}
+id: 330


### PR DESCRIPTION
While testing out more streaming examples, discovered some minor bugs around reasoning. This patch:

- Preserve structured AI message content blocks when converting assembled stream messages, so reasoning blocks are not collapsed into plain text.
- Update message reconciliation to prefer finalized `values.messages` tool-call args when they contain meaningful data missing from the streamed message.
- Add coverage for mixed reasoning/text content blocks using the reasoning token stream fixture.
