### PR TITLE
fix(sdk): unwrap Command tool outputs and hide scoped task tools

### DIFF
--- a/.changeset/fix-subagent-tool-call-output.md
+++ b/.changeset/fix-subagent-tool-call-output.md
@@ -1,0 +1,13 @@
+---
+"@langchain/langgraph-sdk": patch
+"@langchain/react": patch
+"@langchain/vue": patch
+"@langchain/svelte": patch
+"@langchain/angular": patch
+---
+
+fix(sdk): unwrap Command tool outputs and hide scoped task tools
+
+Filter wrapper `task` dispatch events from subagent-scoped tool-call
+projections and parse embedded ToolMessage results from LangGraph
+`Command` payloads on `tool-finished`.

--- a/libs/sdk/src/client/stream/handles/subagents.ts
+++ b/libs/sdk/src/client/stream/handles/subagents.ts
@@ -9,7 +9,11 @@ import type { SubscriptionHandle } from "../index.js";
 import { MultiCursorBuffer } from "../multi-cursor-buffer.js";
 import { StreamingMessageAssembler } from "../messages.js";
 import type { StreamingMessage, StreamingMessageHandle } from "../messages.js";
-import { ToolCallAssembler, toClientAssembledToolCall } from "./tools.js";
+import {
+  shouldIgnoreScopedTaskToolEvent,
+  ToolCallAssembler,
+  toClientAssembledToolCall,
+} from "./tools.js";
 import type { ClientAssembledToolCall } from "./tools.js";
 import { MediaAssembler } from "../media.js";
 import type {
@@ -102,7 +106,9 @@ export class SubagentHandle {
       ["tools"],
       (event) => {
         if (event.method !== "tools") return;
-        const tc = assembler.consume(event as ToolsEvent);
+        const toolsEvent = event as ToolsEvent;
+        if (shouldIgnoreScopedTaskToolEvent(this.namespace, toolsEvent)) return;
+        const tc = assembler.consume(toolsEvent);
         if (tc) buffer.push(toClientAssembledToolCall(tc));
       },
       () => buffer.close()

--- a/libs/sdk/src/client/stream/handles/tools.test.ts
+++ b/libs/sdk/src/client/stream/handles/tools.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ToolCallAssembler,
+  parseToolOutput,
+  shouldIgnoreScopedTaskToolEvent,
+} from "./tools.js";
+import { eventOf } from "../test/utils.js";
+
+describe("shouldIgnoreScopedTaskToolEvent", () => {
+  it("ignores scoped task tool-started events", () => {
+    const event = eventOf(
+      "tools",
+      {
+        event: "tool-started",
+        tool_call_id: "task_1",
+        tool_name: "task",
+        input: { description: "Work", subagent_type: "worker" },
+      },
+      { namespace: ["tools:worker"], seq: 1 }
+    );
+
+    expect(
+      shouldIgnoreScopedTaskToolEvent(["tools:worker"], event as never)
+    ).toBe(true);
+  });
+
+  it("does not ignore real tools in a scoped namespace", () => {
+    const event = eventOf(
+      "tools",
+      {
+        event: "tool-started",
+        tool_call_id: "search-1",
+        tool_name: "search_web",
+        input: { query: "test" },
+      },
+      { namespace: ["tools:worker"], seq: 1 }
+    );
+
+    expect(
+      shouldIgnoreScopedTaskToolEvent(["tools:worker"], event as never)
+    ).toBe(false);
+  });
+
+  it("does not ignore task events from a different namespace", () => {
+    const event = eventOf(
+      "tools",
+      {
+        event: "tool-started",
+        tool_call_id: "task_1",
+        tool_name: "task",
+        input: { description: "Work", subagent_type: "worker" },
+      },
+      { namespace: ["tools:other-worker"], seq: 1 }
+    );
+
+    expect(
+      shouldIgnoreScopedTaskToolEvent(["tools:worker"], event as never)
+    ).toBe(false);
+  });
+
+  it("does not ignore root-level task dispatch events", () => {
+    const event = eventOf(
+      "tools",
+      {
+        event: "tool-started",
+        tool_call_id: "task_1",
+        tool_name: "task",
+        input: { description: "Work", subagent_type: "worker" },
+      },
+      { namespace: [], seq: 1 }
+    );
+
+    expect(shouldIgnoreScopedTaskToolEvent([], event as never)).toBe(false);
+  });
+});
+
+describe("parseToolOutput", () => {
+  it("unwraps Command outputs with a matching ToolMessage", () => {
+    expect(
+      parseToolOutput(
+        {
+          lg_name: "Command",
+          update: {
+            messages: [
+              {
+                type: "tool",
+                tool_call_id: "query-1",
+                name: "query_database",
+                content: JSON.stringify({
+                  status: "success",
+                  table: "users",
+                  count: 2,
+                }),
+              },
+            ],
+          },
+        },
+        "query-1"
+      )
+    ).toEqual({
+      status: "success",
+      table: "users",
+      count: 2,
+    });
+  });
+
+  it("unwraps Command outputs serialized as JSON strings", () => {
+    expect(
+      parseToolOutput(
+        JSON.stringify({
+          lg_name: "Command",
+          update: {
+            messages: [
+              {
+                type: "tool",
+                tool_call_id: "search-1",
+                content: "Weather in SF: sunny",
+              },
+            ],
+          },
+        }),
+        "search-1"
+      )
+    ).toBe("Weather in SF: sunny");
+  });
+
+  it("preserves Command outputs without ToolMessages", () => {
+    const command = {
+        lg_name: "Command",
+        update: {
+          files: {},
+          messages: [
+            {
+              type: "ai",
+              content: [{ type: "text", text: "Done" }],
+            },
+          ],
+        },
+      };
+
+    expect(parseToolOutput(command)).toBe(command);
+  });
+
+  it("preserves Command outputs when no ToolMessage matches the call id", () => {
+    const command = {
+      lg_name: "Command",
+      update: {
+        messages: [
+          {
+            type: "tool",
+            tool_call_id: "other-call",
+            content: JSON.stringify({ count: 2 }),
+          },
+        ],
+      },
+    };
+
+    expect(parseToolOutput(command, "query-1")).toBe(command);
+  });
+});
+
+describe("ToolCallAssembler Command outputs", () => {
+  it("resolves parsed tool values from Command tool-finished payloads", async () => {
+    const assembler = new ToolCallAssembler();
+    const started = assembler.consume(
+      eventOf(
+        "tools",
+        {
+          event: "tool-started",
+          tool_call_id: "query-1",
+          tool_name: "query_database",
+          input: { table: "users" },
+        },
+        { namespace: ["tools:worker"], seq: 1 }
+      ) as never
+    );
+
+    assembler.consume(
+      eventOf(
+        "tools",
+        {
+          event: "tool-finished",
+          tool_call_id: "query-1",
+          output: {
+            lg_name: "Command",
+            update: {
+              messages: [
+                {
+                  type: "tool",
+                  tool_call_id: "query-1",
+                  name: "query_database",
+                  content: JSON.stringify({ count: 2 }),
+                },
+              ],
+            },
+          },
+        },
+        { namespace: ["tools:worker"], seq: 2 }
+      ) as never
+    );
+
+    expect(started!.output).toEqual({ count: 2 });
+    await expect(started!.outputPromise).resolves.toEqual({ count: 2 });
+  });
+});

--- a/libs/sdk/src/client/stream/handles/tools.ts
+++ b/libs/sdk/src/client/stream/handles/tools.ts
@@ -118,13 +118,64 @@ export function parseToolPayload(value: unknown): unknown {
   }
 }
 
+/**
+ * Skip wrapper `task` tool events scoped to a subagent namespace.
+ *
+ * Deep-agent subagents are discovered from root-level `task` tool calls;
+ * replaying the same dispatch tool inside the worker namespace would
+ * otherwise surface as a spurious entry in `sub.toolCalls`.
+ */
+export function shouldIgnoreScopedTaskToolEvent(
+  scopeNamespace: readonly string[],
+  event: ToolsEvent
+): boolean {
+  const data = event.params.data;
+  return (
+    scopeNamespace.length > 0 &&
+    event.params.namespace.length === scopeNamespace.length &&
+    event.params.namespace.every(
+      (segment, index) => segment === scopeNamespace[index]
+    ) &&
+    "tool_name" in data &&
+    data.tool_name === "task"
+  );
+}
+
+function getWireMessageField(message: unknown, field: string): unknown {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return undefined;
+  }
+  const record = message as Record<string, unknown>;
+  if (field in record) return record[field];
+  const kwargs = record.kwargs as Record<string, unknown> | undefined;
+  if (kwargs != null && field in kwargs) return kwargs[field];
+  const lcKwargs = record.lc_kwargs as Record<string, unknown> | undefined;
+  if (lcKwargs != null && field in lcKwargs) return lcKwargs[field];
+  return undefined;
+}
+
 function isToolMessageLike(
   value: unknown
 ): value is Record<string, unknown> & { content: unknown } {
   if (!value || typeof value !== "object") return false;
   const record = value as Record<string, unknown>;
   if (record.type === "tool") return true;
-  return typeof record.tool_call_id === "string" && "content" in record;
+  const type = getWireMessageField(value, "type");
+  if (type === "tool") return true;
+  return (
+    typeof getWireMessageField(value, "tool_call_id") === "string" &&
+    getWireMessageField(value, "content") !== undefined
+  );
+}
+
+function isCommandLike(
+  value: unknown
+): value is Record<string, unknown> & { update?: unknown } {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    (value as Record<string, unknown>).lg_name === "Command"
+  );
 }
 
 function textFromContentBlocks(content: unknown[]): string {
@@ -165,19 +216,72 @@ function parseToolResultContent(content: unknown): unknown | null {
   return null;
 }
 
+function parseToolMessageRecord(message: unknown): unknown | null {
+  const content = getWireMessageField(message, "content");
+  return parseToolResultContent(content);
+}
+
+type ParsedCommandToolOutput =
+  | { found: true; value: unknown | null }
+  | { found: false };
+
+function parseCommandToolOutput(
+  command: Record<string, unknown> & { update?: unknown },
+  toolCallId?: string
+): ParsedCommandToolOutput {
+  const update = command.update;
+  if (update == null || typeof update !== "object" || Array.isArray(update)) {
+    return { found: false };
+  }
+
+  const messages = (update as Record<string, unknown>).messages;
+  if (!Array.isArray(messages)) return { found: false };
+
+  const toolMessages = messages.filter((message) => isToolMessageLike(message));
+  if (toolMessages.length === 0) return { found: false };
+
+  if (toolCallId != null) {
+    for (const message of toolMessages) {
+      const callId = getWireMessageField(message, "tool_call_id");
+      if (callId !== toolCallId) continue;
+      return { found: true, value: parseToolMessageRecord(message) };
+    }
+    return { found: false };
+  }
+
+  if (toolMessages.length === 1) {
+    return { found: true, value: parseToolMessageRecord(toolMessages[0]) };
+  }
+
+  for (let i = toolMessages.length - 1; i >= 0; i -= 1) {
+    const parsed = parseToolMessageRecord(toolMessages[i]);
+    if (parsed != null) return { found: true, value: parsed };
+  }
+
+  return { found: true, value: null };
+}
+
 /**
  * Parse a `tool-finished` output payload into the tool's return value.
  *
  * Wire events often wrap structured tool results in a ToolMessage-shaped
- * object (`{ type: "tool", content: "..." }`). This unwraps that envelope,
- * JSON-decodes string content when possible, and leaves plain strings as-is.
- * Returns `null` when a ToolMessage envelope is present but its content
- * cannot be normalised.
+ * object (`{ type: "tool", content: "..." }`) or a LangGraph
+ * {@link Command} whose `update.messages` carries the ToolMessage.
+ * This unwraps those envelopes, JSON-decodes string content when possible,
+ * and leaves plain strings as-is. Returns `null` when a ToolMessage envelope
+ * is present but its content cannot be normalised.
  */
-export function parseToolOutput(value: unknown): unknown | null {
+export function parseToolOutput(
+  value: unknown,
+  toolCallId?: string
+): unknown | null {
   const parsed = parseToolPayload(value);
+  if (isCommandLike(parsed)) {
+    const commandOutput = parseCommandToolOutput(parsed, toolCallId);
+    return commandOutput.found ? commandOutput.value : parsed;
+  }
   if (isToolMessageLike(parsed)) {
-    return parseToolResultContent(parsed.content);
+    return parseToolResultContent(getWireMessageField(parsed, "content"));
   }
   return parsed ?? null;
 }
@@ -277,7 +381,7 @@ export class ToolCallAssembler {
     const entry = this.active.get(data.tool_call_id);
     if (!entry) return undefined;
     this.active.delete(data.tool_call_id);
-    const value = parseToolOutput(data.output);
+    const value = parseToolOutput(data.output, data.tool_call_id);
     entry.resolveOutput(value);
     entry.handle.output = value;
     entry.handle.status = "finished";

--- a/libs/sdk/src/client/stream/index.test.ts
+++ b/libs/sdk/src/client/stream/index.test.ts
@@ -1181,6 +1181,94 @@ describe("thread.subagents projection", () => {
 
     await expect(sub.output).rejects.toThrow("Subagent crashed");
   });
+
+  it("does not surface wrapper task tools on sub.toolCalls", async () => {
+    const transport = new MockTransport();
+    const thread = new ThreadStream(transport, { assistantId: "test-agent" });
+    const iter = thread.subagents[Symbol.asyncIterator]();
+    await new Promise((r) => setTimeout(r, 0));
+
+    transport.pushEvent(
+      eventOf(
+        "tools",
+        {
+          event: "tool-started",
+          tool_call_id: "task_1",
+          tool_name: "task",
+          input: { description: "Research", subagent_type: "researcher" },
+        } as Event["params"]["data"],
+        { namespace: ["tools:worker"], seq: 1 }
+      )
+    );
+
+    const sub = (await iter.next()).value as SubagentHandle;
+    const toolCalls = sub.toolCalls;
+    await new Promise((r) => setTimeout(r, 0));
+
+    transport.pushEvent(
+      eventOf(
+        "tools",
+        {
+          event: "tool-finished",
+          tool_call_id: "task_1",
+          output: {
+            lg_name: "Command",
+            update: {
+              messages: [
+                {
+                  type: "ai",
+                  content: [{ type: "text", text: "Done" }],
+                },
+              ],
+            },
+          },
+        } as Event["params"]["data"],
+        { namespace: ["tools:worker"], seq: 2 }
+      )
+    );
+
+    transport.pushEvent(
+      eventOf(
+        "tools",
+        {
+          event: "tool-started",
+          tool_call_id: "search-1",
+          tool_name: "search_web",
+          input: { query: "AI trends" },
+        } as Event["params"]["data"],
+        { namespace: ["tools:worker"], seq: 3 }
+      )
+    );
+
+    const tc = await nextValue(toolCalls);
+    expect(tc.name).toBe("search_web");
+
+    transport.pushEvent(
+      eventOf(
+        "tools",
+        {
+          event: "tool-finished",
+          tool_call_id: "search-1",
+          output: {
+            lg_name: "Command",
+            update: {
+              messages: [
+                {
+                  type: "tool",
+                  tool_call_id: "search-1",
+                  name: "search_web",
+                  content: JSON.stringify({ results: ["one"] }),
+                },
+              ],
+            },
+          },
+        } as Event["params"]["data"],
+        { namespace: ["tools:worker"], seq: 4 }
+      )
+    );
+
+    await expect(tc.output).resolves.toEqual({ results: ["one"] });
+  });
 });
 
 describe("SSE transport: per-stream delivery", () => {

--- a/libs/sdk/src/stream/projections/tool-calls.ts
+++ b/libs/sdk/src/stream/projections/tool-calls.ts
@@ -9,7 +9,10 @@
  * (`null` until the call succeeds).
  */
 import type { ToolsEvent } from "@langchain/protocol";
-import { ToolCallAssembler } from "../../client/stream/handles/tools.js";
+import {
+  shouldIgnoreScopedTaskToolEvent,
+  ToolCallAssembler,
+} from "../../client/stream/handles/tools.js";
 import type { AssembledToolCall } from "../../client/stream/handles/tools.js";
 import type { ProjectionSpec, ProjectionRuntime } from "../types.js";
 import { isRootNamespace, namespaceKey } from "../namespace.js";
@@ -30,14 +33,7 @@ export function toolCallsProjection(
       const assembler = new ToolCallAssembler();
 
       const applyToolsEvent = (event: ToolsEvent): void => {
-        const data = event.params.data;
-        if (
-          ns.length > 0 &&
-          event.params.namespace.length === ns.length &&
-          data.tool_name === "task"
-        ) {
-          return;
-        }
+        if (shouldIgnoreScopedTaskToolEvent(ns, event)) return;
         const tc = assembler.consume(event);
         if (tc == null) return;
         const next = upsertToolCall(store.getSnapshot(), tc);


### PR DESCRIPTION
## Summary

- Filter scoped deep-agent `task` dispatch events out of `sub.toolCalls` so subagent tool streams only show real worker tools.
- Unwrap LangGraph `Command` payloads in `parseToolOutput` when they carry an embedded `ToolMessage`, so `tc.output` resolves to the actual tool result instead of raw graph state.
- Share the scoped-task filter between client subagent handles and framework tool-call projections.
