### PR TITLE
feat(langgraph): add node-level timeouts (timeout on addNode, task, entrypoint, Send)

### DIFF
--- a/.changeset/node-level-timeouts.md
+++ b/.changeset/node-level-timeouts.md
@@ -1,0 +1,39 @@
+---
+"@langchain/langgraph": minor
+"@langchain/langgraph-checkpoint": patch
+---
+
+Add node-level timeouts.
+
+A `timeout` option is now supported on `StateGraph.addNode`, the functional API
+(`task`/`entrypoint`), and the `Send` constructor. Pass a number of milliseconds
+for a hard wall-clock cap, or a `TimeoutPolicy` for finer control:
+
+```ts
+import { TimeoutPolicy } from "@langchain/langgraph";
+
+// hard wall-clock cap on each attempt
+builder.addNode("agent", agentFn, { timeout: 60_000 });
+
+// full control
+builder.addNode("agent", agentFn, {
+  timeout: {
+    runTimeout: 60_000, // hard wall-clock cap, never refreshed
+    idleTimeout: 10_000, // cap on time without observable progress
+    refreshOn: "auto", // "auto" | "heartbeat"
+  },
+});
+
+// per-task override
+new Send("agent", state, { idleTimeout: 5_000 });
+```
+
+When a timeout fires, a `NodeTimeoutError` (carrying `node`, `kind`
+(`"run"`/`"idle"`), `timeout`, `elapsed`, `runTimeout`, `idleTimeout`) is raised,
+the attempt's buffered writes are dropped, and the node's `AbortSignal` is
+aborted. `idleTimeout` is refreshed by observable progress (writes, custom
+stream-writer calls, child-task scheduling, callback events) or an explicit
+`runtime.heartbeat()` call. The timer resets per retry attempt, and
+`NodeTimeoutError` is retryable under the default retry policy.
+
+Ports langchain-ai/langgraph#7599, #7646, and #7659.

--- a/.changeset/node-level-timeouts.md
+++ b/.changeset/node-level-timeouts.md
@@ -25,7 +25,7 @@ builder.addNode("agent", agentFn, {
 });
 
 // per-task override
-new Send("agent", state, { idleTimeout: 5_000 });
+new Send("agent", state, { timeout: { idleTimeout: 5_000 } });
 ```
 
 When a timeout fires, a `NodeTimeoutError` (carrying `node`, `kind`

--- a/libs/checkpoint/src/serde/jsonplus.ts
+++ b/libs/checkpoint/src/serde/jsonplus.ts
@@ -120,6 +120,8 @@ function _default(obj: any): any {
     return {
       node: obj.node,
       args: obj.args,
+      // preserve an optional per-task timeout policy across (de)serialization
+      ...(obj.timeout !== undefined ? { timeout: obj.timeout } : {}),
     };
   } else if (obj instanceof Uint8Array) {
     return _encodeConstructorArgs(Uint8Array, "from", [Array.from(obj)]);

--- a/libs/checkpoint/src/serde/tests/jsonplus.test.ts
+++ b/libs/checkpoint/src/serde/tests/jsonplus.test.ts
@@ -133,6 +133,31 @@ it.each(VALUES)(
   }
 );
 
+it("Should preserve a Send's timeout policy across serialization", async () => {
+  const serde = new JsonPlusSerializer();
+  const packet = {
+    lg_name: "Send",
+    node: "worker",
+    args: { x: 1 },
+    timeout: { runTimeout: 1000, idleTimeout: 2000, refreshOn: "auto" },
+  };
+  const [type, serialized] = await serde.dumpsTyped(packet);
+  const loaded = await serde.loadsTyped(type, serialized);
+  expect(loaded).toEqual({
+    node: "worker",
+    args: { x: 1 },
+    timeout: { runTimeout: 1000, idleTimeout: 2000, refreshOn: "auto" },
+  });
+});
+
+it("Should serialize a Send without a timeout unchanged", async () => {
+  const serde = new JsonPlusSerializer();
+  const packet = { lg_name: "Send", node: "worker", args: { x: 1 } };
+  const [type, serialized] = await serde.dumpsTyped(packet);
+  const loaded = await serde.loadsTyped(type, serialized);
+  expect(loaded).toEqual({ node: "worker", args: { x: 1 } });
+});
+
 it("Should replace circular JSON inputs", async () => {
   const a: Record<string, unknown> = {};
   const b: Record<string, unknown> = {};

--- a/libs/checkpoint/src/serde/types.ts
+++ b/libs/checkpoint/src/serde/types.ts
@@ -60,4 +60,11 @@ export interface SendProtocol {
   node: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   args: any;
+  // Optional per-task timeout policy. Structural to avoid a dependency on the
+  // langgraph package; mirrors `TimeoutPolicy` in "@langchain/langgraph".
+  timeout?: {
+    runTimeout?: number;
+    idleTimeout?: number;
+    refreshOn?: "auto" | "heartbeat";
+  };
 }

--- a/libs/langgraph-core/src/constants.ts
+++ b/libs/langgraph-core/src/constants.ts
@@ -130,6 +130,15 @@ export interface SendInterface<Node extends string = string, Args = any> {
   timeout?: TimeoutPolicy;
 }
 
+/** Keyword options for {@link Send}. */
+export type SendOptions = {
+  /**
+   * Per-task timeout policy overriding the target node's timeout for this
+   * pushed task. A bare number is treated as `runTimeout` (milliseconds).
+   */
+  timeout?: number | TimeoutPolicy;
+};
+
 export function _isSendInterface(x: unknown): x is SendInterface {
   const operation = x as SendInterface;
   return (
@@ -172,11 +181,11 @@ export function _isSendInterface(x: unknown): x is SendInterface {
  * };
  *
  * @remarks
- * A per-task timeout can be supplied as the third argument to override the
- * target node's configured timeout for this specific pushed task:
+ * A per-task timeout can be supplied via the third argument's `timeout` option
+ * to override the target node's configured timeout for this specific pushed task:
  *
  * ```typescript
- * new Send("generate_joke", { subjects: [subject] }, { idleTimeout: 5000 });
+ * new Send("generate_joke", { subjects: [subject] }, { timeout: { idleTimeout: 5000 } });
  * ```
  *
  * const graph = new StateGraph(ChainState)
@@ -212,10 +221,10 @@ export class Send<
    */
   public timeout?: TimeoutPolicy;
 
-  constructor(node: Node, args: Args, timeout?: number | TimeoutPolicy) {
+  constructor(node: Node, args: Args, options?: SendOptions) {
     this.node = node;
     this.args = _deserializeCommandSendObjectGraph(args) as Args;
-    this.timeout = coerceTimeoutPolicy(timeout);
+    this.timeout = coerceTimeoutPolicy(options?.timeout);
   }
 
   toJSON() {
@@ -407,9 +416,9 @@ export type CommandParams<
    *   - sequence of `Send` objects
    */
   goto?:
-  | Nodes
-  | SendInterface<Nodes> // eslint-disable-line @typescript-eslint/no-explicit-any
-  | (Nodes | SendInterface<Nodes>)[]; // eslint-disable-line @typescript-eslint/no-explicit-any
+    | Nodes
+    | SendInterface<Nodes> // eslint-disable-line @typescript-eslint/no-explicit-any
+    | (Nodes | SendInterface<Nodes>)[]; // eslint-disable-line @typescript-eslint/no-explicit-any
 };
 
 /**
@@ -651,7 +660,11 @@ export function _deserializeCommandSendObjectGraph(
       result = new Command(x);
       seen.set(x, result);
     } else if (_isSendInterface(x)) {
-      result = new Send(x.node, x.args, x.timeout);
+      result = new Send(
+        x.node,
+        x.args,
+        x.timeout !== undefined ? { timeout: x.timeout } : undefined
+      );
       seen.set(x, result);
     } else if ("lc_serializable" in x && x.lc_serializable) {
       result = x;

--- a/libs/langgraph-core/src/constants.ts
+++ b/libs/langgraph-core/src/constants.ts
@@ -1,4 +1,8 @@
 import { PendingWrite } from "@langchain/langgraph-checkpoint";
+import {
+  coerceTimeoutPolicy,
+  type TimeoutPolicy,
+} from "./pregel/utils/timeout.js";
 
 /** Special reserved node name denoting the start of a graph. */
 export const START = "__start__";
@@ -119,6 +123,11 @@ export class CommandInstance<
 export interface SendInterface<Node extends string = string, Args = any> {
   node: Node;
   args: Args;
+  /**
+   * Optional per-task timeout policy that overrides the target node's timeout
+   * for this specific pushed task.
+   */
+  timeout?: TimeoutPolicy;
 }
 
 export function _isSendInterface(x: unknown): x is SendInterface {
@@ -162,6 +171,14 @@ export function _isSendInterface(x: unknown): x is SendInterface {
  *   });
  * };
  *
+ * @remarks
+ * A per-task timeout can be supplied as the third argument to override the
+ * target node's configured timeout for this specific pushed task:
+ *
+ * ```typescript
+ * new Send("generate_joke", { subjects: [subject] }, { idleTimeout: 5000 });
+ * ```
+ *
  * const graph = new StateGraph(ChainState)
  *   .addNode("generate_joke", (state) => ({
  *     jokes: [`Joke about ${state.subjects}`],
@@ -188,13 +205,26 @@ export class Send<
 
   public args: Args;
 
-  constructor(node: Node, args: Args) {
+  /**
+   * Optional per-task timeout policy that overrides the target node's timeout
+   * for this specific pushed task. A bare number is treated as a hard
+   * `runTimeout` (in milliseconds).
+   */
+  public timeout?: TimeoutPolicy;
+
+  constructor(node: Node, args: Args, timeout?: number | TimeoutPolicy) {
     this.node = node;
     this.args = _deserializeCommandSendObjectGraph(args) as Args;
+    this.timeout = coerceTimeoutPolicy(timeout);
   }
 
   toJSON() {
-    return { lg_name: this.lg_name, node: this.node, args: this.args };
+    return {
+      lg_name: this.lg_name,
+      node: this.node,
+      args: this.args,
+      timeout: this.timeout,
+    };
   }
 }
 
@@ -377,9 +407,9 @@ export type CommandParams<
    *   - sequence of `Send` objects
    */
   goto?:
-    | Nodes
-    | SendInterface<Nodes> // eslint-disable-line @typescript-eslint/no-explicit-any
-    | (Nodes | SendInterface<Nodes>)[]; // eslint-disable-line @typescript-eslint/no-explicit-any
+  | Nodes
+  | SendInterface<Nodes> // eslint-disable-line @typescript-eslint/no-explicit-any
+  | (Nodes | SendInterface<Nodes>)[]; // eslint-disable-line @typescript-eslint/no-explicit-any
 };
 
 /**
@@ -620,9 +650,8 @@ export function _deserializeCommandSendObjectGraph(
     } else if (isCommand(x)) {
       result = new Command(x);
       seen.set(x, result);
-      // eslint-disable-next-line no-instanceof/no-instanceof
     } else if (_isSendInterface(x)) {
-      result = new Send(x.node, x.args);
+      result = new Send(x.node, x.args, x.timeout);
       seen.set(x, result);
     } else if ("lc_serializable" in x && x.lc_serializable) {
       result = x;

--- a/libs/langgraph-core/src/errors.ts
+++ b/libs/langgraph-core/src/errors.ts
@@ -117,6 +117,92 @@ export function isGraphInterrupt(e?: unknown): e is GraphInterrupt {
   );
 }
 
+/**
+ * Raised when a node invocation exceeds one of its configured timeouts.
+ *
+ * Does **not** extend {@link GraphBubbleUp} (so it flows through the normal node
+ * error path) and is intentionally treated as retryable by the default retry
+ * policy — its message/name do not match the default `retryOn` blocklist, so a
+ * configured {@link RetryPolicy} will retry it (see langchain-ai/langgraph#7659).
+ *
+ * Both {@link NodeTimeoutError.runTimeout} and {@link NodeTimeoutError.idleTimeout}
+ * reflect the configured policy at the time of the failure (each `undefined` if
+ * not configured). {@link NodeTimeoutError.kind} and {@link NodeTimeoutError.timeout}
+ * identify which one fired.
+ *
+ * @category Errors
+ */
+export class NodeTimeoutError extends BaseLangGraphError {
+  /** Name of the node/task that timed out. */
+  node: string;
+
+  /** Which timeout fired: a hard `"run"` cap or a progress-resetting `"idle"` cap. */
+  kind: "run" | "idle";
+
+  /** The value (ms) of the timeout that fired (`runTimeout` or `idleTimeout`). */
+  timeout: number;
+
+  /** Elapsed time (ms) since the attempt started, at the moment the timeout fired. */
+  elapsed: number;
+
+  /** Configured run timeout (ms), if any. */
+  runTimeout?: number;
+
+  /** Configured idle timeout (ms), if any. */
+  idleTimeout?: number;
+
+  constructor(
+    fields: {
+      node: string;
+      elapsed: number;
+      kind: "run" | "idle";
+      runTimeout?: number;
+      idleTimeout?: number;
+    },
+    errorFields?: BaseLangGraphErrorFields
+  ) {
+    const { node, elapsed, kind, runTimeout, idleTimeout } = fields;
+    let message: string;
+    let timeout: number;
+    if (kind === "idle") {
+      if (idleTimeout === undefined) {
+        throw new Error("idleTimeout is required when kind='idle'");
+      }
+      timeout = idleTimeout;
+      message =
+        `Node "${node}" exceeded its idle timeout of ${idleTimeout}ms ` +
+        `without making progress (elapsed: ${elapsed}ms).`;
+    } else {
+      if (runTimeout === undefined) {
+        throw new Error("runTimeout is required when kind='run'");
+      }
+      timeout = runTimeout;
+      message =
+        `Node "${node}" exceeded its run timeout of ${runTimeout}ms ` +
+        `(elapsed: ${elapsed}ms).`;
+    }
+    super(message, errorFields);
+    this.name = "NodeTimeoutError";
+    this.node = node;
+    this.kind = kind;
+    this.timeout = timeout;
+    this.elapsed = elapsed;
+    this.runTimeout = runTimeout;
+    this.idleTimeout = idleTimeout;
+  }
+
+  static get unminifiable_name() {
+    return "NodeTimeoutError";
+  }
+}
+
+export function isNodeTimeoutError(e?: unknown): e is NodeTimeoutError {
+  return (
+    e !== undefined &&
+    (e as NodeTimeoutError).name === NodeTimeoutError.unminifiable_name
+  );
+}
+
 export class EmptyInputError extends BaseLangGraphError {
   constructor(message?: string, fields?: BaseLangGraphErrorFields) {
     super(message, fields);

--- a/libs/langgraph-core/src/func/index.ts
+++ b/libs/langgraph-core/src/func/index.ts
@@ -15,7 +15,12 @@ import {
 } from "../constants.js";
 import { EphemeralValue } from "../channels/ephemeral_value.js";
 import { call, getRunnableForEntrypoint } from "../pregel/call.js";
-import type { CachePolicy, RetryPolicy } from "../pregel/utils/index.js";
+import type {
+  CachePolicy,
+  RetryPolicy,
+  TimeoutPolicy,
+} from "../pregel/utils/index.js";
+import { coerceTimeoutPolicy } from "../pregel/utils/index.js";
 import { LastValue } from "../channels/last_value.js";
 import {
   EntrypointFinal,
@@ -50,6 +55,14 @@ export interface TaskOptions {
    * The cache policy for the task. Configures how the task should be cached.
    */
   cachePolicy?: CachePolicy;
+
+  /**
+   * Maximum duration for a single attempt of this task. Accepts a number of
+   * milliseconds (a hard wall-clock cap) or a {@link TimeoutPolicy} for finer
+   * control. When exceeded, a {@link NodeTimeoutError} is raised and the task's
+   * retry policy (if any) decides whether to retry.
+   */
+  timeout?: number | TimeoutPolicy;
 }
 
 /**
@@ -105,10 +118,16 @@ export function task<ArgsT extends unknown[], OutputT>(
 ): (...args: ArgsT) => Promise<OutputT> {
   const options =
     typeof optionsOrName === "string"
-      ? { name: optionsOrName, retry: undefined, cachePolicy: undefined }
+      ? {
+          name: optionsOrName,
+          retry: undefined,
+          cachePolicy: undefined,
+          timeout: undefined,
+        }
       : optionsOrName;
 
   const { name, retry } = options;
+  const timeout = coerceTimeoutPolicy(options.timeout);
   if (isAsyncGeneratorFunction(func) || isGeneratorFunction(func)) {
     throw new Error(
       "Generators are disallowed as tasks. For streaming responses, use config.write."
@@ -129,7 +148,7 @@ export function task<ArgsT extends unknown[], OutputT>(
   }
 
   return (...args: ArgsT) => {
-    return call({ func, name, retry, cache }, ...args);
+    return call({ func, name, retry, cache, timeout }, ...args);
   };
 }
 
@@ -156,6 +175,13 @@ export type EntrypointOptions = {
    * The cache for the {@link entrypoint}. Used to cache values between workflow runs.
    */
   cache?: BaseCache;
+
+  /**
+   * Maximum duration for a single attempt of this entrypoint. Accepts a number
+   * of milliseconds (a hard wall-clock cap) or a {@link TimeoutPolicy} for finer
+   * control. When exceeded, a {@link NodeTimeoutError} is raised.
+   */
+  timeout?: number | TimeoutPolicy;
 };
 
 /**
@@ -347,6 +373,9 @@ export const entrypoint = function entrypoint<InputT, OutputT>(
     typeof optionsOrName === "string"
       ? { name: optionsOrName, checkpointer: undefined, store: undefined }
       : optionsOrName;
+  const timeout = coerceTimeoutPolicy(
+    typeof optionsOrName === "string" ? undefined : optionsOrName.timeout
+  );
   if (isAsyncGeneratorFunction(func) || isGeneratorFunction(func)) {
     throw new Error(
       "Generators are disallowed as entrypoints. For streaming responses, use config.write."
@@ -387,6 +416,7 @@ export const entrypoint = function entrypoint<InputT, OutputT>(
     bound,
     triggers: [START],
     channels: [START],
+    timeout,
     writers: [
       new ChannelWrite(
         [

--- a/libs/langgraph-core/src/graph/state.ts
+++ b/libs/langgraph-core/src/graph/state.ts
@@ -67,7 +67,12 @@ import {
   StateType,
 } from "./annotation.js";
 import { StateSchema } from "../state/index.js";
-import type { CachePolicy, RetryPolicy } from "../pregel/utils/index.js";
+import type {
+  CachePolicy,
+  RetryPolicy,
+  TimeoutPolicy,
+} from "../pregel/utils/index.js";
+import { coerceTimeoutPolicy } from "../pregel/utils/index.js";
 import { isPregelLike } from "../pregel/utils/subgraph.js";
 import { LastValueAfterFinish } from "../channels/last_value.js";
 import { type SchemaMetaRegistry, schemaMetaRegistry } from "./zod/meta.js";
@@ -134,6 +139,15 @@ export type NodePolicyOptions = {
    * @see {@link CachePolicy}
    */
   cachePolicy?: CachePolicy | boolean;
+  /**
+   * Maximum duration for a single attempt of this node. Accepts a number of
+   * milliseconds (a hard wall-clock cap) or a {@link TimeoutPolicy} for finer
+   * control over run / idle timeouts. When exceeded, a {@link NodeTimeoutError}
+   * is raised and the node's retry policy (if any) decides whether to retry.
+   *
+   * @see {@link TimeoutPolicy}
+   */
+  timeout?: number | TimeoutPolicy;
 };
 
 /**
@@ -146,6 +160,8 @@ export type NodePolicies = {
   retryPolicy?: RetryPolicy;
   /** `false` opts out of graph defaults set via {@link StateGraph.setNodeDefaults}. */
   cachePolicy?: CachePolicy | false;
+  /** Resolved timeout policy after the `number` shorthand is normalized. */
+  timeout?: TimeoutPolicy;
 };
 
 export type StateGraphNodeSpec<RunInput, RunOutput> = NodeSpec<
@@ -618,6 +634,7 @@ export class StateGraph<
    *   .setNodeDefaults({
    *     retryPolicy: { maxAttempts: 3 },
    *     cachePolicy: { ttl: 60 },
+   *     timeout: 60_000,
    *   })
    *   .addNode("a", nodeA)
    *   .addNode("b", nodeB, { retryPolicy: { maxAttempts: 5 } }) // overrides default
@@ -649,6 +666,9 @@ export class StateGraph<
             ? {}
             : undefined
           : defaults.cachePolicy;
+    }
+    if (defaults.timeout !== undefined) {
+      this._nodeDefaults.timeout = coerceTimeoutPolicy(defaults.timeout);
     }
     return this;
   }
@@ -1020,6 +1040,7 @@ export class StateGraph<
         runnable: runnable as unknown as Runnable<S, U>,
         retryPolicy: options?.retryPolicy,
         cachePolicy,
+        timeout: coerceTimeoutPolicy(options?.timeout),
         metadata: options?.metadata,
         input: inputSpec ?? this._schemaDefinition,
         subgraphs: isPregelLike(runnable)
@@ -1283,7 +1304,8 @@ export class StateGraph<
     const nodeDefaults = this._nodeDefaults;
     const hasNodeDefaults =
       nodeDefaults.retryPolicy !== undefined ||
-      nodeDefaults.cachePolicy !== undefined;
+      nodeDefaults.cachePolicy !== undefined ||
+      nodeDefaults.timeout !== undefined;
     for (const [key, node] of Object.entries<StateGraphNodeSpec<S, U>>(
       this.nodes
     )) {
@@ -1295,6 +1317,7 @@ export class StateGraph<
               node.cachePolicy === false
                 ? undefined
                 : (node.cachePolicy ?? nodeDefaults.cachePolicy),
+            timeout: node.timeout ?? nodeDefaults.timeout,
           }
         : node;
       compiled.attachNode(key as N, resolvedNode);
@@ -1587,6 +1610,7 @@ export class CompiledStateGraph<
         metadata: node?.metadata,
         retryPolicy: node?.retryPolicy,
         cachePolicy,
+        timeout: node?.timeout,
         subgraphs: node?.subgraphs,
         ends: node?.ends,
       });

--- a/libs/langgraph-core/src/pregel/algo.ts
+++ b/libs/langgraph-core/src/pregel/algo.ts
@@ -775,6 +775,7 @@ export function _prepareSingleTask<
         id,
         path: outputTaskPath,
         writers: [],
+        timeout: call.timeout,
       } satisfies PregelExecutableTask<keyof Nn, keyof Cc>;
       return task;
     } else {
@@ -802,7 +803,7 @@ export function _prepareSingleTask<
 
     const packet =
       _isSendInterface(sends[index]) && !_isSend(sends[index])
-        ? new Send(sends[index].node, sends[index].args)
+        ? new Send(sends[index].node, sends[index].args, sends[index].timeout)
         : sends[index];
 
     if (!_isSendInterface(packet)) {
@@ -935,6 +936,8 @@ export function _prepareSingleTask<
           id: taskId,
           path: taskPath,
           writers: proc.getWriters(),
+          // a per-Send timeout overrides the target node's configured timeout
+          timeout: (packet as Send).timeout ?? proc.timeout,
         } satisfies PregelExecutableTask<keyof Nn, keyof Cc>;
       }
     } else {
@@ -1119,6 +1122,7 @@ export function _prepareSingleTask<
             id: taskId,
             path: taskPath,
             writers: proc.getWriters(),
+            timeout: proc.timeout,
           } satisfies PregelExecutableTask<keyof Nn, keyof Cc>;
         }
       } else {

--- a/libs/langgraph-core/src/pregel/algo.ts
+++ b/libs/langgraph-core/src/pregel/algo.ts
@@ -803,7 +803,13 @@ export function _prepareSingleTask<
 
     const packet =
       _isSendInterface(sends[index]) && !_isSend(sends[index])
-        ? new Send(sends[index].node, sends[index].args, sends[index].timeout)
+        ? new Send(
+            sends[index].node,
+            sends[index].args,
+            sends[index].timeout !== undefined
+              ? { timeout: sends[index].timeout }
+              : undefined
+          )
         : sends[index];
 
     if (!_isSendInterface(packet)) {
@@ -937,7 +943,7 @@ export function _prepareSingleTask<
           path: taskPath,
           writers: proc.getWriters(),
           // a per-Send timeout overrides the target node's configured timeout
-          timeout: (packet as Send).timeout ?? proc.timeout,
+          timeout: packet.timeout ?? proc.timeout,
         } satisfies PregelExecutableTask<keyof Nn, keyof Cc>;
       }
     } else {

--- a/libs/langgraph-core/src/pregel/call.ts
+++ b/libs/langgraph-core/src/pregel/call.ts
@@ -6,7 +6,7 @@ import {
 import { AsyncLocalStorageProviderSingleton } from "@langchain/core/singletons";
 import { CONFIG_KEY_CALL, RETURN, TAG_HIDDEN } from "../constants.js";
 import { ChannelWrite, PASSTHROUGH } from "./write.js";
-import { CachePolicy, RetryPolicy } from "./utils/index.js";
+import { CachePolicy, RetryPolicy, TimeoutPolicy } from "./utils/index.js";
 import { RunnableCallable, type RunnableCallableArgs } from "../utils.js";
 import { EntrypointFunc, EntrypointReturnT, TaskFunc } from "../func/types.js";
 import { LangGraphRunnableConfig } from "./runnable_types.js";
@@ -56,10 +56,11 @@ export type CallWrapperOptions<ArgsT extends unknown[], OutputT> = {
   name: string;
   retry?: RetryPolicy;
   cache?: CachePolicy;
+  timeout?: TimeoutPolicy;
 };
 
 export function call<ArgsT extends unknown[], OutputT>(
-  { func, name, cache, retry }: CallWrapperOptions<ArgsT, OutputT>,
+  { func, name, cache, retry, timeout }: CallWrapperOptions<ArgsT, OutputT>,
   ...args: ArgsT
 ): Promise<OutputT> {
   const config =
@@ -68,6 +69,7 @@ export function call<ArgsT extends unknown[], OutputT>(
     return config.configurable[CONFIG_KEY_CALL](func, name, args, {
       retry,
       cache,
+      timeout,
       callbacks: config.callbacks,
     });
   }

--- a/libs/langgraph-core/src/pregel/read.ts
+++ b/libs/langgraph-core/src/pregel/read.ts
@@ -11,7 +11,7 @@ import {
 import { CONFIG_KEY_READ } from "../constants.js";
 import { ChannelWrite } from "./write.js";
 import { RunnableCallable } from "../utils.js";
-import type { CachePolicy, RetryPolicy } from "./utils/index.js";
+import type { CachePolicy, RetryPolicy, TimeoutPolicy } from "./utils/index.js";
 
 export class ChannelRead<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -86,6 +86,7 @@ interface PregelNodeArgs<RunInput, RunOutput> extends Partial<
   metadata?: Record<string, unknown>;
   retryPolicy?: RetryPolicy;
   cachePolicy?: CachePolicy;
+  timeout?: TimeoutPolicy;
   subgraphs?: Runnable[];
   ends?: string[];
 }
@@ -124,6 +125,8 @@ export class PregelNode<
 
   cachePolicy?: CachePolicy;
 
+  timeout?: TimeoutPolicy;
+
   subgraphs?: Runnable[];
 
   ends?: string[];
@@ -139,6 +142,7 @@ export class PregelNode<
       metadata,
       retryPolicy,
       cachePolicy,
+      timeout,
       tags,
       subgraphs,
       ends,
@@ -169,6 +173,7 @@ export class PregelNode<
     this.tags = mergedTags;
     this.retryPolicy = retryPolicy;
     this.cachePolicy = cachePolicy;
+    this.timeout = timeout;
     this.subgraphs = subgraphs;
     this.ends = ends;
   }
@@ -241,6 +246,7 @@ export class PregelNode<
       config: this.config,
       retryPolicy: this.retryPolicy,
       cachePolicy: this.cachePolicy,
+      timeout: this.timeout,
     });
   }
 
@@ -261,6 +267,7 @@ export class PregelNode<
         kwargs: this.kwargs,
         retryPolicy: this.retryPolicy,
         cachePolicy: this.cachePolicy,
+        timeout: this.timeout,
       });
     } else if (this.bound === defaultRunnableBound) {
       return new PregelNode<RunInput, Exclude<NewRunOutput, Error>>({
@@ -273,6 +280,7 @@ export class PregelNode<
         kwargs: this.kwargs,
         retryPolicy: this.retryPolicy,
         cachePolicy: this.cachePolicy,
+        timeout: this.timeout,
       });
     } else {
       return new PregelNode<RunInput, Exclude<NewRunOutput, Error>>({
@@ -285,6 +293,7 @@ export class PregelNode<
         kwargs: this.kwargs,
         retryPolicy: this.retryPolicy,
         cachePolicy: this.cachePolicy,
+        timeout: this.timeout,
       });
     }
   }

--- a/libs/langgraph-core/src/pregel/retry.ts
+++ b/libs/langgraph-core/src/pregel/retry.ts
@@ -1,6 +1,7 @@
 import { Command, CONFIG_KEY_RESUMING } from "../constants.js";
 import { isGraphBubbleUp, isParentCommand } from "../errors.js";
 import type { LangGraphRunnableConfig } from "./runnable_types.js";
+import { runAttemptWithTimeout } from "./timeout.js";
 import { PregelExecutableTask } from "./types.js";
 import { getParentCheckpointNamespace } from "./utils/config.js";
 import { patchConfigurable, type RetryPolicy } from "./utils/index.js";
@@ -111,7 +112,19 @@ export async function _runWithRetry<
     pregelTask.writes.splice(0, pregelTask.writes.length);
     error = undefined;
     try {
-      result = await pregelTask.proc.invoke(pregelTask.input, config);
+      if (pregelTask.timeout !== undefined) {
+        // Enforce a per-attempt timeout. The timer resets on each retry since
+        // a fresh attempt scope is created here per iteration.
+        result = await runAttemptWithTimeout(
+          pregelTask as PregelExecutableTask<string, string>,
+          config,
+          pregelTask.timeout,
+          (scopedConfig) =>
+            pregelTask.proc.invoke(pregelTask.input, scopedConfig)
+        );
+      } else {
+        result = await pregelTask.proc.invoke(pregelTask.input, config);
+      }
       break;
     } catch (e: unknown) {
       error = e;

--- a/libs/langgraph-core/src/pregel/runnable_types.ts
+++ b/libs/langgraph-core/src/pregel/runnable_types.ts
@@ -99,6 +99,17 @@ export interface Runtime<
   /** Abort signal to cancel the run. */
   signal: AbortSignal;
 
+  /**
+   * Manually signal that the node is still making progress, resetting the
+   * `idleTimeout` of the node's {@link TimeoutPolicy} (if configured).
+   *
+   * This is a no-op when the node has no `idleTimeout` configured. It is the
+   * only progress signal when `refreshOn` is `"heartbeat"`, and is useful for
+   * long-running work that doesn't otherwise emit writes, stream events, child
+   * tasks, or callback events.
+   */
+  heartbeat?: () => void;
+
   /** Read-only execution information/metadata for the current node run. Undefined before task preparation. */
   executionInfo?: ExecutionInfo;
 

--- a/libs/langgraph-core/src/pregel/runner.ts
+++ b/libs/langgraph-core/src/pregel/runner.ts
@@ -10,6 +10,7 @@ import {
   combineAbortSignals,
   patchConfigurable,
   RetryPolicy,
+  TimeoutPolicy,
 } from "./utils/index.js";
 import {
   CONFIG_KEY_SCRATCHPAD,
@@ -420,6 +421,7 @@ async function call(
   options: {
     retry?: RetryPolicy;
     cache?: CachePolicy;
+    timeout?: TimeoutPolicy;
     callbacks?: unknown;
   } = {}
 ): Promise<unknown> {
@@ -444,6 +446,7 @@ async function call(
     input,
     cache: options.cache,
     retry: options.retry,
+    timeout: options.timeout,
     callbacks: options.callbacks,
   });
   const nextTask = await this.scheduleTask(task, cnt, wcall);

--- a/libs/langgraph-core/src/pregel/timeout.ts
+++ b/libs/langgraph-core/src/pregel/timeout.ts
@@ -1,0 +1,304 @@
+import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
+import { PendingWrite } from "@langchain/langgraph-checkpoint";
+import { CONFIG_KEY_CALL, CONFIG_KEY_SEND } from "../constants.js";
+import { NodeTimeoutError } from "../errors.js";
+import { LangGraphRunnableConfig } from "./runnable_types.js";
+import { PregelExecutableTask } from "./types.js";
+import {
+  combineAbortSignals,
+  patchConfigurable,
+  TimeoutPolicy,
+} from "./utils/index.js";
+
+/**
+ * Tracks the live progress state of a single timed node attempt.
+ *
+ * The scope guards observable-progress channels (writes, child-task
+ * scheduling, the custom stream writer, callbacks) so that:
+ *
+ * 1. `idleTimeout` is refreshed whenever the node makes progress, and
+ * 2. once the attempt is `close()`d after a timeout fires, late writes/calls
+ *    from the still-running background task are dropped (Python parity:
+ *    buffered writes from the failed attempt must not leak into the
+ *    checkpoint).
+ *
+ * @internal
+ */
+class TimedAttemptScope {
+  active = true;
+
+  lastProgress = Date.now();
+
+  private refreshOn: "auto" | "heartbeat";
+
+  constructor(refreshOn: "auto" | "heartbeat") {
+    this.refreshOn = refreshOn;
+  }
+
+  /** Record progress now. Always honored (used by `runtime.heartbeat()`). */
+  touch(): void {
+    this.lastProgress = Date.now();
+  }
+
+  /**
+   * Record progress for an automatic signal (write/call/stream/callback).
+   * No-op when `refreshOn === "heartbeat"`, where only explicit heartbeats
+   * count as progress.
+   */
+  autoTouch(): void {
+    if (this.refreshOn === "auto") {
+      this.lastProgress = Date.now();
+    }
+  }
+
+  close(): void {
+    this.active = false;
+  }
+}
+
+/**
+ * Callback handler that refreshes a {@link TimedAttemptScope} on any LangChain
+ * callback event emitted under the node's run. Because it is attached via
+ * `config.callbacks`, it only observes events from runs descended from this
+ * node's attempt, not from sibling nodes.
+ *
+ * @internal
+ */
+class IdleProgressCallbackHandler extends BaseCallbackHandler {
+  name = "IdleProgressCallbackHandler";
+
+  awaitHandlers = false;
+
+  private scope: TimedAttemptScope;
+
+  constructor(scope: TimedAttemptScope) {
+    super();
+    this.scope = scope;
+  }
+
+  private touch = () => {
+    this.scope.autoTouch();
+  };
+
+  handleLLMStart = this.touch;
+
+  handleChatModelStart = this.touch;
+
+  handleLLMNewToken = this.touch;
+
+  handleLLMEnd = this.touch;
+
+  handleLLMError = this.touch;
+
+  handleChainStart = this.touch;
+
+  handleChainEnd = this.touch;
+
+  handleChainError = this.touch;
+
+  handleToolStart = this.touch;
+
+  handleToolEnd = this.touch;
+
+  handleToolError = this.touch;
+
+  handleText = this.touch;
+
+  handleRetrieverStart = this.touch;
+
+  handleRetrieverEnd = this.touch;
+
+  handleRetrieverError = this.touch;
+
+  handleCustomEvent = this.touch;
+}
+
+/**
+ * Wrap the node attempt config so observable-progress signals refresh the idle
+ * clock and are dropped once the scope is closed. Also injects
+ * {@link LangGraphRunnableConfig.heartbeat}.
+ */
+function wrapConfig(
+  config: LangGraphRunnableConfig,
+  scope: TimedAttemptScope,
+  policy: TimeoutPolicy,
+  taskName: string
+): LangGraphRunnableConfig {
+  const configurable = config.configurable ?? {};
+  const patch: Record<string, unknown> = {};
+
+  const send = configurable[CONFIG_KEY_SEND];
+  if (typeof send === "function") {
+    patch[CONFIG_KEY_SEND] = (writes: PendingWrite[]) => {
+      if (!scope.active) return undefined;
+      if (writes && writes.length) scope.autoTouch();
+      return send(writes);
+    };
+  }
+
+  const callFn = configurable[CONFIG_KEY_CALL];
+  if (typeof callFn === "function") {
+    patch[CONFIG_KEY_CALL] = (...args: unknown[]) => {
+      if (!scope.active) {
+        throw new Error(
+          `Node "${taskName}" attempt was cancelled after its timeout fired`
+        );
+      }
+      scope.autoTouch();
+      return (callFn as (...a: unknown[]) => unknown)(...args);
+    };
+  }
+
+  const out: LangGraphRunnableConfig =
+    Object.keys(patch).length > 0 ? patchConfigurable(config, patch) : config;
+  const wrapped: LangGraphRunnableConfig = { ...out };
+
+  // `heartbeat` always resets the idle clock, even under `refreshOn:
+  // "heartbeat"`. It is a no-op when no idle timeout is configured.
+  wrapped.heartbeat = () => {
+    if (policy.idleTimeout !== undefined) scope.touch();
+  };
+
+  if (typeof wrapped.writer === "function") {
+    const writer = wrapped.writer;
+    wrapped.writer = ((chunk: unknown) => {
+      if (!scope.active) return undefined;
+      scope.autoTouch();
+      return (writer as (c: unknown) => unknown)(chunk);
+    }) as typeof wrapped.writer;
+  }
+
+  if (
+    (policy.refreshOn ?? "auto") === "auto" &&
+    policy.idleTimeout !== undefined
+  ) {
+    const handler = new IdleProgressCallbackHandler(scope);
+    const cb = wrapped.callbacks;
+    if (cb === undefined) {
+      wrapped.callbacks = [handler];
+    } else if (Array.isArray(cb)) {
+      wrapped.callbacks = [...cb, handler];
+    } else {
+      const copied = cb.copy();
+      copied.addHandler(handler, true);
+      wrapped.callbacks = copied;
+    }
+  }
+
+  return wrapped;
+}
+
+type AttemptOutcome<T> =
+  | { type: "ok"; value: T }
+  | { type: "err"; error: unknown }
+  | { type: "timeout"; kind: "run" | "idle" };
+
+/**
+ * Run a single node attempt under a {@link TimeoutPolicy}.
+ *
+ * Races the node invocation against per-attempt run/idle watchdogs. On
+ * successful completion (or node error), returns/rethrows normally. When a
+ * watchdog fires first, the scope is closed, the task's buffered writes are
+ * dropped, the attempt's {@link AbortSignal} is aborted, and a
+ * {@link NodeTimeoutError} is thrown.
+ *
+ * @internal
+ */
+export async function runAttemptWithTimeout<T>(
+  task: PregelExecutableTask<string, string>,
+  config: LangGraphRunnableConfig,
+  policy: TimeoutPolicy,
+  invoke: (scopedConfig: LangGraphRunnableConfig) => Promise<T>
+): Promise<T> {
+  const refreshOn = policy.refreshOn ?? "auto";
+  const scope = new TimedAttemptScope(refreshOn);
+
+  const timeoutController = new AbortController();
+  const { signal: composedSignal, dispose } = combineAbortSignals(
+    config.signal,
+    timeoutController.signal
+  );
+
+  const scopedConfig = wrapConfig(
+    { ...config, signal: composedSignal },
+    scope,
+    policy,
+    String(task.name)
+  );
+
+  const start = Date.now();
+  const bg = invoke(scopedConfig);
+
+  const outcome = await new Promise<AttemptOutcome<T>>((resolve) => {
+    let settled = false;
+    let runTimer: ReturnType<typeof setTimeout> | undefined;
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = () => {
+      if (runTimer !== undefined) clearTimeout(runTimer);
+      if (idleTimer !== undefined) clearTimeout(idleTimer);
+    };
+
+    const finish = (result: AttemptOutcome<T>) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(result);
+    };
+
+    bg.then(
+      (value) => finish({ type: "ok", value }),
+      (error) => finish({ type: "err", error })
+    );
+
+    if (policy.runTimeout !== undefined) {
+      runTimer = setTimeout(
+        () => finish({ type: "timeout", kind: "run" }),
+        policy.runTimeout
+      );
+    }
+
+    if (policy.idleTimeout !== undefined) {
+      const idleMs = policy.idleTimeout;
+      const checkIdle = () => {
+        if (settled) return;
+        const remaining = scope.lastProgress + idleMs - Date.now();
+        if (remaining <= 0) {
+          finish({ type: "timeout", kind: "idle" });
+        } else {
+          idleTimer = setTimeout(checkIdle, remaining);
+        }
+      };
+      idleTimer = setTimeout(checkIdle, idleMs);
+    }
+  });
+
+  if (outcome.type === "ok") {
+    dispose?.();
+    return outcome.value;
+  }
+  if (outcome.type === "err") {
+    dispose?.();
+    throw outcome.error;
+  }
+
+  // A watchdog fired: close the scope (drop late writes/calls), discard the
+  // attempt's buffered writes, abort the node, and surface a NodeTimeoutError.
+  const elapsed = Date.now() - start;
+  scope.close();
+  task.writes.splice(0, task.writes.length);
+  // Abort BEFORE disposing the combined signal so the abort actually
+  // propagates to the node's signal (dispose removes the relay listeners).
+  timeoutController.abort();
+  // Prevent an unhandled rejection from the abandoned background task.
+  bg.catch(() => undefined);
+  dispose?.();
+
+  throw new NodeTimeoutError({
+    node: String(task.name),
+    elapsed,
+    kind: outcome.kind,
+    runTimeout: policy.runTimeout,
+    idleTimeout: policy.idleTimeout,
+  });
+}

--- a/libs/langgraph-core/src/pregel/timeout.ts
+++ b/libs/langgraph-core/src/pregel/timeout.ts
@@ -69,48 +69,48 @@ class IdleProgressCallbackHandler extends BaseCallbackHandler {
 
   awaitHandlers = false;
 
-  private scope: TimedAttemptScope;
+  #scope: TimedAttemptScope;
 
   constructor(scope: TimedAttemptScope) {
     super();
-    this.scope = scope;
+    this.#scope = scope;
   }
 
-  private touch = () => {
-    this.scope.autoTouch();
+  #touch = () => {
+    this.#scope.autoTouch();
   };
 
-  handleLLMStart = this.touch;
+  handleLLMStart = this.#touch;
 
-  handleChatModelStart = this.touch;
+  handleChatModelStart = this.#touch;
 
-  handleLLMNewToken = this.touch;
+  handleLLMNewToken = this.#touch;
 
-  handleLLMEnd = this.touch;
+  handleLLMEnd = this.#touch;
 
-  handleLLMError = this.touch;
+  handleLLMError = this.#touch;
 
-  handleChainStart = this.touch;
+  handleChainStart = this.#touch;
 
-  handleChainEnd = this.touch;
+  handleChainEnd = this.#touch;
 
-  handleChainError = this.touch;
+  handleChainError = this.#touch;
 
-  handleToolStart = this.touch;
+  handleToolStart = this.#touch;
 
-  handleToolEnd = this.touch;
+  handleToolEnd = this.#touch;
 
-  handleToolError = this.touch;
+  handleToolError = this.#touch;
 
-  handleText = this.touch;
+  handleText = this.#touch;
 
-  handleRetrieverStart = this.touch;
+  handleRetrieverStart = this.#touch;
 
-  handleRetrieverEnd = this.touch;
+  handleRetrieverEnd = this.#touch;
 
-  handleRetrieverError = this.touch;
+  handleRetrieverError = this.#touch;
 
-  handleCustomEvent = this.touch;
+  handleCustomEvent = this.#touch;
 }
 
 /**

--- a/libs/langgraph-core/src/pregel/timeout.ts
+++ b/libs/langgraph-core/src/pregel/timeout.ts
@@ -278,6 +278,25 @@ export async function runAttemptWithTimeout<T>(
     clearTimers();
   }
 
+  // Watchdog timers are macrotasks and cannot fire while a synchronous
+  // (CPU-bound) node blocks the event loop. Such a node — or one with a long
+  // synchronous prefix — can therefore settle the race as "ok"/"err" before an
+  // already-expired timer ever runs, bypassing the documented hard wall-clock
+  // cap. Re-check the budget against wall-clock time here so the caps hold for
+  // synchronous nodes too. (For genuinely async work the watchdog already
+  // wins the race, so this only catches what timers structurally cannot.)
+  if (outcome.type !== "timeout") {
+    const now = Date.now();
+    if (policy.runTimeout !== undefined && now - start >= policy.runTimeout) {
+      outcome = { type: "timeout", kind: "run" };
+    } else if (
+      policy.idleTimeout !== undefined &&
+      now - scope.lastProgress >= policy.idleTimeout
+    ) {
+      outcome = { type: "timeout", kind: "idle" };
+    }
+  }
+
   if (outcome.type === "ok") {
     dispose?.();
     return outcome.value;

--- a/libs/langgraph-core/src/pregel/timeout.ts
+++ b/libs/langgraph-core/src/pregel/timeout.ts
@@ -229,31 +229,30 @@ export async function runAttemptWithTimeout<T>(
   const start = Date.now();
   const bg = invoke(scopedConfig);
 
-  const outcome = await new Promise<AttemptOutcome<T>>((resolve) => {
-    let settled = false;
-    let runTimer: ReturnType<typeof setTimeout> | undefined;
-    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  // Normalize the node result into an outcome. Catching the rejection here
+  // (rather than via a separate `bg.catch`) keeps `bg` handled even when a
+  // watchdog wins the race below, so its late settlement can never surface as
+  // an unhandled rejection.
+  const nodeOutcome: Promise<AttemptOutcome<T>> = bg.then(
+    (value) => ({ type: "ok", value }),
+    (error) => ({ type: "err", error })
+  );
 
-    const cleanup = () => {
-      if (runTimer !== undefined) clearTimeout(runTimer);
-      if (idleTimer !== undefined) clearTimeout(idleTimer);
-    };
+  let runTimer: ReturnType<typeof setTimeout> | undefined;
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  const clearTimers = () => {
+    if (runTimer !== undefined) clearTimeout(runTimer);
+    if (idleTimer !== undefined) clearTimeout(idleTimer);
+  };
 
-    const finish = (result: AttemptOutcome<T>) => {
-      if (settled) return;
-      settled = true;
-      cleanup();
-      resolve(result);
-    };
-
-    bg.then(
-      (value) => finish({ type: "ok", value }),
-      (error) => finish({ type: "err", error })
-    );
-
+  // The watchdog never rejects: it either resolves with a timeout outcome or
+  // stays pending forever (and is dropped) when the node wins the race. The
+  // idle timer re-arms itself off `scope.lastProgress`, so it can't be a single
+  // fixed `setTimeout`.
+  const watchdog = new Promise<AttemptOutcome<T>>((resolve) => {
     if (policy.runTimeout !== undefined) {
       runTimer = setTimeout(
-        () => finish({ type: "timeout", kind: "run" }),
+        () => resolve({ type: "timeout", kind: "run" }),
         policy.runTimeout
       );
     }
@@ -261,10 +260,9 @@ export async function runAttemptWithTimeout<T>(
     if (policy.idleTimeout !== undefined) {
       const idleMs = policy.idleTimeout;
       const checkIdle = () => {
-        if (settled) return;
         const remaining = scope.lastProgress + idleMs - Date.now();
         if (remaining <= 0) {
-          finish({ type: "timeout", kind: "idle" });
+          resolve({ type: "timeout", kind: "idle" });
         } else {
           idleTimer = setTimeout(checkIdle, remaining);
         }
@@ -272,6 +270,13 @@ export async function runAttemptWithTimeout<T>(
       idleTimer = setTimeout(checkIdle, idleMs);
     }
   });
+
+  let outcome: AttemptOutcome<T>;
+  try {
+    outcome = await Promise.race([nodeOutcome, watchdog]);
+  } finally {
+    clearTimers();
+  }
 
   if (outcome.type === "ok") {
     dispose?.();
@@ -290,8 +295,6 @@ export async function runAttemptWithTimeout<T>(
   // Abort BEFORE disposing the combined signal so the abort actually
   // propagates to the node's signal (dispose removes the relay listeners).
   timeoutController.abort();
-  // Prevent an unhandled rejection from the abandoned background task.
-  bg.catch(() => undefined);
   dispose?.();
 
   throw new NodeTimeoutError({

--- a/libs/langgraph-core/src/pregel/types.ts
+++ b/libs/langgraph-core/src/pregel/types.ts
@@ -15,7 +15,7 @@ import type { BaseChannel } from "../channels/base.js";
 import type { PregelNode } from "./read.js";
 import type { Interrupt } from "../constants.js";
 import type { StreamTransformer } from "../stream/types.js";
-import { CachePolicy, RetryPolicy } from "./utils/index.js";
+import { CachePolicy, RetryPolicy, TimeoutPolicy } from "./utils/index.js";
 import { LangGraphRunnableConfig } from "./runnable_types.js";
 
 /**
@@ -595,6 +595,12 @@ export interface PregelExecutableTask<
   readonly path?: TaskPath;
   readonly subgraphs?: Runnable[];
   readonly writers: Runnable[];
+  /**
+   * The (already coerced) timeout policy to enforce for each attempt of this
+   * task. Resolved from the node's `timeout`, or overridden by a per-task
+   * {@link Send} timeout / functional `Call` timeout.
+   */
+  readonly timeout?: TimeoutPolicy;
 }
 
 export interface StateSnapshot {
@@ -714,6 +720,7 @@ export type CallOptions = {
   input: unknown;
   cache?: CachePolicy;
   retry?: RetryPolicy;
+  timeout?: TimeoutPolicy;
   callbacks?: unknown;
 };
 
@@ -728,16 +735,27 @@ export class Call {
 
   cache?: CachePolicy;
 
+  timeout?: TimeoutPolicy;
+
   callbacks?: unknown;
 
   readonly __lg_type = "call";
 
-  constructor({ func, name, input, retry, cache, callbacks }: CallOptions) {
+  constructor({
+    func,
+    name,
+    input,
+    retry,
+    cache,
+    timeout,
+    callbacks,
+  }: CallOptions) {
     this.func = func;
     this.name = name;
     this.input = input;
     this.retry = retry;
     this.cache = cache;
+    this.timeout = timeout;
     this.callbacks = callbacks;
   }
 }

--- a/libs/langgraph-core/src/pregel/utils/config.ts
+++ b/libs/langgraph-core/src/pregel/utils/config.ts
@@ -30,6 +30,7 @@ const CONFIG_KEYS = [
   "checkpointDuring",
   "durability",
   "signal",
+  "heartbeat",
   "executionInfo",
   "serverInfo",
 ];

--- a/libs/langgraph-core/src/pregel/utils/index.ts
+++ b/libs/langgraph-core/src/pregel/utils/index.ts
@@ -88,6 +88,9 @@ export type RetryPolicy = {
   logWarning?: boolean;
 };
 
+export type { TimeoutPolicy } from "./timeout.js";
+export { coerceTimeoutPolicy } from "./timeout.js";
+
 /**
  * Configuration for caching nodes.
  */

--- a/libs/langgraph-core/src/pregel/utils/timeout.ts
+++ b/libs/langgraph-core/src/pregel/utils/timeout.ts
@@ -1,0 +1,91 @@
+/**
+ * Configuration for timing out node attempts.
+ *
+ * A timeout applies to a single attempt of a node/task. When a node has a
+ * {@link RetryPolicy}, the timer resets for each retry attempt.
+ *
+ * Timeouts are expressed in **milliseconds**, matching other LangGraph.js
+ * durations (e.g. {@link RetryPolicy} intervals and `stepTimeout`).
+ *
+ * @remarks
+ * Cooperative cancellation: timeouts rely on aborting the node's
+ * {@link AbortSignal} and dropping its buffered writes. A node that ignores its
+ * `signal` and performs blocking work cannot be interrupted mid-operation, but
+ * its writes are still discarded and `NodeTimeoutError` is raised.
+ */
+export type TimeoutPolicy = {
+  /**
+   * Hard wall-clock cap (in milliseconds) for a single node attempt.
+   *
+   * This timeout is never refreshed by progress signals or
+   * `runtime.heartbeat()`.
+   */
+  runTimeout?: number;
+
+  /**
+   * Maximum time (in milliseconds) a single node attempt may go without
+   * observable progress before timing out.
+   *
+   * Refreshed by writes, custom stream writer calls, child-task scheduling,
+   * LangChain callback events emitted under the node's run, and explicit
+   * `runtime.heartbeat()` calls (see {@link TimeoutPolicy.refreshOn}).
+   */
+  idleTimeout?: number;
+
+  /**
+   * Which signals refresh {@link TimeoutPolicy.idleTimeout}.
+   *
+   * - `"auto"` (default): refreshes on standard graph progress signals and
+   *   explicit heartbeats.
+   * - `"heartbeat"`: refreshes only on explicit `runtime.heartbeat()` calls.
+   */
+  refreshOn?: "auto" | "heartbeat";
+};
+
+function _coerceTimeoutMs(
+  value: number | undefined,
+  field: string
+): number | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== "number" || Number.isNaN(value) || value <= 0) {
+    throw new Error(`${field} must be greater than 0`);
+  }
+  return value;
+}
+
+/**
+ * Normalize a timeout value into a {@link TimeoutPolicy} with positive
+ * millisecond fields, or `undefined` if no timeout is configured.
+ *
+ * A bare number (or `undefined`) is treated as a hard {@link
+ * TimeoutPolicy.runTimeout}. Throws if any configured timeout is not greater
+ * than 0, or if `refreshOn` is not `"auto"` or `"heartbeat"`.
+ *
+ * @internal
+ */
+export function coerceTimeoutPolicy(
+  value?: number | TimeoutPolicy
+): TimeoutPolicy | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  const policy: TimeoutPolicy =
+    typeof value === "number" ? { runTimeout: value } : value;
+
+  const refreshOn = policy.refreshOn ?? "auto";
+  if (refreshOn !== "auto" && refreshOn !== "heartbeat") {
+    throw new Error('refreshOn must be "auto" or "heartbeat"');
+  }
+
+  const runTimeout = _coerceTimeoutMs(policy.runTimeout, "runTimeout");
+  const idleTimeout = _coerceTimeoutMs(policy.idleTimeout, "idleTimeout");
+
+  if (runTimeout === undefined && idleTimeout === undefined) {
+    return undefined;
+  }
+
+  return { runTimeout, idleTimeout, refreshOn };
+}

--- a/libs/langgraph-core/src/tests/timeout.test.ts
+++ b/libs/langgraph-core/src/tests/timeout.test.ts
@@ -1,0 +1,439 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { it, expect, describe, beforeAll } from "vitest";
+import { type PendingWrite } from "@langchain/langgraph-checkpoint";
+import { Annotation, StateGraph } from "../graph/index.js";
+import { START, END, Send, CONFIG_KEY_SEND } from "../constants.js";
+import { NodeTimeoutError, isNodeTimeoutError } from "../errors.js";
+import { entrypoint, task } from "../func/index.js";
+import { RunnableCallable } from "../utils.js";
+import { _runWithRetry } from "../pregel/retry.js";
+import type { PregelExecutableTask } from "../pregel/types.js";
+import {
+  coerceTimeoutPolicy,
+  type RetryPolicy,
+  type TimeoutPolicy,
+} from "../pregel/utils/index.js";
+import type { Runtime } from "../web.js";
+import { initializeAsyncLocalStorageSingleton } from "../setup/async_local_storage.js";
+
+beforeAll(() => {
+  initializeAsyncLocalStorageSingleton();
+});
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(resolve, ms);
+    if (signal) {
+      signal.addEventListener(
+        "abort",
+        () => {
+          clearTimeout(t);
+          reject(new Error("aborted"));
+        },
+        { once: true }
+      );
+    }
+  });
+}
+
+/**
+ * Build a minimal {@link PregelExecutableTask} that runs `func` and routes its
+ * writes (via CONFIG_KEY_SEND) into the same `writes` buffer exposed as
+ * `task.writes`, mirroring how the real algo wires tasks.
+ */
+function makeTask(
+  func: (input: unknown, config: any) => unknown | Promise<unknown>,
+  options: {
+    timeout?: number | TimeoutPolicy;
+    retryPolicy?: RetryPolicy;
+    name?: string;
+  } = {}
+): PregelExecutableTask<string, string> {
+  const name = options.name ?? "timed";
+  const writes: PendingWrite<string>[] = [];
+  const proc = new RunnableCallable({
+    func: (input: unknown, config: any) => func(input, config),
+    name,
+    trace: false,
+    recurse: false,
+  });
+  return {
+    name,
+    input: null,
+    proc: proc as any,
+    writes,
+    config: {
+      configurable: {
+        [CONFIG_KEY_SEND]: (w: PendingWrite[]) =>
+          writes.push(...(w as PendingWrite<string>[])),
+        thread_id: "thread-1",
+      },
+    },
+    triggers: [name],
+    retry_policy: options.retryPolicy,
+    id: "task-1",
+    path: ["__pregel_pull", name],
+    writers: [],
+    timeout: coerceTimeoutPolicy(options.timeout),
+  } as PregelExecutableTask<string, string>;
+}
+
+describe("coerceTimeoutPolicy", () => {
+  it("normalizes scalars, policies, and rejects non-positive timeouts", () => {
+    expect(coerceTimeoutPolicy(undefined)).toBeUndefined();
+    expect(coerceTimeoutPolicy(1500)).toEqual({
+      runTimeout: 1500,
+      idleTimeout: undefined,
+      refreshOn: "auto",
+    });
+    expect(coerceTimeoutPolicy({ idleTimeout: 250 })).toEqual({
+      runTimeout: undefined,
+      idleTimeout: 250,
+      refreshOn: "auto",
+    });
+    // empty policy collapses to undefined
+    expect(coerceTimeoutPolicy({})).toBeUndefined();
+    expect(() => coerceTimeoutPolicy(0)).toThrow("greater than 0");
+    expect(() => coerceTimeoutPolicy({ idleTimeout: 0 })).toThrow(
+      "greater than 0"
+    );
+    expect(() =>
+      coerceTimeoutPolicy({ runTimeout: 1, refreshOn: "nope" as any })
+    ).toThrow('refreshOn must be "auto" or "heartbeat"');
+  });
+});
+
+describe("NodeTimeoutError", () => {
+  it("carries node/kind/timeouts/elapsed and is not a graph bubble-up", () => {
+    const err = new NodeTimeoutError({
+      node: "n",
+      elapsed: 12,
+      kind: "idle",
+      idleTimeout: 50,
+      runTimeout: 100,
+    });
+    expect(err.name).toBe("NodeTimeoutError");
+    expect(err.node).toBe("n");
+    expect(err.kind).toBe("idle");
+    expect(err.timeout).toBe(50);
+    expect(err.idleTimeout).toBe(50);
+    expect(err.runTimeout).toBe(100);
+    expect(err.elapsed).toBe(12);
+    expect(isNodeTimeoutError(err)).toBe(true);
+    expect((err as any).is_bubble_up).toBeUndefined();
+  });
+
+  it("requires the matching timeout for the fired kind", () => {
+    expect(
+      () => new NodeTimeoutError({ node: "n", elapsed: 1, kind: "run" })
+    ).toThrow("runTimeout is required");
+    expect(
+      () => new NodeTimeoutError({ node: "n", elapsed: 1, kind: "idle" })
+    ).toThrow("idleTimeout is required");
+  });
+});
+
+describe("_runWithRetry timeout enforcement", () => {
+  it("fires a run timeout (kind=run)", async () => {
+    const taskObj = makeTask(
+      async (_input, config) => {
+        await sleep(1000, config.signal);
+        return "late";
+      },
+      { timeout: 50, name: "runslow" }
+    );
+    const { result, error } = await _runWithRetry(taskObj);
+    expect(result).toBeUndefined();
+    expect(isNodeTimeoutError(error)).toBe(true);
+    const timeoutErr = error as unknown as NodeTimeoutError;
+    expect(timeoutErr.kind).toBe("run");
+    expect(timeoutErr.node).toBe("runslow");
+    expect(timeoutErr.runTimeout).toBe(50);
+  });
+
+  it("fires an idle timeout (kind=idle) when no progress is made", async () => {
+    const taskObj = makeTask(
+      async (_input, config) => {
+        await sleep(1000, config.signal);
+        return "late";
+      },
+      { timeout: { idleTimeout: 50 }, name: "idleslow" }
+    );
+    const { error } = await _runWithRetry(taskObj);
+    expect(isNodeTimeoutError(error)).toBe(true);
+    expect((error as unknown as NodeTimeoutError).kind).toBe("idle");
+    expect((error as unknown as NodeTimeoutError).idleTimeout).toBe(50);
+  });
+
+  it("succeeds when the node finishes within its timeout", async () => {
+    const taskObj = makeTask(async () => "ok", { timeout: 1000 });
+    const { result, error } = await _runWithRetry(taskObj);
+    expect(error).toBeUndefined();
+    expect(result).toBe("ok");
+  });
+
+  it("does not fire an idle timeout while heartbeats keep arriving", async () => {
+    const taskObj = makeTask(
+      async (_input, config) => {
+        for (let i = 0; i < 5; i += 1) {
+          await sleep(40);
+          config.heartbeat?.();
+        }
+        return "ok";
+      },
+      { timeout: { idleTimeout: 120 }, name: "heartbeating" }
+    );
+    const { result, error } = await _runWithRetry(taskObj);
+    expect(error).toBeUndefined();
+    expect(result).toBe("ok");
+  });
+
+  it("under refreshOn=heartbeat, only heartbeats refresh the idle clock", async () => {
+    // The node writes (an auto progress signal) but never heartbeats, so the
+    // strict idle clock must still fire.
+    const taskObj = makeTask(
+      async (_input, config) => {
+        for (let i = 0; i < 10; i += 1) {
+          await sleep(30);
+          config.configurable?.[CONFIG_KEY_SEND]?.([["value", i]]);
+        }
+        return "ok";
+      },
+      {
+        timeout: { idleTimeout: 80, refreshOn: "heartbeat" },
+        name: "strict-idle",
+      }
+    );
+    const { error } = await _runWithRetry(taskObj);
+    expect(isNodeTimeoutError(error)).toBe(true);
+    expect((error as unknown as NodeTimeoutError).kind).toBe("idle");
+  });
+
+  it("aborts the node's signal when the timeout fires (combined with an external signal)", async () => {
+    let sawAbort: boolean | undefined;
+    const taskObj = makeTask(
+      async (_input, config) => {
+        try {
+          await sleep(1000, config.signal);
+        } catch {
+          sawAbort = config.signal?.aborted ?? false;
+          throw new Error("node observed abort");
+        }
+        return "late";
+      },
+      { timeout: 50, name: "abortme" }
+    );
+    const external = new AbortController();
+    const { error } = await _runWithRetry(
+      taskObj,
+      undefined,
+      undefined,
+      external.signal
+    );
+    expect(isNodeTimeoutError(error)).toBe(true);
+    // give the aborted background task a tick to observe the abort
+    await sleep(10);
+    expect(sawAbort).toBe(true);
+  });
+
+  it("drops buffered writes from the timed-out attempt", async () => {
+    const taskObj = makeTask(
+      async (_input, config) => {
+        config.configurable[CONFIG_KEY_SEND]([["value", "stale"]]);
+        await sleep(1000, config.signal);
+        return "late";
+      },
+      { timeout: 50, name: "writer" }
+    );
+    const { error } = await _runWithRetry(taskObj);
+    expect(isNodeTimeoutError(error)).toBe(true);
+    // pre-timeout writes from the failed attempt must not leak
+    expect(taskObj.writes).toEqual([]);
+  });
+
+  it("is retryable under the default retry policy and resets the timer per attempt", async () => {
+    let calls = 0;
+    const taskObj = makeTask(
+      async (_input, config) => {
+        calls += 1;
+        if (calls < 2) {
+          await sleep(1000, config.signal);
+          return "late";
+        }
+        return "ok";
+      },
+      {
+        timeout: 50,
+        name: "flaky",
+        // default retryOn (no explicit retryOn) must treat NodeTimeoutError as retryable
+        retryPolicy: { maxAttempts: 3, initialInterval: 1, logWarning: false },
+      }
+    );
+    const { result, error } = await _runWithRetry(taskObj);
+    expect(error).toBeUndefined();
+    expect(result).toBe("ok");
+    expect(calls).toBe(2);
+  });
+});
+
+const TimeoutState = Annotation.Root({
+  x: Annotation<number>,
+});
+
+describe("addNode timeout (end-to-end)", () => {
+  it("raises NodeTimeoutError when a node exceeds its run timeout", async () => {
+    const graph = new StateGraph(TimeoutState)
+      .addNode(
+        "slow",
+        async (state, runtime: Runtime) => {
+          await sleep(1000, runtime.signal);
+          return { x: state.x + 1 };
+        },
+        { timeout: 50 }
+      )
+      .addEdge(START, "slow")
+      .addEdge("slow", END)
+      .compile();
+
+    let caught: unknown;
+    try {
+      await graph.invoke({ x: 1 });
+    } catch (e) {
+      caught = e;
+    }
+    expect(isNodeTimeoutError(caught)).toBe(true);
+    expect((caught as NodeTimeoutError).node).toBe("slow");
+  });
+
+  it("composes with a retry policy: retries then succeeds", async () => {
+    const attempts: number[] = [];
+    const graph = new StateGraph(TimeoutState)
+      .addNode(
+        "flaky",
+        async (state, runtime: Runtime) => {
+          attempts.push(attempts.length);
+          if (attempts.length < 2) {
+            await sleep(1000, runtime.signal);
+          }
+          return { x: state.x + 1 };
+        },
+        {
+          timeout: 80,
+          retryPolicy: {
+            maxAttempts: 3,
+            initialInterval: 1,
+            logWarning: false,
+          },
+        }
+      )
+      .addEdge(START, "flaky")
+      .addEdge("flaky", END)
+      .compile();
+
+    const result = await graph.invoke({ x: 0 });
+    expect(result).toEqual({ x: 1 });
+    expect(attempts.length).toBe(2);
+  });
+});
+
+describe("Send timeout (end-to-end)", () => {
+  it("overrides the target node's timeout for a specific pushed task", async () => {
+    const graph = new StateGraph(TimeoutState)
+      .addNode(
+        "slow",
+        async (state, runtime: Runtime) => {
+          await sleep(1000, runtime.signal);
+          return { x: state.x + 1 };
+        },
+        // generous node-level idle timeout
+        { timeout: { idleTimeout: 5000 } }
+      )
+      .addConditionalEdges(
+        START,
+        (state) => [new Send("slow", state, { idleTimeout: 50 })],
+        ["slow"]
+      )
+      .addEdge("slow", END)
+      .compile();
+
+    let caught: unknown;
+    try {
+      await graph.invoke({ x: 1 });
+    } catch (e) {
+      caught = e;
+    }
+    expect(isNodeTimeoutError(caught)).toBe(true);
+    expect((caught as NodeTimeoutError).node).toBe("slow");
+    expect((caught as NodeTimeoutError).kind).toBe("idle");
+    expect((caught as NodeTimeoutError).idleTimeout).toBe(50);
+  });
+});
+
+describe("functional API timeout", () => {
+  it("task() enforces a per-attempt timeout", async () => {
+    const slowTask = task(
+      { name: "slow_task", timeout: 50 },
+      async (x: number) => {
+        await sleep(1000);
+        return x + 1;
+      }
+    );
+    const workflow = entrypoint("wf_task", async (x: number) => {
+      return await slowTask(x);
+    });
+
+    let caught: unknown;
+    try {
+      await workflow.invoke(1);
+    } catch (e) {
+      caught = e;
+    }
+    expect(isNodeTimeoutError(caught)).toBe(true);
+  });
+
+  it("entrypoint() enforces a per-attempt timeout", async () => {
+    const slowWorkflow = entrypoint(
+      { name: "wf_slow", timeout: 50 },
+      async (x: number, config: any) => {
+        await sleep(1000, config.signal);
+        return x;
+      }
+    );
+
+    let caught: unknown;
+    try {
+      await slowWorkflow.invoke(1);
+    } catch (e) {
+      caught = e;
+    }
+    expect(isNodeTimeoutError(caught)).toBe(true);
+  });
+
+  it("lets a child task scheduled before the timeout run to completion", async () => {
+    let childRan = false;
+    const child = task("child", async (value: number) => {
+      childRan = true;
+      return value + 1;
+    });
+
+    const parent = entrypoint(
+      { name: "parent", timeout: 60 },
+      async (value: number, config: any) => {
+        // schedule the child before we time out
+        const childPromise = child(value);
+        await sleep(1000, config.signal);
+        return childPromise;
+      }
+    );
+
+    let caught: unknown;
+    try {
+      await parent.invoke(1);
+    } catch (e) {
+      caught = e;
+    }
+    expect(isNodeTimeoutError(caught)).toBe(true);
+    // the already-scheduled child task still completes
+    expect(childRan).toBe(true);
+  });
+});

--- a/libs/langgraph-core/src/tests/timeout.test.ts
+++ b/libs/langgraph-core/src/tests/timeout.test.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { it, expect, describe, beforeAll } from "vitest";
 import { type PendingWrite } from "@langchain/langgraph-checkpoint";
-import { Annotation, StateGraph } from "../graph/index.js";
+import { z } from "zod";
+import { StateGraph } from "../graph/index.js";
+import { StateSchema } from "../state/schema.js";
 import { START, END, Send, CONFIG_KEY_SEND } from "../constants.js";
 import { NodeTimeoutError, isNodeTimeoutError } from "../errors.js";
 import { entrypoint, task } from "../func/index.js";
@@ -236,6 +238,40 @@ describe("_runWithRetry timeout enforcement", () => {
     expect(sawAbort).toBe(true);
   });
 
+  it("does not surface an unhandled rejection when the abandoned attempt rejects after timeout", async () => {
+    const unhandledRejections: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+    let postTimeoutRejection = false;
+    try {
+      const taskObj = makeTask(
+        async (_input, config) => {
+          try {
+            await sleep(1000, config.signal);
+          } catch {
+            // Timeout already fired; the invoke promise still rejects here.
+            postTimeoutRejection = true;
+            await sleep(0);
+            throw new Error("post-timeout rejection");
+          }
+          return "late";
+        },
+        { timeout: 50, name: "late-reject" }
+      );
+      const { error } = await _runWithRetry(taskObj);
+      expect(isNodeTimeoutError(error)).toBe(true);
+      expect((error as NodeTimeoutError).node).toBe("late-reject");
+      // Let the abandoned background invoke settle (reject).
+      await sleep(50);
+      expect(postTimeoutRejection).toBe(true);
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+
   it("drops buffered writes from the timed-out attempt", async () => {
     const taskObj = makeTask(
       async (_input, config) => {
@@ -276,8 +312,8 @@ describe("_runWithRetry timeout enforcement", () => {
   });
 });
 
-const TimeoutState = Annotation.Root({
-  x: Annotation<number>,
+const TimeoutState = new StateSchema({
+  x: z.number(),
 });
 
 describe("addNode timeout (end-to-end)", () => {
@@ -350,7 +386,7 @@ describe("Send timeout (end-to-end)", () => {
       )
       .addConditionalEdges(
         START,
-        (state) => [new Send("slow", state, { idleTimeout: 50 })],
+        (state) => [new Send("slow", state, { timeout: { idleTimeout: 50 } })],
         ["slow"]
       )
       .addEdge("slow", END)

--- a/libs/langgraph-core/src/tests/timeout.test.ts
+++ b/libs/langgraph-core/src/tests/timeout.test.ts
@@ -16,7 +16,7 @@ import {
   type TimeoutPolicy,
 } from "../pregel/utils/index.js";
 import type { Runtime } from "../web.js";
-import { initializeAsyncLocalStorageSingleton } from "../setup/async_local_storage.js";
+import { initializeAsyncLocalStorageSingleton } from "../node.js";
 
 beforeAll(() => {
   initializeAsyncLocalStorageSingleton();

--- a/libs/langgraph-core/src/tests/timeout.test.ts
+++ b/libs/langgraph-core/src/tests/timeout.test.ts
@@ -22,6 +22,13 @@ beforeAll(() => {
   initializeAsyncLocalStorageSingleton();
 });
 
+/** Block the event loop synchronously for ~`ms` (simulates a CPU-bound node). */
+function busyWait(ms: number): void {
+  const end = Date.now() + ms;
+  // eslint-disable-next-line no-empty
+  while (Date.now() < end) {}
+}
+
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
     const t = setTimeout(resolve, ms);
@@ -285,6 +292,53 @@ describe("_runWithRetry timeout enforcement", () => {
     expect(isNodeTimeoutError(error)).toBe(true);
     // pre-timeout writes from the failed attempt must not leak
     expect(taskObj.writes).toEqual([]);
+  });
+
+  it("enforces the run timeout for a synchronous CPU-bound node that blocks the event loop", async () => {
+    // The node never yields to the event loop, so the watchdog timer (a
+    // macrotask) cannot fire while it runs. The post-race wall-clock check must
+    // still report a run timeout.
+    const taskObj = makeTask(
+      () => {
+        busyWait(150);
+        return "done";
+      },
+      { timeout: 50, name: "cpu-bound" }
+    );
+    const { result, error } = await _runWithRetry(taskObj);
+    expect(result).toBeUndefined();
+    expect(isNodeTimeoutError(error)).toBe(true);
+    const timeoutErr = error as unknown as NodeTimeoutError;
+    expect(timeoutErr.kind).toBe("run");
+    expect(timeoutErr.node).toBe("cpu-bound");
+    expect(timeoutErr.runTimeout).toBe(50);
+  });
+
+  it("discards writes from a synchronous node that blew its run budget", async () => {
+    const taskObj = makeTask(
+      (_input, config) => {
+        config.configurable[CONFIG_KEY_SEND]([["value", "stale"]]);
+        busyWait(150);
+        return "done";
+      },
+      { timeout: 50, name: "cpu-writer" }
+    );
+    const { error } = await _runWithRetry(taskObj);
+    expect(isNodeTimeoutError(error)).toBe(true);
+    expect(taskObj.writes).toEqual([]);
+  });
+
+  it("does not falsely time out a fast synchronous node", async () => {
+    const taskObj = makeTask(
+      () => {
+        busyWait(10);
+        return "done";
+      },
+      { timeout: 200, name: "cpu-fast" }
+    );
+    const { result, error } = await _runWithRetry(taskObj);
+    expect(error).toBeUndefined();
+    expect(result).toBe("done");
   });
 
   it("is retryable under the default retry policy and resets the timer per attempt", async () => {

--- a/libs/langgraph-core/src/web.ts
+++ b/libs/langgraph-core/src/web.ts
@@ -114,6 +114,7 @@ export {
 } from "./pregel/utils/index.js";
 export {
   Send,
+  type SendOptions,
   Command,
   CommandInstance,
   type CommandParams,

--- a/libs/langgraph-core/src/web.ts
+++ b/libs/langgraph-core/src/web.ts
@@ -107,7 +107,11 @@ export {
 export type { EphemeralValue } from "./channels/ephemeral_value.js";
 export { UntrackedValueChannel } from "./channels/untracked_value.js";
 export { type AnnotationRoot } from "./graph/index.js";
-export { type RetryPolicy, type CachePolicy } from "./pregel/utils/index.js";
+export {
+  type RetryPolicy,
+  type CachePolicy,
+  type TimeoutPolicy,
+} from "./pregel/utils/index.js";
 export {
   Send,
   Command,


### PR DESCRIPTION
A `timeout` option is now supported on `StateGraph.addNode`, the functional API (`task`/`entrypoint`), and the `Send` constructor. Pass a number of milliseconds for a hard wall-clock cap, or a `TimeoutPolicy` for finer control:

```ts
import { TimeoutPolicy } from "@langchain/langgraph";

// hard wall-clock cap on each attempt
builder.addNode("agent", agentFn, { timeout: 60_000 });

// full control
builder.addNode("agent", agentFn, {
  timeout: {
    runTimeout: 60_000, // hard wall-clock cap, never refreshed
    idleTimeout: 10_000, // cap on time without observable progress
    refreshOn: "auto", // "auto" | "heartbeat"
  },
});

// per-task override
new Send("agent", state, { idleTimeout: 5_000 });
```

When a timeout fires, a `NodeTimeoutError` (carrying `node`, `kind` (`"run"`/`"idle"`), `timeout`, `elapsed`, `runTimeout`, `idleTimeout`) is raised, the attempt's buffered writes are dropped, and the node's `AbortSignal` is aborted. `idleTimeout` is refreshed by observable progress (writes, custom stream-writer calls, child-task scheduling, callback events) or an explicit `runtime.heartbeat()` call. The timer resets per retry attempt, and `NodeTimeoutError` is retryable under the default retry policy.

Ports langchain-ai/langgraph `#7599`, `#7646`, and `#7659`.