### PR TITLE
fix(sdk): normalize BaseMessage instances to canonical dicts in request bodies

### DIFF
--- a/.changeset/normalize-base-message-instances.md
+++ b/.changeset/normalize-base-message-instances.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+Normalize `BaseMessage` instances to canonical `{type, content, ...}` dicts in client request bodies (HTTP `json` payloads and v2 transport command bodies). Previously the default `JSON.stringify` invoked `BaseMessage.toJSON()` and emitted the `{lc:1, type:"constructor", id, kwargs}` envelope, which the `langgraph-api` Python server can no longer revive (the `langchain_core.load.load()` deserializer was removed from the request path as a CWE-502 mitigation). Plain-dict callers are unaffected — the `isBaseMessage` typeguard rejects POJOs and they pass through unchanged.

--- a/libs/sdk/src/client/base.test.ts
+++ b/libs/sdk/src/client/base.test.ts
@@ -1,4 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  AIMessage,
+  HumanMessage,
+  SystemMessage,
+  ToolMessage,
+} from "@langchain/core/messages";
 import { Client } from "../client.js";
 import { overrideFetchImplementation } from "../singletons/fetch.js";
 import * as envUtils from "../utils/env.js";
@@ -320,3 +326,167 @@ describe.each([["global"], ["mocked"]])(
     });
   }
 );
+
+describe("Client BaseMessage normalization on outbound requests", () => {
+  // The langgraph-api server used to revive ``{lc:1, type:"constructor", ...}``
+  // envelopes via ``langchain_core.load.load`` to undo this very
+  // ``JSON.stringify(BaseMessage)`` shape. That deserialization gadget was
+  // removed (Corridor CWE-502 finding); the SDK now normalises to canonical
+  // dicts on the way out so the wire shape never carries an envelope.
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  function captureBody(): unknown {
+    const lastCall = fetchMock.mock.calls.at(-1);
+    if (!lastCall) throw new Error("fetch was not called");
+    const init = lastCall[1] as { body?: string };
+    if (!init?.body) throw new Error("request had no body");
+    return JSON.parse(init.body);
+  }
+
+  beforeEach(() => {
+    fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({}),
+        text: () => Promise.resolve(""),
+        headers: new Headers({}),
+      })
+    );
+    overrideFetchImplementation(fetchMock);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("converts a HumanMessage instance to a {type, content} dict", async () => {
+    const client = new Client({ apiKey: "k" });
+    await (client.threads as any).fetch("/test", {
+      method: "POST",
+      json: { input: { messages: [new HumanMessage("hi")] } },
+    });
+    const body = captureBody() as {
+      input: { messages: Array<Record<string, unknown>> };
+    };
+    expect(body.input.messages).toEqual([{ type: "human", content: "hi" }]);
+    // No envelope field should leak through.
+    expect(body.input.messages[0]).not.toHaveProperty("lc");
+    expect(body.input.messages[0]).not.toHaveProperty("kwargs");
+  });
+
+  it("preserves AIMessage tool_calls and additional metadata", async () => {
+    const client = new Client({ apiKey: "k" });
+    const msg = new AIMessage({
+      content: "thinking",
+      tool_calls: [
+        {
+          id: "tc-1",
+          name: "search",
+          args: { q: "weather" },
+          type: "tool_call",
+        },
+      ],
+      additional_kwargs: { custom: 1 },
+    });
+    await (client.threads as any).fetch("/test", {
+      method: "POST",
+      json: { input: { messages: [msg] } },
+    });
+    const body = captureBody() as {
+      input: { messages: Array<Record<string, unknown>> };
+    };
+    expect(body.input.messages[0]).toMatchObject({
+      type: "ai",
+      content: "thinking",
+      tool_calls: [
+        {
+          id: "tc-1",
+          name: "search",
+          args: { q: "weather" },
+          type: "tool_call",
+        },
+      ],
+      additional_kwargs: { custom: 1 },
+    });
+  });
+
+  it("preserves ToolMessage tool_call_id", async () => {
+    const client = new Client({ apiKey: "k" });
+    const msg = new ToolMessage({
+      content: "result",
+      tool_call_id: "tc-1",
+    });
+    await (client.threads as any).fetch("/test", {
+      method: "POST",
+      json: { input: { messages: [msg] } },
+    });
+    const body = captureBody() as {
+      input: { messages: Array<Record<string, unknown>> };
+    };
+    expect(body.input.messages[0]).toMatchObject({
+      type: "tool",
+      content: "result",
+      tool_call_id: "tc-1",
+    });
+  });
+
+  it("passes plain dicts through unchanged", async () => {
+    const client = new Client({ apiKey: "k" });
+    const dictPayload = {
+      input: {
+        messages: [{ type: "human", content: "already a dict" }],
+        config: { tags: ["t"] },
+      },
+    };
+    await (client.threads as any).fetch("/test", {
+      method: "POST",
+      json: dictPayload,
+    });
+    expect(captureBody()).toEqual(dictPayload);
+  });
+
+  it("normalises mixed arrays of instances and dicts", async () => {
+    const client = new Client({ apiKey: "k" });
+    await (client.threads as any).fetch("/test", {
+      method: "POST",
+      json: {
+        input: {
+          messages: [
+            new SystemMessage("you are helpful"),
+            { type: "human", content: "hi" },
+            new AIMessage("hello"),
+          ],
+        },
+      },
+    });
+    const body = captureBody() as {
+      input: { messages: Array<Record<string, unknown>> };
+    };
+    expect(body.input.messages).toEqual([
+      { type: "system", content: "you are helpful" },
+      { type: "human", content: "hi" },
+      { type: "ai", content: "hello" },
+    ]);
+  });
+
+  it("walks nested message arrays anywhere in the body", async () => {
+    const client = new Client({ apiKey: "k" });
+    await (client.threads as any).fetch("/test", {
+      method: "POST",
+      // ``command.update`` payloads can carry messages too — the
+      // replacer walks the whole tree, so this works without enumerating
+      // known field names.
+      json: {
+        command: {
+          update: { messages: [new HumanMessage("nested")] },
+        },
+      },
+    });
+    const body = captureBody() as {
+      command: { update: { messages: Array<Record<string, unknown>> } };
+    };
+    expect(body.command.update.messages).toEqual([
+      { type: "human", content: "nested" },
+    ]);
+  });
+});

--- a/libs/sdk/src/client/base.test.ts
+++ b/libs/sdk/src/client/base.test.ts
@@ -469,6 +469,70 @@ describe("Client BaseMessage normalization on outbound requests", () => {
     ]);
   });
 
+  it("normalises BaseMessage nested inside tool_calls.args", async () => {
+    const client = new Client({ apiKey: "k" });
+    const inner = new HumanMessage("inner");
+    const msg = new AIMessage({
+      content: "x",
+      tool_calls: [
+        { id: "t", name: "tool", args: { msg: inner }, type: "tool_call" },
+      ],
+    });
+    await (client.threads as any).fetch("/test", {
+      method: "POST",
+      json: { input: { messages: [msg] } },
+    });
+    const body = captureBody() as {
+      input: {
+        messages: Array<{
+          tool_calls: Array<{ args: { msg: Record<string, unknown> } }>;
+        }>;
+      };
+    };
+    const innerOnWire = body.input.messages[0].tool_calls[0].args.msg;
+    expect(innerOnWire).toEqual({ type: "human", content: "inner" });
+    expect(innerOnWire).not.toHaveProperty("lc");
+    expect(innerOnWire).not.toHaveProperty("kwargs");
+  });
+
+  it("normalises BaseMessage nested inside additional_kwargs", async () => {
+    const client = new Client({ apiKey: "k" });
+    const memo = new SystemMessage("memo");
+    const msg = new AIMessage({
+      content: "x",
+      additional_kwargs: { memo },
+    });
+    await (client.threads as any).fetch("/test", {
+      method: "POST",
+      json: { input: { messages: [msg] } },
+    });
+    const body = captureBody() as {
+      input: {
+        messages: Array<{ additional_kwargs: { memo: Record<string, unknown> } }>;
+      };
+    };
+    expect(body.input.messages[0].additional_kwargs.memo).toEqual({
+      type: "system",
+      content: "memo",
+    });
+  });
+
+  it("does not stack-overflow on cyclic POJOs", async () => {
+    const client = new Client({ apiKey: "k" });
+    const cyclic: Record<string, unknown> = { type: "human", content: "x" };
+    cyclic.self = cyclic;
+    // JSON.stringify would throw on a cyclic graph; the normalizer now
+    // emits a sentinel and lets stringify succeed.
+    await expect(
+      (client.threads as any).fetch("/test", {
+        method: "POST",
+        json: { meta: cyclic },
+      })
+    ).resolves.toBeDefined();
+    const body = captureBody() as { meta: Record<string, unknown> };
+    expect(body.meta.self).toBe("[Circular]");
+  });
+
   it("walks nested message arrays anywhere in the body", async () => {
     const client = new Client({ apiKey: "k" });
     await (client.threads as any).fetch("/test", {

--- a/libs/sdk/src/client/base.test.ts
+++ b/libs/sdk/src/client/base.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   AIMessage,
+  AIMessageChunk,
   HumanMessage,
+  RemoveMessage,
   SystemMessage,
   ToolMessage,
+  coerceMessageLikeToMessage,
 } from "@langchain/core/messages";
 import { Client } from "../client.js";
 import { overrideFetchImplementation } from "../singletons/fetch.js";
@@ -552,5 +555,127 @@ describe("Client BaseMessage normalization on outbound requests", () => {
     expect(body.command.update.messages).toEqual([
       { type: "human", content: "nested" },
     ]);
+  });
+
+  // The wire shape we emit on the way out is the same shape the JS server
+  // receives on the way in. ``coerceMessageLikeToMessage`` (which the JS
+  // server-side ``messagesStateReducer`` uses) is the canonical consumer
+  // of canonical message dicts — round-tripping every standard subclass
+  // through it locks the JS→JS contract: no class that worked under the
+  // pre-PR envelope shape should fail under the post-PR canonical shape.
+  describe("canonical dict round-trips through coerceMessageLikeToMessage", () => {
+    async function dictForMessage(
+      m: unknown
+    ): Promise<Record<string, unknown>> {
+      const client = new Client({ apiKey: "k" });
+      await (client.threads as any).fetch("/test", {
+        method: "POST",
+        json: { messages: [m] },
+      });
+      const body = captureBody() as {
+        messages: Array<Record<string, unknown>>;
+      };
+      return body.messages[0];
+    }
+
+    it("HumanMessage", async () => {
+      const original = new HumanMessage({
+        content: "hi",
+        id: "h1",
+        additional_kwargs: { custom: 1 },
+      });
+      const dict = await dictForMessage(original);
+      const revived = coerceMessageLikeToMessage(dict as never);
+      expect(HumanMessage.isInstance(revived)).toBe(true);
+      expect(revived.content).toBe("hi");
+      expect(revived.id).toBe("h1");
+      expect(revived.additional_kwargs).toEqual({ custom: 1 });
+    });
+
+    it("AIMessage with tool_calls / invalid_tool_calls / usage_metadata", async () => {
+      const original = new AIMessage({
+        content: "thinking",
+        tool_calls: [
+          { id: "tc1", name: "search", args: { q: "x" }, type: "tool_call" },
+        ],
+        invalid_tool_calls: [
+          {
+            id: "tc2",
+            name: "broken",
+            args: "{not json",
+            error: "parse failed",
+            type: "invalid_tool_call",
+          },
+        ],
+        usage_metadata: {
+          input_tokens: 10,
+          output_tokens: 5,
+          total_tokens: 15,
+        },
+      });
+      const dict = await dictForMessage(original);
+      const revived = coerceMessageLikeToMessage(dict as never) as AIMessage;
+      expect(AIMessage.isInstance(revived)).toBe(true);
+      expect(revived.content).toBe("thinking");
+      expect(revived.tool_calls).toEqual(original.tool_calls);
+      expect(revived.invalid_tool_calls).toEqual(original.invalid_tool_calls);
+      expect(revived.usage_metadata).toEqual(original.usage_metadata);
+    });
+
+    it("AIMessageChunk emits tool_call_chunks on the wire", async () => {
+      // ``_constructMessageFromParams`` routes both AIMessage and
+      // AIMessageChunk to ``new AIMessage(rest)`` and AIMessage has no
+      // ``tool_call_chunks`` field, so the server-side coercion drops
+      // them on revival — pre-existing and unrelated to this PR. The
+      // wire-level contract we're locking is just that the SDK doesn't
+      // *silently* eat the field on the way out.
+      const original = new AIMessageChunk({
+        content: "partial",
+        tool_call_chunks: [
+          { id: "tc1", name: "search", args: '{"q":', index: 0 },
+        ],
+      });
+      const dict = await dictForMessage(original);
+      expect(dict.tool_call_chunks).toEqual(original.tool_call_chunks);
+      expect(dict.type).toBe("ai");
+    });
+
+    it("SystemMessage", async () => {
+      const original = new SystemMessage({
+        content: "you are a helpful assistant",
+        id: "s1",
+      });
+      const dict = await dictForMessage(original);
+      const revived = coerceMessageLikeToMessage(dict as never);
+      expect(SystemMessage.isInstance(revived)).toBe(true);
+      expect(revived.content).toBe("you are a helpful assistant");
+      expect(revived.id).toBe("s1");
+    });
+
+    it("ToolMessage with status / artifact", async () => {
+      const original = new ToolMessage({
+        content: "result body",
+        tool_call_id: "tc-99",
+        name: "search",
+        status: "success",
+        artifact: { extra: "payload" },
+      });
+      const dict = await dictForMessage(original);
+      const revived = coerceMessageLikeToMessage(dict as never) as ToolMessage;
+      expect(ToolMessage.isInstance(revived)).toBe(true);
+      expect(revived.content).toBe("result body");
+      expect(revived.tool_call_id).toBe("tc-99");
+      expect(revived.name).toBe("search");
+      expect(revived.status).toBe("success");
+      expect(revived.artifact).toEqual({ extra: "payload" });
+    });
+
+    it("RemoveMessage", async () => {
+      const original = new RemoveMessage({ id: "msg-to-delete" });
+      const dict = await dictForMessage(original);
+      const revived = coerceMessageLikeToMessage(dict as never);
+      expect(RemoveMessage.isInstance(revived)).toBe(true);
+      expect(revived.id).toBe("msg-to-delete");
+    });
   });
 });

--- a/libs/sdk/src/client/base.ts
+++ b/libs/sdk/src/client/base.ts
@@ -1,9 +1,105 @@
+import { isBaseMessage } from "@langchain/core/messages";
+import type { BaseMessage } from "@langchain/core/messages";
+
 import { AsyncCaller, AsyncCallerParams } from "../utils/async_caller.js";
 import { getEnvironmentVariable } from "../utils/env.js";
 import { mergeSignals } from "../utils/signals.js";
 import { BytesLineDecoder, SSEDecoder } from "../utils/sse.js";
 import { streamWithRetry, StreamRequestParams } from "../utils/stream.js";
 import type { StreamProtocol } from "../types.js";
+
+/**
+ * Convert a langchain.js ``BaseMessage`` instance to the canonical dict
+ * shape the langgraph-api Python server's ``convert_to_messages`` accepts.
+ *
+ * The default JSON.stringify on a BaseMessage invokes its ``toJSON()``
+ * method, which produces an ``{lc, type:"constructor", id, kwargs}``
+ * envelope. The server used to revive those via ``langchain_core.load.load``
+ * but that path was removed (Corridor CWE-502 finding) since the
+ * deserializer was broader than message types and a moderate-severity
+ * gadget. Normalising on the way out means the wire shape is always one
+ * the server already understands without a deserialization step.
+ *
+ * Plain dicts pass through this helper unchanged because the
+ * ``isBaseMessage`` typeguard rejects them.
+ */
+function messageToDict(m: BaseMessage): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    type: m.getType(),
+    content: m.content,
+  };
+  // Optional fields: only include when set so the wire payload stays
+  // minimal and matches what a hand-crafted dict client would send.
+  const additional = (m as { additional_kwargs?: Record<string, unknown> })
+    .additional_kwargs;
+  if (additional && Object.keys(additional).length > 0) {
+    out.additional_kwargs = additional;
+  }
+  const responseMetadata = (
+    m as { response_metadata?: Record<string, unknown> }
+  ).response_metadata;
+  if (responseMetadata && Object.keys(responseMetadata).length > 0) {
+    out.response_metadata = responseMetadata;
+  }
+  const id = (m as { id?: string }).id;
+  if (id) out.id = id;
+  const name = (m as { name?: string }).name;
+  if (name) out.name = name;
+  // AIMessage carries tool_calls / invalid_tool_calls / usage_metadata
+  const toolCalls = (m as { tool_calls?: unknown[] }).tool_calls;
+  if (Array.isArray(toolCalls) && toolCalls.length > 0) {
+    out.tool_calls = toolCalls;
+  }
+  const invalidToolCalls = (m as { invalid_tool_calls?: unknown[] })
+    .invalid_tool_calls;
+  if (Array.isArray(invalidToolCalls) && invalidToolCalls.length > 0) {
+    out.invalid_tool_calls = invalidToolCalls;
+  }
+  const usageMetadata = (m as { usage_metadata?: unknown }).usage_metadata;
+  if (usageMetadata) out.usage_metadata = usageMetadata;
+  // ToolMessage carries tool_call_id / status / artifact
+  const toolCallId = (m as { tool_call_id?: string }).tool_call_id;
+  if (toolCallId) out.tool_call_id = toolCallId;
+  const status = (m as { status?: string }).status;
+  if (status) out.status = status;
+  const artifact = (m as { artifact?: unknown }).artifact;
+  if (artifact !== undefined) out.artifact = artifact;
+  return out;
+}
+
+/**
+ * Pre-walk the request payload, replacing any ``BaseMessage`` instance
+ * with the canonical dict shape returned by :func:`messageToDict`.
+ *
+ * A JSON.stringify replacer cannot do this: ``BaseMessage.toJSON()``
+ * runs *before* the replacer is invoked, so by the time the replacer
+ * sees the value it's already the legacy ``{lc, type:"constructor",
+ * id, kwargs}`` envelope dict — the BaseMessage typeguard fails. We
+ * have to intercept on the original object graph instead.
+ *
+ * Walks dicts, arrays, and ``Map``-like containers; primitives and
+ * unrecognised objects pass through unchanged. Plain objects from
+ * client code (already in the canonical dict shape) hit the
+ * fall-through branch and are returned untouched.
+ */
+function normalizeMessageInstances(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (isBaseMessage(value)) return messageToDict(value);
+  if (Array.isArray(value)) return value.map(normalizeMessageInstances);
+  // Plain object — recurse on each value. We don't try to handle
+  // ``Map`` / ``Set`` / class instances generically; those would be
+  // unusual in a JSON request body and the existing JSON.stringify
+  // semantics still apply for anything we don't unwrap.
+  const proto = Object.getPrototypeOf(value);
+  if (proto === Object.prototype || proto === null) {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = normalizeMessageInstances(v);
+    }
+    return out;
+  }
+  return value;
+}
 
 export type HeaderValue = string | undefined | null;
 
@@ -190,7 +286,9 @@ export class BaseClient {
     };
 
     if (mutatedOptions.json) {
-      mutatedOptions.body = JSON.stringify(mutatedOptions.json);
+      mutatedOptions.body = JSON.stringify(
+        normalizeMessageInstances(mutatedOptions.json)
+      );
       mutatedOptions.headers = mergeHeaders(mutatedOptions.headers, {
         "content-type": "application/json",
       });

--- a/libs/sdk/src/client/base.ts
+++ b/libs/sdk/src/client/base.ts
@@ -63,13 +63,30 @@ function messageToDict(
   }
   const usageMetadata = (m as { usage_metadata?: unknown }).usage_metadata;
   if (usageMetadata) out.usage_metadata = walk(usageMetadata, seen);
-  // ToolMessage carries tool_call_id / status / artifact
+  // AIMessageChunk carries streaming tool-call slices; clients rarely
+  // submit chunks but include them for lossless round-trips.
+  const toolCallChunks = (m as { tool_call_chunks?: unknown[] })
+    .tool_call_chunks;
+  if (Array.isArray(toolCallChunks) && toolCallChunks.length > 0) {
+    out.tool_call_chunks = walk(toolCallChunks, seen);
+  }
+  // ToolMessage carries tool_call_id / status / artifact / metadata
   const toolCallId = (m as { tool_call_id?: string }).tool_call_id;
   if (toolCallId) out.tool_call_id = toolCallId;
   const status = (m as { status?: string }).status;
   if (status) out.status = status;
   const artifact = (m as { artifact?: unknown }).artifact;
   if (artifact !== undefined) out.artifact = walk(artifact, seen);
+  const toolMetadata = (m as { metadata?: Record<string, unknown> }).metadata;
+  if (toolMetadata && Object.keys(toolMetadata).length > 0) {
+    out.metadata = walk(toolMetadata, seen);
+  }
+  // ChatMessage carries an arbitrary role; the server's
+  // ``_constructMessageFromParams`` only handles a fixed set of types,
+  // but emitting role keeps the round-trip lossless for any callers
+  // that *do* know how to handle it.
+  const role = (m as { role?: string }).role;
+  if (role) out.role = role;
   return out;
 }
 

--- a/libs/sdk/src/client/base.ts
+++ b/libs/sdk/src/client/base.ts
@@ -1,5 +1,4 @@
-import { isBaseMessage } from "@langchain/core/messages";
-import type { BaseMessage } from "@langchain/core/messages";
+import { BaseMessage } from "@langchain/core/messages";
 
 import { AsyncCaller, AsyncCallerParams } from "../utils/async_caller.js";
 import { getEnvironmentVariable } from "../utils/env.js";
@@ -23,23 +22,30 @@ import type { StreamProtocol } from "../types.js";
  * Plain dicts pass through this helper unchanged because the
  * ``isBaseMessage`` typeguard rejects them.
  */
-function messageToDict(m: BaseMessage): Record<string, unknown> {
+function messageToDict(
+  m: BaseMessage,
+  seen: WeakSet<object>
+): Record<string, unknown> {
   const out: Record<string, unknown> = {
     type: m.getType(),
-    content: m.content,
+    content: walk(m.content, seen),
   };
   // Optional fields: only include when set so the wire payload stays
   // minimal and matches what a hand-crafted dict client would send.
+  // Nested BaseMessage instances inside structured fields (tool_calls.args,
+  // additional_kwargs, artifact, ...) are recursively normalized too — a
+  // shallow copy would let toJSON() leak the legacy envelope back into
+  // the wire payload.
   const additional = (m as { additional_kwargs?: Record<string, unknown> })
     .additional_kwargs;
   if (additional && Object.keys(additional).length > 0) {
-    out.additional_kwargs = additional;
+    out.additional_kwargs = walk(additional, seen);
   }
   const responseMetadata = (
     m as { response_metadata?: Record<string, unknown> }
   ).response_metadata;
   if (responseMetadata && Object.keys(responseMetadata).length > 0) {
-    out.response_metadata = responseMetadata;
+    out.response_metadata = walk(responseMetadata, seen);
   }
   const id = (m as { id?: string }).id;
   if (id) out.id = id;
@@ -48,22 +54,22 @@ function messageToDict(m: BaseMessage): Record<string, unknown> {
   // AIMessage carries tool_calls / invalid_tool_calls / usage_metadata
   const toolCalls = (m as { tool_calls?: unknown[] }).tool_calls;
   if (Array.isArray(toolCalls) && toolCalls.length > 0) {
-    out.tool_calls = toolCalls;
+    out.tool_calls = walk(toolCalls, seen);
   }
   const invalidToolCalls = (m as { invalid_tool_calls?: unknown[] })
     .invalid_tool_calls;
   if (Array.isArray(invalidToolCalls) && invalidToolCalls.length > 0) {
-    out.invalid_tool_calls = invalidToolCalls;
+    out.invalid_tool_calls = walk(invalidToolCalls, seen);
   }
   const usageMetadata = (m as { usage_metadata?: unknown }).usage_metadata;
-  if (usageMetadata) out.usage_metadata = usageMetadata;
+  if (usageMetadata) out.usage_metadata = walk(usageMetadata, seen);
   // ToolMessage carries tool_call_id / status / artifact
   const toolCallId = (m as { tool_call_id?: string }).tool_call_id;
   if (toolCallId) out.tool_call_id = toolCallId;
   const status = (m as { status?: string }).status;
   if (status) out.status = status;
   const artifact = (m as { artifact?: unknown }).artifact;
-  if (artifact !== undefined) out.artifact = artifact;
+  if (artifact !== undefined) out.artifact = walk(artifact, seen);
   return out;
 }
 
@@ -77,25 +83,40 @@ function messageToDict(m: BaseMessage): Record<string, unknown> {
  * id, kwargs}`` envelope dict — the BaseMessage typeguard fails. We
  * have to intercept on the original object graph instead.
  *
- * Walks dicts, arrays, and ``Map``-like containers; primitives and
- * unrecognised objects pass through unchanged. Plain objects from
- * client code (already in the canonical dict shape) hit the
- * fall-through branch and are returned untouched.
+ * Walks plain objects and arrays. ``Map`` / ``Set`` / ``Date`` / ``URL``
+ * and other class instances pass through unchanged so JSON.stringify's
+ * native handling still applies. Plain objects from client code
+ * (already in the canonical dict shape) hit the fall-through branch
+ * and are returned untouched.
+ *
+ * Cyclic graphs (``a.self = a``) return a sentinel placeholder rather
+ * than stack-overflowing — ``JSON.stringify`` would throw on the same
+ * input, so we degrade to a defined-shape value instead.
  */
-function normalizeMessageInstances(value: unknown): unknown {
+export function normalizeMessageInstances(value: unknown): unknown {
+  return walk(value, new WeakSet<object>());
+}
+
+function walk(value: unknown, seen: WeakSet<object>): unknown {
   if (value === null || typeof value !== "object") return value;
-  if (isBaseMessage(value)) return messageToDict(value);
-  if (Array.isArray(value)) return value.map(normalizeMessageInstances);
-  // Plain object — recurse on each value. We don't try to handle
-  // ``Map`` / ``Set`` / class instances generically; those would be
-  // unusual in a JSON request body and the existing JSON.stringify
-  // semantics still apply for anything we don't unwrap.
+  if (BaseMessage.isInstance(value)) return messageToDict(value, seen);
+  if (seen.has(value)) return "[Circular]";
+  if (Array.isArray(value)) {
+    seen.add(value);
+    const out = value.map((v) => walk(v, seen));
+    seen.delete(value);
+    return out;
+  }
+  // Plain object — recurse on each value. Class instances (Map, Set,
+  // Date, URL, ...) are left to JSON.stringify's default semantics.
   const proto = Object.getPrototypeOf(value);
   if (proto === Object.prototype || proto === null) {
+    seen.add(value);
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      out[k] = normalizeMessageInstances(v);
+      out[k] = walk(v, seen);
     }
+    seen.delete(value);
     return out;
   }
   return value;

--- a/libs/sdk/src/client/index.test.ts
+++ b/libs/sdk/src/client/index.test.ts
@@ -97,6 +97,45 @@ describe("Client", () => {
     expect(calls[0].pathname).toContain("/threads/my-thread/stream/events");
   });
 
+  it("normalises BaseMessage instances in v2 SSE command bodies", async () => {
+    // Regression: the v2 transport JSON.stringifies commands directly,
+    // bypassing BaseClient.prepareFetchOptions. Without normalization the
+    // server (which no longer revives the legacy ``{lc, type:"constructor",
+    // id, kwargs}`` envelope post-CWE-502) would reject these payloads.
+    const bodies: string[] = [];
+    const customFetch = ((_input: URL | RequestInfo, init?: RequestInit) => {
+      bodies.push(String(init?.body ?? ""));
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ type: "success", id: 1, result: {} }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      );
+    }) as typeof fetch;
+
+    const { HumanMessage } = await import("@langchain/core/messages");
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: "http://localhost:9999",
+      threadId: "t",
+      fetch: customFetch,
+    });
+
+    await transport.send({
+      id: 1,
+      method: "run.start",
+      params: {
+        assistant_id: "a",
+        input: { messages: [new HumanMessage("hi")] },
+      },
+    } as Parameters<typeof transport.send>[0]);
+
+    const body = JSON.parse(bodies[0]);
+    const msg = body.params.input.messages[0];
+    expect(msg).toEqual({ type: "human", content: "hi" });
+    expect(msg).not.toHaveProperty("lc");
+    expect(msg).not.toHaveProperty("kwargs");
+  });
+
   it("uses the protocol commands path for sse commands", async () => {
     const calls: URL[] = [];
     const customFetch = ((input: URL | RequestInfo) => {

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -20,6 +20,7 @@ import {
   toError,
   isProtocolResponse,
 } from "./utils.js";
+import { normalizeMessageInstances } from "../../base.js";
 import { BytesLineDecoder, SSEDecoder } from "./decoder.js";
 import { IterableReadableStream } from "./stream.js";
 
@@ -88,7 +89,7 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
     const response = await this.request(this.commandsUrl, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify(command),
+      body: JSON.stringify(normalizeMessageInstances(command)),
       signal: this.sessionAbortController.signal,
     });
 

--- a/libs/sdk/src/client/stream/transport/websocket.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.ts
@@ -7,6 +7,7 @@ import type {
 } from "@langchain/protocol";
 
 import { toWebSocketUrl, isRecord, hasHeaders, toError } from "./utils.js";
+import { normalizeMessageInstances } from "../../base.js";
 import type {
   HeaderValue,
   ProtocolRequestHook,
@@ -174,7 +175,7 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
         this.pending.set(command.id, { resolve, reject });
 
         try {
-          socket.send(JSON.stringify(command));
+          socket.send(JSON.stringify(normalizeMessageInstances(command)));
         } catch (error) {
           this.pending.delete(command.id);
           reject(toError(error));


### PR DESCRIPTION
Client-side counterpart to the server-side fix that removed
`langchain_core.load.load()` from `langgraph-api`'s request path
(flagged as CWE-502 — the deserializer was broader than message types
and worked as a moderate-severity gadget).

`BaseClient` now pre-walks the request payload and replaces every
`@langchain/core/messages` `BaseMessage` instance with the canonical
`{type, content, additional_kwargs?, tool_calls?, ...}` dict before
`JSON.stringify`. A JSON.stringify replacer can't do this —
`BaseMessage.toJSON()` runs before the replacer is invoked, so by the
time the replacer sees the value it's already the legacy
`{lc, type:"constructor", id, kwargs}` envelope and the
`isBaseMessage` typeguard fails. We intercept on the original object
graph instead.

Plain-dict callers are unaffected — the typeguard rejects POJOs and
they pass through unchanged.

Same change as #2378 (merged then reverted on May 12 without a stated
reason). Validated end-to-end against the streaming-cookbook multimodal
example: with this patch linked locally and the Python agent stripped
of its workaround coercion shim, the wire payload arrives as
`{"type":"human","content":"..."}` and the Python `add_messages`
reducer accepts it natively. Without it, every JS frontend hitting a
Python langgraph-api graph blows up with `MESSAGE_COERCION_FAILURE` on
the first input.

## Release Note

None