### PR TITLE
fix(sdk): bind subagent namespace to execution scope via taskInput

### DIFF
--- a/.changeset/subagent-execution-namespace.md
+++ b/.changeset/subagent-execution-namespace.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+Bind deepagents subagent discovery to the execution namespace via taskInput so `useMessages(stream, subagent)` resolves the streaming scope instead of the trigger tool-call namespace.

--- a/libs/sdk/src/stream/discovery/subagents.test.ts
+++ b/libs/sdk/src/stream/discovery/subagents.test.ts
@@ -438,4 +438,130 @@ describe("SubagentDiscovery", () => {
     });
     expect(commits).toHaveLength(1);
   });
+
+  // When two parallel dispatches share the same `taskInput` (LLM
+  // re-uses a description, or the prompt asks for N copies of the
+  // same task), the content match alone is ambiguous. Pregel
+  // dispatches and starts executions in superstep order, so FIFO
+  // attribution by dispatch order matches execution start order.
+  it("attributes duplicate-taskInput dispatches to executions in FIFO order", () => {
+    const discovery = new SubagentDiscovery();
+
+    discovery.discoverFromMessage(
+      new AIMessage({
+        id: "orchestrator",
+        content: "",
+        tool_calls: [
+          {
+            id: "toolu_A",
+            name: "task",
+            args: {
+              description: "Write a haiku",
+              subagent_type: "haiku-drafter",
+            },
+          },
+          {
+            id: "toolu_B",
+            name: "task",
+            args: {
+              description: "Write a haiku",
+              subagent_type: "haiku-drafter",
+            },
+          },
+        ],
+      }),
+      []
+    );
+
+    // First execution fires.
+    discovery.push({
+      type: "event",
+      method: "values",
+      params: {
+        namespace: ["tools:exec-X"],
+        timestamp: Date.now(),
+        data: { messages: [{ type: "human", content: "Write a haiku" }] },
+      },
+    } as ValuesEvent & Event);
+
+    // Second execution fires.
+    discovery.push({
+      type: "event",
+      method: "values",
+      params: {
+        namespace: ["tools:exec-Y"],
+        timestamp: Date.now() + 1,
+        data: { messages: [{ type: "human", content: "Write a haiku" }] },
+      },
+    } as ValuesEvent & Event);
+
+    expect(discovery.snapshot.get("toolu_A")?.namespace).toEqual([
+      "tools:exec-X",
+    ]);
+    expect(discovery.snapshot.get("toolu_B")?.namespace).toEqual([
+      "tools:exec-Y",
+    ]);
+  });
+
+  // Deepagents-style: the parent's task tool call uses an Anthropic id
+  // (`toolu_*`), but the subagent's pregel execution emits at a
+  // distinct `tools:<uuid>` namespace. The wire carries no explicit
+  // link — taskInput → HumanMessage content is the deterministic one.
+  it("promotes deepagents-style subagents to the execution namespace by matching HumanMessage content to taskInput", () => {
+    const discovery = new SubagentDiscovery();
+
+    // Coordinator dispatches; subagent will execute under a distinct UUID.
+    discovery.discoverFromMessage(
+      new AIMessage({
+        id: "orchestrator",
+        content: "",
+        tool_calls: [
+          {
+            id: "toolu_haiku",
+            name: "task",
+            args: {
+              description: "Write a haiku about cats",
+              subagent_type: "haiku-drafter",
+            },
+          },
+        ],
+      }),
+      []
+    );
+
+    expect(discovery.snapshot.get("toolu_haiku")).toMatchObject({
+      id: "toolu_haiku",
+      name: "haiku-drafter",
+      namespace: ["tools:toolu_haiku"],
+      taskInput: "Write a haiku about cats",
+    });
+
+    // First values event at the execution namespace seeds the
+    // subagent with a HumanMessage of the taskInput.
+    discovery.push({
+      type: "event",
+      method: "values",
+      params: {
+        namespace: ["tools:exec-uuid-123"],
+        timestamp: Date.now(),
+        data: {
+          messages: [
+            {
+              type: "human",
+              content: "Write a haiku about cats",
+              id: "subagent-human-1",
+            },
+          ],
+        },
+      },
+    } as ValuesEvent & Event);
+
+    // Subagent should now point at the execution namespace so
+    // `useMessages(stream, subagent)` resolves to the right scope.
+    expect(discovery.snapshot.get("toolu_haiku")).toMatchObject({
+      id: "toolu_haiku",
+      name: "haiku-drafter",
+      namespace: ["tools:exec-uuid-123"],
+    });
+  });
 });

--- a/libs/sdk/src/stream/discovery/subagents.ts
+++ b/libs/sdk/src/stream/discovery/subagents.ts
@@ -46,6 +46,16 @@ export class SubagentDiscovery {
   #map = new Map<string, MutableSubagent>();
   #taskIdByObservedNamespace = new Map<string, string>();
   #observedOwnNamespaces = new Set<string>();
+  // Index from `taskInput` (the `description` arg) to a FIFO queue of
+  // pending parent `tool_call_id`s. Bridges the wire's missing link
+  // between a deepagents `task` dispatch and its subagent execution
+  // namespace — the server seeds the subagent's first HumanMessage
+  // with `taskInput` verbatim, so an exact-equality lookup is
+  // deterministic. The queue (not a single value) handles the case
+  // where the coordinator dispatches N task calls with identical
+  // descriptions; pregel preserves dispatch order across executions,
+  // so FIFO pop attributes them correctly.
+  #toolCallIdByTaskInput = new Map<string, string[]>();
 
   /** Feed a single root event. Non-discovery events are ignored. */
   push(event: Event): void {
@@ -119,6 +129,11 @@ export class SubagentDiscovery {
     if (data == null || typeof data !== "object" || Array.isArray(data)) return;
     const messages = (data as { messages?: unknown }).messages;
     if (!Array.isArray(messages)) return;
+
+    // If a `tools:<id>` namespace's first HumanMessage matches a known
+    // taskInput, that's the subagent's execution scope. Record the
+    // binding so `#recordObservedWorkNamespace` can promote it.
+    this.#bindNamespaceByTaskInput(event.params.namespace, messages);
 
     let changed = this.#recordObservedWorkNamespace(event.params.namespace);
     for (const message of messages) {
@@ -202,6 +217,12 @@ export class SubagentDiscovery {
     // the worker's scoped message/tool state exists.
     const { parentId, depth } = lineageFromNamespace(eventNamespace);
     this.#recordTaskNamespaceCandidate(toolCallId, eventNamespace);
+    if (input.description != null) {
+      const queue =
+        this.#toolCallIdByTaskInput.get(input.description) ?? [];
+      queue.push(toolCallId);
+      this.#toolCallIdByTaskInput.set(input.description, queue);
+    }
     this.#map.set(toolCallId, {
       id: toolCallId,
       name: input.subagent_type ?? "unknown",
@@ -252,6 +273,47 @@ export class SubagentDiscovery {
     if (!isConcreteToolNamespace(namespace)) return;
     this.#taskIdByObservedNamespace.set(namespaceKey(namespace), toolCallId);
   }
+
+  /**
+   * Bind a `tools:<id>` namespace to a registered subagent by looking
+   * up the first HumanMessage content in the `taskInput` index.
+   */
+  #bindNamespaceByTaskInput(
+    namespace: readonly string[],
+    messages: unknown[]
+  ): void {
+    if (!isConcreteToolNamespace(namespace)) return;
+    const namespaceKeyed = namespaceKey(namespace);
+    if (this.#taskIdByObservedNamespace.has(namespaceKeyed)) return;
+
+    const text = getFirstHumanMessageText(messages);
+    if (text == null) return;
+    const toolCallId = this.#toolCallIdByTaskInput.get(text)?.shift();
+    if (toolCallId == null) return;
+    this.#taskIdByObservedNamespace.set(namespaceKeyed, toolCallId);
+  }
+}
+
+function getFirstHumanMessageText(messages: unknown[]): string | null {
+  for (const message of messages) {
+    if (message == null || typeof message !== "object") continue;
+    const record = message as {
+      type?: unknown;
+      role?: unknown;
+      content?: unknown;
+      kwargs?: { type?: unknown; content?: unknown };
+      lc_kwargs?: { type?: unknown; content?: unknown };
+    };
+    const type =
+      record.type ?? record.role ?? record.kwargs?.type ?? record.lc_kwargs?.type;
+    if (type !== "human") continue;
+    const content =
+      record.content ??
+      record.kwargs?.content ??
+      record.lc_kwargs?.content;
+    return typeof content === "string" && content.length > 0 ? content : null;
+  }
+  return null;
 }
 
 function shouldPromoteToObservedNamespace(entry: MutableSubagent): boolean {

--- a/libs/sdk/src/stream/discovery/subagents.ts
+++ b/libs/sdk/src/stream/discovery/subagents.ts
@@ -218,8 +218,7 @@ export class SubagentDiscovery {
     const { parentId, depth } = lineageFromNamespace(eventNamespace);
     this.#recordTaskNamespaceCandidate(toolCallId, eventNamespace);
     if (input.description != null) {
-      const queue =
-        this.#toolCallIdByTaskInput.get(input.description) ?? [];
+      const queue = this.#toolCallIdByTaskInput.get(input.description) ?? [];
       queue.push(toolCallId);
       this.#toolCallIdByTaskInput.set(input.description, queue);
     }
@@ -305,12 +304,13 @@ function getFirstHumanMessageText(messages: unknown[]): string | null {
       lc_kwargs?: { type?: unknown; content?: unknown };
     };
     const type =
-      record.type ?? record.role ?? record.kwargs?.type ?? record.lc_kwargs?.type;
+      record.type ??
+      record.role ??
+      record.kwargs?.type ??
+      record.lc_kwargs?.type;
     if (type !== "human") continue;
     const content =
-      record.content ??
-      record.kwargs?.content ??
-      record.lc_kwargs?.content;
+      record.content ?? record.kwargs?.content ?? record.lc_kwargs?.content;
     return typeof content === "string" && content.length > 0 ? content : null;
   }
   return null;


### PR DESCRIPTION
## Summary

When the SDK consumes a deepagents run over protocol-v2, the parent's `task` tool call registers a subagent under `tools:<tool_call_id>` (e.g. `tools:toolu_*`), but the subagent's pregel execution emits its `values`/`messages`/`lifecycle` events at a **sibling** namespace `tools:<pregel-uuid>` — not nested, no shared segment. `SubagentDiscovery` tracked the trigger namespace, so `useMessages(stream, subagent)` filtered the wrong scope and consumers saw empty subagent cards while content streamed server-side.

The wire carries no first-class link between the two namespaces — the lifecycle event's `trigger_call_id` is the Pregel UUID, not the Anthropic `tool_call_id`.

## Approach

The server seeds the subagent's first state with `HumanMessage(content=description)`, so an exact-equality match against `taskInput` is deterministic. Adds:

- `#toolCallIdByTaskInput: Map<string, string[]>` — FIFO queue keyed by taskInput, populated when a `task` tool call is registered.
- `#bindNamespaceByTaskInput` — on the first `values` event at a `tools:<id>` namespace, look up the first HumanMessage text, shift the matching `tool_call_id`, and seed `#taskIdByObservedNamespace`. `#recordObservedWorkNamespace` promotes the namespace as before.

The queue handles parallel dispatches that share a description. Pregel preserves dispatch order across executions, so FIFO pop attributes them correctly.

## Known cliff edges (all silent — card stays empty)

- Wrapper middleware mutates the seeded HumanMessage before it reaches the subagent.
- The HumanMessage uses multimodal content blocks instead of a string.
- A custom \`CompiledSubAgent\` state doesn't include a HumanMessage.

The upstream fix that eliminates the whole class is for langgraph's \`_TasksLifecycleBase\` (or deepagents) to enrich the subagent's lifecycle payload with \`cause: { tool_call_id }\`. That would replace this bridge with a flat lookup.