### PR TITLE
fix(sdk): avoid eager stream getter evaluation

### DIFF
--- a/.changeset/silent-stream-getters.md
+++ b/.changeset/silent-stream-getters.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(react): avoid eager stream getter evaluation during object spread
+
+Mark optional `useStream` accessors as non-enumerable so object spread/rest destructuring does not accidentally read guarded fields like `history` or opt into additional stream modes.

--- a/libs/sdk/src/react/stream.lgp.test.tsx
+++ b/libs/sdk/src/react/stream.lgp.test.tsx
@@ -1,0 +1,111 @@
+import { renderToString } from "react-dom/server";
+import { expect, it, vi } from "vitest";
+
+import { useStream } from "./stream.js";
+import type { StreamMode } from "../types.stream.js";
+import type { Client } from "../client.js";
+
+function createMockClient(): Client {
+  return {
+    threads: {
+      getState: vi.fn().mockResolvedValue({
+        values: { messages: [] },
+        checkpoint: {
+          thread_id: "t1",
+          checkpoint_id: "cp1",
+          checkpoint_ns: "",
+          checkpoint_map: null,
+        },
+        next: [],
+        tasks: [],
+        metadata: undefined,
+        created_at: null,
+        parent_checkpoint: null,
+      }),
+      getHistory: vi.fn().mockResolvedValue([]),
+      create: vi.fn().mockResolvedValue({ thread_id: "t1" }),
+    },
+    runs: {
+      stream: vi.fn().mockImplementation(
+        async function* () {
+          // no-op stream
+        }
+      ),
+      joinStream: vi.fn(),
+      cancel: vi.fn().mockResolvedValue(undefined),
+      create: vi.fn().mockResolvedValue({
+        run_id: "run-1",
+        created_at: new Date().toISOString(),
+      }),
+    },
+  } as unknown as Client;
+}
+
+function mountThread(client: Client) {
+  let thread:
+    | ReturnType<typeof useStream<Record<string, unknown>>>
+    | undefined;
+
+  function Probe() {
+    thread = useStream<Record<string, unknown>>({
+      assistantId: "test-assistant",
+      client,
+      threadId: "t1",
+      fetchStateHistory: false,
+    });
+    return null;
+  }
+
+  renderToString(<Probe />);
+  if (thread == null) {
+    throw new Error("Failed to mount stream handle.");
+  }
+  return thread;
+}
+
+it("does not evaluate guarded accessors during object spread", () => {
+  const client = createMockClient();
+  const thread = mountThread(client);
+
+  expect(Object.prototype.propertyIsEnumerable.call(thread, "history")).toBe(
+    false
+  );
+  expect(
+    Object.prototype.propertyIsEnumerable.call(thread, "experimental_branchTree")
+  ).toBe(false);
+
+  expect(() => ({ ...thread })).not.toThrow();
+  expect(() => thread.history).toThrow(
+    "`fetchStateHistory` must be set to `true` to use `history`"
+  );
+});
+
+it("does not auto-add tools/updates stream modes from spread", async () => {
+  const client = createMockClient();
+  const thread = mountThread(client);
+
+  void { ...thread };
+
+  await thread.submit({ messages: [] });
+
+  const streamCall = (client.runs.stream as ReturnType<typeof vi.fn>).mock
+    .calls[0]?.[2] as { streamMode?: StreamMode[] } | undefined;
+  expect(streamCall?.streamMode).toBeDefined();
+  expect(streamCall?.streamMode).not.toContain("tools");
+  expect(streamCall?.streamMode).not.toContain("updates");
+});
+
+it("still opts into tools/updates when explicitly accessed", async () => {
+  const client = createMockClient();
+  const thread = mountThread(client);
+
+  void thread.toolProgress;
+  void (thread as unknown as { subagents: unknown }).subagents;
+
+  await thread.submit({ messages: [] });
+
+  const streamCall = (client.runs.stream as ReturnType<typeof vi.fn>).mock
+    .calls[0]?.[2] as { streamMode?: StreamMode[] } | undefined;
+  expect(streamCall?.streamMode).toContain("tools");
+  expect(streamCall?.streamMode).toContain("updates");
+});

--- a/libs/sdk/src/react/stream.lgp.tsx
+++ b/libs/sdk/src/react/stream.lgp.tsx
@@ -799,7 +799,7 @@ export function useStreamLGP<
     );
   }, [options.onTool, options.tools, submit, values]);
 
-  return {
+  const streamHandle: UseStream<StateType, Bag> = {
     get values() {
       trackStreamMode("values");
       return values;
@@ -896,7 +896,7 @@ export function useStreamLGP<
       return Array.from(toolProgressMap.values());
     },
 
-    getToolCalls(message) {
+    getToolCalls(message: Message<ToolCallType>) {
       trackStreamMode("messages-tuple", "values");
       const msgs = getMessages(values) as Message<ToolCallType>[];
       const allToolCalls = getToolCallsWithResults<ToolCallType>(msgs);
@@ -949,4 +949,25 @@ export function useStreamLGP<
       return stream.getSubagentsByMessage(messageId);
     },
   };
+
+  // Avoid eager getter evaluation during object spread/rest destructuring.
+  // These accessors are opt-in and should only run when explicitly read.
+  const nonEnumerableAccessors = [
+    "history",
+    "experimental_branchTree",
+    "toolProgress",
+    "subagents",
+    "activeSubagents",
+  ] as const;
+  for (const key of nonEnumerableAccessors) {
+    const descriptor = Object.getOwnPropertyDescriptor(streamHandle, key);
+    if (descriptor?.get) {
+      Object.defineProperty(streamHandle, key, {
+        ...descriptor,
+        enumerable: false,
+      });
+    }
+  }
+
+  return streamHandle;
 }


### PR DESCRIPTION
## Summary

fix(sdk): avoid eager stream getter evaluation during spread

This fixes a React `useStream` development-mode failure where passing the stream handle through components that clone or rest-spread props could accidentally read lazy getters. The guarded `history` getter still throws when explicitly accessed with `fetchStateHistory: false`, but object spread no longer trips that path or widens `streamMode` by touching optional accessors.

## Changes

`@langchain/langgraph-sdk`

- Marks optional `useStream` accessors (`history`, `experimental_branchTree`, `toolProgress`, `subagents`, `activeSubagents`) as non-enumerable on the returned stream handle.
- Preserves explicit access behavior for those accessors, including the existing `history` guard and stream mode opt-in for `toolProgress`/`subagents`.
- Adds React hook regression coverage for object spread, explicit getter access, and stream mode inference.
