### PR TITLE
fix(sdk): retry connection failures before throwing ConnectionError

### DIFF
--- a/.changeset/hunter-retry-connection-error-coalesce.md
+++ b/.changeset/hunter-retry-connection-error-coalesce.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): retry connection failures before throwing ConnectionError

--- a/libs/sdk-react/src/tests/stream.suspense.test.tsx
+++ b/libs/sdk-react/src/tests/stream.suspense.test.tsx
@@ -90,6 +90,7 @@ function ErrorChat({
     assistantId: "error_graph",
     apiUrl,
     threadId,
+    callerOptions: { maxRetries: 0 },
   });
   return (
     <div>
@@ -129,8 +130,9 @@ it("routes non-streaming errors to the nearest Error Boundary", async () => {
     );
 
     try {
-      // The hydrate request fails (unreachable host). The rejection
-      // propagates through `hydrationPromise` into the Error Boundary.
+      // The hydrate request fails (unreachable host). Retries are
+      // disabled for this test so the failure reaches the boundary
+      // within the suite's 5s timeout.
       await expect
         .element(screen.getByTestId("boundary"), { timeout: 5_000 })
         .toBeInTheDocument();

--- a/libs/sdk-react/src/tests/stream.suspense.test.tsx
+++ b/libs/sdk-react/src/tests/stream.suspense.test.tsx
@@ -65,10 +65,7 @@ interface BoundaryProps {
   fallback: (error: Error) => ReactNode;
 }
 
-class ErrorBoundary extends Component<
-  BoundaryProps,
-  { error: Error | null }
-> {
+class ErrorBoundary extends Component<BoundaryProps, { error: Error | null }> {
   state = { error: null as Error | null };
   static getDerivedStateFromError(error: Error) {
     return { error };
@@ -79,17 +76,12 @@ class ErrorBoundary extends Component<
   }
 }
 
-function ErrorChat({
-  apiUrl,
-  threadId,
-}: {
-  apiUrl: string;
-  threadId: string;
-}) {
+function ErrorChat({ apiUrl, threadId }: { apiUrl: string; threadId: string }) {
   const stream = useSuspenseStream<{ messages: BaseMessage[] }>({
     assistantId: "error_graph",
     apiUrl,
     threadId,
+    // Connection errors trip retry logic, so we choose to fail fast here
     callerOptions: { maxRetries: 0 },
   });
   return (
@@ -119,9 +111,7 @@ it("routes non-streaming errors to the nearest Error Boundary", async () => {
 
     const screen = await render(
       <ErrorBoundary
-        fallback={(error) => (
-          <div data-testid="boundary">{error.message}</div>
-        )}
+        fallback={(error) => <div data-testid="boundary">{error.message}</div>}
       >
         <Suspense fallback={<div data-testid="fallback">loading</div>}>
           <ErrorChat apiUrl={invalidUrl} threadId={threadId} />

--- a/libs/sdk/src/utils/async_caller.test.ts
+++ b/libs/sdk/src/utils/async_caller.test.ts
@@ -172,6 +172,22 @@ describe("AsyncCaller", () => {
         "HTTP 400: Invalid parameters"
       );
     });
+
+    it("should retry connection errors and throw ConnectionError when retries are exhausted", async () => {
+      const caller = new AsyncCaller({ maxRetries: 1 });
+
+      const failingCallable = vi.fn(() =>
+        Promise.reject(new Error("fetch failed: connect ECONNREFUSED"))
+      );
+
+      await expect(caller.call(failingCallable)).rejects.toMatchObject({
+        name: "ConnectionError",
+        message: expect.stringContaining(
+          "Unable to connect to LangGraph server"
+        ),
+      });
+      expect(failingCallable).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe("onFailedResponseHook", () => {

--- a/libs/sdk/src/utils/async_caller.ts
+++ b/libs/sdk/src/utils/async_caller.ts
@@ -154,7 +154,7 @@ export class AsyncCaller {
               }
             }),
           {
-            async onFailedAttempt({ error }) {
+            async onFailedAttempt({ error, retriesLeft }) {
               const errorMessage = error.message ?? "";
               if (
                 errorMessage.startsWith("Cancel") ||
@@ -175,6 +175,7 @@ export class AsyncCaller {
                 errorMessage.includes("Failed to fetch") ||
                 errorMessage.includes("NetworkError")
               ) {
+                if (retriesLeft > 0) return;
                 const connectionError = new Error(
                   `Unable to connect to LangGraph server. Please ensure the server is running and accessible. Original error: ${errorMessage}`
                 );


### PR DESCRIPTION
## Summary

This change updates SDK retry behavior so connection-related failures are retried instead of immediately aborting inside `onFailedAttempt`.
When retries are exhausted, the final surfaced error is still coalesced to a `ConnectionError` with the existing LangGraph-specific guidance.
A focused unit test was added to lock in this behavior.

## Changes

### @langchain/langgraph-sdk

- Updated `AsyncCaller` connection-error handling to only throw `ConnectionError` on the final failed attempt (`retriesLeft === 0`), while allowing retries on earlier attempts.
- Added a regression test covering retry count plus final `ConnectionError` coalescing for connection-refused/fetch-failed style errors.
- Added a patch changeset for `@langchain/langgraph-sdk` documenting the retry/coalescing fix.
