### PR TITLE
fix: clear stream values after joinStream refetch

### DIFF
--- a/.changeset/clear-join-stream-values.md
+++ b/.changeset/clear-join-stream-values.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+Clear local stream values after joinStream refetches fresh history.

--- a/libs/sdk/src/react/stream.lgp.tsx
+++ b/libs/sdk/src/react/stream.lgp.tsx
@@ -732,7 +732,11 @@ export function useStreamLGP<
           }
           const newHistory = await history.mutate(threadId);
           const lastHead = newHistory?.at(0);
-          if (lastHead) options.onFinish?.(lastHead, callbackMeta);
+          if (lastHead) {
+            options.onFinish?.(lastHead, callbackMeta);
+            return null;
+          }
+          return undefined;
         },
         onError(error) {
           options.onError?.(error, callbackMeta);

--- a/libs/sdk/src/ui/orchestrator.ts
+++ b/libs/sdk/src/ui/orchestrator.ts
@@ -895,7 +895,11 @@ export class StreamOrchestrator<
           }
           const newHistory = await this.#mutate(tid);
           const lastHead = newHistory?.at(0);
-          if (lastHead) this.#options.onFinish?.(lastHead, callbackMeta);
+          if (lastHead) {
+            this.#options.onFinish?.(lastHead, callbackMeta);
+            return null;
+          }
+          return undefined;
         },
         onError: (error) => {
           this.#options.onError?.(error, callbackMeta);


### PR DESCRIPTION
Fixes #1969

When `joinStream` refetches history successfully, return `null` from `onSuccess` so local stream values are cleared and the hook falls back to the fresh history state. This updates both the React stream path and the UI orchestrator path.

Validation:
- `oxfmt --check libs/sdk/src/react/stream.lgp.tsx libs/sdk/src/ui/orchestrator.ts`
- `oxlint libs/sdk/src/react/stream.lgp.tsx libs/sdk/src/ui/orchestrator.ts`
- `pnpm --filter @langchain/langgraph-sdk exec vitest run src/ui/manager.test.ts src/ui/orchestrator.test.ts`
- `pnpm --filter @langchain/langgraph-sdk exec tsc --noEmit --project tsconfig.json --pretty false`
- `pnpm --filter @langchain/build compile @langchain/langgraph-sdk`
- `git diff --check`