### PR TITLE
fix(sdk): hydrate-time lifecycle watcher + deferred root pump for self-created threads

### DIFF
--- a/libs/sdk/src/client/stream/index.ts
+++ b/libs/sdk/src/client/stream/index.ts
@@ -1394,9 +1394,11 @@ export class ThreadStream<
    * stream would 404 if opened before the server has the thread row.
    * Callers that already know the thread exists server-side
    * (`StreamController.hydrate` of an existing thread) can use this
-   * to start the watcher up front, which is what makes first-level
-   * subagent discovery work for historical thread loads when the
-   * content pump is run at `depth: 0`.
+   * to start the watcher up front. The watcher subscribes to wildcard
+   * lifecycle events across every namespace, so it sees arbitrarily-
+   * nested subagent lifecycle messages that the narrow root content
+   * pump (running at `depth: 1`) wouldn't reach — that's what makes
+   * subagent discovery work for historical thread loads.
    *
    * Idempotent — repeat calls reuse the in-flight start promise.
    */

--- a/libs/sdk/src/client/stream/index.ts
+++ b/libs/sdk/src/client/stream/index.ts
@@ -1385,6 +1385,25 @@ export class ThreadStream<
     this.#lifecycleWatcherStartPromise = this.#startLifecycleWatcherWebSocket();
   }
 
+  /**
+   * Public, idempotent entry point to start the wildcard lifecycle
+   * watcher.
+   *
+   * The watcher is normally started lazily by `submitRun` /
+   * `respondInput` because for fresh (self-created) threads the SSE
+   * stream would 404 if opened before the server has the thread row.
+   * Callers that already know the thread exists server-side
+   * (`StreamController.hydrate` of an existing thread) can use this
+   * to start the watcher up front, which is what makes first-level
+   * subagent discovery work for historical thread loads when the
+   * content pump is run at `depth: 0`.
+   *
+   * Idempotent — repeat calls reuse the in-flight start promise.
+   */
+  startLifecycleWatcher(): void {
+    this.#startLifecycleWatcher();
+  }
+
   async #startLifecycleWatcherSse(): Promise<void> {
     // Wait for any in-flight `run.start` send to commit the thread
     // server-side. Without this the SSE GET on

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -284,4 +284,61 @@ describe("StreamController", () => {
     unsubscribe();
     await controller.dispose();
   });
+
+  it("calls thread.startLifecycleWatcher() on hydrate of an existing thread", async () => {
+    const startLifecycleWatcher = vi.fn(() => undefined);
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      startLifecycleWatcher,
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {} })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, unknown>({
+      assistantId: "deep-agent",
+      client: client as never,
+      threadId: "thread-existing",
+    });
+    await controller.hydrationPromise;
+
+    expect(startLifecycleWatcher).toHaveBeenCalledOnce();
+    await controller.dispose();
+  });
+
+  it("does not call thread.startLifecycleWatcher() on hydrate when no threadId is bound", async () => {
+    const startLifecycleWatcher = vi.fn(() => undefined);
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      startLifecycleWatcher,
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {} })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, unknown>({
+      assistantId: "deep-agent",
+      client: client as never,
+      threadId: null,
+    });
+    await controller.hydrationPromise;
+
+    // No thread bound → no lifecycle watcher attached yet. The
+    // submit-path call inside `submitRun` is what kicks it for
+    // self-created threads (covered by submit-coordinator tests).
+    expect(startLifecycleWatcher).not.toHaveBeenCalled();
+    await controller.dispose();
+  });
 });

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -153,6 +153,7 @@ describe("StreamController", () => {
       }),
       close: vi.fn(async () => undefined),
       interrupts: [],
+      startLifecycleWatcher: vi.fn(() => undefined),
     } as unknown as ThreadStream;
     const client = {
       threads: {
@@ -193,6 +194,7 @@ describe("StreamController", () => {
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
+      startLifecycleWatcher: vi.fn(() => undefined),
     } as unknown as ThreadStream;
     const client = {
       threads: {

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -237,7 +237,12 @@ export class StreamController<
         this.#selfCreatedThreadIds.add(threadId);
       },
       hydrate: (threadId) => this.hydrate(threadId),
-      ensureThread: (threadId) => this.#ensureThread(threadId),
+      ensureThread: (threadId, deferRootPump) =>
+        this.#ensureThread(threadId, deferRootPump),
+      startDeferredRootPump: () => this.#startDeferredRootPump(),
+      forgetSelfCreatedThreadId: (threadId) => {
+        this.#selfCreatedThreadIds.delete(threadId);
+      },
       waitForRootPumpReady: () => this.#rootPumpReady,
       awaitNextTerminal: (signal) => this.#awaitNextTerminal(signal),
       latestUnresolvedInterrupt: () => this.#latestUnresolvedInterrupt(),
@@ -368,10 +373,12 @@ export class StreamController<
 
     this.rootStore.setState((s) => ({ ...s, isThreadLoading: true }));
     let hydrationError: unknown;
+    let threadExists = false;
     try {
       const state = await this.#options.client.threads.getState<StateType>(
         this.#currentThreadId
       );
+      threadExists = state != null;
       if (state?.values != null) {
         /**
          * `threads.getState()` returns the legacy `ThreadState` shape
@@ -426,7 +433,23 @@ export class StreamController<
      * `isLoading` transitions are driven by the persistent root
      * lifecycle listener registered in `#startRootPump`.
      */
-    this.#ensureThread(this.#currentThreadId);
+    const thread = this.#ensureThread(this.#currentThreadId);
+
+    /**
+     * Start the wildcard lifecycle watcher up-front for existing
+     * threads. The root content pump runs at `depth: 1`, which covers
+     * root-namespace and one-deep events but not arbitrarily-nested
+     * subagent / subgraph lifecycle — the dedicated watcher handles
+     * those.
+     *
+     * For self-created (new) threads we skip — the watcher would 404
+     * against a not-yet-existent thread. `submitRun` / `respondInput`
+     * call `startLifecycleWatcher` on first submission to cover that
+     * case.
+     */
+    if (threadExists) {
+      thread.startLifecycleWatcher();
+    }
   }
 
   /**
@@ -624,8 +647,24 @@ export class StreamController<
    * Return the active thread stream, creating and binding one when needed.
    *
    * @param threadId - Thread id used when constructing the stream.
+   * @param deferRootPump - When `true`, build the ThreadStream and bind
+   *   the registry but skip starting the persistent root SSE pump. Used
+   *   for client-self-created thread ids whose server-side thread row
+   *   doesn't exist yet — opening the pump's `subscription.subscribe`
+   *   against a not-yet-existent thread produces a `404: Thread not
+   *   found` protocol error that strands terminal lifecycle events and
+   *   leaves the UI showing nothing until the user reloads. The pump is
+   *   started later via {@link #startDeferredRootPump} after `submitRun`
+   *   / `respondInput` commits the thread server-side.
+   *
+   *   Note: PR 2381's `#runStartReady` gate covers the analogous race
+   *   for the in-flight `run.start` send, but only when that send is
+   *   already pending. `#ensureThread` runs *before* `submitRun` is
+   *   called (and thus before the gate is armed), so on transports
+   *   that subscribe synchronously (WebSocket) the deferred path is
+   *   still required.
    */
-  #ensureThread(threadId: string): ThreadStream {
+  #ensureThread(threadId: string, deferRootPump = false): ThreadStream {
     if (this.#thread != null) return this.#thread;
     this.#thread = this.#options.client.threads.stream(threadId, {
       assistantId: this.#options.assistantId,
@@ -634,10 +673,36 @@ export class StreamController<
       webSocketFactory: this.#options.webSocketFactory,
     });
     this.registry.bind(this.#thread);
-    this.#startRootPump(this.#thread);
+    if (deferRootPump) {
+      // Resolve `#rootPumpReady` immediately so `submit()`'s `await
+      // this.#rootPumpReady` doesn't block — the dispatch path only
+      // needs the ThreadStream wired up to call `submitRun`, not the
+      // persistent subscription.
+      this.#rootPumpReady = Promise.resolve();
+      this.#rootPumpDeferred = true;
+    } else {
+      this.#startRootPump(this.#thread);
+    }
     this.#notifyThreadListeners();
     return this.#thread;
   }
+
+  /**
+   * Start the previously-deferred root SSE pump after the first
+   * `submitRun` / `respondInput` has committed the thread server-side.
+   *
+   * No-op when the pump was started eagerly in {@link #ensureThread}
+   * (i.e. for hydrated existing threads, or for any thread whose pump
+   * has already been brought up).
+   */
+  #startDeferredRootPump(): void {
+    if (!this.#rootPumpDeferred) return;
+    if (this.#thread == null) return;
+    this.#rootPumpDeferred = false;
+    this.#startRootPump(this.#thread);
+  }
+
+  #rootPumpDeferred: boolean = false;
 
   /**
    * Close the current thread stream and reset per-thread assembly state.
@@ -734,13 +799,16 @@ export class StreamController<
     this.#rootPump = (async () => {
       try {
         /**
-         * Narrow the content pump to the root namespace, depth 1:
-         * this is enough to observe root LLM deltas and first-level
-         * discovery hints (tool-started for task:* / subgraph
-         * boundaries) without downloading content from every nested
-         * subagent / subgraph. Deeper content is pulled in lazily by
-         * per-namespace selector projections (e.g. `useMessages(sub)`),
-         * which expand `#computeUnionFilter` progressively.
+         * Root content pump: depth 1 is required because the controller
+         * classifies tool events at namespace length ≤ 1 as root-level
+         * (see `#onWildcardEvent`'s `isRootLevelTool` check). The deep-
+         * agent `task` dispatcher fires `tools.tool-started` at
+         * `["tools:<id>"]` (length 1), so a depth-0 filter would drop
+         * those events server-side before they reached `root.toolCalls`.
+         *
+         * Deeper content (subagent message tokens, values snapshots) is
+         * pulled in on demand by per-namespace selector projections
+         * (e.g. `useMessages(sub)`).
          */
         const subscriptionPromise = thread.subscribe({
           channels: [...ROOT_PUMP_CHANNELS] as Channel[],

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -146,6 +146,12 @@ export class StreamController<
   #rootSubscription: SubscriptionHandle<Event> | undefined;
   #rootPump: Promise<void> | undefined;
   #rootPumpReady: Promise<void> | undefined;
+  /**
+   * `true` while a self-created thread has its root pump deferred until
+   * the first `submitRun` / `respondInput` commits the thread row
+   * server-side. See `#ensureThread` and `#startDeferredRootPump`.
+   */
+  #rootPumpDeferred = false;
   #threadEventUnsubscribe: (() => void) | undefined;
   #disposed = false;
   #pendingDisposeTimer: ReturnType<typeof setTimeout> | null = null;
@@ -240,6 +246,7 @@ export class StreamController<
       ensureThread: (threadId, deferRootPump) =>
         this.#ensureThread(threadId, deferRootPump),
       startDeferredRootPump: () => this.#startDeferredRootPump(),
+      abandonDeferredRootPump: () => this.#abandonDeferredRootPump(),
       forgetSelfCreatedThreadId: (threadId) => {
         this.#selfCreatedThreadIds.delete(threadId);
       },
@@ -702,7 +709,30 @@ export class StreamController<
     this.#startRootPump(this.#thread);
   }
 
-  #rootPumpDeferred: boolean = false;
+  /**
+   * Abandon a deferred root pump that never started because its
+   * triggering dispatch (`submitRun` / `respondInput`) failed.
+   *
+   * Without this, the controller would be wedged in a state where:
+   *   - `#thread` is wired but no content pump is open
+   *   - `#rootPumpDeferred` stays `true`
+   *   - `selfCreatedThreadIds` still holds the id
+   *
+   * A retry submit on the same controller would see
+   * `wasSelfCreated=false` (because `currentThreadId` is no longer
+   * null), `#ensureThread(id, false)` would early-return because
+   * `#thread != null`, and the pump would never start. The thread
+   * would have an id committed to the URL but no live subscription.
+   *
+   * Tearing down `#thread` so the next submit re-runs `#ensureThread`
+   * from scratch is the simplest recovery — the failed dispatch
+   * means there was nothing to subscribe to anyway.
+   */
+  #abandonDeferredRootPump(): void {
+    if (!this.#rootPumpDeferred) return;
+    this.#rootPumpDeferred = false;
+    void this.#teardownThread();
+  }
 
   /**
    * Close the current thread stream and reset per-thread assembly state.
@@ -726,6 +756,10 @@ export class StreamController<
     }
     this.#rootSubscription = undefined;
     this.#rootPumpReady = undefined;
+    // Reset so a swap to a new thread doesn't carry over a stale
+    // deferred flag — `#ensureThread` will set it again if the new
+    // thread is self-created.
+    this.#rootPumpDeferred = false;
     try {
       await this.#rootPump;
     } catch {

--- a/libs/sdk/src/stream/submit-coordinator.test.ts
+++ b/libs/sdk/src/stream/submit-coordinator.test.ts
@@ -132,11 +132,13 @@ function makeHarness(initial: { threadId?: string | null } = {}): Harness {
   const hydrate = vi.fn(async (id?: string | null) => {
     currentThreadId = id ?? null;
   });
-  const ensureThread = vi.fn((_id: string) => thread);
+  const ensureThread = vi.fn((_id: string, _deferRootPump?: boolean) => thread);
+  const startDeferredRootPump = vi.fn(() => undefined);
   const setCurrentThreadId = vi.fn((id: string | null) => {
     currentThreadId = id;
   });
   const rememberSelfCreatedThreadId = vi.fn(() => undefined);
+  const forgetSelfCreatedThreadId = vi.fn(() => undefined);
   const markInterruptResolved = vi.fn(() => undefined);
 
   const onCreated = vi.fn();
@@ -158,8 +160,10 @@ function makeHarness(initial: { threadId?: string | null } = {}): Harness {
     getCurrentThreadId: () => currentThreadId,
     setCurrentThreadId,
     rememberSelfCreatedThreadId,
+    forgetSelfCreatedThreadId,
     hydrate,
     ensureThread,
+    startDeferredRootPump,
     waitForRootPumpReady: () => Promise.resolve(),
     awaitNextTerminal,
     latestUnresolvedInterrupt: () => latestInterrupt,

--- a/libs/sdk/src/stream/submit-coordinator.test.ts
+++ b/libs/sdk/src/stream/submit-coordinator.test.ts
@@ -48,6 +48,9 @@ interface Harness {
   options: StreamControllerOptions<State>;
   hydrate: ReturnType<typeof vi.fn>;
   ensureThread: ReturnType<typeof vi.fn>;
+  startDeferredRootPump: ReturnType<typeof vi.fn>;
+  abandonDeferredRootPump: ReturnType<typeof vi.fn>;
+  forgetSelfCreatedThreadId: ReturnType<typeof vi.fn>;
   markInterruptResolved: ReturnType<typeof vi.fn>;
   rememberSelfCreatedThreadId: ReturnType<typeof vi.fn>;
   setCurrentThreadId: ReturnType<typeof vi.fn>;
@@ -134,6 +137,7 @@ function makeHarness(initial: { threadId?: string | null } = {}): Harness {
   });
   const ensureThread = vi.fn((_id: string, _deferRootPump?: boolean) => thread);
   const startDeferredRootPump = vi.fn(() => undefined);
+  const abandonDeferredRootPump = vi.fn(() => undefined);
   const setCurrentThreadId = vi.fn((id: string | null) => {
     currentThreadId = id;
   });
@@ -164,6 +168,7 @@ function makeHarness(initial: { threadId?: string | null } = {}): Harness {
     hydrate,
     ensureThread,
     startDeferredRootPump,
+    abandonDeferredRootPump,
     waitForRootPumpReady: () => Promise.resolve(),
     awaitNextTerminal,
     latestUnresolvedInterrupt: () => latestInterrupt,
@@ -204,6 +209,9 @@ function makeHarness(initial: { threadId?: string | null } = {}): Harness {
     options,
     hydrate,
     ensureThread,
+    startDeferredRootPump,
+    abandonDeferredRootPump,
+    forgetSelfCreatedThreadId,
     markInterruptResolved,
     rememberSelfCreatedThreadId,
     setCurrentThreadId,
@@ -622,6 +630,74 @@ describe("SubmitCoordinator", () => {
       h.resolveTerminal({ event: "completed" });
       await vi.runAllTimersAsync();
       await submitPromise;
+    });
+  });
+
+  describe("self-created thread lifecycle", () => {
+    it("passes deferRootPump=true to ensureThread on a self-created submit", async () => {
+      const h = makeHarness({ threadId: null });
+      const submitPromise = h.coordinator.submit({ count: 1 });
+      await h.terminalRegistered();
+
+      const lastEnsureCall = h.ensureThread.mock.calls.at(-1);
+      expect(lastEnsureCall).toBeDefined();
+      expect(lastEnsureCall![1]).toBe(true);
+
+      h.resolveSubmit();
+      h.resolveTerminal({ event: "completed" });
+      await vi.runAllTimersAsync();
+      await submitPromise;
+    });
+
+    it("fires startDeferredRootPump and forgetSelfCreatedThreadId after dispatch resolves", async () => {
+      const h = makeHarness({ threadId: null });
+      const submitPromise = h.coordinator.submit({ count: 1 });
+      await h.terminalRegistered();
+
+      expect(h.startDeferredRootPump).not.toHaveBeenCalled();
+      expect(h.forgetSelfCreatedThreadId).not.toHaveBeenCalled();
+
+      h.resolveSubmit();
+      // Let the .then() microtasks fan out.
+      await vi.runAllTimersAsync();
+
+      expect(h.startDeferredRootPump).toHaveBeenCalledOnce();
+      expect(h.forgetSelfCreatedThreadId).toHaveBeenCalledOnce();
+      expect(h.abandonDeferredRootPump).not.toHaveBeenCalled();
+
+      h.resolveTerminal({ event: "completed" });
+      await vi.runAllTimersAsync();
+      await submitPromise;
+    });
+
+    it("calls abandonDeferredRootPump when a self-created dispatch fails", async () => {
+      const h = makeHarness({ threadId: null });
+      const submitPromise = h.coordinator.submit({ count: 1 });
+      await h.terminalRegistered();
+
+      const err = new Error("dispatch failed");
+      h.rejectSubmit(err);
+      await vi.runAllTimersAsync();
+      await submitPromise;
+
+      expect(h.rootStore.getSnapshot().error).toBe(err);
+      expect(h.abandonDeferredRootPump).toHaveBeenCalledOnce();
+      expect(h.forgetSelfCreatedThreadId).toHaveBeenCalledOnce();
+      expect(h.startDeferredRootPump).not.toHaveBeenCalled();
+    });
+
+    it("does not call abandonDeferredRootPump when dispatch fails on a hydrated thread", async () => {
+      const h = makeHarness({ threadId: "thread-existing" });
+      const submitPromise = h.coordinator.submit({ count: 1 });
+      await h.terminalRegistered();
+
+      const err = new Error("dispatch failed");
+      h.rejectSubmit(err);
+      await vi.runAllTimersAsync();
+      await submitPromise;
+
+      expect(h.rootStore.getSnapshot().error).toBe(err);
+      expect(h.abandonDeferredRootPump).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/sdk/src/stream/submit-coordinator.ts
+++ b/libs/sdk/src/stream/submit-coordinator.ts
@@ -155,10 +155,17 @@ export class SubmitCoordinator<
   readonly #setCurrentThreadId: (threadId: string | null) => void;
   /** Records a thread id we created client-side so hydrate can skip a 404 round-trip. */
   readonly #rememberSelfCreatedThreadId: (threadId: string) => void;
+  /** Drops a thread id from the self-created set once it's committed server-side. */
+  readonly #forgetSelfCreatedThreadId: (threadId: string) => void;
   /** Triggers a hydrate on the controller (used by `options.threadId` rebinds). */
   readonly #hydrate: (threadId?: string | null) => Promise<void>;
   /** Lazily creates / returns the active {@link ThreadStream}. */
-  readonly #ensureThread: (threadId: string) => ThreadStream;
+  readonly #ensureThread: (
+    threadId: string,
+    deferRootPump?: boolean
+  ) => ThreadStream;
+  /** Starts the previously-deferred root pump after a self-created thread commits. */
+  readonly #startDeferredRootPump: () => void;
   /** Resolves once the controller's root subscription pump is up. */
   readonly #waitForRootPumpReady: () => Promise<void> | undefined;
   /** Resolves on the next root terminal lifecycle (or on abort). */
@@ -185,8 +192,10 @@ export class SubmitCoordinator<
     getCurrentThreadId: () => string | null;
     setCurrentThreadId: (threadId: string | null) => void;
     rememberSelfCreatedThreadId: (threadId: string) => void;
+    forgetSelfCreatedThreadId: (threadId: string) => void;
     hydrate: (threadId?: string | null) => Promise<void>;
-    ensureThread: (threadId: string) => ThreadStream;
+    ensureThread: (threadId: string, deferRootPump?: boolean) => ThreadStream;
+    startDeferredRootPump: () => void;
     waitForRootPumpReady: () => Promise<void> | undefined;
     awaitNextTerminal: (signal: AbortSignal) => Promise<TerminalResult>;
     latestUnresolvedInterrupt: () => ResolvedInterrupt | null;
@@ -199,8 +208,10 @@ export class SubmitCoordinator<
     this.#getCurrentThreadId = params.getCurrentThreadId;
     this.#setCurrentThreadId = params.setCurrentThreadId;
     this.#rememberSelfCreatedThreadId = params.rememberSelfCreatedThreadId;
+    this.#forgetSelfCreatedThreadId = params.forgetSelfCreatedThreadId;
     this.#hydrate = params.hydrate;
     this.#ensureThread = params.ensureThread;
+    this.#startDeferredRootPump = params.startDeferredRootPump;
     this.#waitForRootPumpReady = params.waitForRootPumpReady;
     this.#awaitNextTerminal = params.awaitNextTerminal;
     this.#latestUnresolvedInterrupt = params.latestUnresolvedInterrupt;
@@ -249,7 +260,8 @@ export class SubmitCoordinator<
     // Self-created thread id path: mint client-side so the controller
     // (and Suspense boundaries) get a stable id even before the run
     // is dispatched.
-    if (this.#getCurrentThreadId() == null) {
+    const wasSelfCreated = this.#getCurrentThreadId() == null;
+    if (wasSelfCreated) {
       const threadId = uuidv7();
       this.#setCurrentThreadId(threadId);
       this.#rememberSelfCreatedThreadId(threadId);
@@ -262,7 +274,14 @@ export class SubmitCoordinator<
 
     const currentThreadId = this.#getCurrentThreadId();
     if (currentThreadId == null) return;
-    const thread = this.#ensureThread(currentThreadId);
+    // For client-self-created threads we defer the persistent root SSE
+    // pump until after `submitRun` / `respondInput` commits the thread
+    // server-side. Opening the pump's `subscription.subscribe` against
+    // a not-yet-existent thread row produces a `404: Thread not found`
+    // protocol error that strands lifecycle / messages events for the
+    // first run. The deferred path starts the pump after dispatch
+    // returns (see `#startDeferredRootPump` calls below).
+    const thread = this.#ensureThread(currentThreadId, wasSelfCreated);
     const activeThreadId = currentThreadId;
     // Wait for the root subscription to be live; otherwise the
     // dispatch could resolve before we're listening for events and
@@ -270,8 +289,19 @@ export class SubmitCoordinator<
     await this.#waitForRootPumpReady();
 
     const strategy = options?.multitaskStrategy ?? "rollback";
+    // `wasSelfCreated` short-circuit: when this submit just minted a
+    // brand-new thread id (the user clicked "New Thread"), the
+    // strategy check shouldn't see a run on the *previous* thread as
+    // a reason to enqueue. The previous run is on a thread the user
+    // navigated away from; abandoning its client-side abort tracking
+    // is correct (the server-side run continues independently).
+    // Without this, `enqueue` would trap the new submission and
+    // `submitRun` never fires for the new thread — leaving a freshly-
+    // minted thread id committed to the URL but never to the server.
     const hasActiveRun =
-      this.#runAbort != null && !this.#runAbort.signal.aborted;
+      !wasSelfCreated &&
+      this.#runAbort != null &&
+      !this.#runAbort.signal.aborted;
     if (hasActiveRun && strategy === "reject") {
       throw new Error(
         "submit() rejected: a run is already in flight and multitaskStrategy is 'reject'."
@@ -332,6 +362,17 @@ export class SubmitCoordinator<
           interrupt_id: target.interruptId,
           response: resumeCommand,
         });
+        // Defer the pump start until the dispatch HTTP response
+        // lands — see the analogous block in the non-resume path
+        // below for the rationale (thread row not committed
+        // synchronously). For a resume the thread exists already
+        // (it must, since `latestUnresolvedInterrupt()` was non-null),
+        // so `#startDeferredRootPump` is typically a no-op here, but
+        // we keep the same shape to avoid a future regression.
+        void commandPromise.then(
+          () => this.#startDeferredRootPump(),
+          () => {}
+        );
         // Mark resolved synchronously: even if the response races and
         // the command settles after the terminal, we don't want to
         // re-target this same interrupt on the next submit.
@@ -367,6 +408,26 @@ export class SubmitCoordinator<
               ? "enqueue"
               : options?.multitaskStrategy,
         });
+        // Start the deferred root pump *after* the dispatch HTTP
+        // response lands — that's when the thread row exists server-
+        // side. Doing it synchronously here would race the response
+        // and the pump's `subscription.subscribe` would 404. Same
+        // reason we drop the self-created flag only after dispatch:
+        // future hydrates need the thread to exist before they fetch
+        // state.
+        //
+        // Fire-and-forget: we don't want to gate Promise.race on this,
+        // and `commandPromise.catch` is already handled below. A
+        // dispatch failure means there's no thread to pump anyway.
+        void commandPromise.then(
+          () => {
+            this.#startDeferredRootPump();
+            this.#forgetSelfCreatedThreadId(activeThreadId);
+          },
+          () => {
+            /* dispatch failed — error handling below surfaces it */
+          }
+        );
         const notifyCreated = (result: { run_id?: unknown }) => {
           this.#options.onCreated?.({
             run_id: result.run_id as string,

--- a/libs/sdk/src/stream/submit-coordinator.ts
+++ b/libs/sdk/src/stream/submit-coordinator.ts
@@ -166,6 +166,8 @@ export class SubmitCoordinator<
   ) => ThreadStream;
   /** Starts the previously-deferred root pump after a self-created thread commits. */
   readonly #startDeferredRootPump: () => void;
+  /** Abandons a deferred root pump after a self-created dispatch fails. */
+  readonly #abandonDeferredRootPump: () => void;
   /** Resolves once the controller's root subscription pump is up. */
   readonly #waitForRootPumpReady: () => Promise<void> | undefined;
   /** Resolves on the next root terminal lifecycle (or on abort). */
@@ -196,6 +198,7 @@ export class SubmitCoordinator<
     hydrate: (threadId?: string | null) => Promise<void>;
     ensureThread: (threadId: string, deferRootPump?: boolean) => ThreadStream;
     startDeferredRootPump: () => void;
+    abandonDeferredRootPump: () => void;
     waitForRootPumpReady: () => Promise<void> | undefined;
     awaitNextTerminal: (signal: AbortSignal) => Promise<TerminalResult>;
     latestUnresolvedInterrupt: () => ResolvedInterrupt | null;
@@ -212,6 +215,7 @@ export class SubmitCoordinator<
     this.#hydrate = params.hydrate;
     this.#ensureThread = params.ensureThread;
     this.#startDeferredRootPump = params.startDeferredRootPump;
+    this.#abandonDeferredRootPump = params.abandonDeferredRootPump;
     this.#waitForRootPumpReady = params.waitForRootPumpReady;
     this.#awaitNextTerminal = params.awaitNextTerminal;
     this.#latestUnresolvedInterrupt = params.latestUnresolvedInterrupt;
@@ -369,6 +373,12 @@ export class SubmitCoordinator<
         // (it must, since `latestUnresolvedInterrupt()` was non-null),
         // so `#startDeferredRootPump` is typically a no-op here, but
         // we keep the same shape to avoid a future regression.
+        //
+        // Asymmetry with the non-resume path: we don't call
+        // `#forgetSelfCreatedThreadId` because a resume implies the
+        // thread already committed, so the self-created marker was
+        // already cleared on the original submit. Same reason we
+        // don't call `#abandonDeferredRootPump` on failure here.
         void commandPromise.then(
           () => this.#startDeferredRootPump(),
           () => {}
@@ -425,7 +435,17 @@ export class SubmitCoordinator<
             this.#forgetSelfCreatedThreadId(activeThreadId);
           },
           () => {
-            /* dispatch failed — error handling below surfaces it */
+            // Dispatch failed. Without abandoning, `#rootPumpDeferred`
+            // stays armed and `selfCreatedThreadIds` still holds this
+            // id — a retry submit would see `wasSelfCreated=false`
+            // (currentThreadId is no longer null), `#ensureThread`
+            // would early-return because `#thread != null`, and the
+            // root pump would never start. Tear down so the next
+            // submit re-runs `#ensureThread` from scratch.
+            if (wasSelfCreated) {
+              this.#abandonDeferredRootPump();
+              this.#forgetSelfCreatedThreadId(activeThreadId);
+            }
           }
         );
         const notifyCreated = (result: { run_id?: unknown }) => {


### PR DESCRIPTION
Two correctness fixes layered on top of PR #2381's `#runStartReady` gate.

## 1. Lifecycle watcher on hydrate

Discovery (subagents / subgraphs at nested namespaces) reaches the controller through the wildcard lifecycle watcher, which was previously kicked only by `submitRun` / `respondInput`. Hydrating an existing thread therefore showed no subagents until the user submitted again. Exposes `ThreadStream.startLifecycleWatcher()` and has `StreamController.hydrate` call it for threads the server already has (skipping self-created ids whose row doesn't exist yet — those are covered by the existing submit-path call inside `submitRun`).

## 2. Deferred root pump for self-created threads

PR #2381's gate defers any subscribe started inside `submitRun` / `respondInput` until `run.start` commits, but the root content pump opens in `StreamController.#ensureThread`, which runs *before* `submitRun` is invoked — so the gate is null and the SSE GET on `/threads/{id}/stream/events` 404s against the not-yet-existent thread.

`#ensureThread` now takes a `deferRootPump` flag, `SubmitCoordinator` passes it for self-created threads, and `#startDeferredRootPump` brings the pump up after the dispatch response commits the thread server-side. `forgetSelfCreatedThreadId` drops the self-created marker on commit so future hydrates can `getState` cleanly.

## 3. `hasActiveRun` short-circuit on `wasSelfCreated`

When a submit mints a brand-new thread id (e.g. the user clicked "New Thread"), the strategy check shouldn't see the *previous* thread's `#runAbort` as a reason to enqueue. Without this, `enqueue` would trap the new submission and `submitRun` would never fire for the new thread — leaving a freshly-minted id committed to the URL but never to the server.

## Release Note

None