### PR TITLE
fix(langgraph-checkpoint-mongodb): validate configurable checkpoint IDs

### DIFF
--- a/.changeset/khaki-pugs-cheer.md
+++ b/.changeset/khaki-pugs-cheer.md
@@ -1,0 +1,10 @@
+---
+"@langchain/langgraph-checkpoint-mongodb": patch
+---
+
+fix(checkpoint-mongodb): validate configurable checkpoint identifiers before queries
+
+Add runtime validation for `thread_id`, `checkpoint_ns`, and `checkpoint_id` in
+`MongoDBSaver` methods that read and write checkpoints. This prevents object-based
+operator payloads from being passed into MongoDB query filters and ensures invalid
+configurable values fail fast with explicit errors.

--- a/libs/checkpoint-mongodb/src/checkpoint.ts
+++ b/libs/checkpoint-mongodb/src/checkpoint.ts
@@ -23,6 +23,25 @@ export type MongoDBSaverParams = {
   enableTimestamps?: boolean;
 };
 
+function getStringConfigValue(
+  name: string,
+  value: unknown,
+  { required = false }: { required?: boolean } = {}
+): string | undefined {
+  if (value === undefined) {
+    if (required) {
+      throw new Error(`Invalid configurable.${name}: expected a string`);
+    }
+    return undefined;
+  }
+
+  if (value === null || typeof value !== "string") {
+    throw new Error(`Invalid configurable.${name}: expected a string`);
+  }
+
+  return value;
+}
+
 /**
  * A LangGraph checkpoint saver backed by a MongoDB database.
  */
@@ -73,11 +92,23 @@ export class MongoDBSaver extends BaseCheckpointSaver {
    * for the given thread ID is retrieved.
    */
   async getTuple(config: RunnableConfig): Promise<CheckpointTuple | undefined> {
-    const {
-      thread_id,
-      checkpoint_ns = "",
-      checkpoint_id,
-    } = config.configurable ?? {};
+    const thread_id = getStringConfigValue(
+      "thread_id",
+      config.configurable?.thread_id
+    );
+    if (thread_id === undefined) {
+      return undefined;
+    }
+    const checkpoint_ns =
+      getStringConfigValue(
+        "checkpoint_ns",
+        config.configurable?.checkpoint_ns
+      ) ?? "";
+    const checkpoint_id = getStringConfigValue(
+      "checkpoint_id",
+      config.configurable?.checkpoint_id
+    );
+
     let query;
     if (checkpoint_id) {
       query = {
@@ -155,16 +186,20 @@ export class MongoDBSaver extends BaseCheckpointSaver {
   ): AsyncGenerator<CheckpointTuple> {
     const { limit, before, filter } = options ?? {};
     const query: Record<string, unknown> = {};
+    const thread_id = getStringConfigValue(
+      "thread_id",
+      config.configurable?.thread_id
+    );
+    const checkpoint_ns = getStringConfigValue(
+      "checkpoint_ns",
+      config.configurable?.checkpoint_ns
+    );
 
-    if (config?.configurable?.thread_id) {
-      query.thread_id = config.configurable.thread_id;
+    if (thread_id) {
+      query.thread_id = thread_id;
     }
-
-    if (
-      config?.configurable?.checkpoint_ns !== undefined &&
-      config?.configurable?.checkpoint_ns !== null
-    ) {
-      query.checkpoint_ns = config.configurable.checkpoint_ns;
+    if (checkpoint_ns !== undefined) {
+      query.checkpoint_ns = checkpoint_ns;
     }
 
     if (filter) {
@@ -179,8 +214,12 @@ export class MongoDBSaver extends BaseCheckpointSaver {
       });
     }
 
-    if (before) {
-      query.checkpoint_id = { $lt: before.configurable?.checkpoint_id };
+    if (before?.configurable?.checkpoint_id !== undefined) {
+      const before_checkpoint_id = getStringConfigValue(
+        "checkpoint_id",
+        before.configurable?.checkpoint_id
+      );
+      query.checkpoint_id = { $lt: before_checkpoint_id };
     }
 
     let result = this.db
@@ -234,14 +273,22 @@ export class MongoDBSaver extends BaseCheckpointSaver {
     checkpoint: Checkpoint,
     metadata: CheckpointMetadata
   ): Promise<RunnableConfig> {
-    const thread_id = config.configurable?.thread_id;
-    const checkpoint_ns = config.configurable?.checkpoint_ns ?? "";
+    const thread_id = getStringConfigValue(
+      "thread_id",
+      config.configurable?.thread_id,
+      { required: true }
+    );
+    const checkpoint_ns =
+      getStringConfigValue(
+        "checkpoint_ns",
+        config.configurable?.checkpoint_ns
+      ) ?? "";
+    const parent_checkpoint_id = getStringConfigValue(
+      "checkpoint_id",
+      config.configurable?.checkpoint_id
+    );
     const checkpoint_id = checkpoint.id;
-    if (thread_id === undefined) {
-      throw new Error(
-        `The provided config must contain a configurable field with a "thread_id" field.`
-      );
-    }
+
     const [
       [checkpointType, serializedCheckpoint],
       [metadataType, serializedMetadata],
@@ -254,7 +301,7 @@ export class MongoDBSaver extends BaseCheckpointSaver {
       throw new Error("Mismatched checkpoint and metadata types.");
     }
     const doc = {
-      parent_checkpoint_id: config.configurable?.checkpoint_id,
+      parent_checkpoint_id,
       type: checkpointType,
       checkpoint: serializedCheckpoint,
       metadata: serializedMetadata,
@@ -289,18 +336,21 @@ export class MongoDBSaver extends BaseCheckpointSaver {
     writes: PendingWrite[],
     taskId: string
   ): Promise<void> {
-    const thread_id = config.configurable?.thread_id;
-    const checkpoint_ns = config.configurable?.checkpoint_ns;
-    const checkpoint_id = config.configurable?.checkpoint_id;
-    if (
-      thread_id === undefined ||
-      checkpoint_ns === undefined ||
-      checkpoint_id === undefined
-    ) {
-      throw new Error(
-        `The provided config must contain a configurable field with "thread_id", "checkpoint_ns" and "checkpoint_id" fields.`
-      );
-    }
+    const thread_id = getStringConfigValue(
+      "thread_id",
+      config.configurable?.thread_id,
+      { required: true }
+    );
+    const checkpoint_ns = getStringConfigValue(
+      "checkpoint_ns",
+      config.configurable?.checkpoint_ns,
+      { required: true }
+    );
+    const checkpoint_id = getStringConfigValue(
+      "checkpoint_id",
+      config.configurable?.checkpoint_id,
+      { required: true }
+    );
 
     const operations = await Promise.all(
       writes.map(async ([channel, value], idx) => {
@@ -333,6 +383,10 @@ export class MongoDBSaver extends BaseCheckpointSaver {
   }
 
   async deleteThread(threadId: string) {
+    if (typeof threadId !== "string") {
+      throw new Error("Invalid threadId: expected a string");
+    }
+
     await this.db
       .collection(this.checkpointCollectionName)
       .deleteMany({ thread_id: threadId });

--- a/libs/checkpoint-mongodb/src/tests/checkpoints.test.ts
+++ b/libs/checkpoint-mongodb/src/tests/checkpoints.test.ts
@@ -121,4 +121,198 @@ describe("MongoDBSaver", () => {
       expect(result.done).toBe(true);
     });
   });
+
+  describe("configurable validation", () => {
+    it("should return undefined when thread_id is missing in getTuple", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(saver.getTuple({ configurable: {} })).resolves.toBeUndefined();
+    });
+
+    it("should reject object thread_id in getTuple", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(
+        saver.getTuple({
+          configurable: { thread_id: { $gt: "" }, checkpoint_ns: "" },
+        } as never)
+      ).rejects.toThrow('Invalid configurable.thread_id: expected a string');
+    });
+
+    it("should reject object checkpoint_ns in getTuple", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(
+        saver.getTuple({
+          configurable: { thread_id: "safe-thread", checkpoint_ns: { $ne: null } },
+        } as never)
+      ).rejects.toThrow('Invalid configurable.checkpoint_ns: expected a string');
+    });
+
+    it("should reject object checkpoint_id in getTuple", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(
+        saver.getTuple({
+          configurable: {
+            thread_id: "safe-thread",
+            checkpoint_ns: "",
+            checkpoint_id: { $gt: "" },
+          },
+        } as never)
+      ).rejects.toThrow('Invalid configurable.checkpoint_id: expected a string');
+    });
+
+    it("should reject object thread_id in list", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const generator = saver.list({
+        configurable: { thread_id: { $gt: "" } },
+      } as never);
+      await expect(generator.next()).rejects.toThrow(
+        'Invalid configurable.thread_id: expected a string'
+      );
+    });
+
+    it("should reject object checkpoint_ns in list", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const generator = saver.list({
+        configurable: { thread_id: "safe-thread", checkpoint_ns: { $ne: null } },
+      } as never);
+      await expect(generator.next()).rejects.toThrow(
+        'Invalid configurable.checkpoint_ns: expected a string'
+      );
+    });
+
+    it("should reject object before.checkpoint_id in list", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const generator = saver.list(
+        { configurable: { thread_id: "safe-thread", checkpoint_ns: "" } },
+        { before: { configurable: { checkpoint_id: { $lt: "zzz" } } } as never }
+      );
+      await expect(generator.next()).rejects.toThrow(
+        'Invalid configurable.checkpoint_id: expected a string'
+      );
+    });
+
+    it("should reject non-string thread_id in put", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+      const checkpoint = {
+        v: 4,
+        id: "cp-1",
+        ts: new Date().toISOString(),
+        channel_values: {},
+        channel_versions: {},
+        versions_seen: {},
+      } as never;
+
+      await expect(
+        saver.put(
+          { configurable: { thread_id: { $gt: "" } } } as never,
+          checkpoint,
+          { source: "input", step: 1, parents: {} } as never
+        )
+      ).rejects.toThrow('Invalid configurable.thread_id: expected a string');
+    });
+
+    it("should reject non-string thread_id in putWrites", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(
+        saver.putWrites(
+          {
+            configurable: {
+              thread_id: { $gt: "" },
+              checkpoint_ns: "",
+              checkpoint_id: "cp-1",
+            },
+          } as never,
+          [["foo", "bar"]],
+          "task-1"
+        )
+      ).rejects.toThrow('Invalid configurable.thread_id: expected a string');
+    });
+
+    it("should reject non-string checkpoint_ns in putWrites", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(
+        saver.putWrites(
+          {
+            configurable: {
+              thread_id: "safe-thread",
+              checkpoint_ns: { $ne: null },
+              checkpoint_id: "cp-1",
+            },
+          } as never,
+          [["foo", "bar"]],
+          "task-1"
+        )
+      ).rejects.toThrow('Invalid configurable.checkpoint_ns: expected a string');
+    });
+
+    it("should reject non-string checkpoint_id in putWrites", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(
+        saver.putWrites(
+          {
+            configurable: {
+              thread_id: "safe-thread",
+              checkpoint_ns: "",
+              checkpoint_id: { $gt: "" },
+            },
+          } as never,
+          [["foo", "bar"]],
+          "task-1"
+        )
+      ).rejects.toThrow('Invalid configurable.checkpoint_id: expected a string');
+    });
+
+    it("should reject non-string threadId in deleteThread", async () => {
+      const client = createMockClient();
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      await expect(saver.deleteThread({} as never)).rejects.toThrow(
+        "Invalid threadId: expected a string"
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #2351.

This change hardens `@langchain/langgraph-checkpoint-mongodb` against object-based configurable input in checkpoint identifiers. It adds runtime validation for `thread_id`, `checkpoint_ns`, and `checkpoint_id` before any MongoDB query/write path uses these values, so operator-like payloads are rejected early with explicit errors.

## Changes

### `@langchain/langgraph-checkpoint-mongodb`

- Added a shared `getStringConfigValue` runtime validator in [`libs/checkpoint-mongodb/src/checkpoint.ts`](libs/checkpoint-mongodb/src/checkpoint.ts).
- Applied validation to `getTuple`, `list`, `put`, `putWrites`, and `deleteThread`.
- Preserved existing behavior where `getTuple` returns `undefined` when `thread_id` is missing, while now rejecting non-string values.
- Added regression tests in [`libs/checkpoint-mongodb/src/tests/checkpoints.test.ts`](libs/checkpoint-mongodb/src/tests/checkpoints.test.ts) for object/operator payloads across the affected methods.
- Added a patch changeset for `@langchain/langgraph-checkpoint-mongodb`.
