### PR TITLE
fix(sdk): coalesce RootMessageProjection writes via setTimeout(0)

### DIFF
--- a/.changeset/batched-root-projection.md
+++ b/.changeset/batched-root-projection.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+Coalesce `RootMessageProjection` store writes through a single `setTimeout(0)` flush so long `messages`-channel replays (on refresh, mid-run join, or rapid subagent streaming) no longer drain as a per-event microtask chain that trips React's `Maximum update depth exceeded` guard. Replaces the previous `MessageChannel`-based batching, which deferred initial-submit events past the first render and left the UI looking frozen until refresh.

--- a/libs/sdk/src/stream/root-message-projection.test.ts
+++ b/libs/sdk/src/stream/root-message-projection.test.ts
@@ -35,14 +35,20 @@ function makeProjection() {
     messagesKey: "messages",
     store,
     subagents,
-    // Tests assert against the store immediately after each call
-    // (no await ticks), so opt out of the production-side macrotask
-    // batching that `RootMessageProjection` uses to coalesce SSE
-    // replay bursts. Production wiring (`StreamController`) leaves
-    // this default-false so the batching is in effect.
-    flushImmediately: true,
   });
   return { store, subagents, projection };
+}
+
+/**
+ * Drain one macrotask so the projection's batched `setTimeout(0)`
+ * flush commits to the store. The projection coalesces a burst of
+ * synchronous writes (a microtask chain of SSE events) into one
+ * `store.setState` at the next macrotask boundary, so every test
+ * that asserts against the store after a `handleMessage` /
+ * `applyValues` call has to drain a macrotask first.
+ */
+function drainFlush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 function startEvent(
@@ -148,7 +154,7 @@ function isInternalWorkNamespace(namespace: readonly string[]): boolean {
   );
 }
 
-function replayRootProjection(events: readonly Event[]) {
+async function replayRootProjection(events: readonly Event[]) {
   const { store, projection } = makeProjection();
   for (const event of events) {
     if (
@@ -168,6 +174,7 @@ function replayRootProjection(events: readonly Event[]) {
       );
     }
   }
+  await drainFlush();
   return store.getSnapshot();
 }
 
@@ -232,7 +239,7 @@ function summarizeMessage(
 
 describe("RootMessageProjection", () => {
   describe("handleMessage", () => {
-    it("appends a new assembled message into the root snapshot", () => {
+    it("appends a new assembled message into the root snapshot", async () => {
       const { store, projection } = makeProjection();
 
       projection.handleMessage(startEvent({ id: "m1", role: "ai" }));
@@ -243,21 +250,24 @@ describe("RootMessageProjection", () => {
         blockDeltaEvent(0, { type: "text", text: "there" })
       );
 
+      await drainFlush();
       const snap = store.getSnapshot();
       expect(snap.messages).toHaveLength(1);
       expect(snap.messages[0].id).toBe("m1");
       expect(snap.messages[0].text).toBe("Hi there");
     });
 
-    it("updates the same message index in place across deltas", () => {
+    it("updates the same message index in place across deltas", async () => {
       const { store, projection } = makeProjection();
 
       projection.handleMessage(startEvent({ id: "m1", role: "ai" }));
       projection.handleMessage(blockStartEvent(0, { type: "text", text: "" }));
       projection.handleMessage(blockDeltaEvent(0, { type: "text", text: "a" }));
+      await drainFlush();
       const after1 = store.getSnapshot().messages;
 
       projection.handleMessage(blockDeltaEvent(0, { type: "text", text: "b" }));
+      await drainFlush();
       const after2 = store.getSnapshot().messages;
 
       expect(after2).toHaveLength(1);
@@ -266,7 +276,7 @@ describe("RootMessageProjection", () => {
       expect(after2).not.toBe(after1);
     });
 
-    it("applies typed content-block deltas", () => {
+    it("applies typed content-block deltas", async () => {
       const { store, projection } = makeProjection();
 
       projection.handleMessage(startEvent({ id: "m1", role: "ai" }));
@@ -278,12 +288,13 @@ describe("RootMessageProjection", () => {
         coreBlockDeltaEvent(0, { type: "text-delta", text: " there" })
       );
 
+      await drainFlush();
       const snap = store.getSnapshot();
       expect(snap.messages).toHaveLength(1);
       expect(snap.messages[0].text).toBe("Hi there");
     });
 
-    it("mirrors messages into values[messagesKey]", () => {
+    it("mirrors messages into values[messagesKey]", async () => {
       const { store, projection } = makeProjection();
 
       projection.handleMessage(startEvent({ id: "m1", role: "ai" }));
@@ -291,12 +302,13 @@ describe("RootMessageProjection", () => {
         blockStartEvent(0, { type: "text", text: "hi" })
       );
 
+      await drainFlush();
       const values = store.getSnapshot().values as State;
       expect(Array.isArray(values.messages)).toBe(true);
       expect((values.messages as Array<{ id?: string }>)[0]?.id).toBe("m1");
     });
 
-    it("does not duplicate an existing id on subsequent message-start events", () => {
+    it("does not duplicate an existing id on subsequent message-start events", async () => {
       const { store, projection } = makeProjection();
 
       projection.handleMessage(startEvent({ id: "m1", role: "ai" }));
@@ -313,12 +325,13 @@ describe("RootMessageProjection", () => {
         blockStartEvent(0, { type: "text", text: "reset" })
       );
 
+      await drainFlush();
       const after = store.getSnapshot();
       expect(after.messages).toHaveLength(1);
       expect(after.messages[0].id).toBe("m1");
     });
 
-    it("uses message-start role to construct correct message classes", () => {
+    it("uses message-start role to construct correct message classes", async () => {
       const { store, projection } = makeProjection();
 
       projection.handleMessage(startEvent({ id: "human-1", role: "human" }));
@@ -326,11 +339,12 @@ describe("RootMessageProjection", () => {
         blockStartEvent(0, { type: "text", text: "hello" })
       );
 
+      await drainFlush();
       const msg = store.getSnapshot().messages[0];
       expect(msg).toBeInstanceOf(HumanMessage);
     });
 
-    it("recovers tool_call_id from the legacy `<id>-tool-<callId>` message id format", () => {
+    it("recovers tool_call_id from the legacy `<id>-tool-<callId>` message id format", async () => {
       const { store, projection } = makeProjection();
 
       projection.handleMessage(
@@ -340,12 +354,13 @@ describe("RootMessageProjection", () => {
         blockStartEvent(0, { type: "text", text: "result" })
       );
 
+      await drainFlush();
       const msg = store.getSnapshot().messages[0] as ToolMessage;
       expect(msg).toBeInstanceOf(ToolMessage);
       expect(msg.tool_call_id).toBe("call_42");
     });
 
-    it("recovers tool_call_id from a recorded tool-started namespace mapping", () => {
+    it("recovers tool_call_id from a recorded tool-started namespace mapping", async () => {
       const { store, projection } = makeProjection();
 
       projection.recordToolCallNamespace(["tools:abc"], "call_99");
@@ -358,11 +373,12 @@ describe("RootMessageProjection", () => {
         ])
       );
 
+      await drainFlush();
       const msg = store.getSnapshot().messages[0] as ToolMessage;
       expect(msg.tool_call_id).toBe("call_99");
     });
 
-    it("prefers an explicit tool_call_id on message-start over fallbacks", () => {
+    it("prefers an explicit tool_call_id on message-start over fallbacks", async () => {
       const { store, projection } = makeProjection();
 
       projection.recordToolCallNamespace(["tools:abc"], "call_namespace");
@@ -380,12 +396,15 @@ describe("RootMessageProjection", () => {
         blockStartEvent(0, { type: "text", text: "x" }, ["tools:abc"])
       );
 
+      await drainFlush();
       const msg = store.getSnapshot().messages[0] as ToolMessage;
       expect(msg.tool_call_id).toBe("call_explicit");
     });
 
-    it("feeds new assembled messages into subagent discovery", () => {
+    it("feeds new assembled messages into subagent discovery", async () => {
       const { subagents, projection } = makeProjection();
+      // Subagent discovery runs synchronously inside `handleMessage`
+      // (independent of the store-write flush), so no drain needed.
 
       // The simplest way to drive discovery is via the subagents'
       // value-flow, but we can also exercise the message-flow. Use a
@@ -408,7 +427,7 @@ describe("RootMessageProjection", () => {
   });
 
   describe("applyValues", () => {
-    it("seeds messages from a values snapshot when nothing has streamed yet", () => {
+    it("seeds messages from a values snapshot when nothing has streamed yet", async () => {
       const { store, projection } = makeProjection();
 
       const valueMsg = new AIMessage({ id: "a1", content: "values hello" });
@@ -417,10 +436,11 @@ describe("RootMessageProjection", () => {
         [valueMsg]
       );
 
+      await drainFlush();
       expect(store.getSnapshot().messages).toEqual([valueMsg]);
     });
 
-    it("keeps streamed in-flight content while values dictates ordering", () => {
+    it("keeps streamed in-flight content while values dictates ordering", async () => {
       const { store, projection } = makeProjection();
 
       // Stream an AI message in.
@@ -437,6 +457,7 @@ describe("RootMessageProjection", () => {
         [human, aiFromValues]
       );
 
+      await drainFlush();
       const snap = store.getSnapshot();
       expect(snap.messages).toHaveLength(2);
       expect(snap.messages[0]).toBe(human);
@@ -444,7 +465,7 @@ describe("RootMessageProjection", () => {
       expect(snap.messages[1].text).toBe("streamed");
     });
 
-    it("prefers the values version when it carries finalized tool-call data the stream lacks", () => {
+    it("prefers the values version when it carries finalized tool-call data the stream lacks", async () => {
       const { store, projection } = makeProjection();
 
       // Stream an AI message with no tool calls.
@@ -463,12 +484,13 @@ describe("RootMessageProjection", () => {
         [finalized]
       );
 
+      await drainFlush();
       const out = store.getSnapshot().messages[0] as AIMessage;
       expect(out.tool_calls).toHaveLength(1);
       expect(out.tool_calls?.[0]?.id).toBe("tc-1");
     });
 
-    it("continues to process values snapshots after message usage events", () => {
+    it("continues to process values snapshots after message usage events", async () => {
       const { store, projection } = makeProjection();
 
       projection.handleMessage(startEvent({ id: "a1", role: "ai" }, ["model:1"]));
@@ -495,6 +517,7 @@ describe("RootMessageProjection", () => {
         [human, ai, tool, final]
       );
 
+      await drainFlush();
       expect(store.getSnapshot().messages.map((message) => message.id)).toEqual([
         "h1",
         "a1",
@@ -503,8 +526,8 @@ describe("RootMessageProjection", () => {
       ]);
     });
 
-    it("replays the React agent tool-result stream fixture", () => {
-      const snapshot = replayRootProjection(
+    it("replays the React agent tool-result stream fixture", async () => {
+      const snapshot = await replayRootProjection(
         parseSseFixture(
           new URL(
             "../tests/fixtures/react-agent-tool-result-events.sse",
@@ -603,11 +626,11 @@ describe("RootMessageProjection", () => {
       `);
     });
 
-    it("replays the reasoning token stream fixture without collapsing reasoning blocks", () => {
+    it("replays the reasoning token stream fixture without collapsing reasoning blocks", async () => {
       const events = parseSseFixture(
         new URL("../tests/fixtures/reasoning-token-events.sse", import.meta.url)
       );
-      const textDeltaSnapshot = replayRootProjection(
+      const textDeltaSnapshot = await replayRootProjection(
         events.filter((event) => event.seq != null && event.seq <= 201)
       );
       const textDeltaAiMessage = textDeltaSnapshot.messages.find(
@@ -655,7 +678,7 @@ describe("RootMessageProjection", () => {
         }
       `);
 
-      const snapshot = replayRootProjection(events);
+      const snapshot = await replayRootProjection(events);
 
       expect(snapshot.messages).toHaveLength(2);
       expect(snapshot.messages.map(summarizeMessage)).toMatchInlineSnapshot(`
@@ -712,7 +735,7 @@ describe("RootMessageProjection", () => {
       `);
     });
 
-    it("drops messages removed from a later values snapshot", () => {
+    it("drops messages removed from a later values snapshot", async () => {
       const { store, projection } = makeProjection();
 
       const a = new AIMessage({ id: "a1", content: "first" });
@@ -721,16 +744,18 @@ describe("RootMessageProjection", () => {
         { messages: [a, b] } as State,
         [a, b]
       );
+      await drainFlush();
       expect(store.getSnapshot().messages).toHaveLength(2);
 
       projection.applyValues(
         { messages: [a] } as State,
         [a]
       );
+      await drainFlush();
       expect(store.getSnapshot().messages).toEqual([a]);
     });
 
-    it("only updates values when messages are empty", () => {
+    it("only updates values when messages are empty", async () => {
       const { store, projection } = makeProjection();
 
       projection.applyValues(
@@ -738,12 +763,13 @@ describe("RootMessageProjection", () => {
         []
       );
 
+      await drainFlush();
       const snap = store.getSnapshot();
       expect(snap.messages).toEqual([]);
       expect((snap.values as State).cursor).toBe("step-1");
     });
 
-    it("preserves snapshot identity for repeated values snapshots", () => {
+    it("preserves snapshot identity for repeated values snapshots", async () => {
       const { store, projection } = makeProjection();
 
       const a = new AIMessage({ id: "a1", content: "stable" });
@@ -751,6 +777,7 @@ describe("RootMessageProjection", () => {
         { messages: [a] } as State,
         [a]
       );
+      await drainFlush();
       const before = store.getSnapshot();
 
       const aClone = new AIMessage({ id: "a1", content: "stable" });
@@ -759,10 +786,11 @@ describe("RootMessageProjection", () => {
         [aClone]
       );
 
+      await drainFlush();
       expect(store.getSnapshot()).toBe(before);
     });
 
-    it("rebuilds the id index after a values reorder so subsequent deltas target the right slot", () => {
+    it("rebuilds the id index after a values reorder so subsequent deltas target the right slot", async () => {
       const { store, projection } = makeProjection();
 
       // Stream message a1 first.
@@ -785,6 +813,7 @@ describe("RootMessageProjection", () => {
         blockDeltaEvent(0, { type: "text", text: "+more" })
       );
 
+      await drainFlush();
       const snap = store.getSnapshot();
       expect(snap.messages).toHaveLength(2);
       expect(snap.messages[0]).toBe(human);
@@ -794,7 +823,7 @@ describe("RootMessageProjection", () => {
   });
 
   describe("reset", () => {
-    it("clears all per-thread state", () => {
+    it("clears all per-thread state", async () => {
       const { store, projection } = makeProjection();
 
       projection.handleMessage(startEvent({ id: "a1", role: "ai" }));
@@ -802,6 +831,7 @@ describe("RootMessageProjection", () => {
         blockStartEvent(0, { type: "text", text: "hello" })
       );
       projection.recordToolCallNamespace(["tools:1"], "call_1");
+      await drainFlush();
       expect(store.getSnapshot().messages).toHaveLength(1);
 
       projection.reset();
@@ -816,17 +846,19 @@ describe("RootMessageProjection", () => {
         blockStartEvent(0, { type: "text", text: "fresh" })
       );
 
+      await drainFlush();
       const after = store.getSnapshot();
       // Without the reset, the projection would have reused index 0.
       // After reset, the new message is appended at the next slot.
       expect(after.messages.length).toBeGreaterThan(beforeReplay.messages.length);
     });
 
-    it("re-clears the values-message id set so removals work after a thread swap", () => {
+    it("re-clears the values-message id set so removals work after a thread swap", async () => {
       const { store, projection } = makeProjection();
 
       const a = new AIMessage({ id: "a1", content: "v1" });
       projection.applyValues({ messages: [a] } as State, [a]);
+      await drainFlush();
       expect(store.getSnapshot().messages).toEqual([a]);
 
       // Simulate the controller resetting per-thread state on swap.
@@ -843,20 +875,141 @@ describe("RootMessageProjection", () => {
       );
 
       projection.applyValues({ messages: [] } as State, []);
+      await drainFlush();
       const messages = store.getSnapshot().messages;
       expect(messages.some((m) => m.id === "b1")).toBe(true);
     });
   });
 
+  describe("scheduling", () => {
+    // Two regressions live here:
+    //
+    //  1. The freeze that motivated PR #2384. When a long thread
+    //     replays through the `messages` channel — on refresh, on
+    //     resume of an in-flight run, or on a rapidly-streaming
+    //     subagent — many events drain through the `for await` pump
+    //     as a long microtask chain. Calling `store.setState` per
+    //     event fires `useSyncExternalStore` notifications per
+    //     event, and after enough notifications React's
+    //     `nestedUpdateCount` guard trips with "Maximum update
+    //     depth exceeded", freezing the UI on the first few messages.
+    //
+    //  2. PR #2384 itself, which fixed (1) by batching every write
+    //     through a `MessageChannel` macrotask but broke initial-
+    //     submit streaming — the user message and the streaming AI
+    //     response never rendered in the live browser until refresh.
+    //
+    // The contract this projection guarantees:
+    //   - A streamed event commits to the store within one
+    //     macrotask, so React renders it on the very next paint.
+    //   - A burst of events arriving in a single microtask chain
+    //     collapses to a small, bounded number of store
+    //     notifications.
+
+    it("commits a streamed event within one macrotask so the next render sees it", async () => {
+      const { store, projection } = makeProjection();
+
+      projection.handleMessage(startEvent({ id: "m1", role: "ai" }));
+      projection.handleMessage(
+        blockStartEvent(0, { type: "text", text: "hello" })
+      );
+
+      // `drainFlush` is one `setTimeout(0)` — the same macrotask
+      // boundary the projection schedules its flush on. By the time
+      // it resolves, the store must reflect the streamed content.
+      // A scheduler that needed more than one macrotask (a chain of
+      // deferrals) would still show the pre-event state here and
+      // break initial-submit streaming in the live browser.
+      await drainFlush();
+      const snap = store.getSnapshot();
+      expect(snap.messages).toHaveLength(1);
+      expect(snap.messages[0].text).toBe("hello");
+    });
+
+    it("commits a values snapshot within one macrotask", async () => {
+      const { store, projection } = makeProjection();
+
+      const human = new HumanMessage({ id: "h1", content: "hi" });
+      projection.applyValues({ messages: [human] } as State, [human]);
+
+      // Hydrate on thread bind goes through `applyValues`. The
+      // hydrated state must be visible to React on the first paint
+      // after thread navigation; an unbounded deferral chain here
+      // would flash an empty state.
+      await drainFlush();
+      expect(store.getSnapshot().messages).toEqual([human]);
+    });
+
+    it("coalesces a synchronous burst of deltas so the store is notified a bounded number of times", async () => {
+      const { store, projection } = makeProjection();
+      let notifications = 0;
+      store.subscribe(() => {
+        notifications += 1;
+      });
+
+      projection.handleMessage(startEvent({ id: "m1", role: "ai" }));
+      projection.handleMessage(
+        blockStartEvent(0, { type: "text", text: "" })
+      );
+      const burst = 200;
+      for (let i = 0; i < burst; i += 1) {
+        projection.handleMessage(
+          blockDeltaEvent(0, { type: "text", text: "x" })
+        );
+      }
+
+      // Drain the next macrotask so the coalesced flush commits.
+      await drainFlush();
+
+      // Without batching, each delta calls `store.setState`, which
+      // notifies once — over 200 notifications for this loop, which
+      // is what trips React's `nestedUpdateCount` guard in the
+      // browser. With macrotask coalescing the entire burst becomes
+      // a single store notification.
+      expect(notifications).toBeLessThan(10);
+      // The final accumulated content has to commit by the time the
+      // flush settles — losing the tail would mean stuck UI.
+      expect(store.getSnapshot().messages[0].text.length).toBe(burst);
+    });
+
+    it("coalesces a long values replay into the store", async () => {
+      const { store, projection } = makeProjection();
+      let notifications = 0;
+      store.subscribe(() => {
+        notifications += 1;
+      });
+
+      // Many sequential `applyValues` calls in the same tick — what
+      // a long-thread hydrate or a fast checkpoint replay looks like.
+      for (let i = 0; i < 50; i += 1) {
+        const a = new AIMessage({ id: `m${i}`, content: `v${i}` });
+        projection.applyValues(
+          { messages: [a] } as State,
+          [a]
+        );
+      }
+
+      await drainFlush();
+
+      // The final snapshot must commit; otherwise the UI shows a
+      // stale earlier replay step on first render.
+      expect((store.getSnapshot().messages[0] as AIMessage).content).toBe(
+        "v49"
+      );
+      // And the burst must coalesce — 50 sequential per-event
+      // notifications is what trips React's nested-update guard.
+      expect(notifications).toBeLessThan(10);
+    });
+  });
+
   describe("messagesKey customization", () => {
-    it("respects an alternate messages key", () => {
+    it("respects an alternate messages key", async () => {
       const store = makeRootStore();
       const subagents = new SubagentDiscovery();
       const projection = new RootMessageProjection({
         messagesKey: "history",
         store,
         subagents,
-        flushImmediately: true,
       });
 
       projection.handleMessage(startEvent({ id: "m1", role: "ai" }));
@@ -864,6 +1017,7 @@ describe("RootMessageProjection", () => {
         blockStartEvent(0, { type: "text", text: "hi" })
       );
 
+      await drainFlush();
       const values = store.getSnapshot().values as Record<string, unknown>;
       expect(Array.isArray(values.history)).toBe(true);
       expect(values.messages).toBeUndefined();

--- a/libs/sdk/src/stream/root-message-projection.ts
+++ b/libs/sdk/src/stream/root-message-projection.ts
@@ -45,6 +45,24 @@
  * `tool_call_id` and downstream UIs can't pair them with the
  * originating tool call.
  *
+ * # Store-write batching
+ *
+ * Every {@link handleMessage} / {@link applyValues} call updates the
+ * in-projection bookkeeping (assembler state, id index, role cache)
+ * synchronously, then stages the new `messages` / `values` into a
+ * pending buffer and schedules a `setTimeout(0)` flush. A single
+ * coalesced `store.setState` runs at the next macrotask boundary.
+ *
+ * The motivation is the long-replay freeze: a thread with hundreds
+ * of messages replays through the `messages` channel on refresh or
+ * mid-run join. Those events drain through the controller's
+ * `for await` pump as a long microtask chain. Per-event
+ * `store.setState` notifies `useSyncExternalStore` per event, and
+ * after enough notifications React's `nestedUpdateCount` guard trips
+ * with "Maximum update depth exceeded", permanently freezing the UI
+ * on the first few messages. Coalescing to one notification per
+ * macrotask lets React's scheduler commit between flushes.
+ *
  * # Lifecycle
  *
  *   - `handleMessage(event)`              — apply a `messages` event delta.
@@ -148,125 +166,36 @@ export class RootMessageProjection<
 
   /**
    * Coalescing buffer for store writes. {@link handleMessage} and
-   * {@link applyValues} compute their new ``messages`` / ``values``
-   * synchronously (and mutate {@link #indexById} /
-   * {@link #valuesMessageIds} synchronously, so subsequent calls in
-   * the same tick see the up-to-date positions) but stage the result
-   * here instead of calling ``store.setState`` per event. A single
-   * ``MessageChannel`` (macrotask) flush copies the staged values
-   * onto the store in one ``setState`` call per tick.
+   * {@link applyValues} stage their computed `messages` / `values`
+   * here instead of calling `store.setState` per event. A single
+   * `setTimeout(0)` flush commits them in one `setState`, so a
+   * burst of SSE events draining as a microtask chain becomes one
+   * store notification at the next macrotask boundary.
    *
-   * This is the same pattern the namespace-scoped messages projection
-   * uses (``projections/messages.ts``). The motivation is identical:
-   * when many messages-channel events land in a single SSE parse
-   * (replay of an in-flight run, mid-run join after navigating back,
-   * or a rapidly-streaming subagent), they drain through the
-   * ``for await`` pump as a long microtask chain. ``store.setValue``
-   * per event fires ``useSyncExternalStore`` notifications per event,
-   * each scheduling a React update, and after ~50 the depth check
-   * trips with "Maximum update depth exceeded". Batching collapses
-   * the burst to one notification per macrotask and lets React's
-   * scheduler commit between flushes.
-   *
-   * ``null`` when there's nothing pending — the pending fields and
-   * the ``flushScheduled`` flag together represent the dirty bit.
+   * `null` means "no staged write" — once a flush settles, the
+   * slots are cleared so the next call starts from the latest
+   * committed store snapshot.
    */
   #pendingMessages: BaseMessage[] | null = null;
   #pendingValues: StateType | null = null;
   #flushScheduled = false;
-  readonly #flushChannel: MessageChannel | null;
 
   /**
-   * When ``true``, ``handleMessage`` / ``applyValues`` write to the
-   * store synchronously instead of deferring through the
-   * ``MessageChannel``. Used by unit tests that assert against the
-   * store immediately after a call; production callers leave it
-   * ``false`` so the batching kicks in and the ``setState`` burst
-   * during heavy SSE replay collapses to one notification per
-   * macrotask.
-   */
-  readonly #flushImmediately: boolean;
-
-  /**
-   * @param params.messagesKey      - Key inside `values` that holds
-   *   the message array.
-   * @param params.store            - Root snapshot store to mutate.
-   * @param params.subagents        - Discovery runner fed by each
-   *   new assembled message.
-   * @param params.flushImmediately - Test-only: bypass the macrotask
-   *   batching so the store reflects each write synchronously.
-   *   Defaults to ``false``.
+   * @param params.messagesKey - Key inside `values` that holds the
+   *   message array.
+   * @param params.store       - Root snapshot store to mutate.
+   * @param params.subagents   - Discovery runner fed by each new
+   *   assembled message.
    */
   constructor(params: {
     messagesKey: string;
     store: StreamStore<RootSnapshot<StateType, InterruptType>>;
     subagents: SubagentDiscovery;
-    flushImmediately?: boolean;
   }) {
     this.#messagesKey = params.messagesKey;
     this.#store = params.store;
     this.#subagents = params.subagents;
-    this.#flushImmediately = params.flushImmediately ?? false;
-    this.#flushChannel =
-      !this.#flushImmediately && typeof MessageChannel !== "undefined"
-        ? new MessageChannel()
-        : null;
-    if (this.#flushChannel != null) {
-      this.#flushChannel.port1.onmessage = this.#flushPending;
-    }
   }
-
-  /**
-   * Drain ``#pendingMessages`` / ``#pendingValues`` to the store in a
-   * single ``setState`` call. Called from the ``MessageChannel``
-   * macrotask handler (or ``setTimeout`` fallback in environments
-   * without ``MessageChannel``).
-   */
-  #flushPending = (): void => {
-    this.#flushScheduled = false;
-    const messages = this.#pendingMessages;
-    const values = this.#pendingValues;
-    this.#pendingMessages = null;
-    this.#pendingValues = null;
-    if (messages == null && values == null) return;
-    this.#store.setState((s) => {
-      // Other rootStore mutators (controller-driven `isLoading`,
-      // `interrupts`, `toolCalls`, etc.) do not touch
-      // `s.messages` / `s.values`, so a last-write-wins commit on
-      // those two fields is safe. If that ever changes, this is the
-      // spot to add a per-field merge instead.
-      if (messages == null) {
-        return values == null ? s : { ...s, values };
-      }
-      if (values == null) return { ...s, messages };
-      return { ...s, messages, values };
-    });
-  };
-
-  /**
-   * Schedule a ``#flushPending`` on the next macrotask. Idempotent
-   * within a tick — multiple ``handleMessage`` / ``applyValues``
-   * calls before the flush coalesce into one store write.
-   */
-  #scheduleFlush = (): void => {
-    if (this.#flushImmediately) {
-      // Synchronous path for unit tests — the test asserts against
-      // the store directly after each ``handleMessage`` /
-      // ``applyValues`` call without awaiting a tick.
-      this.#flushPending();
-      return;
-    }
-    if (this.#flushScheduled) return;
-    this.#flushScheduled = true;
-    if (this.#flushChannel != null) {
-      this.#flushChannel.port2.postMessage(null);
-    } else {
-      // ``setTimeout(0)`` is a macrotask in every browser/Node — same
-      // ordering as ``MessageChannel`` for our purposes (runs after
-      // the current microtask chain drains, so React gets to commit).
-      setTimeout(this.#flushPending, 0);
-    }
-  };
 
   /**
    * Drop all per-thread state. Called by the controller on thread
@@ -278,9 +207,9 @@ export class RootMessageProjection<
     this.#indexById.clear();
     this.#valuesMessageIds = new Set();
     this.#toolCallIdByNamespace.clear();
-    // Drop any unflushed pending state — it was computed against the
-    // previous thread's baseline, so committing it after reset would
-    // bleed stale messages into the new thread's snapshot.
+    // Drop any unflushed pending writes — they were computed against
+    // the previous thread's baseline and committing them after a
+    // rebind would bleed stale messages into the new thread.
     this.#pendingMessages = null;
     this.#pendingValues = null;
     this.#flushScheduled = false;
@@ -310,7 +239,7 @@ export class RootMessageProjection<
    * Captures role/tool metadata on `message-start`, feeds the chunk
    * to the assembler, projects the assembled output to a
    * {@link BaseMessage}, and either appends or in-place updates the
-   * store's messages array based on whether the id was seen before.
+   * pending messages buffer based on whether the id was seen before.
    *
    * @param event - The `messages` channel event to consume.
    */
@@ -358,24 +287,21 @@ export class RootMessageProjection<
     // Compute against the pending baseline if we have one (so an
     // earlier handleMessage in the same tick is the input to this
     // one), else against the latest committed store snapshot.
-    // ``#indexById`` is the synchronous source of truth for "where
-    // is each id in the current messages list" — every code path in
-    // this method updates it before returning.
+    // `#indexById` is the synchronous source of truth for "where is
+    // each id in the current messages list" — every code path below
+    // keeps it in sync before returning.
     const baselineMessages =
       this.#pendingMessages ?? this.#store.getSnapshot().messages;
     const existingIdx = this.#indexById.get(id);
     let messages: BaseMessage[];
     if (existingIdx == null) {
-      // First sighting: append at end and remember its index for
-      // future delta updates.
       this.#indexById.set(id, baselineMessages.length);
       messages = [...baselineMessages, base];
     } else if (messagesEqual(baselineMessages[existingIdx], base)) {
-      // Identical re-emission of an already-projected message —
-      // skip the store write to keep snapshot identity stable.
+      // Identical re-emission — skip the store write to keep
+      // snapshot identity stable.
       return;
     } else {
-      // In-place update for a known id.
       messages = baselineMessages.slice();
       messages[existingIdx] = base;
     }
@@ -391,9 +317,7 @@ export class RootMessageProjection<
       messages
     );
     this.#pendingMessages = messages;
-    if (values !== baselineValues) {
-      this.#pendingValues = values;
-    }
+    if (values !== baselineValues) this.#pendingValues = values;
     this.#scheduleFlush();
   }
 
@@ -418,14 +342,19 @@ export class RootMessageProjection<
     const baselineValues = this.#pendingValues ?? baselineSnapshot.values;
 
     if (nextMessages.length === 0) {
-      // Empty messages array — just refresh the values blob if it
-      // changed shape.
       if (
         stateValuesShallowEqual(baselineValues, nextValues, this.#messagesKey)
       ) {
         return;
       }
-      this.#pendingValues = nextValues;
+      // Mirror the current `messages` list back into the values slot
+      // so the staged snapshot stays consistent with the (separately
+      // tracked) messages array.
+      this.#pendingValues = syncMessagesIntoValues(
+        nextValues,
+        this.#messagesKey,
+        baselineMessages
+      );
       this.#scheduleFlush();
       return;
     }
@@ -460,6 +389,46 @@ export class RootMessageProjection<
     this.#pendingValues = values;
     this.#scheduleFlush();
   }
+
+  /**
+   * Schedule a coalesced flush on the next macrotask. Idempotent
+   * within a tick — multiple `handleMessage` / `applyValues` calls
+   * before the flush fires collapse into one store write.
+   *
+   * `setTimeout(0)` is a macrotask: it runs after the current
+   * microtask chain drains, so a burst of SSE events processed by
+   * the controller's `for await` pump becomes one `store.setState`
+   * (and therefore one `useSyncExternalStore` notification).
+   */
+  #scheduleFlush = (): void => {
+    if (this.#flushScheduled) return;
+    this.#flushScheduled = true;
+    setTimeout(this.#flushPending, 0);
+  };
+
+  /**
+   * Drain `#pendingMessages` / `#pendingValues` to the store in a
+   * single `setState` call.
+   */
+  #flushPending = (): void => {
+    this.#flushScheduled = false;
+    const messages = this.#pendingMessages;
+    const values = this.#pendingValues;
+    this.#pendingMessages = null;
+    this.#pendingValues = null;
+    if (messages == null && values == null) return;
+    this.#store.setState((s) => {
+      // Other rootStore mutators (controller-driven `isLoading`,
+      // `interrupts`, `toolCalls`, etc.) do not touch `s.messages`
+      // / `s.values`, so a last-write-wins commit on those two
+      // fields is safe.
+      if (messages == null) {
+        return values == null ? s : { ...s, values };
+      }
+      if (values == null) return { ...s, messages };
+      return { ...s, messages, values };
+    });
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Reworks `RootMessageProjection` batching to fix two regressions at once.

The freeze that #2384 originally addressed: on refresh, mid-run join, or a rapidly-streaming subagent, many `messages`-channel events drain through the controller's `for await` pump as a microtask chain. Per-event `store.setState` calls fire `useSyncExternalStore` notifications per event, and after ~50 React's `nestedUpdateCount` guard trips with "Maximum update depth exceeded", permanently freezing the UI on the first few messages.

The new regression #2384 introduced: its `MessageChannel`-based scheduler deferred the first event of every streaming burst past React's initial render. Initial submit looked frozen — no user message, no AI response — until refresh.

This change keeps the coalescing (so the freeze stays fixed) but swaps the scheduler to `setTimeout(0)` with a `#flushScheduled` idempotency guard:

- `handleMessage` / `applyValues` compute new `messages` / `values` synchronously and stage them in `#pendingMessages` / `#pendingValues`. `#indexById` and `#valuesMessageIds` mutate synchronously so subsequent same-tick calls see up-to-date positions.
- One `setTimeout(0)` flush per tick commits the staged values to the store in a single `setState`. Bursts collapse to one notification; streaming events separated by network latency each flush on their own boundary.
- `reset()` drops pending writes so thread swaps can't bleed staged state.

No test-only flush flag on the projection — the existing tests gained `await drainFlush()` between mutations and assertions.

### New regression coverage

A `scheduling` describe block guards both contracts:

- streamed event commits within one macrotask (would fail on a deferral-chain scheduler — initial-submit freeze)
- values snapshot commits within one macrotask (would fail on hydrate freeze)
- 200-delta synchronous burst → fewer than 10 store notifications (would fail on per-event `setState` — long-replay freeze)
- 50 sequential `applyValues` calls → fewer than 10 store notifications (would fail on hydrate per-event freeze)

Both coalesce tests fail on a sync projection; both single-event tests fail on a multi-macrotask deferral chain.

## Release Note

None