### PR TITLE
fix(core): add RemoteGraph v3 streaming support

### DIFF
--- a/.changeset/remotegraph-v3-streaming.md
+++ b/.changeset/remotegraph-v3-streaming.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph": patch
+---
+
+feat(remote): add RemoteGraph v3 streaming support
+
+Expose the v3 `streamEvents` surface for `RemoteGraph` by adapting remote SDK thread streams to the local `GraphRunStream` shape.

--- a/libs/langgraph-core/src/pregel/remote-run-stream.ts
+++ b/libs/langgraph-core/src/pregel/remote-run-stream.ts
@@ -1,0 +1,174 @@
+import type { Channel, Event } from "@langchain/protocol";
+import type { Client, ThreadStream } from "@langchain/langgraph-sdk";
+
+import { GraphRunStream, SubgraphRunStream } from "../stream/run-stream.js";
+import { StreamMux } from "../stream/mux.js";
+import type {
+  ChatModelStreamHandle,
+  InterruptPayload,
+  ProtocolEvent,
+} from "../stream/types.js";
+import type { LifecycleEntry } from "../stream/transformers/index.js";
+
+const REMOTE_V3_CHANNELS: Channel[] = [
+  "values",
+  "updates",
+  "messages",
+  "tools",
+  "custom",
+  "tasks",
+  "checkpoints",
+  "lifecycle",
+  "input",
+];
+
+/**
+ * Adapts the SDK's remote ThreadStream to the local GraphRunStream shape.
+ */
+export class RemoteGraphRunStream<
+  TValues = Record<string, unknown>,
+  TExtensions extends Record<string, unknown> = Record<string, unknown>,
+> extends GraphRunStream<TValues, TExtensions> {
+  readonly #client: Client;
+
+  readonly #thread: ThreadStream<TExtensions>;
+
+  readonly #runId: string | undefined;
+
+  readonly #abortController: AbortController;
+
+  constructor(params: {
+    client: Client;
+    thread: ThreadStream<TExtensions>;
+    runId?: string;
+    abortController?: AbortController;
+  }) {
+    const abortController = params.abortController ?? new AbortController();
+    super(
+      [],
+      new StreamMux(),
+      0,
+      0,
+      params.thread.extensions as TExtensions,
+      abortController
+    );
+    this.#client = params.client;
+    this.#thread = params.thread;
+    this.#runId = params.runId;
+    this.#abortController = abortController;
+  }
+
+  override [Symbol.asyncIterator](): AsyncIterator<ProtocolEvent> {
+    return this.#iterateEvents()[Symbol.asyncIterator]();
+  }
+
+  override get subgraphs(): AsyncIterable<SubgraphRunStream> {
+    const subgraphs = this.#thread.subgraphs as unknown;
+    return subgraphs as AsyncIterable<SubgraphRunStream>;
+  }
+
+  override get values(): AsyncIterable<TValues> & PromiseLike<TValues> {
+    return this.#thread.values as AsyncIterable<TValues> & PromiseLike<TValues>;
+  }
+
+  override get messages(): AsyncIterable<ChatModelStreamHandle> {
+    const messages = this.#thread.messages as unknown;
+    return messages as AsyncIterable<ChatModelStreamHandle>;
+  }
+
+  override get lifecycle(): AsyncIterable<LifecycleEntry> {
+    return this.#iterateLifecycle();
+  }
+
+  override messagesFrom(node: string): AsyncIterable<ChatModelStreamHandle> {
+    const messages = this.messages;
+    return {
+      async *[Symbol.asyncIterator]() {
+        for await (const message of messages) {
+          if (message.node === node) {
+            yield message;
+          }
+        }
+      },
+    };
+  }
+
+  override get output(): Promise<TValues> {
+    return this.#thread.output as Promise<TValues>;
+  }
+
+  override get interrupted(): boolean {
+    return this.#thread.interrupted;
+  }
+
+  override get interrupts(): readonly InterruptPayload[] {
+    return this.#thread.interrupts as readonly InterruptPayload[];
+  }
+
+  override abort(reason?: unknown): void {
+    if (this.#abortController.signal.aborted) return;
+    this.#abortController.abort(reason);
+    void this.#cancelAndClose();
+  }
+
+  override get signal(): AbortSignal {
+    return this.#abortController.signal;
+  }
+
+  get thread(): ThreadStream<TExtensions> {
+    return this.#thread;
+  }
+
+  async #cancelAndClose(): Promise<void> {
+    try {
+      if (this.#runId != null) {
+        await this.#client.runs.cancel(
+          this.#thread.threadId,
+          this.#runId,
+          false
+        );
+      }
+    } catch {
+      // Best effort: closing the ThreadStream still releases client resources.
+    }
+    try {
+      await this.#thread.close();
+    } catch {
+      // Best effort.
+    }
+  }
+
+  async *#iterateEvents(): AsyncGenerator<ProtocolEvent> {
+    const subscription = await this.#thread.subscribe({
+      channels: REMOTE_V3_CHANNELS,
+    });
+    try {
+      for await (const event of subscription) {
+        yield event as unknown as ProtocolEvent;
+      }
+    } finally {
+      await subscription.unsubscribe();
+    }
+  }
+
+  async *#iterateLifecycle(): AsyncGenerator<LifecycleEntry> {
+    const subscription = await this.#thread.subscribe({
+      channels: ["lifecycle"],
+    });
+    try {
+      for await (const event of subscription) {
+        yield eventToLifecycleEntry(event);
+      }
+    } finally {
+      await subscription.unsubscribe();
+    }
+  }
+}
+
+function eventToLifecycleEntry(event: Event): LifecycleEntry {
+  return {
+    ...(event.params.data as Record<string, unknown>),
+    namespace: event.params.namespace,
+    timestamp: event.params.timestamp,
+  } as LifecycleEntry;
+}

--- a/libs/langgraph-core/src/pregel/remote.ts
+++ b/libs/langgraph-core/src/pregel/remote.ts
@@ -536,7 +536,7 @@ export class RemoteGraph<
     },
     _streamOptions?: StreamEventsOptions
   ):
-    | IterableReadableStream<StreamEvent>
+    | IterableReadableStream<StreamEvent | Uint8Array>
     | Promise<RemoteGraphRunStream<PregelOutputType>>
     | Promise<IterableReadableStream<Uint8Array>>
     | Promise<

--- a/libs/langgraph-core/src/pregel/remote.ts
+++ b/libs/langgraph-core/src/pregel/remote.ts
@@ -204,7 +204,8 @@ export class RemoteGraph<
     PregelOutputType,
     PregelOptions<Nn, Cc, ContextType>
   >
-  implements PregelInterface<Nn, Cc, ContextType> {
+  implements PregelInterface<Nn, Cc, ContextType>
+{
   static lc_name() {
     return "RemoteGraph";
   }
@@ -299,8 +300,8 @@ export class RemoteGraph<
         ) {
           const metadata =
             typeof record.metadata === "object" &&
-              record.metadata != null &&
-              !Array.isArray(record.metadata)
+            record.metadata != null &&
+            !Array.isArray(record.metadata)
               ? (record.metadata as Record<string, unknown>)
               : undefined;
           record.metadata =
@@ -539,8 +540,9 @@ export class RemoteGraph<
     | Promise<RemoteGraphRunStream<PregelOutputType>>
     | Promise<IterableReadableStream<Uint8Array>>
     | Promise<
-      RemoteGraphRunStream<PregelOutputType> | IterableReadableStream<Uint8Array>
-    > {
+        | RemoteGraphRunStream<PregelOutputType>
+        | IterableReadableStream<Uint8Array>
+      > {
     if (options.version === "v3") {
       return this._streamEventsV3(
         input,

--- a/libs/langgraph-core/src/pregel/remote.ts
+++ b/libs/langgraph-core/src/pregel/remote.ts
@@ -30,6 +30,8 @@ import {
 import { StrRecord } from "./algo.js";
 import { PregelInputType, PregelOptions, PregelOutputType } from "./index.js";
 import { PregelNode } from "./read.js";
+import { RemoteGraphRunStream } from "./remote-run-stream.js";
+import { IterableReadableStreamWithAbortSignal } from "./stream.js";
 import {
   PregelParams,
   PregelInterface,
@@ -44,6 +46,7 @@ import {
   isCommand,
 } from "../constants.js";
 import { propagateConfigurableToMetadata } from "./utils/config.js";
+import type { ProtocolEvent } from "../stream/types.js";
 
 export type RemoteGraphParams = Omit<
   PregelParams<StrRecord<string, PregelNode>, StrRecord<string, BaseChannel>>,
@@ -123,6 +126,36 @@ const getStreamModes = (
   };
 };
 
+function protocolEventsToEventStream(run: AsyncIterable<ProtocolEvent>) {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        for await (const event of run) {
+          const namespace = event.params.namespace;
+          const eventName = namespace.length
+            ? `${event.method}|${namespace.join("|")}`
+            : event.method;
+          controller.enqueue(
+            encoder.encode(
+              `event: ${eventName}\ndata: ${JSON.stringify(event.params.data ?? {})}\n\n`
+            )
+          );
+        }
+      } catch (error) {
+        controller.enqueue(
+          encoder.encode(
+            `event: error\ndata: ${JSON.stringify({ message: String(error) })}\n\n`
+          )
+        );
+      } finally {
+        controller.close();
+      }
+    },
+  });
+}
+
 /**
  * The `RemoteGraph` class is a client implementation for calling remote
  * APIs that implement the LangGraph Server API specification.
@@ -171,8 +204,7 @@ export class RemoteGraph<
     PregelOutputType,
     PregelOptions<Nn, Cc, ContextType>
   >
-  implements PregelInterface<Nn, Cc, ContextType>
-{
+  implements PregelInterface<Nn, Cc, ContextType> {
   static lc_name() {
     return "RemoteGraph";
   }
@@ -267,8 +299,8 @@ export class RemoteGraph<
         ) {
           const metadata =
             typeof record.metadata === "object" &&
-            record.metadata != null &&
-            !Array.isArray(record.metadata)
+              record.metadata != null &&
+              !Array.isArray(record.metadata)
               ? (record.metadata as Record<string, unknown>)
               : undefined;
           record.metadata =
@@ -465,6 +497,22 @@ export class RemoteGraph<
   override streamEvents(
     input: PregelInputType,
     options: Partial<PregelOptions<Nn, Cc, ContextType>> & {
+      version: "v3";
+      encoding: "text/event-stream";
+    }
+  ): Promise<IterableReadableStream<Uint8Array>>;
+
+  override streamEvents(
+    input: PregelInputType,
+    options: Partial<PregelOptions<Nn, Cc, ContextType>> & {
+      version: "v3";
+      encoding?: undefined;
+    }
+  ): Promise<RemoteGraphRunStream<PregelOutputType>>;
+
+  override streamEvents(
+    input: PregelInputType,
+    options: Partial<PregelOptions<Nn, Cc, ContextType>> & {
       version: "v1" | "v2";
     },
     streamOptions?: StreamEventsOptions
@@ -480,14 +528,140 @@ export class RemoteGraph<
   ): IterableReadableStream<Uint8Array>;
 
   override streamEvents(
-    _input: PregelInputType,
-    _options: Partial<PregelOptions<Nn, Cc, ContextType>> & {
-      version: "v1" | "v2";
+    input: PregelInputType,
+    options: Partial<PregelOptions<Nn, Cc, ContextType>> & {
+      version: "v1" | "v2" | "v3";
       encoding?: "text/event-stream";
     },
     _streamOptions?: StreamEventsOptions
-  ): IterableReadableStream<StreamEvent | Uint8Array> {
+  ):
+    | IterableReadableStream<StreamEvent>
+    | Promise<RemoteGraphRunStream<PregelOutputType>>
+    | Promise<IterableReadableStream<Uint8Array>>
+    | Promise<
+      RemoteGraphRunStream<PregelOutputType> | IterableReadableStream<Uint8Array>
+    > {
+    if (options.version === "v3") {
+      return this._streamEventsV3(
+        input,
+        options as Partial<PregelOptions<Nn, Cc, ContextType>> & {
+          version: "v3";
+          encoding?: "text/event-stream";
+        }
+      );
+    }
     throw new Error("Not implemented.");
+  }
+
+  protected _rejectV3Unsupported(
+    options: Partial<PregelOptions<Nn, Cc, ContextType>> & {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      transformers?: any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      control?: any;
+    }
+  ) {
+    if (options.transformers !== undefined) {
+      throw new Error(
+        'RemoteGraph.streamEvents({ version: "v3" }) does not support `transformers`.'
+      );
+    }
+    if (options.control !== undefined) {
+      throw new Error(
+        'RemoteGraph.streamEvents({ version: "v3" }) does not support `control`.'
+      );
+    }
+    if (
+      options.interruptBefore !== undefined ||
+      this.interruptBefore !== undefined
+    ) {
+      throw new Error(
+        'RemoteGraph.streamEvents({ version: "v3" }) does not support `interruptBefore`.'
+      );
+    }
+    if (
+      options.interruptAfter !== undefined ||
+      this.interruptAfter !== undefined
+    ) {
+      throw new Error(
+        'RemoteGraph.streamEvents({ version: "v3" }) does not support `interruptAfter`.'
+      );
+    }
+  }
+
+  protected async _streamEventsV3(
+    input: PregelInputType,
+    options: Partial<PregelOptions<Nn, Cc, ContextType>> & {
+      version: "v3";
+      encoding?: "text/event-stream";
+    }
+  ): Promise<
+    RemoteGraphRunStream<PregelOutputType> | IterableReadableStream<Uint8Array>
+  > {
+    this._rejectV3Unsupported(options);
+
+    const abortController = new AbortController();
+    const mergedConfig = mergeConfigs(this.config, options);
+    const sanitizedConfig = this._sanitizeConfig(mergedConfig);
+    const configurable = { ...sanitizedConfig.configurable };
+    const threadId = configurable.thread_id;
+    delete configurable.thread_id;
+
+    const runConfig = {
+      ...sanitizedConfig,
+      configurable,
+    };
+
+    const thread =
+      typeof threadId === "string"
+        ? this.client.threads.stream(threadId, { assistantId: this.graphId })
+        : this.client.threads.stream({ assistantId: this.graphId });
+
+    let serializedInput;
+    if (isCommand(input)) {
+      serializedInput = input.toJSON() as Record<string, unknown>;
+    } else {
+      serializedInput = _serializeInputs(input);
+    }
+
+    const run = await thread.run.start({
+      input: serializedInput,
+      config: runConfig,
+    });
+
+    const graphRun = new RemoteGraphRunStream<PregelOutputType>({
+      client: this.client,
+      thread,
+      runId: run.run_id,
+      abortController,
+    });
+
+    if (mergedConfig.signal != null) {
+      if (mergedConfig.signal.aborted) {
+        graphRun.abort(mergedConfig.signal.reason);
+      } else {
+        mergedConfig.signal.addEventListener(
+          "abort",
+          () => graphRun.abort(mergedConfig.signal?.reason),
+          { once: true }
+        );
+      }
+    }
+
+    if (options.encoding === "text/event-stream") {
+      const encodingAbortController = new AbortController();
+      encodingAbortController.signal.addEventListener(
+        "abort",
+        () => graphRun.abort(encodingAbortController.signal.reason),
+        { once: true }
+      );
+      return new IterableReadableStreamWithAbortSignal(
+        protocolEventsToEventStream(graphRun),
+        encodingAbortController
+      );
+    }
+
+    return graphRun;
   }
 
   override async *_streamIterator(

--- a/libs/langgraph-core/src/tests/remote.int.test.ts
+++ b/libs/langgraph-core/src/tests/remote.int.test.ts
@@ -1,97 +1,170 @@
-/* eslint-disable no-process-env */
-import { describe, test } from "vitest";
-import { v4 } from "uuid";
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { createServer } from "node:net";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { RemoteGraph } from "../pregel/remote.js";
-import { MemorySaver, MessagesAnnotation, StateGraph } from "../web.js";
 
-describe("RemoteGraph", () => {
-  const remotePregel = new RemoteGraph({
-    graphId: process.env.LANGGRAPH_REMOTE_GRAPH_ID!,
-    apiKey: process.env.LANGGRAPH_REMOTE_GRAPH_API_KEY,
-    url: process.env.LANGGRAPH_REMOTE_GRAPH_API_URL,
+let server: ChildProcess | undefined;
+let apiUrl: string;
+const serverLogs: string[] = [];
+
+const serverScript = fileURLToPath(
+  new URL("../../../langgraph-api/tests/utils.server.mts", import.meta.url)
+);
+const serverConfig = fileURLToPath(
+  new URL("../../../langgraph-api/tests/graphs/langgraph.json", import.meta.url)
+);
+const apiDir = dirname(dirname(serverScript));
+
+async function getAvailablePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const listener = createServer();
+    listener.once("error", reject);
+    listener.listen(0, () => {
+      const address = listener.address();
+      listener.close(() => {
+        if (address != null && typeof address === "object") {
+          resolve(address.port);
+        } else {
+          reject(new Error("Unable to allocate a local test port."));
+        }
+      });
+    });
+  });
+}
+
+async function waitForServer(url: string): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${url}/ok`);
+      if (response.ok) return;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 250);
+    });
+  }
+
+  throw new Error(
+    `Timed out waiting for local LangGraph server: ${lastError}\n${serverLogs.join("").slice(-4000)}`
+  );
+}
+
+async function truncateServer(url: string): Promise<void> {
+  await fetch(`${url}/internal/truncate`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      runs: true,
+      threads: true,
+      assistants: true,
+      store: true,
+      checkpoint: true,
+    }),
+  });
+}
+
+beforeAll(async () => {
+  const port = await getAvailablePort();
+  apiUrl = `http://localhost:${port}`;
+  server = spawn("tsx", [serverScript, "--dev", "-c", serverConfig], {
+    cwd: apiDir,
+    env: {
+      ...process.env,
+      PORT: String(port),
+      LANGCHAIN_TRACING_V2: "false",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+    shell: process.platform === "win32",
   });
 
-  const builder = new StateGraph(MessagesAnnotation)
-    .addNode("agent", remotePregel)
-    .addEdge("__start__", "agent")
-    .addEdge("agent", "__end__");
-  const input = {
-    messages: [
+  server.stdout?.on("data", (data) => {
+    serverLogs.push(data.toString());
+  });
+  server.stderr?.on("data", (data) => {
+    serverLogs.push(data.toString());
+  });
+
+  await waitForServer(apiUrl);
+  await truncateServer(apiUrl);
+}, 60_000);
+
+afterAll(() => {
+  server?.kill("SIGTERM");
+});
+
+describe("RemoteGraph local server integration", () => {
+  test("streams v3 events from a local graph through RemoteGraph", async () => {
+    const remoteGraph = new RemoteGraph({
+      graphId: "simple_runtime",
+      url: apiUrl,
+    });
+
+    const run = await remoteGraph.streamEvents(
+      { message: "hello from remote" },
       {
-        role: "human",
-        content: "Hello world!",
-      },
-    ],
-  };
+        version: "v3",
+        configurable: { thread_id: randomUUID() },
+      }
+    );
 
-  const config = {
-    configurable: { thread_id: v4() },
-  };
+    const events = [];
+    for await (const event of run) {
+      events.push(event);
+      if (event.method === "values") break;
+    }
 
-  test("invoke", async () => {
-    const checkpointer = new MemorySaver();
-    const app = builder.compile({ checkpointer });
+    const output = await run.output;
+    await run.thread.close();
 
-    const response = await app.invoke(input, config);
-
-    console.log("response:", response);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "event",
+          method: "values",
+          params: expect.objectContaining({
+            namespace: [],
+            data: expect.objectContaining({
+              message: "hello from remote",
+            }),
+          }),
+        }),
+      ])
+    );
+    expect(output).toMatchObject({
+      message: "hello from remote",
+      model: "unknown",
+    });
   });
 
-  test("stream", async () => {
-    const checkpointer = new MemorySaver();
-    const app = builder.compile({ checkpointer });
-    const stream = await app.stream(input, {
-      ...config,
-      subgraphs: true,
-      streamMode: ["debug", "values"],
+  test("supports text/event-stream encoding over the remote v3 path", async () => {
+    const remoteGraph = new RemoteGraph({
+      graphId: "simple_runtime",
+      url: apiUrl,
     });
 
+    const stream = await remoteGraph.streamEvents(
+      { message: "encoded remote" },
+      {
+        version: "v3",
+        encoding: "text/event-stream",
+        configurable: { thread_id: randomUUID() },
+      }
+    );
+
+    const decoder = new TextDecoder();
+    let text = "";
     for await (const chunk of stream) {
-      console.log("chunk:", chunk);
-    }
-  });
-
-  test("get and update state", async () => {
-    const checkpointer = new MemorySaver();
-    const app = builder.compile({ checkpointer });
-
-    await app.invoke(input, config);
-    // test get state
-    const stateSnapshot = await remotePregel.getState(config, {
-      subgraphs: true,
-    });
-    console.log("state snapshot: ", stateSnapshot);
-
-    // test update state
-    const updateStateResponse = await remotePregel.updateState(config, {
-      messages: [
-        {
-          role: "ai",
-          content: "Hello world again!",
-        },
-      ],
-    });
-    console.log("update state response:", updateStateResponse);
-
-    // test get history
-    for await (const state of remotePregel.getStateHistory(config)) {
-      console.log("state history snapshot:", state);
+      text += decoder.decode(chunk);
     }
 
-    // test get graph
-    const remotePregel2 = new RemoteGraph({
-      graphId: "fe096781-5601-53d2-b2f6-0d3403f7e9ca",
-      apiKey: process.env.LANGGRAPH_REMOTE_GRAPH_API_KEY,
-      url: process.env.LANGGRAPH_REMOTE_GRAPH_API_URL,
-    });
-
-    const graph = await remotePregel2.getGraphAsync({ xray: true });
-    console.log("graph:", graph);
-
-    // test get subgraphs
-    for await (const [name, pregel] of remotePregel2.getSubgraphsAsync()) {
-      console.log("name:", name);
-      console.log("pregel:", pregel);
-    }
+    expect(text).toContain("event: values");
+    expect(text).toContain("encoded remote");
   });
 });

--- a/libs/langgraph-core/src/tests/remote.test.ts
+++ b/libs/langgraph-core/src/tests/remote.test.ts
@@ -747,4 +747,169 @@ describe("RemoteGraph", () => {
       }),
     );
   });
+
+  test("streamEvents v3 starts a remote ThreadStream run", async () => {
+    const client = new Client({});
+    const thread = makeRemoteV3Thread();
+    vi.spyOn(client.threads, "stream").mockReturnValue(thread as any);
+
+    const remotePregel = new RemoteGraph({
+      client,
+      graphId: "test_graph_id",
+    });
+
+    const run = await remotePregel.streamEvents(
+      { input: "data" },
+      {
+        version: "v3",
+        configurable: {
+          thread_id: "thread_1",
+          checkpoint_id: "checkpoint_1",
+          custom_key: "custom_value",
+        },
+        metadata: { source: "test" },
+        tags: ["remote"],
+        recursionLimit: 10,
+      },
+    );
+
+    expect(client.threads.stream).toHaveBeenCalledWith("thread_1", {
+      assistantId: "test_graph_id",
+    });
+    expect(thread.run.start).toHaveBeenCalledWith({
+      input: { input: "data" },
+      config: expect.objectContaining({
+        configurable: { custom_key: "custom_value" },
+        recursion_limit: 10,
+        tags: ["remote"],
+      }),
+    });
+    expect(run.thread).toBe(thread);
+  });
+
+  test("streamEvents v3 creates a thread when no thread_id is configured", async () => {
+    const client = new Client({});
+    const thread = makeRemoteV3Thread();
+    vi.spyOn(client.threads, "stream").mockReturnValue(thread as any);
+
+    const remotePregel = new RemoteGraph({
+      client,
+      graphId: "test_graph_id",
+    });
+
+    await remotePregel.streamEvents({ input: "data" }, { version: "v3" });
+
+    expect(client.threads.stream).toHaveBeenCalledWith({
+      assistantId: "test_graph_id",
+    });
+  });
+
+  test("streamEvents v3 serializes Command input as a command", async () => {
+    const client = new Client({});
+    const thread = makeRemoteV3Thread();
+    vi.spyOn(client.threads, "stream").mockReturnValue(thread as any);
+
+    const remotePregel = new RemoteGraph({
+      client,
+      graphId: "test_graph_id",
+    });
+
+    await remotePregel.streamEvents(
+      new Command({ update: { foo: "bar" }, resume: "yes" }),
+      { version: "v3", configurable: { thread_id: "thread_1" } },
+    );
+
+    expect(thread.run.start).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          lg_name: "Command",
+          update: { foo: "bar" },
+          resume: "yes",
+        }),
+      }),
+    );
+  });
+
+  test("streamEvents v3 rejects unsupported options", async () => {
+    const client = new Client({});
+    const remotePregel = new RemoteGraph({
+      client,
+      graphId: "test_graph_id",
+    });
+
+    await expect(
+      remotePregel.streamEvents(
+        { input: "data" },
+        { version: "v3", transformers: [] } as any,
+      ),
+    ).rejects.toThrow("transformers");
+  });
+
+  test("streamEvents v3 iterates remote protocol events", async () => {
+    const client = new Client({});
+    const thread = makeRemoteV3Thread();
+    const events = [
+      {
+        type: "event",
+        seq: 0,
+        method: "values",
+        params: { namespace: [], timestamp: 1, data: { value: 1 } },
+      },
+    ];
+    const subscription = {
+      async *[Symbol.asyncIterator]() {
+        yield* events;
+      },
+      unsubscribe: vi.fn().mockResolvedValue(undefined),
+    };
+    thread.subscribe.mockResolvedValue(subscription);
+    vi.spyOn(client.threads, "stream").mockReturnValue(thread as any);
+
+    const remotePregel = new RemoteGraph({
+      client,
+      graphId: "test_graph_id",
+    });
+
+    const run = await remotePregel.streamEvents(
+      { input: "data" },
+      { version: "v3", configurable: { thread_id: "thread_1" } },
+    );
+    const chunks = await gatherIterator(run);
+
+    expect(thread.subscribe).toHaveBeenCalledWith({
+      channels: expect.arrayContaining(["values", "lifecycle"]),
+    });
+    expect(chunks).toEqual(events);
+    expect(subscription.unsubscribe).toHaveBeenCalledOnce();
+  });
 });
+
+function emptyAsyncIterable() {
+  return {
+    async *[Symbol.asyncIterator]() {},
+  };
+}
+
+function makeRemoteV3Thread() {
+  const output = Promise.resolve({ value: "done" });
+  return {
+    threadId: "thread_1",
+    run: {
+      start: vi.fn().mockResolvedValue({ run_id: "run_1" }),
+    },
+    subscribe: vi.fn().mockResolvedValue({
+      async *[Symbol.asyncIterator]() {},
+      unsubscribe: vi.fn().mockResolvedValue(undefined),
+    }),
+    close: vi.fn().mockResolvedValue(undefined),
+    extensions: {},
+    values: Object.assign(emptyAsyncIterable(), {
+      then: output.then.bind(output),
+    }),
+    messages: emptyAsyncIterable(),
+    subgraphs: emptyAsyncIterable(),
+    output,
+    interrupted: false,
+    interrupts: [],
+  };
+}


### PR DESCRIPTION
## Summary
- Add `RemoteGraph.streamEvents(..., { version: "v3" })` support backed by SDK `ThreadStream`.
- Adapt remote v3 streams to the local `GraphRunStream` surface, including values, messages, lifecycle, output, interrupts, abort, and SSE encoding.
- Replace external-env RemoteGraph integration coverage with a local LangGraph API server test.