### PR TITLE
fix(core): keep tool results out of v3 message streams

### DIFF
--- a/.changeset/fluffy-adults-work.md
+++ b/.changeset/fluffy-adults-work.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+fix(langgraph-core): keep tool results out of v3 message streams

--- a/.changeset/fluffy-adults-work.md
+++ b/.changeset/fluffy-adults-work.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": patch
+"@langchain/langgraph": patch
 ---
 
 fix(langgraph-core): keep tool results out of v3 message streams

--- a/libs/langgraph-core/src/pregel/messages-v2.test.ts
+++ b/libs/langgraph-core/src/pregel/messages-v2.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { AIMessage } from "@langchain/core/messages";
+import { AIMessage, ToolMessage } from "@langchain/core/messages";
 import { LLMResult } from "@langchain/core/outputs";
 import { Serialized } from "@langchain/core/load/serializable";
 import { ChainValues } from "@langchain/core/utils/types";
@@ -297,5 +297,37 @@ describe("StreamProtocolMessagesHandler", () => {
         responseMetadata: { stop_reason: "tool_use" },
       },
     ]);
+  });
+
+  it("does not emit ToolMessage chain outputs as chat message streams", () => {
+    const streamFn = vi.fn();
+    const handler = new StreamProtocolMessagesHandler(streamFn);
+    const runId = "tool-chain-123";
+
+    handler.handleChainStart(
+      {} as Serialized,
+      {} as ChainValues,
+      runId,
+      undefined,
+      [],
+      {
+        langgraph_checkpoint_ns: "ns1",
+        langgraph_node: "ToolNode",
+      },
+      undefined,
+      "ToolNode"
+    );
+
+    handler.handleChainEnd(
+      new ToolMessage({
+        id: "tool-msg-1",
+        content: "[]",
+        tool_call_id: "call_1",
+        name: "list_items",
+      }),
+      runId
+    );
+
+    expect(streamFn).not.toHaveBeenCalled();
   });
 });

--- a/libs/langgraph-core/src/pregel/messages-v2.ts
+++ b/libs/langgraph-core/src/pregel/messages-v2.ts
@@ -1,9 +1,8 @@
 import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
 import {
   BaseMessage,
-  isBaseMessage,
-  isBaseMessageChunk,
-  isToolMessage,
+  ToolMessage,
+  BaseMessageChunk,
 } from "@langchain/core/messages";
 import { Serialized } from "@langchain/core/load/serializable";
 import { ChatGeneration, LLMResult } from "@langchain/core/outputs";
@@ -132,7 +131,7 @@ export class StreamProtocolMessagesHandler extends BaseCallbackHandler {
     let messageId = message.id;
 
     if (runId != null) {
-      if (isToolMessage(message)) {
+      if (ToolMessage.isInstance(message)) {
         messageId ??= `run-${runId}-tool-${message.tool_call_id}`;
       } else {
         if (messageId == null || messageId === `run-${runId}`) {
@@ -182,7 +181,7 @@ export class StreamProtocolMessagesHandler extends BaseCallbackHandler {
             ? "tool"
             : "ai";
     const toolCallId =
-      role === "tool" && isToolMessage(message)
+      role === "tool" && ToolMessage.isInstance(message)
         ? message.tool_call_id
         : undefined;
 
@@ -296,7 +295,7 @@ export class StreamProtocolMessagesHandler extends BaseCallbackHandler {
     if (meta === undefined) return;
 
     const chatGeneration = output.generations?.[0]?.[0] as ChatGeneration;
-    const message = isBaseMessage(chatGeneration?.message)
+    const message = BaseMessage.isInstance(chatGeneration?.message)
       ? chatGeneration.message
       : undefined;
 
@@ -344,14 +343,16 @@ export class StreamProtocolMessagesHandler extends BaseCallbackHandler {
       if (typeof inputs === "object") {
         for (const value of Object.values(inputs)) {
           if (
-            (isBaseMessage(value) || isBaseMessageChunk(value)) &&
+            (BaseMessage.isInstance(value) ||
+              BaseMessageChunk.isInstance(value)) &&
             value.id !== undefined
           ) {
             this.seen[value.id] = value;
           } else if (Array.isArray(value)) {
             for (const item of value) {
               if (
-                (isBaseMessage(item) || isBaseMessageChunk(item)) &&
+                (BaseMessage.isInstance(item) ||
+                  BaseMessageChunk.isInstance(item)) &&
                 item.id !== undefined
               ) {
                 this.seen[item.id] = item;
@@ -369,12 +370,12 @@ export class StreamProtocolMessagesHandler extends BaseCallbackHandler {
     if (meta === undefined) return;
 
     const emitMessage = (value: unknown) => {
-      if (isBaseMessage(value)) {
+      if (BaseMessage.isInstance(value) && !ToolMessage.isInstance(value)) {
         this.emitFinalMessage(meta, value, runId, true);
       }
     };
 
-    if (isBaseMessage(outputs)) {
+    if (BaseMessage.isInstance(outputs)) {
       emitMessage(outputs);
     } else if (Array.isArray(outputs)) {
       for (const value of outputs) emitMessage(value);

--- a/libs/langgraph-core/src/stream/transformers.test.ts
+++ b/libs/langgraph-core/src/stream/transformers.test.ts
@@ -69,6 +69,69 @@ describe("createMessagesTransformer", () => {
     expect(text).toBe("hello");
   });
 
+  it("ignores tool-role message lifecycles", async () => {
+    const transformer = createMessagesTransformer([]);
+    const proj = transformer.init();
+
+    transformer.process(
+      makeEvent(
+        "messages",
+        { event: "message-start", role: "tool", run_id: "run-tool" },
+        agentNs
+      )
+    );
+    transformer.process(
+      makeEvent(
+        "messages",
+        {
+          event: "content-block-delta",
+          index: 0,
+          delta: { type: "text-delta", text: "[]" },
+          run_id: "run-tool",
+        },
+        agentNs
+      )
+    );
+    transformer.process(
+      makeEvent(
+        "messages",
+        { event: "message-finish", run_id: "run-tool" },
+        agentNs
+      )
+    );
+    transformer.process(
+      makeEvent(
+        "messages",
+        { event: "message-start", role: "ai", run_id: "run-ai" },
+        agentNs
+      )
+    );
+    transformer.process(
+      makeEvent(
+        "messages",
+        {
+          event: "content-block-delta",
+          index: 0,
+          delta: { type: "text-delta", text: "hello" },
+          run_id: "run-ai",
+        },
+        agentNs
+      )
+    );
+    transformer.process(
+      makeEvent(
+        "messages",
+        { event: "message-finish", run_id: "run-ai" },
+        agentNs
+      )
+    );
+    transformer.finalize?.();
+
+    const streams = await collect(proj.messages);
+    expect(streams).toHaveLength(1);
+    await expect(streams[0].text).resolves.toBe("hello");
+  });
+
   it("routes interleaved message streams by run id", async () => {
     const transformer = createMessagesTransformer([]);
     const proj = transformer.init();

--- a/libs/langgraph-core/src/stream/transformers/messages.ts
+++ b/libs/langgraph-core/src/stream/transformers/messages.ts
@@ -46,6 +46,7 @@ export function createMessagesTransformer(
 ): StreamTransformer<MessagesTransformerProjection> {
   const log = StreamChannel.local<ChatModelStream>();
   const active = new Map<string, ActiveMessageStream>();
+  const ignored = new Set<string>();
 
   return {
     init: () => ({
@@ -74,6 +75,13 @@ export function createMessagesTransformer(
       switch (data.event) {
         case "message-start": {
           const key = getMessageStreamKey(data);
+          const role = (data as unknown as Record<string, unknown>).role;
+          // Tool results belong on the tools stream and state snapshots, not
+          // the chat-token projection exposed as `run.messages`.
+          if (role === "tool") {
+            ignored.add(key);
+            break;
+          }
           const source = StreamChannel.local<ChatModelStreamEvent>();
           const stream = Object.assign(
             new CoreChatModelStream(source.toAsyncIterable()),
@@ -91,6 +99,7 @@ export function createMessagesTransformer(
         case "content-block-start":
         case "content-block-delta":
         case "content-block-finish":
+          if (ignored.has(getMessageStreamKey(data))) break;
           active
             .get(getMessageStreamKey(data))
             ?.source.push(data as unknown as ChatModelStreamEvent);
@@ -98,6 +107,7 @@ export function createMessagesTransformer(
 
         case "message-finish": {
           const key = getMessageStreamKey(data);
+          if (ignored.delete(key)) break;
           const stream = active.get(key);
           if (stream) {
             stream.source.push(data as unknown as ChatModelStreamEvent);
@@ -108,6 +118,7 @@ export function createMessagesTransformer(
         }
 
         case "error":
+          if (ignored.has(getMessageStreamKey(data))) break;
           active
             .get(getMessageStreamKey(data))
             ?.source.push(data as unknown as ChatModelStreamEvent);
@@ -123,6 +134,7 @@ export function createMessagesTransformer(
         stream.source.close();
         active.delete(key);
       }
+      ignored.clear();
       log.close();
     },
 
@@ -131,6 +143,7 @@ export function createMessagesTransformer(
         stream.source.fail(err);
         active.delete(key);
       }
+      ignored.clear();
       log.fail(err);
     },
   };


### PR DESCRIPTION
## Summary
- Prevent v3 `run.messages` from surfacing `ToolMessage` outputs as assistant text.
- Skip tool-role message lifecycles in the messages transformer while preserving tool messages in state snapshots.
- Add regression coverage for tool-result message leakage.

fixes https://github.com/langchain-ai/deepagentsjs/issues/534