### PR TITLE
fix(langgraph-cli): allow hyphenated prerelease api_version

### DIFF
--- a/.changeset/hunter-allow-js-prerelease.md
+++ b/.changeset/hunter-allow-js-prerelease.md
@@ -1,0 +1,6 @@
+---
+"@langchain/langgraph-api": patch
+"@langchain/langgraph-cli": patch
+---
+
+fix(langgraph-cli): accept hyphenated prerelease tags in `api_version` values.

--- a/libs/langgraph-api/src/semver/index.mts
+++ b/libs/langgraph-api/src/semver/index.mts
@@ -1,7 +1,7 @@
 import * as url from "node:url";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import * as semver from "semver";
+import { satisfiesPeerRange } from "./satisfiesPeerRange.mjs";
 
 const packageJsonPath = path.resolve(
   url.fileURLToPath(import.meta.url),
@@ -23,27 +23,6 @@ export async function checkSemver(
 
     const satisfies = satisfiesPeerRange(pkg.version, required);
     return { ...pkg, required, satisfies };
-  });
-}
-
-function satisfiesPeerRange(version: string, required: string): boolean {
-  if (semver.satisfies(version, required, { includePrerelease: true })) {
-    return true;
-  }
-
-  const parsed = semver.parse(version);
-  if (parsed == null || parsed.prerelease.length === 0) {
-    return false;
-  }
-
-  // CI often installs internal dev builds such as
-  // `1.1.44-dev-<timestamp>`. Semver orders those below the final
-  // `1.1.44`, so `^1.1.44` does not match directly even though the
-  // build targets that release line. Validate the release tuple as a
-  // compatibility check while still rejecting prereleases below range.
-  const releaseVersion = `${parsed.major}.${parsed.minor}.${parsed.patch}`;
-  return semver.satisfies(releaseVersion, required, {
-    includePrerelease: true,
   });
 }
 

--- a/libs/langgraph-api/src/semver/satisfiesPeerRange.mts
+++ b/libs/langgraph-api/src/semver/satisfiesPeerRange.mts
@@ -1,0 +1,22 @@
+import * as semver from "semver";
+
+export function satisfiesPeerRange(version: string, required: string): boolean {
+  if (semver.satisfies(version, required, { includePrerelease: true })) {
+    return true;
+  }
+
+  const parsed = semver.parse(version);
+  if (parsed == null || parsed.prerelease.length === 0) {
+    return false;
+  }
+
+  // CI often installs internal dev builds such as
+  // `1.1.44-dev-<timestamp>`. Semver orders those below the final
+  // `1.1.44`, so `^1.1.44` does not match directly even though the
+  // build targets that release line. Validate the release tuple as a
+  // compatibility check while still rejecting prereleases below range.
+  const releaseVersion = `${parsed.major}.${parsed.minor}.${parsed.patch}`;
+  return semver.satisfies(releaseVersion, required, {
+    includePrerelease: true,
+  });
+}

--- a/libs/langgraph-cli/src/utils/config.mts
+++ b/libs/langgraph-cli/src/utils/config.mts
@@ -1,7 +1,8 @@
 import { z } from "zod/v3";
 import { extname } from "node:path";
 
-const API_VERSION_PATTERN = /^\d+(?:\.\d+){0,2}(?:[A-Za-z][0-9A-Za-z.-]*)?$/;
+const API_VERSION_PATTERN =
+  /^\d+(?:\.\d+){0,2}(?:(?:-[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*)|(?:[A-Za-z][0-9A-Za-z.-]*))?$/;
 
 const GraphPathSchema = z.string().refine((i) => i.includes(":"), {
   message: "Import string must be in format '<file>:<export>'",

--- a/libs/langgraph-cli/tests/config.test.mts
+++ b/libs/langgraph-cli/tests/config.test.mts
@@ -1253,14 +1253,18 @@ it("node config and python config", () => {
     api_version: "0.7.29rc1",
   });
 
-  // Invalid api_version format - hyphen prerelease suffix
-  expect
-    .soft(() =>
-      getConfig({
-        node_version: "22",
-        graphs: { agent: "./agent.js:graph" },
-        api_version: "0.7.29-rc1",
-      })
-    )
-    .toThrow();
+  // Valid api_version with hyphen prerelease suffix
+  expect(
+    getConfig({
+      node_version: "22",
+      graphs: { agent: "./agent.js:graph" },
+      api_version: "0.7.29-rc.0",
+    })
+  ).toEqual({
+    node_version: "22",
+    dockerfile_lines: [],
+    graphs: { agent: "./agent.js:graph" },
+    env: {},
+    api_version: "0.7.29-rc.0",
+  });
 });


### PR DESCRIPTION
## Summary

This PR updates `@langchain/langgraph-cli` to accept hyphenated prerelease `api_version` values (for example, `1.0.0-rc.0`) when parsing `langgraph.json`.
It also refactors semver peer-range evaluation in `@langchain/langgraph-api` by extracting `satisfiesPeerRange` into a dedicated module to keep semver compatibility logic isolated and reusable.

## Changes

### @langchain/langgraph-cli

- Expanded `API_VERSION_PATTERN` to accept hyphenated prerelease segments like `-rc.0` in addition to existing compact suffix formats.
- Updated config tests to treat hyphenated prerelease versions as valid and assert parsing behavior for `0.7.29-rc.0`.

### @langchain/langgraph-api

- Moved `satisfiesPeerRange` out of `src/semver/index.mts` into `src/semver/satisfiesPeerRange.mts`.
- Updated `src/semver/index.mts` to import and use the extracted helper while preserving existing semver compatibility behavior.
