### PR TITLE
ci(infra): run framework browser tests only when paths change

### DIFF
--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -19,7 +19,47 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Path rules:
+  # - libs/sdk/** → all framework browser jobs (sdk output)
+  # - libs/sdk-{react,angular,vue,svelte}/** → that package only
+  # - edits to this workflow → full matrix
+  # - workflow_dispatch → full matrix
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      sdk: ${{ steps.changes.outputs.sdk }}
+      sdk-react: ${{ steps.changes.outputs.sdk-react }}
+      sdk-angular: ${{ steps.changes.outputs.sdk-angular }}
+      sdk-vue: ${{ steps.changes.outputs.sdk-vue }}
+      sdk-svelte: ${{ steps.changes.outputs.sdk-svelte }}
+      workflow: ${{ steps.changes.outputs.workflow }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        with:
+          filters: |
+            sdk:
+              - 'libs/sdk/**'
+              - '!libs/sdk-*/**'
+            sdk-react:
+              - 'libs/sdk-react/**'
+            sdk-angular:
+              - 'libs/sdk-angular/**'
+            sdk-vue:
+              - 'libs/sdk-vue/**'
+            sdk-svelte:
+              - 'libs/sdk-svelte/**'
+            workflow:
+              - '.github/workflows/test-browser.yml'
+
   sdk-react:
+    needs: detect-changes
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.workflow == 'true' ||
+      needs.detect-changes.outputs.sdk == 'true' ||
+      needs.detect-changes.outputs.sdk-react == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -30,6 +70,12 @@ jobs:
         run: pnpm --filter @langchain/react run test
 
   sdk-angular:
+    needs: detect-changes
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.workflow == 'true' ||
+      needs.detect-changes.outputs.sdk == 'true' ||
+      needs.detect-changes.outputs.sdk-angular == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -40,6 +86,12 @@ jobs:
         run: pnpm --filter @langchain/angular run test
 
   sdk-vue:
+    needs: detect-changes
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.workflow == 'true' ||
+      needs.detect-changes.outputs.sdk == 'true' ||
+      needs.detect-changes.outputs.sdk-vue == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -50,6 +102,12 @@ jobs:
         run: pnpm --filter @langchain/vue run test
 
   sdk-svelte:
+    needs: detect-changes
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.workflow == 'true' ||
+      needs.detect-changes.outputs.sdk == 'true' ||
+      needs.detect-changes.outputs.sdk-svelte == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/examples/sql-agent/package.json
+++ b/examples/sql-agent/package.json
@@ -10,7 +10,7 @@
     "@langchain/core": "^1.1.44",
     "@langchain/langgraph": "workspace:*",
     "@langchain/openai": "^1.4.5",
-    "better-sqlite3": "^11.0.0",
+    "better-sqlite3": "^12.10.0",
     "dotenv": "^16.4.5",
     "langchain": "^1.3.5",
     "reflect-metadata": "^0.2.2",

--- a/libs/checkpoint-sqlite/package.json
+++ b/libs/checkpoint-sqlite/package.json
@@ -27,7 +27,7 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "better-sqlite3": "^12.6.0"
+    "better-sqlite3": "^12.10.0"
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.44",
@@ -39,7 +39,7 @@
     "@tsconfig/recommended": "^1.0.3",
     "@types/better-sqlite3": "^7.6.12",
     "@types/uuid": "^10",
-    "better-sqlite3": "^12.6.0",
+    "better-sqlite3": "^12.10.0",
     "dotenv": "^16.3.1",
     "dpdm": "^3.12.0",
     "rollup": "^4.37.0",

--- a/libs/checkpoint-validation/package.json
+++ b/libs/checkpoint-validation/package.json
@@ -49,7 +49,7 @@
     "@tsconfig/recommended": "^1.0.3",
     "@types/uuid": "^10",
     "@types/yargs": "^17.0.33",
-    "better-sqlite3": "^11.7.0",
+    "better-sqlite3": "^12.10.0",
     "dotenv": "^16.3.1",
     "dpdm": "^3.12.0",
     "mongodb": "^6.21.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
       "protobufjs@>=7 <8": ">=7.5.5 <8",
       "basic-ftp@>=5 <6": ">=5.3.0 <6",
       "vite@>=7 <8": ">=7.3.2",
-      "defu@>=6 <7": ">=6.1.5 <7"
+      "defu@>=6 <7": ">=6.1.5 <7",
+      "better-sqlite3": "^12.10.0"
     },
     "onlyBuiltDependencies": [
       "@swc/core",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,7 @@ overrides:
   basic-ftp@>=5 <6: '>=5.3.0 <6'
   vite@>=7 <8: '>=7.3.2'
   defu@>=6 <7: '>=6.1.5 <7'
+  better-sqlite3: ^12.10.0
 
 importers:
 
@@ -965,7 +966,7 @@ importers:
     devDependencies:
       '@langchain/classic':
         specifier: ^1.0.32
-        version: 1.0.32(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1))(@opentelemetry/api@1.9.0)(cheerio@1.2.0)(openai@6.35.0(ws@8.20.1)(zod@4.3.6))(typeorm@0.3.28(better-sqlite3@11.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1))(ws@8.20.1)
+        version: 1.0.32(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1))(@opentelemetry/api@1.9.0)(cheerio@1.2.0)(openai@6.35.0(ws@8.20.1)(zod@4.3.6))(typeorm@0.3.28(better-sqlite3@12.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1))(ws@8.20.1)
       '@langchain/core':
         specifier: ^1.1.44
         version: 1.1.44(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)
@@ -976,8 +977,8 @@ importers:
         specifier: ^1.4.5
         version: 1.4.5(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1))(ws@8.20.1)
       better-sqlite3:
-        specifier: ^11.0.0
-        version: 11.10.0
+        specifier: ^12.10.0
+        version: 12.10.0
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
@@ -992,7 +993,7 @@ importers:
         version: 4.21.0
       typeorm:
         specifier: ^0.3.0
-        version: 0.3.28(better-sqlite3@11.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1)
+        version: 0.3.28(better-sqlite3@12.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1)
       zod:
         specifier: ^4.3.5
         version: 4.3.6
@@ -1644,8 +1645,8 @@ importers:
         specifier: ^1.1.44
         version: 1.1.44(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.20.1)(zod@4.4.2))(ws@8.20.1)
       better-sqlite3:
-        specifier: ^12.6.0
-        version: 12.6.2
+        specifier: ^12.10.0
+        version: 12.10.0
     devDependencies:
       '@langchain/langgraph-checkpoint':
         specifier: workspace:*
@@ -1730,8 +1731,8 @@ importers:
         specifier: ^17.0.33
         version: 17.0.35
       better-sqlite3:
-        specifier: ^11.7.0
-        version: 11.10.0
+        specifier: ^12.10.0
+        version: 12.10.0
       dotenv:
         specifier: ^16.3.1
         version: 16.6.1
@@ -7562,12 +7563,9 @@ packages:
   before-after-hook@3.0.2:
     resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
 
-  better-sqlite3@11.10.0:
-    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
-
-  better-sqlite3@12.6.2:
-    resolution: {integrity: sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==}
-    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+  better-sqlite3@12.10.0:
+    resolution: {integrity: sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -11911,7 +11909,7 @@ packages:
     peerDependencies:
       '@google-cloud/spanner': ^5.18.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       '@sap/hana-client': ^2.14.22
-      better-sqlite3: ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0
+      better-sqlite3: ^12.10.0
       ioredis: ^5.0.4
       mongodb: ^5.8.0 || ^6.0.0
       mssql: ^9.1.1 || ^10.0.0 || ^11.0.0 || ^12.0.0
@@ -14165,7 +14163,7 @@ snapshots:
       '@langchain/core': 1.1.44(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.20.1)(zod@4.4.2))(ws@8.20.1)
       zod: 4.3.6
 
-  '@langchain/classic@1.0.32(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1))(@opentelemetry/api@1.9.0)(cheerio@1.2.0)(openai@6.35.0(ws@8.20.1)(zod@4.3.6))(typeorm@0.3.28(better-sqlite3@11.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1))(ws@8.20.1)':
+  '@langchain/classic@1.0.32(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1))(@opentelemetry/api@1.9.0)(cheerio@1.2.0)(openai@6.35.0(ws@8.20.1)(zod@4.3.6))(typeorm@0.3.28(better-sqlite3@12.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1))(ws@8.20.1)':
     dependencies:
       '@langchain/core': 1.1.44(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)
       '@langchain/openai': 1.4.5(@langchain/core@1.1.44(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1))(ws@8.20.1)
@@ -14179,7 +14177,7 @@ snapshots:
     optionalDependencies:
       cheerio: 1.2.0
       langsmith: 0.6.0(@opentelemetry/api@1.9.0)(openai@6.35.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)
-      typeorm: 0.3.28(better-sqlite3@11.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1)
+      typeorm: 0.3.28(better-sqlite3@12.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -17998,12 +17996,7 @@ snapshots:
 
   before-after-hook@3.0.2: {}
 
-  better-sqlite3@11.10.0:
-    dependencies:
-      bindings: 1.5.0
-      prebuild-install: 7.1.3
-
-  better-sqlite3@12.6.2:
+  better-sqlite3@12.10.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
@@ -23496,7 +23489,7 @@ snapshots:
       es-errors: 1.3.0
       is-typed-array: 1.1.15
 
-  typeorm@0.3.28(better-sqlite3@11.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1):
+  typeorm@0.3.28(better-sqlite3@12.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1):
     dependencies:
       '@sqltools/formatter': 1.2.5
       ansis: 4.2.0
@@ -23514,7 +23507,7 @@ snapshots:
       uuid: 11.1.0
       yargs: 17.7.2
     optionalDependencies:
-      better-sqlite3: 11.10.0
+      better-sqlite3: 12.10.0
       mongodb: 6.21.0(socks@2.8.7)
       pg: 8.20.0
       redis: 4.7.1


### PR DESCRIPTION
## Summary
- Add a `detect-changes` job to the browser test workflow using `dorny/paths-filter@v3.0.2`.
- Run all four framework browser jobs when `libs/sdk/**` changes or when this workflow file changes.
- Run only the matching job when `libs/sdk-react`, `libs/sdk-angular`, `libs/sdk-vue`, or `libs/sdk-svelte` changes.
- Keep the full matrix on `workflow_dispatch` (manual runs and CI dispatched via workflow_dispatch).
