### PR TITLE
fix(sdk): preserve apiUrl path prefix in stream transport URLs

### DIFF
--- a/.changeset/fix-sdk-proxied-api-url-path-prefix.md
+++ b/.changeset/fix-sdk-proxied-api-url-path-prefix.md
@@ -1,0 +1,9 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): preserve apiUrl path prefix in stream transport URLs
+
+Use BaseClient-style URL concatenation in `toAbsoluteUrl` so SSE and WebSocket
+subscriptions work when the SDK is pointed at a proxied apiUrl with a path
+prefix (e.g. `/api/chat-langchain`).

--- a/libs/sdk/src/client/index.test.ts
+++ b/libs/sdk/src/client/index.test.ts
@@ -3,6 +3,12 @@ import { describe, expect, it } from "vitest";
 import { Client } from "./index.js";
 import { ThreadStream } from "./stream/index.js";
 import { ProtocolSseTransportAdapter } from "./stream/transport/http.js";
+import {
+  PROXIED_API_URL,
+  THREAD_ID,
+  createFetchRecorder,
+  createWebSocketUrlRecorder,
+} from "./stream/transport/test-helpers.js";
 
 describe("Client", () => {
   it("exposes sub-clients on main Client", () => {
@@ -98,25 +104,7 @@ describe("Client", () => {
   });
 
   it("uses the protocol commands path for sse commands", async () => {
-    const calls: URL[] = [];
-    const customFetch = ((input: URL | RequestInfo) => {
-      calls.push(
-        // oxlint-disable-next-line no-instanceof/no-instanceof
-        input instanceof URL
-          ? input
-          : new URL(typeof input === "string" ? input : input.url)
-      );
-      return Promise.resolve(
-        new Response(
-          JSON.stringify({
-            type: "success",
-            id: 1,
-            result: {},
-          }),
-          { status: 200, headers: { "content-type": "application/json" } }
-        )
-      );
-    }) as typeof fetch;
+    const { calls, fetch: customFetch } = createFetchRecorder();
 
     const transport = new ProtocolSseTransportAdapter({
       apiUrl: "http://localhost:9999",
@@ -128,5 +116,46 @@ describe("Client", () => {
 
     expect(calls).toHaveLength(1);
     expect(calls[0].pathname).toBe("/threads/my-thread/commands");
+  });
+
+  it("threads.stream preserves proxied apiUrl path prefix for sse subscriptions", async () => {
+    const sentinel = new Error("sentinel-fetch");
+    const { calls, fetch: customFetch } = createFetchRecorder({ error: sentinel });
+    const client = new Client({
+      apiUrl: PROXIED_API_URL,
+      apiKey: null,
+    });
+
+    const thread = client.threads.stream(THREAD_ID, {
+      assistantId: "docs_agent",
+      transport: "sse",
+      fetch: customFetch,
+    });
+
+    await expect(thread.subscribe(["values"])).rejects.toBe(sentinel);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].href).toBe(
+      `${PROXIED_API_URL}/threads/${THREAD_ID}/stream/events`
+    );
+  });
+
+  it("threads.stream preserves proxied apiUrl path prefix for websocket subscriptions", async () => {
+    const { calls, webSocketFactory, sentinel } = createWebSocketUrlRecorder();
+    const client = new Client({
+      apiUrl: PROXIED_API_URL,
+      apiKey: null,
+    });
+
+    const thread = client.threads.stream(THREAD_ID, {
+      assistantId: "docs_agent",
+      transport: "websocket",
+      webSocketFactory,
+    });
+
+    await expect(thread.subscribe(["values"])).rejects.toBe(sentinel);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe(
+      `ws://localhost:4100/api/chat-langchain/threads/${THREAD_ID}/stream/events`
+    );
   });
 });

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { ProtocolSseTransportAdapter } from "./http.js";
+import {
+  LANGGRAPH_PROXY_API_URL,
+  PROXIED_API_URL,
+  THREAD_ID,
+  createFetchRecorder,
+} from "./test-helpers.js";
+
+describe("ProtocolSseTransportAdapter URL resolution", () => {
+  it("preserves apiUrl path prefix for protocol commands", async () => {
+    const { calls, fetch } = createFetchRecorder();
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: PROXIED_API_URL,
+      threadId: THREAD_ID,
+      fetch,
+    });
+
+    await transport.send({
+      id: 1,
+      method: "state.get",
+      params: { namespace: [] },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].href).toBe(
+      `${PROXIED_API_URL}/threads/${THREAD_ID}/commands`
+    );
+  });
+
+  it("preserves apiUrl path prefix for stream event subscriptions", async () => {
+    const sentinel = new Error("stream-open");
+    const { calls, fetch } = createFetchRecorder({ error: sentinel });
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: PROXIED_API_URL,
+      threadId: THREAD_ID,
+      fetch,
+    });
+
+    const handle = transport.openEventStream({ channels: ["values"] });
+    await expect(handle.ready).rejects.toBe(sentinel);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].href).toBe(
+      `${PROXIED_API_URL}/threads/${THREAD_ID}/stream/events`
+    );
+    handle.close();
+  });
+
+  it("preserves custom command and stream paths under a proxied apiUrl", async () => {
+    const { calls, fetch } = createFetchRecorder();
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: LANGGRAPH_PROXY_API_URL,
+      threadId: THREAD_ID,
+      fetch,
+      paths: {
+        commands: `/threads/${THREAD_ID}/commands`,
+        stream: `/threads/${THREAD_ID}/stream/events`,
+      },
+    });
+
+    await transport.send({
+      id: 1,
+      method: "state.get",
+      params: { namespace: [] },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].href).toBe(
+      `${LANGGRAPH_PROXY_API_URL}/threads/${THREAD_ID}/commands`
+    );
+  });
+});

--- a/libs/sdk/src/client/stream/transport/test-helpers.ts
+++ b/libs/sdk/src/client/stream/transport/test-helpers.ts
@@ -1,0 +1,52 @@
+export const PROXIED_API_URL = "http://localhost:4100/api/chat-langchain";
+export const LANGGRAPH_PROXY_API_URL = "http://localhost:4100/api/langgraph";
+export const THREAD_ID = "019e6ab9-a2ed-7313-af02-f0e48847601b";
+
+function toUrl(input: URL | RequestInfo): URL {
+  // oxlint-disable-next-line no-instanceof/no-instanceof
+  return input instanceof URL
+    ? input
+    : new URL(typeof input === "string" ? input : input.url);
+}
+
+export function protocolSuccessResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      type: "success",
+      id: 1,
+      result: {},
+    }),
+    { status: 200, headers: { "content-type": "application/json" } }
+  );
+}
+
+export function createFetchRecorder(options?: {
+  response?: Response;
+  error?: Error;
+}): { calls: URL[]; fetch: typeof fetch } {
+  const calls: URL[] = [];
+  const fetchImpl = ((input: URL | RequestInfo) => {
+    calls.push(toUrl(input));
+    if (options?.error) {
+      return Promise.reject(options.error);
+    }
+    return Promise.resolve(options?.response ?? protocolSuccessResponse());
+  }) as typeof fetch;
+
+  return { calls, fetch: fetchImpl };
+}
+
+export function createWebSocketUrlRecorder(): {
+  calls: string[];
+  webSocketFactory: (url: string) => WebSocket;
+  sentinel: Error;
+} {
+  const calls: string[] = [];
+  const sentinel = new Error("websocket-open");
+  const webSocketFactory = ((url: string) => {
+    calls.push(url);
+    throw sentinel;
+  }) as (url: string) => WebSocket;
+
+  return { calls, webSocketFactory, sentinel };
+}

--- a/libs/sdk/src/client/stream/transport/utils.test.ts
+++ b/libs/sdk/src/client/stream/transport/utils.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { toAbsoluteUrl, toWebSocketUrl } from "./utils.js";
+import {
+  LANGGRAPH_PROXY_API_URL,
+  PROXIED_API_URL,
+  THREAD_ID,
+} from "./test-helpers.js";
+
+describe("toAbsoluteUrl", () => {
+  it("preserves apiUrl path prefixes for absolute paths", () => {
+    expect(
+      toAbsoluteUrl(
+        PROXIED_API_URL,
+        `/threads/${THREAD_ID}/commands`
+      ).toString()
+    ).toBe(`${PROXIED_API_URL}/threads/${THREAD_ID}/commands`);
+  });
+
+  it("preserves apiUrl path prefixes for stream event paths", () => {
+    expect(
+      toAbsoluteUrl(
+        PROXIED_API_URL,
+        `/threads/${THREAD_ID}/stream/events`
+      ).toString()
+    ).toBe(`${PROXIED_API_URL}/threads/${THREAD_ID}/stream/events`);
+  });
+
+  it("matches BaseClient-style concatenation for bare apiUrl hosts", () => {
+    expect(
+      toAbsoluteUrl(
+        "http://localhost:2024",
+        `/threads/${THREAD_ID}/commands`
+      ).toString()
+    ).toBe(`http://localhost:2024/threads/${THREAD_ID}/commands`);
+  });
+
+  it("strips a trailing slash from apiUrl before joining", () => {
+    expect(
+      toAbsoluteUrl(`${LANGGRAPH_PROXY_API_URL}/`, "/threads/search").toString()
+    ).toBe(`${LANGGRAPH_PROXY_API_URL}/threads/search`);
+  });
+
+  it("aligns with BaseClient.prepareFetchOptions for proxied deployments", () => {
+    const apiUrl = PROXIED_API_URL.replace(/\/$/, "");
+    const path = `/threads/${THREAD_ID}/commands`;
+
+    expect(toAbsoluteUrl(apiUrl, path).toString()).toBe(
+      new URL(`${apiUrl}${path}`).toString()
+    );
+  });
+});
+
+describe("toWebSocketUrl", () => {
+  it("preserves path prefixes when converting http(s) to ws(s)", () => {
+    expect(
+      toWebSocketUrl(
+        toAbsoluteUrl(
+          PROXIED_API_URL,
+          `/threads/${THREAD_ID}/stream/events`
+        ).toString()
+      )
+    ).toBe(
+      `ws://localhost:4100/api/chat-langchain/threads/${THREAD_ID}/stream/events`
+    );
+  });
+});

--- a/libs/sdk/src/client/stream/transport/utils.ts
+++ b/libs/sdk/src/client/stream/transport/utils.ts
@@ -4,8 +4,9 @@ import type { CommandResponse, ErrorResponse } from "@langchain/protocol";
 export const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
+/** Match {@link BaseClient.prepareFetchOptions}: preserve any apiUrl path prefix. */
 export const toAbsoluteUrl = (apiUrl: string, path: string) =>
-  new URL(path, apiUrl.endsWith("/") ? apiUrl : `${apiUrl}/`);
+  new URL(`${apiUrl.replace(/\/$/, "")}${path}`);
 
 export const toError = (error: unknown) =>
   // oxlint-disable-next-line no-instanceof/no-instanceof

--- a/libs/sdk/src/client/stream/transport/websocket.test.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { ProtocolWebSocketTransportAdapter } from "./websocket.js";
+import {
+  PROXIED_API_URL,
+  THREAD_ID,
+  createWebSocketUrlRecorder,
+} from "./test-helpers.js";
+
+describe("ProtocolWebSocketTransportAdapter URL resolution", () => {
+  it("preserves apiUrl path prefix when opening the stream socket", async () => {
+    const { calls, webSocketFactory, sentinel } = createWebSocketUrlRecorder();
+    const transport = new ProtocolWebSocketTransportAdapter({
+      apiUrl: PROXIED_API_URL,
+      threadId: THREAD_ID,
+      webSocketFactory,
+    });
+
+    await expect(transport.open()).rejects.toBe(sentinel);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe(
+      `ws://localhost:4100/api/chat-langchain/threads/${THREAD_ID}/stream/events`
+    );
+  });
+
+  it("preserves custom stream paths under a proxied apiUrl", async () => {
+    const customStreamPath = `/threads/${THREAD_ID}/stream/events`;
+    const { calls, webSocketFactory, sentinel } = createWebSocketUrlRecorder();
+    const transport = new ProtocolWebSocketTransportAdapter({
+      apiUrl: PROXIED_API_URL,
+      threadId: THREAD_ID,
+      paths: { stream: customStreamPath },
+      webSocketFactory,
+    });
+
+    await expect(transport.open()).rejects.toBe(sentinel);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe(
+      `ws://localhost:4100/api/chat-langchain${customStreamPath}`
+    );
+  });
+});

--- a/libs/sdk/src/client/stream/transport/websocket.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.ts
@@ -6,7 +6,13 @@ import type {
   ErrorResponse,
 } from "@langchain/protocol";
 
-import { toWebSocketUrl, isRecord, hasHeaders, toError } from "./utils.js";
+import {
+  toAbsoluteUrl,
+  toWebSocketUrl,
+  isRecord,
+  hasHeaders,
+  toError,
+} from "./utils.js";
 import type {
   HeaderValue,
   ProtocolRequestHook,
@@ -59,10 +65,7 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
     this.assertBrowserSafeTransportConfig();
 
     const wsUrl = toWebSocketUrl(
-      new URL(
-        this.streamUrl,
-        this.apiUrl.endsWith("/") ? this.apiUrl : `${this.apiUrl}/`
-      ).toString()
+      toAbsoluteUrl(this.apiUrl, this.streamUrl).toString()
     );
     const socket = this.webSocketFactory(wsUrl);
     this.socket = socket;


### PR DESCRIPTION
## Summary
- Fix `toAbsoluteUrl` to concatenate `apiUrl` and path instead of using `new URL(path, base)`, which dropped path prefixes on proxied deployments.
- Route WebSocket stream URL construction through `toAbsoluteUrl` for consistency with SSE transport.
- Add unit and integration tests for proxied apiUrl paths, plus shared transport test helpers.
