### PR TITLE
fix: support pre-release versions in api_version

### DIFF
--- a/.changeset/common-items-fix.md
+++ b/.changeset/common-items-fix.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-cli": patch
+---
+
+Adding support for pre-release versions in api_version.

--- a/libs/langgraph-cli/src/utils/config.mts
+++ b/libs/langgraph-cli/src/utils/config.mts
@@ -1,8 +1,7 @@
 import { z } from "zod/v3";
 import { extname } from "node:path";
 
-const API_VERSION_PATTERN =
-  /^\d+(?:\.\d+){0,2}(?:[A-Za-z][0-9A-Za-z.-]*)?$/;
+const API_VERSION_PATTERN = /^\d+(?:\.\d+){0,2}(?:[A-Za-z][0-9A-Za-z.-]*)?$/;
 
 const GraphPathSchema = z.string().refine((i) => i.includes(":"), {
   message: "Import string must be in format '<file>:<export>'",

--- a/libs/langgraph-cli/src/utils/config.mts
+++ b/libs/langgraph-cli/src/utils/config.mts
@@ -1,6 +1,9 @@
 import { z } from "zod/v3";
 import { extname } from "node:path";
 
+const API_VERSION_PATTERN =
+  /^\d+(?:\.\d+){0,2}(?:[A-Za-z][0-9A-Za-z.-]*)?$/;
+
 const GraphPathSchema = z.string().refine((i) => i.includes(":"), {
   message: "Import string must be in format '<file>:<export>'",
 });
@@ -22,18 +25,10 @@ const BaseConfigSchema = z.object({
   _INTERNAL_docker_tag: z.string().optional(),
   api_version: z
     .string()
-    .refine(
-      (v) => {
-        const base = v.split("-")[0];
-        const parts = base.split(".");
-        if (parts.length === 0 || parts.length > 3) return false;
-        return parts.every((p) => /^\d+$/.test(p));
-      },
-      {
-        message:
-          "api_version must be in format major, major.minor, or major.minor.patch",
-      }
-    )
+    .refine((v) => API_VERSION_PATTERN.test(v), {
+      message:
+        "api_version must be in format major, major.minor, or major.minor.patch with optional prerelease suffix",
+    })
     .optional(),
   env: z
     .union([z.array(z.string()), z.record(z.string()), z.string()])

--- a/libs/langgraph-cli/tests/config.test.mts
+++ b/libs/langgraph-cli/tests/config.test.mts
@@ -1024,14 +1024,14 @@ describe("getBaseImage", () => {
     );
   });
 
-  it("api_version with suffix", () => {
+  it("api_version with compact suffix", () => {
     const config = getConfig({
       node_version: "22",
       graphs: { agent: "./agent.js:graph" },
-      api_version: "0.7.29-rc1",
+      api_version: "0.7.29rc1",
     });
     expect(getBaseImage(config)).toBe(
-      "langchain/langgraphjs-api:0.7.29-rc1-node22"
+      "langchain/langgraphjs-api:0.7.29rc1-node22"
     );
   });
 
@@ -1238,18 +1238,29 @@ it("node config and python config", () => {
     )
     .toThrow();
 
-  // Valid api_version with suffix
+  // Valid api_version with compact suffix
   expect(
     getConfig({
       node_version: "22",
       graphs: { agent: "./agent.js:graph" },
-      api_version: "0.7.29-rc1",
+      api_version: "0.7.29rc1",
     })
   ).toEqual({
     node_version: "22",
     dockerfile_lines: [],
     graphs: { agent: "./agent.js:graph" },
     env: {},
-    api_version: "0.7.29-rc1",
+    api_version: "0.7.29rc1",
   });
+
+  // Invalid api_version format - hyphen prerelease suffix
+  expect
+    .soft(() =>
+      getConfig({
+        node_version: "22",
+        graphs: { agent: "./agent.js:graph" },
+        api_version: "0.7.29-rc1",
+      })
+    )
+    .toThrow();
 });


### PR DESCRIPTION
<!--
Thank you for contributing to LangGraph.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langgraphjs/blob/main/CONTRIBUTING.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixing api_version in langgraph.json to support PEP compatible versions (e.g. `0.9.0rc1`). Today we support JS compatible versions (e.g. `0.9.0-rc1` but langgraph-api is a python package so the versioning doesn't make sense and runs into issues with the image names.