### PR TITLE
fix(sdk): re-encode finalized tool_call blocks as chunks during streaming

### DIFF
--- a/libs/sdk/src/stream/assembled-to-message.test.ts
+++ b/libs/sdk/src/stream/assembled-to-message.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from "vitest";
+import { AIMessage, AIMessageChunk } from "@langchain/core/messages";
+import type { ContentBlock } from "@langchain/protocol";
+import { assembledToBaseMessage } from "./assembled-to-message.js";
+
+describe("assembledToBaseMessage — tool_call / tool_call_chunk handling", () => {
+  // These tests pin the WORKAROUND for langchain-core's
+  // ``AIMessageChunk`` constructor, which discards caller-supplied
+  // ``tool_calls`` and rebuilds them from ``tool_call_chunks`` via
+  // ``collapseToolCallChunks``. Without re-encoding finalized tool_call
+  // blocks as chunks, parallel-tool-call UIs render incrementally
+  // wrong (only the streaming call is visible, finished ones disappear
+  // until message-finish).
+
+  it("pure-chunks: forwards tool_call_chunk blocks unmodified", () => {
+    const blocks: ContentBlock[] = [
+      {
+        type: "tool_call_chunk",
+        id: "a",
+        name: "search",
+        args: '{"q":',
+        index: 0,
+      } as ContentBlock,
+    ];
+    const msg = assembledToBaseMessage({
+      role: "ai",
+      blocks,
+    }) as AIMessageChunk;
+    expect(msg).toBeInstanceOf(AIMessageChunk);
+    expect(msg.tool_call_chunks).toHaveLength(1);
+    expect(msg.tool_call_chunks?.[0]).toMatchObject({
+      id: "a",
+      name: "search",
+      args: '{"q":',
+    });
+  });
+
+  it("pure-finalized: emits AIMessageChunk with re-encoded chunks and intact args", () => {
+    const blocks: ContentBlock[] = [
+      {
+        type: "tool_call",
+        id: "a",
+        name: "search",
+        args: { q: "weather" },
+      } as ContentBlock,
+    ];
+    const msg = assembledToBaseMessage({
+      role: "ai",
+      blocks,
+    }) as AIMessageChunk;
+    // Re-encoded chunk forces AIMessageChunk path.
+    expect(msg).toBeInstanceOf(AIMessageChunk);
+    expect(msg.tool_calls).toHaveLength(1);
+    expect(msg.tool_calls?.[0]).toMatchObject({
+      id: "a",
+      name: "search",
+      args: { q: "weather" },
+    });
+  });
+
+  it("mixed finalized+streaming: complete tool_calls survives constructor's collapse", () => {
+    // The bug scenario: block A is fully done (tool_call), block B is
+    // still streaming (tool_call_chunk). Without re-encoding A as a
+    // chunk, A.tool_calls would be dropped by AIMessageChunk and the
+    // UI loses the finished card mid-stream.
+    const blocks: ContentBlock[] = [
+      {
+        type: "tool_call",
+        id: "A",
+        name: "search",
+        args: { q: "weather" },
+      } as ContentBlock,
+      {
+        type: "tool_call_chunk",
+        id: "B",
+        name: "search",
+        args: '{"q":"',
+        index: 1,
+      } as ContentBlock,
+    ];
+    const msg = assembledToBaseMessage({
+      role: "ai",
+      blocks,
+    }) as AIMessageChunk;
+    expect(msg).toBeInstanceOf(AIMessageChunk);
+    expect(msg.tool_call_chunks).toHaveLength(2);
+    // The completed call (A) must be visible on tool_calls during the
+    // stream, with args intact — that's the regression this PR fixes.
+    // ``parsePartialJson`` may also surface the streaming call (B) as
+    // a partial tool_call with degraded args; we only pin behavior for
+    // the finished one to keep the test resilient to upstream
+    // partial-parse changes.
+    const finishedCalls = msg.tool_calls ?? [];
+    const callA = finishedCalls.find((tc) => tc.id === "A");
+    expect(callA).toMatchObject({
+      id: "A",
+      name: "search",
+      args: { q: "weather" },
+    });
+  });
+
+  it("four-parallel finalized: every completed call appears on tool_calls", () => {
+    // Matches the original symptom: "only one Subagent Task card during
+    // streaming, then four at the end".
+    const blocks: ContentBlock[] = [0, 1, 2, 3].map(
+      (i) =>
+        ({
+          type: "tool_call",
+          id: `tc-${i}`,
+          name: "task",
+          args: { description: `subtask ${i}` },
+        }) as ContentBlock
+    );
+    const msg = assembledToBaseMessage({
+      role: "ai",
+      blocks,
+    }) as AIMessageChunk;
+    expect(msg.tool_calls).toHaveLength(4);
+    expect(msg.tool_calls?.map((tc) => tc.id)).toEqual([
+      "tc-0",
+      "tc-1",
+      "tc-2",
+      "tc-3",
+    ]);
+  });
+
+  it("no tool blocks: emits AIMessage (not AIMessageChunk)", () => {
+    const blocks: ContentBlock[] = [
+      { type: "text", text: "hi" } as ContentBlock,
+    ];
+    const msg = assembledToBaseMessage({
+      role: "ai",
+      blocks,
+    }) as AIMessageChunk;
+    expect(msg).toBeInstanceOf(AIMessage);
+    expect(msg).not.toBeInstanceOf(AIMessageChunk);
+  });
+
+  it("args=string (pre-stringified) is forwarded without double-encoding", () => {
+    const blocks: ContentBlock[] = [
+      {
+        type: "tool_call",
+        id: "a",
+        name: "t",
+        args: '{"q":"x"}' as unknown as Record<string, unknown>,
+      } as ContentBlock,
+    ];
+    const msg = assembledToBaseMessage({
+      role: "ai",
+      blocks,
+    }) as AIMessageChunk;
+    expect(msg.tool_calls?.[0]).toMatchObject({ id: "a", args: { q: "x" } });
+  });
+
+  it("cyclic args: warns and surfaces an invalid_tool_call instead of throwing", () => {
+    const cyclic: Record<string, unknown> = { k: 1 };
+    cyclic.self = cyclic;
+    const blocks: ContentBlock[] = [
+      {
+        type: "tool_call",
+        id: "bad",
+        name: "t",
+        args: cyclic,
+      } as ContentBlock,
+    ];
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const msg = assembledToBaseMessage({
+      role: "ai",
+      blocks,
+    }) as AIMessageChunk;
+    try {
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn.mock.calls[0]?.[0]).toMatch(/failed to JSON-stringify/);
+      // Cyclic args degrade to "" — parsePartialJson treats "" as "{}",
+      // so the call surfaces with empty args (still better than blowing
+      // up the stream).
+      const allCalls = [
+        ...(msg.tool_calls ?? []),
+        ...(msg.invalid_tool_calls ?? []),
+      ];
+      expect(allCalls.find((c) => c.id === "bad")).toBeDefined();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/libs/sdk/src/stream/assembled-to-message.ts
+++ b/libs/sdk/src/stream/assembled-to-message.ts
@@ -189,20 +189,55 @@ interface LooseToolCallChunk {
 function extractToolCallChunks(blocks: ContentBlock[]): LooseToolCallChunk[] {
   const out: LooseToolCallChunk[] = [];
   for (const block of blocks) {
-    if (block.type !== "tool_call_chunk") continue;
-    const tc = block as {
-      id?: string;
-      name?: string;
-      args?: string;
-      index?: number;
-    };
-    out.push({
-      id: tc.id,
-      name: tc.name,
-      args: tc.args,
-      index: tc.index,
-      type: "tool_call_chunk",
-    });
+    if (block.type === "tool_call_chunk") {
+      const tc = block as {
+        id?: string;
+        name?: string;
+        args?: string;
+        index?: number;
+      };
+      out.push({
+        id: tc.id,
+        name: tc.name,
+        args: tc.args,
+        index: tc.index,
+        type: "tool_call_chunk",
+      });
+      continue;
+    }
+    if (block.type === "tool_call") {
+      // Re-encode finalized ``tool_call`` blocks as chunks. When a
+      // streaming AI message has BOTH finalized and still-streaming
+      // tool calls (parallel tool calls land sequentially during a
+      // single message — block 1 finishes while blocks 2-N are still
+      // streaming) the LangChain core ``AIMessageChunk`` constructor
+      // drops the caller-supplied ``tool_calls`` field and rebuilds
+      // it from ``tool_call_chunks`` via ``collapseToolCallChunks``.
+      // Without this re-encoding, every finished tool call disappears
+      // from ``message.tool_calls`` until ``message-finish`` flips
+      // the message to a plain ``AIMessage`` — visible on the
+      // coordinator panel as "only one Subagent Task card during
+      // streaming, then four at the end".
+      const tc = block as {
+        id?: string;
+        name?: string;
+        args?: unknown;
+        index?: number;
+      };
+      const argsString =
+        tc.args != null && typeof tc.args === "object"
+          ? safeJsonStringify(tc.args)
+          : typeof tc.args === "string"
+            ? tc.args
+            : "";
+      out.push({
+        id: tc.id,
+        name: tc.name,
+        args: argsString,
+        index: tc.index,
+        type: "tool_call_chunk",
+      });
+    }
   }
   return out;
 }
@@ -226,4 +261,12 @@ function normalizeToolCallArgs(value: unknown): Record<string, unknown> {
     }
   }
   return {};
+}
+
+function safeJsonStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "";
+  }
 }

--- a/libs/sdk/src/stream/assembled-to-message.ts
+++ b/libs/sdk/src/stream/assembled-to-message.ts
@@ -206,6 +206,7 @@ function extractToolCallChunks(blocks: ContentBlock[]): LooseToolCallChunk[] {
       continue;
     }
     if (block.type === "tool_call") {
+      // WORKAROUND(@langchain/core AIMessageChunk constructor):
       // Re-encode finalized ``tool_call`` blocks as chunks. When a
       // streaming AI message has BOTH finalized and still-streaming
       // tool calls (parallel tool calls land sequentially during a
@@ -218,6 +219,19 @@ function extractToolCallChunks(blocks: ContentBlock[]): LooseToolCallChunk[] {
       // the message to a plain ``AIMessage`` — visible on the
       // coordinator panel as "only one Subagent Task card during
       // streaming, then four at the end".
+      //
+      // The ``tool_calls`` field at line 97 is therefore *also*
+      // redundant on the chunk path: AIMessageChunk discards it. We
+      // keep it for the no-chunks AIMessage branch below, where it's
+      // still load-bearing.
+      //
+      // TODO: remove this branch once upstream preserves the caller
+      // ``tool_calls`` field when ``tool_call_chunks`` is non-empty.
+      // Args are assumed JSON-safe (LLM-emitted): NaN/Infinity/Date/
+      // undefined will round-trip lossily through JSON.stringify ->
+      // parsePartialJson. Cyclic or BigInt args trigger
+      // safeJsonStringify's fallback and the call surfaces as an
+      // invalid_tool_call with a marker args string.
       const tc = block as {
         id?: string;
         name?: string;
@@ -225,8 +239,10 @@ function extractToolCallChunks(blocks: ContentBlock[]): LooseToolCallChunk[] {
         index?: number;
       };
       const argsString =
-        tc.args != null && typeof tc.args === "object"
-          ? safeJsonStringify(tc.args)
+        tc.args != null &&
+        typeof tc.args === "object" &&
+        !Array.isArray(tc.args)
+          ? safeJsonStringify(tc.args, tc.id)
           : typeof tc.args === "string"
             ? tc.args
             : "";
@@ -263,10 +279,23 @@ function normalizeToolCallArgs(value: unknown): Record<string, unknown> {
   return {};
 }
 
-function safeJsonStringify(value: unknown): string {
+function safeJsonStringify(value: unknown, toolCallId?: string): string {
   try {
     return JSON.stringify(value);
-  } catch {
+  } catch (error) {
+    // Cyclic refs / BigInt / other JSON-hostile values surface here.
+    // Returning "" lets ``parsePartialJson`` substitute ``"{}"`` and
+    // produce a tool call with empty args — the call itself survives,
+    // but a UI subagent card would render with no inputs. Warn so the
+    // failure mode isn't silent.
+    const id = toolCallId ? ` (tool_call id=${toolCallId})` : "";
+    // oxlint-disable-next-line no-console
+    console.warn(
+      `[langgraph-sdk] failed to JSON-stringify finalized tool_call.args${id}; ` +
+        `streaming UI will see empty args until message-finish: ${
+          (error as { message?: string } | null)?.message ?? String(error)
+        }`
+    );
     return "";
   }
 }


### PR DESCRIPTION
When a streaming AI message has both finalized and still-streaming
tool calls — common with parallel tool calls, where blocks land
sequentially within a single message — the langchain core
\`AIMessageChunk\` constructor drops the caller-supplied \`tool_calls\`
field and rebuilds it from \`tool_call_chunks\` via
\`collapseToolCallChunks\`. Without re-encoding, every finished tool call
disappears from \`message.tool_calls\` until \`message-finish\` flips the
message to a plain \`AIMessage\`.

UI symptom: only one subagent card visible during streaming, then four
at the end (or the equivalent for any parallel-tool-call UX).

Fix in \`extractToolCallChunks\`: when a finalized \`tool_call\` block is
encountered, re-emit it as a \`tool_call_chunk\` with args
JSON-stringified back to a string, so the constructor's chunk-collapse
path includes it from the moment it arrives.

## Release Note

None