### PR TITLE
fix(sdk): forward config + metadata on respondInput for resume submits

### DIFF
--- a/.changeset/shaggy-items-care.md
+++ b/.changeset/shaggy-items-care.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): forward config + metadata on respondInput for resume submits

--- a/libs/sdk/src/stream/submit-coordinator.test.ts
+++ b/libs/sdk/src/stream/submit-coordinator.test.ts
@@ -555,6 +555,8 @@ describe("SubmitCoordinator", () => {
         namespace: ["task:1"],
         interrupt_id: "interrupt-1",
         response: { value: 42 },
+        config: { configurable: { thread_id: "thread-1" } },
+        metadata: undefined,
       });
       expect(h.markInterruptResolved).toHaveBeenCalledWith("interrupt-1");
 

--- a/libs/sdk/src/stream/submit-coordinator.test.ts
+++ b/libs/sdk/src/stream/submit-coordinator.test.ts
@@ -565,6 +565,42 @@ describe("SubmitCoordinator", () => {
       await submitPromise;
     });
 
+    it("forwards caller-supplied config and metadata through to respondInput", async () => {
+      const h = makeHarness();
+      h.setLatestInterrupt({
+        interruptId: "interrupt-1",
+        namespace: ["task:1"],
+      });
+
+      const submitPromise = h.coordinator.submit(null, {
+        command: { resume: { value: 42 } },
+        config: {
+          configurable: { llm_model_config: { model: "claude-opus-4-7" } },
+        },
+        metadata: { user_id: "u-1", trace_id: "t-9" },
+      });
+      await h.terminalRegistered();
+
+      // bindThreadConfig merges the caller's configurable with the
+      // thread_id stamp — both must survive.
+      expect(h.respondInput).toHaveBeenCalledWith({
+        namespace: ["task:1"],
+        interrupt_id: "interrupt-1",
+        response: { value: 42 },
+        config: {
+          configurable: {
+            thread_id: "thread-1",
+            llm_model_config: { model: "claude-opus-4-7" },
+          },
+        },
+        metadata: { user_id: "u-1", trace_id: "t-9" },
+      });
+
+      h.resolveTerminal({ event: "completed" });
+      await vi.runAllTimersAsync();
+      await submitPromise;
+    });
+
     it("rejects when no pending interrupt is available", async () => {
       const h = makeHarness();
       h.setLatestInterrupt(null);

--- a/libs/sdk/src/stream/submit-coordinator.ts
+++ b/libs/sdk/src/stream/submit-coordinator.ts
@@ -331,7 +331,7 @@ export class SubmitCoordinator<
           namespace: target.namespace,
           interrupt_id: target.interruptId,
           response: resumeCommand,
-          config: boundConfig as Record<string, unknown> | undefined,
+          config: boundConfig,
           metadata: options?.metadata,
         });
         // Mark resolved synchronously: even if the response races and

--- a/libs/sdk/src/stream/submit-coordinator.ts
+++ b/libs/sdk/src/stream/submit-coordinator.ts
@@ -331,6 +331,8 @@ export class SubmitCoordinator<
           namespace: target.namespace,
           interrupt_id: target.interruptId,
           response: resumeCommand,
+          config: boundConfig as Record<string, unknown> | undefined,
+          metadata: options?.metadata,
         });
         // Mark resolved synchronously: even if the response races and
         // the command settles after the terminal, we don't want to


### PR DESCRIPTION
Resumes via \`stream.submit({command: {resume}, config, metadata})\`
were dropping \`config\` and \`metadata\` at the SDK layer —
\`submit-coordinator\` passed only \`namespace\`/\`interrupt_id\`/\`response\`
to \`thread.respondInput\`. The Python \`langgraph-api\` \`input.respond\`
handler already forwards both fields into \`_create_or_resume_run\`, so
the bug was purely client-side: per-run config (e.g.
\`configurable.llm_model_config\`) and metadata never reached the
resumed run, causing the engine to fall back to whatever the assistant
had stored.

## Release Note

None