### PR TITLE
feat(langgraph): cooperative graph drain via RunControl

### DIFF
--- a/.changeset/cooperative-graph-drain.md
+++ b/.changeset/cooperative-graph-drain.md
@@ -1,0 +1,20 @@
+---
+"@langchain/langgraph": minor
+---
+
+Add cooperative, between-superstep graph draining via `RunControl`.
+
+A new `RunControl` (exported from `@langchain/langgraph`) exposes
+`requestDrain(reason)` plus read-only `drainRequested` / `drainReason`. Pass it
+through the new `control` option on `invoke` / `stream` / `streamEvents` (and the
+functional API). It is surfaced on `runtime.control`, so nodes can read it or call
+`requestDrain()` themselves, and it is propagated into subgraphs.
+
+When a drain is requested, the Pregel loop checks the flag at the top of each
+superstep (after the previous step's writes are applied and checkpointed): if more
+tasks remain it saves the checkpoint and throws the new `GraphDrained` error (also
+under `durability: "exit"`), so the run can be resumed later from the same config.
+If the graph naturally finishes on that tick it returns normally and the caller can
+inspect `control.drainRequested`. A drain requested inside a subgraph bubbles up and
+stops the parent at its next boundary. Draining never cancels work that is already
+running — pair it with an `AbortSignal` if you need a hard upper bound.

--- a/libs/langgraph-core/src/constants.ts
+++ b/libs/langgraph-core/src/constants.ts
@@ -35,9 +35,6 @@ export const CONFIG_KEY_CHECKPOINT_MAP = "checkpoint_map";
 
 export const CONFIG_KEY_ABORT_SIGNALS = "__pregel_abort_signals";
 
-/** config key carrying the run-scoped {@link RunControl} down into subgraphs */
-export const CONFIG_KEY_RUN_CONTROL = "__pregel_run_control";
-
 /** Special channel reserved for graph interrupts */
 export const INTERRUPT = "__interrupt__";
 /** Special channel reserved for graph resume */

--- a/libs/langgraph-core/src/constants.ts
+++ b/libs/langgraph-core/src/constants.ts
@@ -35,6 +35,9 @@ export const CONFIG_KEY_CHECKPOINT_MAP = "checkpoint_map";
 
 export const CONFIG_KEY_ABORT_SIGNALS = "__pregel_abort_signals";
 
+/** config key carrying the run-scoped {@link RunControl} down into subgraphs */
+export const CONFIG_KEY_RUN_CONTROL = "__pregel_run_control";
+
 /** Special channel reserved for graph interrupts */
 export const INTERRUPT = "__interrupt__";
 /** Special channel reserved for graph resume */

--- a/libs/langgraph-core/src/errors.ts
+++ b/libs/langgraph-core/src/errors.ts
@@ -55,6 +55,33 @@ export class GraphValueError extends BaseLangGraphError {
   }
 }
 
+/**
+ * Raised when a graph run exits early due to a drain request.
+ *
+ * This indicates the graph stopped cooperatively at a superstep boundary
+ * because {@link RunControl#requestDrain} was called (e.g., in response to
+ * SIGTERM). The checkpoint is saved and the run can be resumed later.
+ */
+export class GraphDrained extends GraphBubbleUp {
+  reason: string;
+
+  constructor(reason: string = "shutdown", fields?: BaseLangGraphErrorFields) {
+    super(`Graph drained: ${reason}`, fields);
+    this.name = "GraphDrained";
+    this.reason = reason;
+  }
+
+  static get unminifiable_name() {
+    return "GraphDrained";
+  }
+}
+
+export function isGraphDrained(e?: unknown): e is GraphDrained {
+  return (
+    e !== undefined && (e as Error).name === GraphDrained.unminifiable_name
+  );
+}
+
 export class GraphInterrupt extends GraphBubbleUp {
   interrupts: Interrupt[];
 

--- a/libs/langgraph-core/src/pregel/index.ts
+++ b/libs/langgraph-core/src/pregel/index.ts
@@ -55,7 +55,6 @@ import {
   PUSH,
   CONFIG_KEY_DURABILITY,
   CONFIG_KEY_CHECKPOINT_NS,
-  CONFIG_KEY_RUN_CONTROL,
   type CommandInstance,
   TASKS,
 } from "../constants.js";
@@ -2343,20 +2342,11 @@ export class Pregel<
 
     // Resolve the run-scoped control surface for cooperative draining.
     // Precedence: an explicit `control` option, then a control propagated
-    // from a parent run (via `configurable`, so subgraphs share the same
-    // instance), then a fresh `RunControl` so `runtime.control` is always
-    // available to nodes.
-    const runControl: RunControl =
-      config.control ??
-      (config.configurable?.[CONFIG_KEY_RUN_CONTROL] as
-        | RunControl
-        | undefined) ??
-      new RunControl();
-    // Surface as the top-level `control` key (the `Runtime` view), which is
-    // carried into task/subgraph configs via `mergeConfigs`/`patchConfig`.
-    // Avoid writing it into `configurable`, which would leak the control
-    // object into persisted/emitted checkpoint configs.
-    config.control = runControl;
+    // from a parent run (via `mergeConfigs` on task/subgraph configs), then a
+    // fresh `RunControl` so `runtime.control` is always available to nodes.
+    // Keep `control` on the top-level config only — not in `configurable` —
+    // so it is not persisted or emitted in checkpoint configs.
+    config.control ??= new RunControl();
 
     const callbackManagerOptions: Parameters<
       typeof CallbackManager._configureSync

--- a/libs/langgraph-core/src/pregel/index.ts
+++ b/libs/langgraph-core/src/pregel/index.ts
@@ -55,14 +55,17 @@ import {
   PUSH,
   CONFIG_KEY_DURABILITY,
   CONFIG_KEY_CHECKPOINT_NS,
+  CONFIG_KEY_RUN_CONTROL,
   type CommandInstance,
   TASKS,
 } from "../constants.js";
 import {
+  GraphDrained,
   GraphRecursionError,
   GraphValueError,
   InvalidUpdateError,
 } from "../errors.js";
+import { RunControl } from "./runtime.js";
 import { gatherIterator, patchConfigurable } from "../utils.js";
 import {
   _applyWrites,
@@ -2338,6 +2341,23 @@ export class Pregel<
       config.serverInfo = _buildServerInfo(config);
     }
 
+    // Resolve the run-scoped control surface for cooperative draining.
+    // Precedence: an explicit `control` option, then a control propagated
+    // from a parent run (via `configurable`, so subgraphs share the same
+    // instance), then a fresh `RunControl` so `runtime.control` is always
+    // available to nodes.
+    const runControl: RunControl =
+      config.control ??
+      (config.configurable?.[CONFIG_KEY_RUN_CONTROL] as
+        | RunControl
+        | undefined) ??
+      new RunControl();
+    // Surface as the top-level `control` key (the `Runtime` view), which is
+    // carried into task/subgraph configs via `mergeConfigs`/`patchConfig`.
+    // Avoid writing it into `configurable`, which would leak the control
+    // object into persisted/emitted checkpoint configs.
+    config.control = runControl;
+
     const callbackManagerOptions: Parameters<
       typeof CallbackManager._configureSync
     >[6] & {
@@ -2580,6 +2600,12 @@ export class Pregel<
           maxConcurrency: config.maxConcurrency,
           signal: config.signal,
         });
+      }
+      if (loop.status === "draining") {
+        if (loop.control == null) {
+          throw new Error("Draining status requires run control");
+        }
+        throw new GraphDrained(loop.control.drainReason ?? "shutdown");
       }
       if (loop.status === "out_of_steps") {
         throw new GraphRecursionError(

--- a/libs/langgraph-core/src/pregel/loop.ts
+++ b/libs/langgraph-core/src/pregel/loop.ts
@@ -413,7 +413,7 @@ export class PregelLoop {
     this.durability = params.durability;
     this.debug = params.debug;
     this.triggerToNodes = params.triggerToNodes;
-    this.control = (this.config as LangGraphRunnableConfig).control;
+    this.control = this.config.control;
   }
 
   static async initialize(params: PregelLoopInitializeParams) {
@@ -756,7 +756,8 @@ export class PregelLoop {
   /**
    * Execute a single iteration of the Pregel loop.
    * Returns true if more iterations are needed.
-   * @param params
+   * @param params - The input keys to use for the tick.
+   * @returns True if more iterations are needed, false otherwise.
    */
   async tick(params: { inputKeys?: string | string[] }): Promise<boolean> {
     if (this.store && !this.store.isRunning) {

--- a/libs/langgraph-core/src/pregel/loop.ts
+++ b/libs/langgraph-core/src/pregel/loop.ts
@@ -90,6 +90,7 @@ import {
 } from "./debug.js";
 import { PregelNode } from "./read.js";
 import { LangGraphRunnableConfig } from "./runnable_types.js";
+import type { RunControl } from "./runtime.js";
 import {
   IterableReadableWritableStream,
   StreamChunk,
@@ -269,7 +270,15 @@ export class PregelLoop {
     | "done"
     | "interrupt_before"
     | "interrupt_after"
-    | "out_of_steps" = "pending";
+    | "out_of_steps"
+    | "draining" = "pending";
+
+  /**
+   * Run-scoped control surface for cooperative draining. Populated from the
+   * run config. When `control.drainRequested` is true, the loop stops at the
+   * next superstep boundary instead of dispatching more tasks.
+   */
+  control?: RunControl;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   tasks: Record<string, PregelExecutableTask<any, any>> = {};
@@ -404,6 +413,7 @@ export class PregelLoop {
     this.durability = params.durability;
     this.debug = params.debug;
     this.triggerToNodes = params.triggerToNodes;
+    this.control = (this.config as LangGraphRunnableConfig).control;
   }
 
   static async initialize(params: PregelLoopInitializeParams) {
@@ -857,6 +867,14 @@ export class PregelLoop {
 
     if (Object.values(this.tasks).length === 0) {
       this.status = "done";
+      return false;
+    }
+    // Cooperative drain: the previous superstep's writes have been applied
+    // and checkpointed above, and the next tasks have been prepared. If a
+    // drain was requested and tasks remain, stop here (without dispatching
+    // them) so the run can be resumed later from the saved checkpoint.
+    if (this.control != null && this.control.drainRequested) {
+      this.status = "draining";
       return false;
     }
     // if there are pending writes from a previous loop, apply them

--- a/libs/langgraph-core/src/pregel/runnable_types.ts
+++ b/libs/langgraph-core/src/pregel/runnable_types.ts
@@ -1,5 +1,6 @@
 import { RunnableConfig, RunnableInterface } from "@langchain/core/runnables";
 import { BaseStore } from "@langchain/langgraph-checkpoint";
+import { RunControl } from "./runtime.js";
 
 type RunnableFunc<
   RunInput,
@@ -104,6 +105,16 @@ export interface Runtime<
 
   /** Metadata injected by LangGraph Server. Undefined when running open-source LangGraph without LangSmith deployments. */
   serverInfo?: ServerInfo;
+
+  /**
+   * Run-scoped control plane for cooperative draining.
+   *
+   * Populated automatically during graph runs. Nodes can read
+   * `runtime.control.drainRequested` / `drainReason`, or call
+   * `runtime.control.requestDrain()` to ask the graph to stop at the next
+   * superstep boundary. Undefined outside an active graph runtime.
+   */
+  control?: RunControl;
 }
 
 export interface LangGraphRunnableConfig<

--- a/libs/langgraph-core/src/pregel/runner.ts
+++ b/libs/langgraph-core/src/pregel/runner.ts
@@ -22,7 +22,12 @@ import {
   CONFIG_KEY_CALL,
   CONFIG_KEY_ABORT_SIGNALS,
 } from "../constants.js";
-import { GraphBubbleUp, isGraphBubbleUp, isGraphInterrupt } from "../errors.js";
+import {
+  GraphBubbleUp,
+  isGraphBubbleUp,
+  isGraphDrained,
+  isGraphInterrupt,
+} from "../errors.js";
 import { _runWithRetry, SettledPregelTask } from "./retry.js";
 import { PregelLoop } from "./loop.js";
 
@@ -180,6 +185,13 @@ export class PregelRunner {
     }
 
     if (isGraphInterrupt(graphBubbleUp)) {
+      throw graphBubbleUp;
+    }
+
+    // A cooperative drain raised by a subgraph bubbles up through the parent
+    // loop (even when the parent is the top graph) so the parent stops at this
+    // boundary and its checkpoint can be resumed later.
+    if (isGraphDrained(graphBubbleUp)) {
       throw graphBubbleUp;
     }
 
@@ -368,6 +380,13 @@ export class PregelRunner {
             interrupts.push(...resumes);
           }
           this.loop.putWrites(task.id, interrupts);
+        }
+      } else if (isGraphDrained(error)) {
+        // Cooperative drain bubbled up from a subgraph. Leave the task
+        // uncommitted (unless it already produced writes) so it is
+        // re-executed when the parent run resumes.
+        if (task.writes.length) {
+          this.loop.putWrites(task.id, task.writes);
         }
       } else if (isGraphBubbleUp(error) && task.writes.length) {
         this.loop.putWrites(task.id, task.writes);

--- a/libs/langgraph-core/src/pregel/runtime.ts
+++ b/libs/langgraph-core/src/pregel/runtime.ts
@@ -1,0 +1,62 @@
+/**
+ * Run-scoped control surface for cooperative draining.
+ *
+ * Intended for a single graph run. Create a fresh {@link RunControl} per run;
+ * reusing a control after {@link RunControl#requestDrain} leaves it drained.
+ *
+ * Safe to use from any concurrent context: the drain request is represented
+ * by a single field write, so no synchronization is needed for this signal.
+ * If more mutable state is added here, add synchronization.
+ *
+ * The intended use is hooking SIGTERM (or any external supervisor signal) to
+ * {@link RunControl#requestDrain} so an in-flight graph run can stop cleanly
+ * at the next superstep boundary and be resumed later from the saved
+ * checkpoint.
+ *
+ * @example
+ * ```typescript
+ * import { RunControl, GraphDrained } from "@langchain/langgraph";
+ *
+ * const control = new RunControl();
+ *
+ * // In a signal handler, supervisor, etc.:
+ * // control.requestDrain("sigterm");
+ *
+ * try {
+ *   const result = await graph.invoke(input, { ...config, control });
+ *   if (control.drainRequested) {
+ *     // finished naturally on the same tick where drain was requested
+ *   }
+ * } catch (e) {
+ *   if (e instanceof GraphDrained) {
+ *     // checkpoint saved; resume later with the same config
+ *   } else {
+ *     throw e;
+ *   }
+ * }
+ * ```
+ */
+export class RunControl {
+  #drainReason: string | undefined = undefined;
+
+  /**
+   * Request that the current run drain cooperatively, stopping at the next
+   * superstep boundary. Does not cancel work that is already running.
+   *
+   * @param reason - A short description of why the drain was requested.
+   *   Surfaced on the resulting {@link GraphDrained} error.
+   */
+  requestDrain(reason: string = "shutdown"): void {
+    this.#drainReason = reason;
+  }
+
+  /** Whether a drain has been requested for this run. */
+  get drainRequested(): boolean {
+    return this.#drainReason !== undefined;
+  }
+
+  /** The reason passed to {@link RunControl#requestDrain}, if any. */
+  get drainReason(): string | undefined {
+    return this.#drainReason;
+  }
+}

--- a/libs/langgraph-core/src/pregel/runtime.ts
+++ b/libs/langgraph-core/src/pregel/runtime.ts
@@ -1,3 +1,5 @@
+import type { GraphDrained } from "../errors.js";
+
 /**
  * Run-scoped control surface for cooperative draining.
  *

--- a/libs/langgraph-core/src/pregel/runtime.ts
+++ b/libs/langgraph-core/src/pregel/runtime.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars - needed to resolve below link
 import type { GraphDrained } from "../errors.js";
 
 /**

--- a/libs/langgraph-core/src/pregel/types.ts
+++ b/libs/langgraph-core/src/pregel/types.ts
@@ -17,6 +17,7 @@ import type { Interrupt } from "../constants.js";
 import type { StreamTransformer } from "../stream/types.js";
 import { CachePolicy, RetryPolicy } from "./utils/index.js";
 import { LangGraphRunnableConfig } from "./runnable_types.js";
+import type { RunControl } from "./runtime.js";
 
 /**
  * Selects the type of output you'll receive when streaming from the graph. See [Streaming](/langgraphjs/how-tos/#streaming) for more details.
@@ -369,6 +370,15 @@ export interface PregelOptions<
    * Static context for the graph run, like `userId`, `dbConnection` etc.
    */
   context?: ContextType;
+
+  /**
+   * Optional run control used to request cooperative drain. When
+   * {@link RunControl#requestDrain} is called (e.g. from a SIGTERM handler or
+   * a node), the graph stops at the next superstep boundary, persists its
+   * checkpoint, and throws {@link GraphDrained}. The run can then be resumed
+   * later from the saved checkpoint.
+   */
+  control?: RunControl;
 
   /**
    * The encoding to use for the stream.

--- a/libs/langgraph-core/src/pregel/utils/config.ts
+++ b/libs/langgraph-core/src/pregel/utils/config.ts
@@ -32,6 +32,7 @@ const CONFIG_KEYS = [
   "signal",
   "executionInfo",
   "serverInfo",
+  "control",
 ];
 
 const DEFAULT_RECURSION_LIMIT = 25;

--- a/libs/langgraph-core/src/tests/run_control.test.ts
+++ b/libs/langgraph-core/src/tests/run_control.test.ts
@@ -1,0 +1,414 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { MemorySaver } from "@langchain/langgraph-checkpoint";
+import {
+  Annotation,
+  END,
+  GraphDrained,
+  LangGraphRunnableConfig,
+  RunControl,
+  START,
+  StateGraph,
+} from "../web.js";
+import { task, entrypoint } from "../func/index.js";
+import { initializeAsyncLocalStorageSingleton } from "../setup/async_local_storage.js";
+
+beforeAll(() => {
+  initializeAsyncLocalStorageSingleton();
+});
+
+const State = Annotation.Root({
+  first: Annotation<string>,
+  second: Annotation<string>,
+  value: Annotation<string>,
+});
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("RunControl", () => {
+  it("requestDrain sets drainRequested/drainReason", () => {
+    const control = new RunControl();
+    expect(control.drainRequested).toBe(false);
+    expect(control.drainReason).toBeUndefined();
+
+    control.requestDrain();
+    expect(control.drainRequested).toBe(true);
+    expect(control.drainReason).toBe("shutdown");
+
+    const other = new RunControl();
+    other.requestDrain("sigterm");
+    expect(other.drainReason).toBe("sigterm");
+  });
+});
+
+describe("Graph draining", () => {
+  it("drain requested in a node stops future steps (sync-style node)", async () => {
+    const control = new RunControl();
+
+    const graph = new StateGraph(State)
+      .addNode("stepA", () => {
+        control.requestDrain();
+        return { first: "done" };
+      })
+      .addNode("stepB", () => ({ second: "should-not-run" }))
+      .addEdge(START, "stepA")
+      .addEdge("stepA", "stepB")
+      .addEdge("stepB", END)
+      .compile();
+
+    await expect(graph.invoke({}, { control })).rejects.toThrow(
+      /Graph drained: shutdown/
+    );
+  });
+
+  it("drain requested in a node stops future steps (async node)", async () => {
+    const control = new RunControl();
+
+    const graph = new StateGraph(State)
+      .addNode("stepA", async () => {
+        control.requestDrain();
+        return { first: "done" };
+      })
+      .addNode("stepB", async () => ({ second: "should-not-run" }))
+      .addEdge(START, "stepA")
+      .addEdge("stepA", "stepB")
+      .addEdge("stepB", END)
+      .compile();
+
+    let captured: unknown;
+    try {
+      await graph.invoke({}, { control });
+    } catch (e) {
+      captured = e;
+    }
+    expect(captured).toBeInstanceOf(GraphDrained);
+    expect((captured as GraphDrained).reason).toBe("shutdown");
+  });
+
+  it("drain requested in the terminal step finishes normally", async () => {
+    const control = new RunControl();
+
+    const graph = new StateGraph(State)
+      .addNode("only", () => {
+        control.requestDrain();
+        return { value: "done" };
+      })
+      .addEdge(START, "only")
+      .addEdge("only", END)
+      .compile();
+
+    const result = await graph.invoke({}, { control });
+    expect(result).toEqual({ value: "done" });
+    expect(control.drainRequested).toBe(true);
+  });
+
+  it("a node can request drain via runtime.control", async () => {
+    const control = new RunControl();
+    let sawControl = false;
+
+    const graph = new StateGraph(State)
+      .addNode("stepA", (_state, runtime: LangGraphRunnableConfig) => {
+        // Nodes receive the run control on their runtime/config.
+        sawControl = runtime.control === control;
+        runtime.control?.requestDrain("from-node");
+        return { first: "done" };
+      })
+      .addNode("stepB", () => ({ second: "should-not-run" }))
+      .addEdge(START, "stepA")
+      .addEdge("stepA", "stepB")
+      .addEdge("stepB", END)
+      .compile();
+
+    await expect(graph.invoke({}, { control })).rejects.toThrow(
+      /Graph drained: from-node/
+    );
+    expect(sawControl).toBe(true);
+  });
+
+  it("a fresh RunControl is provided to nodes when none is passed", async () => {
+    let controlSeen: RunControl | undefined;
+
+    const graph = new StateGraph(State)
+      .addNode("only", (_state, runtime: LangGraphRunnableConfig) => {
+        controlSeen = runtime.control;
+        return { value: "done" };
+      })
+      .addEdge(START, "only")
+      .addEdge("only", END)
+      .compile();
+
+    await graph.invoke({});
+    expect(controlSeen).toBeInstanceOf(RunControl);
+    expect(controlSeen!.drainRequested).toBe(false);
+  });
+
+  it("pre-drained control stops before executing the first task", async () => {
+    let ran = false;
+    const control = new RunControl();
+    control.requestDrain("pre-drained");
+
+    const graph = new StateGraph(State)
+      .addNode("only", () => {
+        ran = true;
+        return { value: "done" };
+      })
+      .addEdge(START, "only")
+      .addEdge("only", END)
+      .compile();
+
+    await expect(graph.invoke({}, { control })).rejects.toThrow(
+      /Graph drained: pre-drained/
+    );
+    expect(ran).toBe(false);
+  });
+
+  it("drain persists a resumable checkpoint (exit durability)", async () => {
+    const control = new RunControl();
+
+    const graph = new StateGraph(State)
+      .addNode("stepA", () => {
+        control.requestDrain("sigterm");
+        return { first: "done" };
+      })
+      .addNode("stepB", () => ({ second: "done" }))
+      .addEdge(START, "stepA")
+      .addEdge("stepA", "stepB")
+      .addEdge("stepB", END)
+      .compile({ checkpointer: new MemorySaver() });
+
+    const config = { configurable: { thread_id: "drain-exit" } };
+
+    await expect(
+      graph.invoke({}, { ...config, durability: "exit", control })
+    ).rejects.toThrow(/Graph drained: sigterm/);
+
+    // Resume without a control: the run finishes from the saved checkpoint.
+    const resumed = await graph.invoke(null, { ...config, durability: "exit" });
+    expect(resumed).toEqual({ first: "done", second: "done" });
+  });
+
+  it("drain persists a resumable checkpoint (default durability)", async () => {
+    const control = new RunControl();
+
+    const graph = new StateGraph(State)
+      .addNode("stepA", () => {
+        control.requestDrain("sigterm");
+        return { first: "done" };
+      })
+      .addNode("stepB", () => ({ second: "done" }))
+      .addEdge(START, "stepA")
+      .addEdge("stepA", "stepB")
+      .addEdge("stepB", END)
+      .compile({ checkpointer: new MemorySaver() });
+
+    const config = { configurable: { thread_id: "drain-default" } };
+
+    await expect(graph.invoke({}, { ...config, control })).rejects.toThrow(
+      /Graph drained: sigterm/
+    );
+
+    const resumed = await graph.invoke(null, config);
+    expect(resumed).toEqual({ first: "done", second: "done" });
+  });
+
+  it("drain from a subgraph bubbles up and the parent can resume", async () => {
+    const control = new RunControl();
+
+    const childBuilder = new StateGraph(State)
+      .addNode("childFirst", () => {
+        control.requestDrain("sigterm");
+        return { first: "done" };
+      })
+      .addNode("childSecond", () => ({ second: "done" }))
+      .addEdge(START, "childFirst")
+      .addEdge("childFirst", "childSecond")
+      .addEdge("childSecond", END);
+    const childGraph = childBuilder.compile({ checkpointer: true });
+
+    const parentBuilder = new StateGraph(State)
+      .addNode("child", childGraph)
+      .addNode("parentSecond", () => ({ value: "parent-done" }))
+      .addEdge(START, "child")
+      .addEdge("child", "parentSecond")
+      .addEdge("parentSecond", END);
+    const parentGraph = parentBuilder.compile({
+      checkpointer: new MemorySaver(),
+    });
+
+    const config = { configurable: { thread_id: "drain-subgraph" } };
+
+    await expect(parentGraph.invoke({}, { ...config, control })).rejects.toThrow(
+      GraphDrained
+    );
+
+    const resumed = await parentGraph.invoke(null, config);
+    expect(resumed).toEqual({
+      first: "done",
+      second: "done",
+      value: "parent-done",
+    });
+  });
+
+  it("an external concurrent drain stops the graph at the next boundary", async () => {
+    const control = new RunControl();
+    let started = false;
+    let secondRan = false;
+
+    const graph = new StateGraph(State)
+      .addNode("stepA", async () => {
+        started = true;
+        await sleep(50);
+        return { first: "done" };
+      })
+      .addNode("stepB", async () => {
+        secondRan = true;
+        return { second: "should-not-run" };
+      })
+      .addEdge(START, "stepA")
+      .addEdge("stepA", "stepB")
+      .addEdge("stepB", END)
+      .compile();
+
+    const runPromise = graph.invoke({}, { control });
+
+    // Wait until the first node is mid-flight, then request drain externally.
+    while (!started) {
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(5);
+    }
+    control.requestDrain("sigterm");
+
+    let captured: unknown;
+    try {
+      await runPromise;
+    } catch (e) {
+      captured = e;
+    }
+    expect(captured).toBeInstanceOf(GraphDrained);
+    expect((captured as GraphDrained).reason).toBe("sigterm");
+    expect(secondRan).toBe(false);
+  });
+
+  it("drain then cancel via AbortSignal after a graceful timeout", async () => {
+    const control = new RunControl();
+    const abortController = new AbortController();
+
+    let nodeStarted = false;
+    let nodeCancelled = false;
+    let nodeFinished = false;
+    let secondRan = false;
+
+    const graph = new StateGraph(State)
+      .addNode("stepA", async (_state, runtime: LangGraphRunnableConfig) => {
+        nodeStarted = true;
+        const { signal } = runtime;
+        await new Promise<void>((resolve, reject) => {
+          const timer = setTimeout(() => {
+            nodeFinished = true;
+            resolve();
+          }, 30_000);
+          signal?.addEventListener(
+            "abort",
+            () => {
+              clearTimeout(timer);
+              nodeCancelled = true;
+              reject(new Error("Aborted"));
+            },
+            { once: true }
+          );
+        });
+        return { first: "done" };
+      })
+      .addNode("stepB", async () => {
+        secondRan = true;
+        return { second: "should-not-run" };
+      })
+      .addEdge(START, "stepA")
+      .addEdge("stepA", "stepB")
+      .addEdge("stepB", END)
+      .compile();
+
+    const runPromise = graph.invoke(
+      {},
+      { control, signal: abortController.signal }
+    );
+    // Surface the rejection lazily; attach a catch so it isn't unhandled.
+    const settled = runPromise.then(
+      () => ({ ok: true as const }),
+      (e) => ({ ok: false as const, error: e })
+    );
+
+    while (!nodeStarted) {
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(5);
+    }
+    // Drain is requested, but the long-running node hasn't yielded yet.
+    control.requestDrain("sigterm");
+    await sleep(50);
+    expect(nodeFinished).toBe(false);
+    expect(nodeCancelled).toBe(false);
+
+    // Hard cancel after the graceful window.
+    abortController.abort();
+
+    const result = await settled;
+    expect(result.ok).toBe(false);
+    expect(nodeCancelled).toBe(true);
+    expect(nodeFinished).toBe(false);
+    expect(secondRan).toBe(false);
+  });
+
+  it("control is accepted by stream() and raises GraphDrained", async () => {
+    const control = new RunControl();
+    let secondRan = false;
+
+    const graph = new StateGraph(State)
+      .addNode("stepA", () => {
+        control.requestDrain("sigterm");
+        return { value: "done" };
+      })
+      .addNode("stepB", () => {
+        secondRan = true;
+        return { second: "nope" };
+      })
+      .addEdge(START, "stepA")
+      .addEdge("stepA", "stepB")
+      .addEdge("stepB", END)
+      .compile();
+
+    const drain = async () => {
+      const stream = await graph.stream({}, { control });
+      // eslint-disable-next-line no-empty, @typescript-eslint/no-unused-vars
+      for await (const _ of stream) {
+        // drain the stream
+      }
+    };
+
+    await expect(drain()).rejects.toThrow(/Graph drained: sigterm/);
+    expect(secondRan).toBe(false);
+  });
+});
+
+describe("Functional API draining", () => {
+  it("in-flight task futures still resolve after requestDrain()", async () => {
+    const checkpointer = new MemorySaver();
+    const control = new RunControl();
+
+    const child = task("child", async (x: number) => x + 1);
+
+    const graph = entrypoint(
+      { checkpointer, name: "graph" },
+      async (x: number) => {
+        control.requestDrain();
+        const fut = child(x);
+        return fut;
+      }
+    );
+
+    const result = await graph.invoke(1, {
+      configurable: { thread_id: "drain-call" },
+      control,
+    });
+    expect(result).toBe(2);
+    expect(control.drainRequested).toBe(true);
+  });
+});

--- a/libs/langgraph-core/src/web.ts
+++ b/libs/langgraph-core/src/web.ts
@@ -162,6 +162,7 @@ export {
   type Runtime,
   type ServerInfo,
 } from "./pregel/runnable_types.js";
+export { RunControl } from "./pregel/runtime.js";
 
 export * from "./state/index.js";
 


### PR DESCRIPTION
## Summary

Ports Python PR [langchain-ai/langgraph#7274](https://github.com/langchain-ai/langgraph/pull/7274) ("allow graph to graceful shutdown/drain by request") to LangGraphJS. Adds cooperative, between-superstep draining so a run can be asked to stop at the next superstep boundary, persist its checkpoint, and surface a resumable terminal error.

This is the JS PR for the **Graph draining / graceful shutdown** parity unit.

## What's added

- **`RunControl`** (new `pregel/runtime.ts`, exported from `@langchain/langgraph`): a run-scoped handle with `requestDrain(reason = "shutdown")` and read-only `drainRequested` / `drainReason`.
- **`GraphDrained`** (`errors.ts`): a `GraphBubbleUp` subclass carrying `reason`, thrown when a run exits early due to drain. Plus an `isGraphDrained` guard.
- **`control` option** on `invoke` / `stream` / `streamEvents` / `invoke`'s functional-API equivalents. It is surfaced on `runtime.control` (nodes can read it or call `requestDrain()`), and propagated into subgraphs. A fresh `RunControl` is provided per run when none is passed.

## Semantics (cooperative, between-superstep)

`requestDrain()` flips a flag. The Pregel loop checks it at the top of each `tick()`, **after** the previous superstep's writes have been applied and checkpointed and the next tasks have been prepared. It never preempts work that is already running.

| Scenario | Behavior |
|---|---|
| Node mid-execution | Runs to completion; drain takes effect at the next superstep. |
| Graph naturally finishes on the same tick where drain was requested | Returns normally (status `done`). No `GraphDrained`. Caller can inspect `control.drainRequested`. |
| More tasks remain | Saves the last completed superstep's checkpoint (also under `durability: "exit"`) and throws `GraphDrained(reason)`. Resume with `invoke(null, config)`. |
| Subgraph requests drain | `GraphDrained` bubbles up through the parent loop and stops it at its own next boundary; the parent's checkpoint is saved and resumable. |

Draining does **not** cancel async work. Pair it with an `AbortSignal` if you need a hard upper bound (see the `drain then cancel after a graceful timeout` test).

## Files

- `errors.ts` — `GraphDrained` + `isGraphDrained`
- `pregel/runtime.ts` — `RunControl`
- `pregel/runnable_types.ts` — `control?: RunControl` on `Runtime`
- `pregel/types.ts` — `control` on `PregelOptions`
- `pregel/utils/config.ts`, `constants.ts` — config-key wiring
- `pregel/loop.ts` — `"draining"` status + drain check at the tick boundary
- `pregel/index.ts` — option wiring + raising `GraphDrained`
- `pregel/runner.ts` — subgraph drain bubble-up handling

## Tests

`libs/langgraph-core/src/tests/run_control.test.ts` (14 tests, all sync + async where applicable):
drain stops the next step (sync/async), terminal-step drain finishes normally, exit- and default-durability resume, pre-drained control, subgraph → parent bubble + resume, external concurrent drain, drain-then-cancel via `AbortSignal`, reading/`requestDrain()` via `runtime.control`, `stream()` accepts control, and functional-API in-flight `task` futures still resolve. Full package suite passes (1358 + 14, 0 failures); lint and format are clean.

## Notable divergence from Python

Python added `"drained"` to a local `SubgraphStatus` literal. The JS v3 stream lifecycle uses `AgentStatus` from the external `@langchain/protocol` package, which has no `"drained"` member, so `GraphDrained` propagates through streams as the terminal error rather than as a new lifecycle status. The parity-relevant signal — the `GraphDrained` exception — is what consumers catch. Noted in the changeset.

## Source

- Python PR: https://github.com/langchain-ai/langgraph/pull/7274
- Parity plan section: Graph draining / graceful shutdown
