### PR TITLE
fix(sdk): fold forkFrom client-side and honor multitaskStrategy

### DIFF
--- a/.changeset/protocol-v2-forkfrom-fold-multitask-strategy.md
+++ b/.changeset/protocol-v2-forkfrom-fold-multitask-strategy.md
@@ -1,0 +1,16 @@
+---
+"@langchain/langgraph-sdk": patch
+"@langchain/langgraph-api": patch
+---
+
+protocol-v2: fold forkFrom client-side and honor per-run multitaskStrategy
+
+The SDK now folds the ergonomic `forkFrom` option into
+`config.configurable.checkpoint_id` before sending `run.start`, so the
+agent server only ever accepts the single, legacy-compliant fork field
+(`forkFrom` no longer hits the wire). The protocol-v2 reference servers
+drop their top-level `forkFrom` normalization accordingly.
+
+The protocol-v2 servers now honor the caller's `multitaskStrategy` per
+run (one of `reject` | `rollback` | `interrupt` | `enqueue`) instead of
+hardcoding it, falling back to `enqueue` when omitted or unrecognized.

--- a/libs/langgraph-api/src/experimental/embed/protocol.mts
+++ b/libs/langgraph-api/src/experimental/embed/protocol.mts
@@ -12,7 +12,11 @@ import { serialiseAsDict } from "../../utils/serde.mjs";
 import { jsonExtra } from "../../utils/hono.mjs";
 import { RunProtocolSession } from "../../protocol/session/index.mjs";
 import { PROTOCOL_STREAM_RUN_KEY } from "../../protocol/constants.mjs";
-import { matchesSinkFilter } from "../../protocol/service.mjs";
+import {
+  matchesSinkFilter,
+  normalizeMultitaskStrategy,
+  DEFAULT_MULTITASK_STRATEGY,
+} from "../../protocol/service.mjs";
 import type {
   EventSinkFilter,
   ProtocolCommand,
@@ -222,14 +226,20 @@ export function registerProtocolRoutes(
       });
     }
 
-    // Promote SDK-side `forkFrom` into
-    // `configurable.checkpoint_id` so the engine replays from the
-    // requested fork target. This mirrors the promotion performed by
-    // `ProtocolService.createOrResumeRun` in the non-embed path and
-    // closes the "client sends forkFrom, server drops it" gap.
+    // Fork/time-travel replays from `config.configurable.checkpoint_id`
+    // — the single legacy-compliant fork field. The SDK folds its
+    // `forkFrom` convenience option into this field client-side, so the
+    // server reads it from there rather than a top-level `forkFrom`.
+    // `createStubRun` only reliably forwards a fork target via the
+    // top-level `checkpoint_id`, so lift it out of `configurable` below.
     const forkCheckpointId = (() => {
-      return typeof params.forkFrom === "string" && params.forkFrom.length > 0
-        ? params.forkFrom
+      const configurable =
+        isRecord(params.config) && isRecord(params.config.configurable)
+          ? params.config.configurable
+          : undefined;
+      const checkpointId = configurable?.checkpoint_id;
+      return typeof checkpointId === "string" && checkpointId.length > 0
+        ? checkpointId
         : undefined;
     })();
 
@@ -270,6 +280,11 @@ export function registerProtocolRoutes(
       ...(forkCheckpointId != null && !isResume
         ? { checkpoint_id: forkCheckpointId }
         : {}),
+      // Honor the caller's `multitaskStrategy`, falling back to `enqueue`
+      // to match the non-embed protocol-v2 server and the Python default.
+      multitask_strategy:
+        normalizeMultitaskStrategy(params.multitaskStrategy) ??
+        DEFAULT_MULTITASK_STRATEGY,
       metadata: Object.keys(runMetadata).length > 0 ? runMetadata : undefined,
       stream_mode: DEFAULT_PROTOCOL_STREAM_MODES,
       stream_subgraphs: true,

--- a/libs/langgraph-api/src/protocol/service.mts
+++ b/libs/langgraph-api/src/protocol/service.mts
@@ -5,6 +5,7 @@ import type {
   RunsRepo,
   ThreadsRepo,
   StreamMode,
+  MultitaskStrategy,
 } from "../storage/types.mjs";
 import type { RunCommand } from "../command.mjs";
 import type {
@@ -51,26 +52,51 @@ const DEFAULT_RUN_STREAM_MODES: StreamMode[] = [
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
+// Concurrency strategies accepted on `run.start`, matching the four values
+// the SDK's `multitaskStrategy` option can take.
+const VALID_MULTITASK_STRATEGIES: readonly MultitaskStrategy[] = [
+  "reject",
+  "rollback",
+  "interrupt",
+  "enqueue",
+];
+
+// Legacy stream-endpoint default: queue new runs behind active ones instead
+// of interrupting. Used when the caller omits `multitaskStrategy`.
+export const DEFAULT_MULTITASK_STRATEGY: MultitaskStrategy = "enqueue";
+
 /**
- * `run.start` params as accepted by the service. Wider than the
- * stock `RunStartParams` from `@langchain/protocol` to carry the
- * SDK-side `forkFrom` checkpoint id convenience field, which
- * `createOrResumeRun` promotes to `config.configurable.checkpoint_id`
- * so the engine replays from the requested fork target. Callers that
- * prefer to set `config.configurable.checkpoint_id` directly remain
- * fully supported — `forkFrom` is merged after the caller's config so
- * it takes precedence when both are provided.
+ * Resolve the per-run `multitaskStrategy`. Honor it when it is one of the
+ * recognized strategies, otherwise return `undefined` so the caller falls
+ * back to {@link DEFAULT_MULTITASK_STRATEGY}. Lenient by design (matches
+ * the rest of `normalizeRunStart` and the Python reference server).
  */
-type ExtendedRunStartParams = RunStartParams & {
-  forkFrom?: string;
+export const normalizeMultitaskStrategy = (
+  value: unknown
+): MultitaskStrategy | undefined => {
+  return typeof value === "string" &&
+    (VALID_MULTITASK_STRATEGIES as readonly string[]).includes(value)
+    ? (value as MultitaskStrategy)
+    : undefined;
 };
 
-const normalizeForkFrom = (value: unknown): string | undefined => {
-  if (typeof value !== "string" || value.length === 0) return undefined;
-  return value;
+/**
+ * `run.start` params after normalization. Extends the stock protocol
+ * `RunStartParams` with the SDK's `multitaskStrategy` option, which the
+ * server honors per-run (see {@link normalizeMultitaskStrategy}).
+ *
+ * Fork/time-travel targets are NOT carried here: they are provided
+ * exclusively via `config.configurable.checkpoint_id` — the same field the
+ * legacy run endpoints accept. The SDK folds its ergonomic `forkFrom`
+ * option into that field client-side before sending `run.start`, so the
+ * server only ever understands a single, legacy-compliant way to select
+ * the checkpoint to replay from.
+ */
+type NormalizedRunStart = RunStartParams & {
+  multitaskStrategy?: MultitaskStrategy;
 };
 
-const normalizeRunStart = (value: unknown): ExtendedRunStartParams => {
+const normalizeRunStart = (value: unknown): NormalizedRunStart => {
   if (isRecord(value)) {
     return {
       assistant_id:
@@ -78,7 +104,7 @@ const normalizeRunStart = (value: unknown): ExtendedRunStartParams => {
       input: value.input,
       config: isRecord(value.config) ? value.config : undefined,
       metadata: isRecord(value.metadata) ? value.metadata : undefined,
-      forkFrom: normalizeForkFrom(value.forkFrom),
+      multitaskStrategy: normalizeMultitaskStrategy(value.multitaskStrategy),
     };
   }
   return {
@@ -361,7 +387,7 @@ export class ProtocolService {
 
   private async createOrResumeRun(
     record: ThreadRecord,
-    params: ExtendedRunStartParams
+    params: NormalizedRunStart
   ) {
     const assistantId = getAssistantId(params.assistant_id);
     const currentRun =
@@ -383,22 +409,17 @@ export class ProtocolService {
         hasPendingInterrupts);
 
     /**
-     * When `forkFrom` is present, promote it to
-     * `configurable.checkpoint_id` so the engine replays from the
-     * requested fork target. `forkFrom` is merged last so it wins over
-     * any `checkpoint_id` the caller may have pre-baked into
-     * `config.configurable`; in resume flows we intentionally skip the
-     * promotion because a resume must follow the thread's active
-     * checkpoint, not a historical fork.
+     * Fork/time-travel replays from `config.configurable.checkpoint_id`
+     * when the caller supplies it (the SDK folds its `forkFrom`
+     * convenience option into this field client-side). Forwarded as-is so
+     * the engine starts from the requested checkpoint instead of the
+     * thread's latest state.
      */
     const runConfig = {
       ...params.config,
       configurable: {
         ...params.config?.configurable,
         thread_id: record.threadId,
-        ...(!isResume && params.forkFrom != null
-          ? { checkpoint_id: params.forkFrom }
-          : {}),
       },
     };
 
@@ -414,7 +435,11 @@ export class ProtocolService {
       stream_subgraphs: true,
       stream_resumable: true,
       if_not_exists: "create" as const,
-      multitask_strategy: "interrupt" as const,
+      // Honor the caller's `multitaskStrategy` (the SDK sends it on every
+      // run.start), falling back to `enqueue` — the legacy stream-endpoint
+      // default — when omitted. Matches the Python protocol-v2 server.
+      multitask_strategy:
+        params.multitaskStrategy ?? DEFAULT_MULTITASK_STRATEGY,
     };
 
     const [run] = await this.bindings.runs.put(

--- a/libs/langgraph-api/tests/protocol-v2/multitask-strategy.test.mts
+++ b/libs/langgraph-api/tests/protocol-v2/multitask-strategy.test.mts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_MULTITASK_STRATEGY,
+  normalizeMultitaskStrategy,
+} from "../../src/protocol/service.mjs";
+
+describe("normalizeMultitaskStrategy", () => {
+  it("defaults to enqueue (matches the Python protocol-v2 server)", () => {
+    expect(DEFAULT_MULTITASK_STRATEGY).toBe("enqueue");
+  });
+
+  it.each(["reject", "rollback", "interrupt", "enqueue"] as const)(
+    "honors the recognized strategy %s",
+    (strategy) => {
+      expect(normalizeMultitaskStrategy(strategy)).toBe(strategy);
+    }
+  );
+
+  it("returns undefined for omitted or unrecognized values", () => {
+    // Caller falls back to DEFAULT_MULTITASK_STRATEGY for these.
+    expect(normalizeMultitaskStrategy(undefined)).toBeUndefined();
+    expect(normalizeMultitaskStrategy(null)).toBeUndefined();
+    expect(normalizeMultitaskStrategy("bogus")).toBeUndefined();
+    expect(normalizeMultitaskStrategy(123)).toBeUndefined();
+  });
+});

--- a/libs/langgraph-api/tests/protocol-v2/stream-sdk.test.mts
+++ b/libs/langgraph-api/tests/protocol-v2/stream-sdk.test.mts
@@ -339,12 +339,10 @@ describe("SDK streaming projections against embed server", () => {
         { assistantId: "agent_with_tools" }
       );
 
-      // `forkFrom` is not part of the protocol's stock `RunStartParams`
-      // type yet (it's an SDK-side convenience consumed by the service
-      // layer), so we cast to reach the wider shape the server accepts.
-      await (
-        forked.run.start as (params: unknown) => Promise<unknown>
-      )({
+      // `forkFrom` is an SDK-side convenience: `run.start` folds it into
+      // `config.configurable.checkpoint_id` before sending, so the server
+      // only ever sees the single legacy-compliant fork field.
+      await forked.run.start({
         input: { messages: [{ role: "user", content: "What is the weather in SF?" }] },
         forkFrom: rootCheckpointId,
       });

--- a/libs/sdk/src/client/stream/index.test.ts
+++ b/libs/sdk/src/client/stream/index.test.ts
@@ -165,6 +165,50 @@ describe("ThreadStream", () => {
     expect(thread.assistantId).toBe("my-agent");
   });
 
+  it("folds forkFrom into config.configurable.checkpoint_id on the wire", async () => {
+    const transport = new MockTransport();
+    const thread = new ThreadStream(transport, { assistantId: "agent" });
+
+    await thread.run.start({
+      input: { step: 1 },
+      forkFrom: "cp-123",
+      config: { configurable: { foo: "bar" } },
+    });
+
+    const cmd = transport.sentCommands.find((c) => c.method === "run.start");
+    const params = cmd?.params as {
+      forkFrom?: unknown;
+      config?: { configurable?: Record<string, unknown> };
+    };
+    // The ergonomic top-level field never reaches the server...
+    expect(params.forkFrom).toBeUndefined();
+    // ...it is folded into the single legacy-compliant field, preserving
+    // any other configurable values the caller passed.
+    expect(params.config?.configurable).toMatchObject({
+      foo: "bar",
+      checkpoint_id: "cp-123",
+    });
+  });
+
+  it("leaves config untouched when forkFrom is absent", async () => {
+    const transport = new MockTransport();
+    const thread = new ThreadStream(transport, { assistantId: "agent" });
+
+    await thread.run.start({
+      input: { step: 1 },
+      config: { configurable: { foo: "bar" } },
+    });
+
+    const cmd = transport.sentCommands.find((c) => c.method === "run.start");
+    const params = cmd?.params as {
+      forkFrom?: unknown;
+      config?: { configurable?: Record<string, unknown> };
+    };
+    expect(params.forkFrom).toBeUndefined();
+    expect(params.config?.configurable).toEqual({ foo: "bar" });
+    expect(params.config?.configurable).not.toHaveProperty("checkpoint_id");
+  });
+
   it("closes thread cleanly", async () => {
     const transport = new MockTransport();
     const thread = new ThreadStream(transport, { assistantId: "test-agent" });

--- a/libs/sdk/src/client/stream/index.ts
+++ b/libs/sdk/src/client/stream/index.ts
@@ -320,6 +320,48 @@ function normalizeSubscribeParams(
 }
 
 /**
+ * Fold the ergonomic top-level `forkFrom` checkpoint id into
+ * `config.configurable.checkpoint_id` and strip `forkFrom` from the
+ * outgoing params.
+ *
+ * `forkFrom` is purely an SDK-side convenience: callers say
+ * `submit(input, { forkFrom })` instead of hand-building a nested
+ * RunnableConfig. The agent server only ever accepts the fork target via
+ * `config.configurable.checkpoint_id` (the same field the legacy run
+ * endpoints use), so we translate here — before the `run.start` message
+ * hits the wire — keeping a single, legacy-compliant way to provide it.
+ *
+ * `forkFrom` takes precedence over any `checkpoint_id` the caller already
+ * placed in `config.configurable`, matching the prior server-side merge.
+ */
+function foldForkFromIntoConfig<
+  T extends { forkFrom?: string; config?: unknown },
+>(params: T): Omit<T, "forkFrom"> {
+  const { forkFrom, ...rest } = params;
+  if (typeof forkFrom !== "string" || forkFrom.length === 0) {
+    return rest;
+  }
+  const config =
+    rest.config != null && typeof rest.config === "object"
+      ? (rest.config as Record<string, unknown>)
+      : {};
+  const configurable =
+    config.configurable != null && typeof config.configurable === "object"
+      ? (config.configurable as Record<string, unknown>)
+      : {};
+  return {
+    ...rest,
+    config: {
+      ...config,
+      configurable: {
+        ...configurable,
+        checkpoint_id: forkFrom,
+      },
+    },
+  } as Omit<T, "forkFrom">;
+}
+
+/**
  * Async iterable handle for raw event subscriptions.
  *
  * An optional `transform` maps each incoming event before it is queued
@@ -670,7 +712,7 @@ export class ThreadStream<
           // subscription landed. This keeps the zero-extensions hot path
           // free of an unused `custom` subscription per run.
           return this.#send("run.start", {
-            ...params,
+            ...foldForkFromIntoConfig(params),
             assistant_id: this.assistantId,
           });
         });
@@ -1294,9 +1336,10 @@ export class ThreadStream<
     metadata?: Record<string, unknown>;
     /**
      * Fork the new run from an explicit checkpoint instead of the
-     * thread's latest. This SDK/API extension is promoted by the
-     * LangGraph API into `config.configurable.checkpoint_id`; it is
-     * not part of the stock agent protocol `RunStartParams`.
+     * thread's latest. This is an SDK-side convenience: it is folded into
+     * `config.configurable.checkpoint_id` before the `run.start` message
+     * is sent, so the agent server only ever sees the single
+     * legacy-compliant fork field (`forkFrom` never hits the wire).
      */
     forkFrom?: string;
     /**
@@ -1315,7 +1358,7 @@ export class ThreadStream<
     return await this.#withRunStartGate(() => {
       this.#startLifecycleWatcher();
       return this.#send("run.start", {
-        ...(params as Record<string, unknown>),
+        ...(foldForkFromIntoConfig(params) as Record<string, unknown>),
         assistant_id: this.assistantId,
       });
     });

--- a/libs/sdk/src/stream/types.ts
+++ b/libs/sdk/src/stream/types.ts
@@ -259,8 +259,10 @@ export interface StreamSubmitOptions<
   metadata?: Record<string, unknown>;
   /**
    * Fork the run from an explicit checkpoint instead of the thread's
-   * latest. This SDK/API extension is promoted by the LangGraph API
-   * into `config.configurable.checkpoint_id`.
+   * latest. Ergonomic alias the SDK folds into
+   * `config.configurable.checkpoint_id` before dispatching the run, so
+   * the server receives the fork target via the single legacy-compliant
+   * field (never a top-level `forkFrom`).
    */
   forkFrom?: string;
   /**


### PR DESCRIPTION
## Summary
- Fold the SDK's top-level `forkFrom` into `config.configurable.checkpoint_id` client-side before sending `run.start`, so `forkFrom` never reaches the server and the fork target travels via the single legacy-compliant field used by the existing run endpoints.
- Drop the server-side `forkFrom` normalization/promotion in both protocol-v2 reference servers (`ProtocolService.createOrResumeRun` and the embed protocol routes), reading the fork target solely from `config.configurable.checkpoint_id`.
- Honor the caller's per-run `multitaskStrategy` (`reject` | `rollback` | `interrupt` | `enqueue`) instead of hardcoding `interrupt`, falling back to `enqueue` (the legacy stream-endpoint default, matching the Python protocol-v2 server) when omitted or unrecognized.
