### PR TITLE
feat(langgraph): add node-level error handlers

### DIFF
--- a/.changeset/node-level-error-handlers.md
+++ b/.changeset/node-level-error-handlers.md
@@ -7,8 +7,9 @@ feat(langgraph): add node-level error handlers
 `StateGraph.addNode(name, fn, { errorHandler })` now accepts a first-class
 node-level error handler. The handler runs ONLY after the failing node's
 `retryPolicy` is exhausted, so retry and handling stay decoupled. It receives a
-typed `NodeError { node, error }`, can return a state update, and can route to a
-recovery branch via `new Command({ goto })` (saga / compensation flows).
+typed `NodeError { node, error }` and the typed node input state, can return a
+state update, and can route to a recovery branch via `new Command({ goto })`
+(saga / compensation flows).
 
 Failure provenance is checkpointed (via a reserved `ERROR_SOURCE_NODE` write) so
 handlers observe the same context after a checkpoint resume. Uncaught node

--- a/.changeset/node-level-error-handlers.md
+++ b/.changeset/node-level-error-handlers.md
@@ -1,0 +1,18 @@
+---
+"@langchain/langgraph": minor
+---
+
+feat(langgraph): add node-level error handlers
+
+`StateGraph.addNode(name, fn, { errorHandler })` now accepts a first-class
+node-level error handler. The handler runs ONLY after the failing node's
+`retryPolicy` is exhausted, so retry and handling stay decoupled. It receives a
+typed `NodeError { node, error }`, can return a state update, and can route to a
+recovery branch via `new Command({ goto })` (saga / compensation flows).
+
+Failure provenance is checkpointed (via a reserved `ERROR_SOURCE_NODE` write) so
+handlers observe the same context after a checkpoint resume. Uncaught node
+errors without a handler still abort the run as before, and `GraphBubbleUp`
+errors (such as `interrupt()`) are never swallowed by a handler.
+
+Ports the Python feature from langchain-ai/langgraph#7233.

--- a/.changeset/node-level-error-handlers.md
+++ b/.changeset/node-level-error-handlers.md
@@ -16,4 +16,11 @@ handlers observe the same context after a checkpoint resume. Uncaught node
 errors without a handler still abort the run as before, and `GraphBubbleUp`
 errors (such as `interrupt()`) are never swallowed by a handler.
 
+`StateGraph.setNodeDefaults({ errorHandler })` now also accepts a graph-wide
+default handler. It is materialized at `compile()` as a single shared handler
+and invoked for every regular node that does not set its own `errorHandler`. A
+per-node handler always takes precedence, the default never catches a failure
+raised by an error-handler node itself (handler failures fail the run), and the
+default is not inherited by subgraphs.
+
 Ports the Python feature from langchain-ai/langgraph#7233.

--- a/libs/langgraph-core/src/constants.ts
+++ b/libs/langgraph-core/src/constants.ts
@@ -11,6 +11,13 @@ export const END = "__end__";
 export const INPUT = "__input__";
 export const COPY = "__copy__";
 export const ERROR = "__error__";
+/**
+ * Special reserved write key recording the name of the node whose execution
+ * failed, so node-level error handlers see the same failure provenance after a
+ * checkpoint resume. Value format in pending writes:
+ * `[taskId, ERROR_SOURCE_NODE, nodeName: string]`.
+ */
+export const ERROR_SOURCE_NODE = "__error_source_node__";
 
 /** Special reserved cache namespaces */
 export const CACHE_NS_WRITES = "__pregel_ns_writes";
@@ -33,6 +40,13 @@ export const CONFIG_KEY_CHECKPOINT_ID = "checkpoint_id";
 export const CONFIG_KEY_CHECKPOINT_NS = "checkpoint_ns";
 
 export const CONFIG_KEY_NODE_FINISHED = "__pregel_node_finished";
+
+/**
+ * Config key holding a {@link NodeError} (failed source node + error) for the
+ * current node-level error handler invocation. Injected when an error handler
+ * task is prepared after the failing node's retry policy is exhausted.
+ */
+export const CONFIG_KEY_NODE_ERROR = "__pregel_node_error";
 
 // this one is part of public API
 export const CONFIG_KEY_CHECKPOINT_MAP = "checkpoint_map";
@@ -69,6 +83,7 @@ export const RESERVED = [
   INTERRUPT,
   RESUME,
   ERROR,
+  ERROR_SOURCE_NODE,
   NO_WRITES,
 
   // reserved config.configurable keys

--- a/libs/langgraph-core/src/errors.ts
+++ b/libs/langgraph-core/src/errors.ts
@@ -82,6 +82,58 @@ export class NodeInterrupt extends GraphInterrupt {
   }
 }
 
+/**
+ * Failure context passed to a node-level error handler.
+ *
+ * A node-level error handler is registered via
+ * `StateGraph.addNode(name, fn, { errorHandler })`. The handler runs ONLY after
+ * the failing node's {@link RetryPolicy} is exhausted, so retry and handling
+ * stay decoupled. The handler receives the failed node's name and the thrown
+ * error via a `NodeError` instance, can return a state update, and can route to
+ * a recovery branch via `new Command({ goto })` (saga / compensation flows).
+ *
+ * @example
+ * ```ts
+ * import { NodeError } from "@langchain/langgraph";
+ *
+ * function handler(state: State, error: NodeError) {
+ *   return new Command({
+ *     update: { status: `recovered from ${error.node}: ${error.error.message}` },
+ *     goto: "finalize",
+ *   });
+ * }
+ * ```
+ */
+export class NodeError {
+  /** Name of the node whose execution failed. */
+  node: string;
+
+  /** Error thrown by the failed node. */
+  error: Error;
+
+  constructor(node: string, error: Error) {
+    this.node = node;
+    this.error = error;
+  }
+
+  static get unminifiable_name() {
+    return "NodeError";
+  }
+}
+
+/**
+ * Type guard that checks whether a value is a {@link NodeError}.
+ */
+export function isNodeError(e?: unknown): e is NodeError {
+  return (
+    e != null &&
+    typeof e === "object" &&
+    e.constructor != null &&
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (e.constructor as any).unminifiable_name === NodeError.unminifiable_name
+  );
+}
+
 export class ParentCommand extends GraphBubbleUp {
   command: Command;
 

--- a/libs/langgraph-core/src/graph/graph.ts
+++ b/libs/langgraph-core/src/graph/graph.ts
@@ -40,6 +40,7 @@ import {
 } from "../utils.js";
 import {
   InvalidUpdateError,
+  NodeError,
   NodeInterrupt,
   UnreachableNodeError,
 } from "../errors.js";
@@ -223,7 +224,27 @@ export type NodeSpec<RunInput, RunOutput> = {
   subgraphs?: Pregel<any, any>[];
   ends?: string[];
   defer?: boolean;
+  /** Whether this node is an auto-generated node-level error handler. */
+  isErrorHandler?: boolean;
+  /** Name of the auto-generated error handler node to run on failure. */
+  errorHandlerNode?: string;
 };
+
+/**
+ * A node-level error handler callable.
+ *
+ * Invoked with the node input state, a {@link NodeError} describing the failed
+ * node and thrown error, and the runnable config. The handler runs ONLY after
+ * the failing node's {@link RetryPolicy} is exhausted. It may return a state
+ * update or a `Command` (to route via `goto`).
+ */
+export type NodeErrorHandler = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  state: any,
+  error: NodeError,
+  config?: LangGraphRunnableConfig
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+) => any;
 
 export type AddNodeOptions<Nodes extends string = string> = {
   metadata?: Record<string, unknown>;
@@ -231,6 +252,12 @@ export type AddNodeOptions<Nodes extends string = string> = {
   subgraphs?: Pregel<any, any>[];
   ends?: Nodes[];
   defer?: boolean;
+  /**
+   * Optional node-level error handler. Runs only after this node's
+   * {@link RetryPolicy} is exhausted. Receives a {@link NodeError} with the
+   * failed node name and error, and may return a state update or `Command`.
+   */
+  errorHandler?: NodeErrorHandler;
 };
 
 export class Graph<
@@ -596,8 +623,26 @@ export class Graph<
         allTargets.add(target);
       }
     }
+    // Node-level error handlers can route to any node via `Command({ goto })`
+    // (saga / compensation flows), so treat them like an open-ended branch:
+    // any node may be a recovery target reachable from a handler.
+    const hasErrorHandler = Object.values<NodeSpecType>(this.nodes).some(
+      (node) => (node as NodeSpec<unknown, unknown>).isErrorHandler
+    );
+    if (hasErrorHandler) {
+      for (const node of Object.keys(this.nodes)) {
+        allTargets.add(node);
+      }
+    }
     // validate targets
     for (const node of Object.keys(this.nodes)) {
+      // auto-generated error handler nodes are reachable only on failure of
+      // their source node, so they are exempt from the reachability check.
+      if (
+        (this.nodes[node as N] as NodeSpec<unknown, unknown>).isErrorHandler
+      ) {
+        continue;
+      }
       if (!allTargets.has(node)) {
         throw new UnreachableNodeError(
           [

--- a/libs/langgraph-core/src/graph/graph.ts
+++ b/libs/langgraph-core/src/graph/graph.ts
@@ -47,6 +47,7 @@ import {
 import { StateDefinition, StateType } from "./annotation.js";
 import { isPregelLike } from "../pregel/utils/subgraph.js";
 import type { StreamTransformer } from "../stream/types.js";
+import type { GraphNodeReturnValue } from "./types.js";
 
 export interface BranchOptions<
   IO,
@@ -231,6 +232,19 @@ export type NodeSpec<RunInput, RunOutput> = {
 };
 
 /**
+ * Return value type for node-level error handlers.
+ *
+ * Handlers may return a partial state update, a `Command`, or a Promise of either.
+ *
+ * @template Update - The update type (what fields can be returned)
+ * @template Nodes - Union of valid node names for Command.goto
+ */
+export type NodeErrorHandlerReturnValue<
+  Update,
+  Nodes extends string = string,
+> = GraphNodeReturnValue<Update, Nodes>;
+
+/**
  * A node-level error handler callable.
  *
  * Invoked with the node input state, a {@link NodeError} describing the failed
@@ -238,11 +252,15 @@ export type NodeSpec<RunInput, RunOutput> = {
  * the failing node's {@link RetryPolicy} is exhausted. It may return a state
  * update or a `Command` (to route via `goto`).
  */
-export type NodeErrorHandler<TState = unknown> = (
+export type NodeErrorHandler<
+  TState = unknown,
+  TUpdate = Partial<TState>,
+  Nodes extends string = string,
+> = (
   state: TState,
   error: NodeError,
   config?: LangGraphRunnableConfig
-) => unknown;
+) => NodeErrorHandlerReturnValue<TUpdate, Nodes>;
 
 export type AddNodeOptions<Nodes extends string = string> = {
   metadata?: Record<string, unknown>;

--- a/libs/langgraph-core/src/graph/graph.ts
+++ b/libs/langgraph-core/src/graph/graph.ts
@@ -238,13 +238,11 @@ export type NodeSpec<RunInput, RunOutput> = {
  * the failing node's {@link RetryPolicy} is exhausted. It may return a state
  * update or a `Command` (to route via `goto`).
  */
-export type NodeErrorHandler = (
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  state: any,
+export type NodeErrorHandler<TState = unknown> = (
+  state: TState,
   error: NodeError,
   config?: LangGraphRunnableConfig
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-) => any;
+) => unknown;
 
 export type AddNodeOptions<Nodes extends string = string> = {
   metadata?: Record<string, unknown>;
@@ -252,12 +250,6 @@ export type AddNodeOptions<Nodes extends string = string> = {
   subgraphs?: Pregel<any, any>[];
   ends?: Nodes[];
   defer?: boolean;
-  /**
-   * Optional node-level error handler. Runs only after this node's
-   * {@link RetryPolicy} is exhausted. Receives a {@link NodeError} with the
-   * failed node name and error, and may return a state update or `Command`.
-   */
-  errorHandler?: NodeErrorHandler;
 };
 
 export class Graph<

--- a/libs/langgraph-core/src/graph/graph.ts
+++ b/libs/langgraph-core/src/graph/graph.ts
@@ -79,16 +79,16 @@ type CompiledGraphTypeStreamTransformers<Spec> = Spec extends {
   streamTransformers: infer Transformers;
 }
   ? Transformers extends ReadonlyArray<
-      () => StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
-    >
-    ? Transformers
-    : Transformers extends ReadonlyArray<
-          StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
-        >
-      ? { readonly [K in keyof Transformers]: () => Transformers[K] }
-      : Transformers extends StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
-        ? readonly [() => Transformers]
-        : []
+    () => StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
+  >
+  ? Transformers
+  : Transformers extends ReadonlyArray<
+    StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
+  >
+  ? { readonly [K in keyof Transformers]: () => Transformers[K] }
+  : Transformers extends StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
+  ? readonly [() => Transformers]
+  : []
   : [];
 
 /**
@@ -144,12 +144,12 @@ export class Branch<
     }
     this.ends = Array.isArray(options.pathMap)
       ? options.pathMap.reduce(
-          (acc, n) => {
-            acc[n] = n;
-            return acc;
-          },
-          {} as Record<string, N | typeof END>
-        )
+        (acc, n) => {
+          acc[n] = n;
+          return acc;
+        },
+        {} as Record<string, N | typeof END>
+      )
       : options.pathMap;
   }
 
@@ -173,7 +173,7 @@ export class Branch<
             if (e.name === NodeInterrupt.unminifiable_name) {
               console.warn(
                 "[WARN]: 'NodeInterrupt' thrown in conditional edge. This is likely a bug in your graph implementation.\n" +
-                  "NodeInterrupt should only be thrown inside a node, not in edge conditions."
+                "NodeInterrupt should only be thrown inside a node, not in edge conditions."
               );
             }
             throw e;
@@ -313,10 +313,10 @@ export class Graph<
     nodes:
       | Record<K, NodeAction<NodeInput, NodeOutput, C>>
       | [
-          key: K,
-          action: NodeAction<NodeInput, NodeOutput, C>,
-          options?: AddNodeOptions,
-        ][]
+        key: K,
+        action: NodeAction<NodeInput, NodeOutput, C>,
+        options?: AddNodeOptions,
+      ][]
   ): Graph<N | K, RunInput, RunOutput>;
 
   addNode<K extends string, NodeInput = RunInput, NodeOutput = RunOutput>(
@@ -328,30 +328,30 @@ export class Graph<
   addNode<K extends string, NodeInput = RunInput, NodeOutput = RunOutput>(
     ...args:
       | [
+        key: K,
+        action: NodeAction<NodeInput, NodeOutput, C>,
+        options?: AddNodeOptions,
+      ]
+      | [
+        nodes:
+        | Record<K, NodeAction<NodeInput, NodeOutput, C>>
+        | [
           key: K,
           action: NodeAction<NodeInput, NodeOutput, C>,
           options?: AddNodeOptions,
-        ]
-      | [
-          nodes:
-            | Record<K, NodeAction<NodeInput, NodeOutput, C>>
-            | [
-                key: K,
-                action: NodeAction<NodeInput, NodeOutput, C>,
-                options?: AddNodeOptions,
-              ][],
-        ]
+        ][],
+      ]
   ): Graph<N | K, RunInput, RunOutput> {
     function isMutlipleNodes(
       args: unknown[]
     ): args is [
       nodes:
-        | Record<K, NodeAction<NodeInput, RunOutput, C>>
-        | [
-            key: K,
-            action: NodeAction<NodeInput, RunOutput, C>,
-            options?: AddNodeOptions,
-          ][],
+      | Record<K, NodeAction<NodeInput, RunOutput, C>>
+      | [
+        key: K,
+        action: NodeAction<NodeInput, RunOutput, C>,
+        options?: AddNodeOptions,
+      ][],
       options?: AddNodeOptions,
     ] {
       return args.length >= 1 && typeof args[0] !== "string";
@@ -521,7 +521,7 @@ export class Graph<
   compile<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const TTransformers extends ReadonlyArray<() => StreamTransformer<any>> =
-      [],
+    [],
   >({
     checkpointer,
     interruptBefore,
@@ -733,7 +733,7 @@ export class CompiledGraph<
 
   override withConfig<
     const TTransformers extends ReadonlyArray<() => StreamTransformer<any>> =
-      [],
+    [],
   >(
     config: Omit<LangGraphRunnableConfig, "store" | "writer" | "interrupt"> & {
       streamTransformers: TTransformers;
@@ -873,6 +873,8 @@ export class CompiledGraph<
       );
     }
 
+    const discoveredEdges: DiscoveredGraphEdge[] = [];
+
     function addEdge(
       start: string,
       end: string,
@@ -888,6 +890,7 @@ export class CompiledGraph<
       if (endNodes[end] === undefined) {
         throw new Error(`End node ${end} not found!`);
       }
+      discoveredEdges.push({ src: start, dest: end, conditional });
       return graph.addEdge(
         startNodes[start],
         endNodes[end],
@@ -918,9 +921,9 @@ export class CompiledGraph<
         const drawableSubgraph =
           subgraphs[key] !== undefined
             ? await subgraphs[key].getGraphAsync({
-                ...config,
-                xray: newXrayValue,
-              })
+              ...config,
+              xray: newXrayValue,
+            })
             : node.getGraph(config);
 
         drawableSubgraph.trimFirstNode();
@@ -1044,6 +1047,11 @@ export class CompiledGraph<
         }
       }
     }
+    addImplicitTerminalEndEdges(
+      this.builder.nodes,
+      discoveredEdges,
+      addEdge
+    );
     return graph;
   }
 
@@ -1077,6 +1085,8 @@ export class CompiledGraph<
       );
     }
 
+    const discoveredEdges: DiscoveredGraphEdge[] = [];
+
     function addEdge(
       start: string,
       end: string,
@@ -1086,6 +1096,13 @@ export class CompiledGraph<
       if (end === END && endNodes[END] === undefined) {
         endNodes[END] = graph.addNode({ schema: z.any() }, END);
       }
+      if (startNodes[start] === undefined) {
+        return;
+      }
+      if (endNodes[end] === undefined) {
+        throw new Error(`End node ${end} not found!`);
+      }
+      discoveredEdges.push({ src: start, dest: end, conditional });
       return graph.addEdge(
         startNodes[start],
         endNodes[end],
@@ -1116,9 +1133,9 @@ export class CompiledGraph<
         const drawableSubgraph =
           subgraphs[key] !== undefined
             ? subgraphs[key].getGraph({
-                ...config,
-                xray: newXrayValue,
-              })
+              ...config,
+              xray: newXrayValue,
+            })
             : node.getGraph(config);
         drawableSubgraph.trimFirstNode();
         drawableSubgraph.trimLastNode();
@@ -1225,6 +1242,26 @@ export class CompiledGraph<
         }
       }
     }
+    for (const [key, node] of Object.entries(this.builder.nodes) as [
+      N,
+      NodeSpec<State, Update>,
+    ][]) {
+      if (node.ends !== undefined) {
+        for (const end of node.ends) {
+          addEdge(
+            _escapeMermaidKeywords(key),
+            _escapeMermaidKeywords(end),
+            undefined,
+            true
+          );
+        }
+      }
+    }
+    addImplicitTerminalEndEdges(
+      this.builder.nodes,
+      discoveredEdges,
+      addEdge
+    );
     return graph;
   }
 }
@@ -1244,4 +1281,61 @@ function _escapeMermaidKeywords(key: string) {
     return `"${key}"`;
   }
   return key;
+}
+
+/**
+ * An edge collected while building a {@link DrawableGraph} from a compiled
+ * {@link StateGraph}.
+ *
+ * Used by {@link addImplicitTerminalEndEdges} to detect nodes that should
+ * receive an implicit edge to {@link END} (terminal nodes with no outgoing
+ * edges in the drawable view).
+ *
+ * @internal
+ */
+type DiscoveredGraphEdge = {
+  /** Display name of the source node (Mermaid-escaped). */
+  src: string;
+  /** Display name of the target node (Mermaid-escaped), or {@link END}. */
+  dest: string;
+  /**
+   * Whether the edge comes from a conditional branch or `node.ends` declaration.
+   * Non-conditional edges alone determine implicit terminal `→ END` links.
+   */
+  conditional: boolean;
+};
+
+/**
+ * Add implicit edges to END for terminal nodes (targets with no outgoing edges).
+ *
+ * Only nodes reached by a non-conditional edge are considered, so
+ * conditional-branch targets are not treated as implicit sinks.
+ */
+function addImplicitTerminalEndEdges<N extends string>(
+  nodes: Record<N, NodeSpec<unknown, unknown>>,
+  discovered: DiscoveredGraphEdge[],
+  addEdge: (
+    start: string,
+    end: string,
+    label?: string,
+    conditional?: boolean
+  ) => void
+): void {
+  const sources = new Set(discovered.map((e) => e.src));
+  const nonConditionalDestinations = [
+    ...new Set(
+      discovered
+        .filter((e) => !e.conditional && e.dest !== END)
+        .map((e) => e.dest)
+    ),
+  ].sort();
+
+  for (const displayDest of nonConditionalDestinations) {
+    if (sources.has(displayDest)) continue;
+    const rawKey = (Object.keys(nodes) as N[]).find(
+      (k) => _escapeMermaidKeywords(k) === displayDest
+    );
+    if (rawKey !== undefined && nodes[rawKey]?.isErrorHandler) continue;
+    addEdge(displayDest, END);
+  }
 }

--- a/libs/langgraph-core/src/graph/graph.ts
+++ b/libs/langgraph-core/src/graph/graph.ts
@@ -619,7 +619,7 @@ export class Graph<
     // (saga / compensation flows), so treat them like an open-ended branch:
     // any node may be a recovery target reachable from a handler.
     const hasErrorHandler = Object.values<NodeSpecType>(this.nodes).some(
-      (node) => (node as NodeSpec<unknown, unknown>).isErrorHandler
+      (node) => node.isErrorHandler
     );
     if (hasErrorHandler) {
       for (const node of Object.keys(this.nodes)) {
@@ -630,9 +630,7 @@ export class Graph<
     for (const node of Object.keys(this.nodes)) {
       // auto-generated error handler nodes are reachable only on failure of
       // their source node, so they are exempt from the reachability check.
-      if (
-        (this.nodes[node as N] as NodeSpec<unknown, unknown>).isErrorHandler
-      ) {
+      if (this.nodes[node as N].isErrorHandler) {
         continue;
       }
       if (!allTargets.has(node)) {

--- a/libs/langgraph-core/src/graph/graph.ts
+++ b/libs/langgraph-core/src/graph/graph.ts
@@ -79,16 +79,16 @@ type CompiledGraphTypeStreamTransformers<Spec> = Spec extends {
   streamTransformers: infer Transformers;
 }
   ? Transformers extends ReadonlyArray<
-    () => StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
-  >
-  ? Transformers
-  : Transformers extends ReadonlyArray<
-    StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
-  >
-  ? { readonly [K in keyof Transformers]: () => Transformers[K] }
-  : Transformers extends StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
-  ? readonly [() => Transformers]
-  : []
+      () => StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
+    >
+    ? Transformers
+    : Transformers extends ReadonlyArray<
+          StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        >
+      ? { readonly [K in keyof Transformers]: () => Transformers[K] }
+      : Transformers extends StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        ? readonly [() => Transformers]
+        : []
   : [];
 
 /**
@@ -144,12 +144,12 @@ export class Branch<
     }
     this.ends = Array.isArray(options.pathMap)
       ? options.pathMap.reduce(
-        (acc, n) => {
-          acc[n] = n;
-          return acc;
-        },
-        {} as Record<string, N | typeof END>
-      )
+          (acc, n) => {
+            acc[n] = n;
+            return acc;
+          },
+          {} as Record<string, N | typeof END>
+        )
       : options.pathMap;
   }
 
@@ -173,7 +173,7 @@ export class Branch<
             if (e.name === NodeInterrupt.unminifiable_name) {
               console.warn(
                 "[WARN]: 'NodeInterrupt' thrown in conditional edge. This is likely a bug in your graph implementation.\n" +
-                "NodeInterrupt should only be thrown inside a node, not in edge conditions."
+                  "NodeInterrupt should only be thrown inside a node, not in edge conditions."
               );
             }
             throw e;
@@ -313,10 +313,10 @@ export class Graph<
     nodes:
       | Record<K, NodeAction<NodeInput, NodeOutput, C>>
       | [
-        key: K,
-        action: NodeAction<NodeInput, NodeOutput, C>,
-        options?: AddNodeOptions,
-      ][]
+          key: K,
+          action: NodeAction<NodeInput, NodeOutput, C>,
+          options?: AddNodeOptions,
+        ][]
   ): Graph<N | K, RunInput, RunOutput>;
 
   addNode<K extends string, NodeInput = RunInput, NodeOutput = RunOutput>(
@@ -328,30 +328,30 @@ export class Graph<
   addNode<K extends string, NodeInput = RunInput, NodeOutput = RunOutput>(
     ...args:
       | [
-        key: K,
-        action: NodeAction<NodeInput, NodeOutput, C>,
-        options?: AddNodeOptions,
-      ]
-      | [
-        nodes:
-        | Record<K, NodeAction<NodeInput, NodeOutput, C>>
-        | [
           key: K,
           action: NodeAction<NodeInput, NodeOutput, C>,
           options?: AddNodeOptions,
-        ][],
-      ]
+        ]
+      | [
+          nodes:
+            | Record<K, NodeAction<NodeInput, NodeOutput, C>>
+            | [
+                key: K,
+                action: NodeAction<NodeInput, NodeOutput, C>,
+                options?: AddNodeOptions,
+              ][],
+        ]
   ): Graph<N | K, RunInput, RunOutput> {
     function isMutlipleNodes(
       args: unknown[]
     ): args is [
       nodes:
-      | Record<K, NodeAction<NodeInput, RunOutput, C>>
-      | [
-        key: K,
-        action: NodeAction<NodeInput, RunOutput, C>,
-        options?: AddNodeOptions,
-      ][],
+        | Record<K, NodeAction<NodeInput, RunOutput, C>>
+        | [
+            key: K,
+            action: NodeAction<NodeInput, RunOutput, C>,
+            options?: AddNodeOptions,
+          ][],
       options?: AddNodeOptions,
     ] {
       return args.length >= 1 && typeof args[0] !== "string";
@@ -521,7 +521,7 @@ export class Graph<
   compile<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const TTransformers extends ReadonlyArray<() => StreamTransformer<any>> =
-    [],
+      [],
   >({
     checkpointer,
     interruptBefore,
@@ -733,7 +733,7 @@ export class CompiledGraph<
 
   override withConfig<
     const TTransformers extends ReadonlyArray<() => StreamTransformer<any>> =
-    [],
+      [],
   >(
     config: Omit<LangGraphRunnableConfig, "store" | "writer" | "interrupt"> & {
       streamTransformers: TTransformers;
@@ -921,9 +921,9 @@ export class CompiledGraph<
         const drawableSubgraph =
           subgraphs[key] !== undefined
             ? await subgraphs[key].getGraphAsync({
-              ...config,
-              xray: newXrayValue,
-            })
+                ...config,
+                xray: newXrayValue,
+              })
             : node.getGraph(config);
 
         drawableSubgraph.trimFirstNode();
@@ -1047,11 +1047,7 @@ export class CompiledGraph<
         }
       }
     }
-    addImplicitTerminalEndEdges(
-      this.builder.nodes,
-      discoveredEdges,
-      addEdge
-    );
+    addImplicitTerminalEndEdges(this.builder.nodes, discoveredEdges, addEdge);
     return graph;
   }
 
@@ -1133,9 +1129,9 @@ export class CompiledGraph<
         const drawableSubgraph =
           subgraphs[key] !== undefined
             ? subgraphs[key].getGraph({
-              ...config,
-              xray: newXrayValue,
-            })
+                ...config,
+                xray: newXrayValue,
+              })
             : node.getGraph(config);
         drawableSubgraph.trimFirstNode();
         drawableSubgraph.trimLastNode();
@@ -1257,11 +1253,7 @@ export class CompiledGraph<
         }
       }
     }
-    addImplicitTerminalEndEdges(
-      this.builder.nodes,
-      discoveredEdges,
-      addEdge
-    );
+    addImplicitTerminalEndEdges(this.builder.nodes, discoveredEdges, addEdge);
     return graph;
   }
 }

--- a/libs/langgraph-core/src/graph/index.ts
+++ b/libs/langgraph-core/src/graph/index.ts
@@ -13,6 +13,8 @@ export {
   type CompiledGraphType,
   type NodeSpec,
   type AddNodeOptions,
+  type NodeErrorHandler,
+  type NodeErrorHandlerReturnValue,
 } from "./graph.js";
 export {
   type StateGraphArgs,

--- a/libs/langgraph-core/src/graph/state.ts
+++ b/libs/langgraph-core/src/graph/state.ts
@@ -205,11 +205,7 @@ export type StateGraphAddNodeOptions<
 type StateGraphAddNodeOptionsWithNodeInput<
   Nodes extends string,
   NodeInput,
-> = StateGraphAddNodeOptions<
-  Nodes,
-  StateDefinitionInit | undefined,
-  NodeInput
->;
+> = StateGraphAddNodeOptions<Nodes, StateDefinitionInit | undefined, NodeInput>;
 
 export type StateGraphArgsWithStateSchema<
   SD extends StateDefinition,

--- a/libs/langgraph-core/src/graph/state.ts
+++ b/libs/langgraph-core/src/graph/state.ts
@@ -182,6 +182,7 @@ export type StateGraphNodeSpec<RunInput, RunOutput> = NodeSpec<
  * @template Nodes - Node name constraints
  * @template InputSchema - Per-node input schema type (inferred from options.input)
  * @template HandlerState - State type passed to the node-level error handler
+ * @template Update - The update type the error handler may return
  */
 export type StateGraphAddNodeOptions<
   Nodes extends string = string,
@@ -191,6 +192,7 @@ export type StateGraphAddNodeOptions<
   HandlerState = InputSchema extends StateDefinitionInit
     ? ExtractStateType<InputSchema>
     : unknown,
+  Update = unknown,
 > = {
   input?: InputSchema;
   /**
@@ -198,14 +200,20 @@ export type StateGraphAddNodeOptions<
    * {@link RetryPolicy} is exhausted. Receives a {@link NodeError} with the
    * failed node name and error, and may return a state update or `Command`.
    */
-  errorHandler?: NodeErrorHandler<HandlerState>;
+  errorHandler?: NodeErrorHandler<HandlerState, Update, Nodes>;
 } & NodePolicyOptions &
   AddNodeOptions<Nodes>;
 
 type StateGraphAddNodeOptionsWithNodeInput<
   Nodes extends string,
   NodeInput,
-> = StateGraphAddNodeOptions<Nodes, StateDefinitionInit | undefined, NodeInput>;
+  Update = unknown,
+> = StateGraphAddNodeOptions<
+  Nodes,
+  StateDefinitionInit | undefined,
+  NodeInput,
+  Update
+>;
 
 export type StateGraphArgsWithStateSchema<
   SD extends StateDefinition,
@@ -860,7 +868,7 @@ export class StateGraph<
     nodes: [
       key: K,
       action: NodeAction<NodeInput, NodeOutput, C, InterruptType, WriterType>,
-      options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput>,
+      options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput, U>,
     ][]
   ): StateGraph<
     SD,
@@ -886,7 +894,12 @@ export class StateGraph<
       InterruptType,
       WriterType
     >,
-    options: StateGraphAddNodeOptions<N | K, InputSchema>
+    options: StateGraphAddNodeOptions<
+      N | K,
+      InputSchema,
+      ExtractStateType<InputSchema>,
+      U
+    >
   ): StateGraph<
     SD,
     S,
@@ -911,7 +924,12 @@ export class StateGraph<
       InterruptType,
       WriterType
     >,
-    options: StateGraphAddNodeOptions<N | K, InputSchema>
+    options: StateGraphAddNodeOptions<
+      N | K,
+      InputSchema,
+      ExtractStateType<InputSchema>,
+      U
+    >
   ): StateGraph<
     SD,
     S,
@@ -926,7 +944,7 @@ export class StateGraph<
   override addNode<K extends string, NodeInput = S, NodeOutput extends U = U>(
     key: K,
     action: NodeAction<NodeInput, NodeOutput, C, InterruptType, WriterType>,
-    options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput>
+    options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput, U>
   ): StateGraph<
     SD,
     S,
@@ -941,7 +959,7 @@ export class StateGraph<
   override addNode<K extends string, NodeInput = S>(
     key: K,
     action: NodeAction<NodeInput, U, C, InterruptType, WriterType>,
-    options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput>
+    options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput, U>
   ): StateGraph<SD, S, U, N | K, I, O, C, NodeReturnType>;
 
   override addNode<K extends string, NodeInput = S, NodeOutput extends U = U>(
@@ -955,7 +973,7 @@ export class StateGraph<
             InterruptType,
             WriterType
           >,
-          options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput>,
+          options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput, U>,
         ]
       | [
           nodes:
@@ -965,7 +983,8 @@ export class StateGraph<
                 action: NodeAction<NodeInput, U, C, InterruptType, WriterType>,
                 options?: StateGraphAddNodeOptionsWithNodeInput<
                   N | K,
-                  NodeInput
+                  NodeInput,
+                  U
                 >,
               ][],
         ]
@@ -978,7 +997,11 @@ export class StateGraph<
         | [
             key: K,
             action: NodeAction<NodeInput, U, C, InterruptType, WriterType>,
-            options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput>,
+            options?: StateGraphAddNodeOptionsWithNodeInput<
+              N | K,
+              NodeInput,
+              U
+            >,
           ][],
     ] {
       return args.length >= 1 && typeof args[0] !== "string";
@@ -993,7 +1016,7 @@ export class StateGraph<
     ) as [
       K,
       NodeAction<NodeInput, U, C, InterruptType, WriterType>,
-      StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput> | undefined,
+      StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput, U> | undefined,
     ][];
 
     if (nodes.length === 0) {
@@ -1157,7 +1180,7 @@ export class StateGraph<
     nodes: [
       key: K,
       action: NodeAction<NodeInput, NodeOutput, C, InterruptType, WriterType>,
-      options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput>,
+      options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput, U>,
     ][]
   ): StateGraph<
     SD,
@@ -1210,7 +1233,7 @@ export class StateGraph<
             InterruptType,
             WriterType
           >,
-          options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput>,
+          options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput, U>,
         ][]
       | Record<
           K,

--- a/libs/langgraph-core/src/graph/state.ts
+++ b/libs/langgraph-core/src/graph/state.ts
@@ -101,6 +101,15 @@ import type { Pregel } from "../pregel/index.js";
 
 const ROOT = "__root__";
 
+/**
+ * Reserved node name for the single shared error handler that is materialized
+ * when a graph-wide default error handler is set via
+ * {@link StateGraph.setNodeDefaults}. Every regular node that lacks its own
+ * `errorHandler` routes failures to this node. Mirrors Python's
+ * `__default_error_handler__`.
+ */
+const DEFAULT_ERROR_HANDLER_NODE = "__default_error_handler__";
+
 export type ChannelReducers<Channels extends object> = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [K in keyof Channels]: SingleReducer<Channels[K], any>;
@@ -166,6 +175,21 @@ export type NodePolicies = {
   cachePolicy?: CachePolicy | false;
   /** Resolved timeout policy after the `number` shorthand is normalized. */
   timeout?: TimeoutPolicy;
+};
+
+/**
+ * Graph-wide node defaults captured by {@link StateGraph.setNodeDefaults} and
+ * resolved at {@link StateGraph.compile} time.
+ *
+ * @internal
+ */
+type ResolvedNodeDefaults = NodePolicies & {
+  /**
+   * Default error handler applied to every regular node that does not set its
+   * own via `addNode(..., { errorHandler })`. Never applied to error-handler
+   * nodes themselves — handlers must not catch their own failures.
+   */
+  errorHandler?: NodeErrorHandler;
 };
 
 export type StateGraphNodeSpec<RunInput, RunOutput> = NodeSpec<
@@ -438,7 +462,7 @@ export class StateGraph<
    * Graph-wide default node policies, resolved at `compile()` time.
    * @internal
    */
-  _nodeDefaults: NodePolicies = {};
+  _nodeDefaults: ResolvedNodeDefaults = {};
 
   declare Node: StrictNodeAction<S, U, C, N, InterruptType, WriterType>;
 
@@ -652,6 +676,12 @@ export class StateGraph<
    *
    * Policies set here are **not** inherited by subgraphs.
    *
+   * `retryPolicy` and `timeout` defaults apply to **all** nodes, including
+   * auto-generated error-handler nodes. `cachePolicy` and `errorHandler`
+   * defaults apply to **regular nodes only** — caching an error-handler result
+   * is unsafe, and a handler must never catch its own (or another handler's)
+   * failure.
+   *
    * @param defaults - The default node policies to apply.
    * @returns The builder instance, for chaining.
    *
@@ -662,6 +692,7 @@ export class StateGraph<
    *     retryPolicy: { maxAttempts: 3 },
    *     cachePolicy: { ttl: 60 },
    *     timeout: 60_000,
+   *     errorHandler: (state, { node, error }) => ({ lastError: error.message }),
    *   })
    *   .addNode("a", nodeA)
    *   .addNode("b", nodeB, { retryPolicy: { maxAttempts: 5 } }) // overrides default
@@ -682,7 +713,18 @@ export class StateGraph<
    *   .compile();
    * ```
    */
-  setNodeDefaults(defaults: NodePolicyOptions): this {
+  setNodeDefaults(
+    defaults: NodePolicyOptions & {
+      /**
+       * Default node-level error handler invoked when any **regular** node
+       * raises and does not have its own handler set via
+       * `addNode(..., { errorHandler })`. Runs only after the failing node's
+       * retry policy is exhausted. It is never invoked when an error-handler
+       * node itself raises — handler failures fail the run.
+       */
+      errorHandler?: NodeErrorHandler<S, U, N>;
+    }
+  ): this {
     if (defaults.retryPolicy !== undefined) {
       this._nodeDefaults.retryPolicy = defaults.retryPolicy;
     }
@@ -697,7 +739,48 @@ export class StateGraph<
     if (defaults.timeout !== undefined) {
       this._nodeDefaults.timeout = coerceTimeoutPolicy(defaults.timeout);
     }
+    if (defaults.errorHandler !== undefined) {
+      this._nodeDefaults.errorHandler =
+        defaults.errorHandler as NodeErrorHandler;
+    }
     return this;
+  }
+
+  /**
+   * Build the shared spec for a graph-wide default error handler, or
+   * `undefined` when {@link setNodeDefaults} did not configure one. The spec is
+   * installed under {@link DEFAULT_ERROR_HANDLER_NODE} for the duration of a
+   * single {@link compile} call and routes failures from every regular node
+   * that lacks its own handler.
+   * @internal
+   */
+  protected _createDefaultErrorHandlerSpec():
+    | StateGraphNodeSpec<S, U>
+    | undefined {
+    const userHandler = this._nodeDefaults.errorHandler;
+    if (userHandler === undefined) {
+      return undefined;
+    }
+    const handlerRunnable = new RunnableCallable({
+      func: (state: unknown, config: LangGraphRunnableConfig) => {
+        // Per-task failure context, injected when the handler task is prepared
+        // (see _prepareNodeErrorHandlerTask).
+        const nodeError = config?.configurable?.[CONFIG_KEY_NODE_ERROR] as
+          | NodeError
+          | undefined;
+        return userHandler(state as S, nodeError as NodeError, config);
+      },
+      name: DEFAULT_ERROR_HANDLER_NODE,
+      trace: false,
+    });
+    return {
+      runnable: handlerRunnable as unknown as Runnable<S, U>,
+      metadata: undefined,
+      input: this._schemaDefinition,
+      retryPolicy: undefined,
+      cachePolicy: undefined,
+      isErrorHandler: true,
+    };
   }
 
   /**
@@ -1335,6 +1418,83 @@ export class StateGraph<
     WriterType,
     TTransformers
   > {
+    // Materialize the single shared default error-handler node (when
+    // `setNodeDefaults({ errorHandler })` configured one) BEFORE validation so
+    // reachability and `Command({ goto })` target checks treat it like any
+    // other error-handler node. It is removed in `finally` so the builder stays
+    // immutable across repeated `compile()` calls.
+    const defaultErrorHandlerSpec = this._createDefaultErrorHandlerSpec();
+    if (defaultErrorHandlerSpec !== undefined) {
+      if (DEFAULT_ERROR_HANDLER_NODE in this.nodes) {
+        throw new Error(
+          `Cannot apply a default error handler: the reserved node name ` +
+            `\`${DEFAULT_ERROR_HANDLER_NODE}\` is already in use. ` +
+            `setNodeDefaults({ errorHandler }) registers a node with that name; ` +
+            `rename the conflicting node.`
+        );
+      }
+      this.nodes[DEFAULT_ERROR_HANDLER_NODE as N] = defaultErrorHandlerSpec;
+    }
+
+    try {
+      return this._compileResolved({
+        checkpointer,
+        store,
+        cache,
+        interruptBefore,
+        interruptAfter,
+        name,
+        description,
+        transformers,
+        defaultErrorHandlerNode:
+          defaultErrorHandlerSpec !== undefined
+            ? DEFAULT_ERROR_HANDLER_NODE
+            : undefined,
+      });
+    } finally {
+      if (defaultErrorHandlerSpec !== undefined) {
+        delete this.nodes[DEFAULT_ERROR_HANDLER_NODE as N];
+      }
+    }
+  }
+
+  /** @internal */
+  protected _compileResolved<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const TTransformers extends ReadonlyArray<() => StreamTransformer<any>> =
+      [],
+  >({
+    checkpointer,
+    store,
+    cache,
+    interruptBefore,
+    interruptAfter,
+    name,
+    description,
+    transformers,
+    defaultErrorHandlerNode,
+  }: {
+    checkpointer?: BaseCheckpointSaver | boolean;
+    store?: BaseStore;
+    cache?: BaseCache;
+    interruptBefore?: N[] | All;
+    interruptAfter?: N[] | All;
+    name?: string;
+    description?: string;
+    transformers?: TTransformers;
+    defaultErrorHandlerNode?: string;
+  }): CompiledStateGraph<
+    Prettify<S>,
+    Prettify<U>,
+    N,
+    I,
+    O,
+    C,
+    NodeReturnType,
+    InterruptType,
+    WriterType,
+    TTransformers
+  > {
     // validate the graph
     this.validate([
       ...(Array.isArray(interruptBefore) ? interruptBefore : []),
@@ -1393,23 +1553,39 @@ export class StateGraph<
     // Resolve graph-wide node defaults. Per-node values always win. Defaults
     // are merged into a copy of each spec so repeated `compile()` calls remain
     // stable (the builder's node specs are never mutated).
+    //
+    //  - `retryPolicy` / `timeout` apply to all nodes, including error-handler
+    //    nodes (a stuck or transiently-failing handler is treated like any
+    //    other node).
+    //  - `cachePolicy` and the default `errorHandler` apply to regular nodes
+    //    only — caching a handler result is unsafe, and a handler must never
+    //    catch its own (or another handler's) failure.
     const nodeDefaults = this._nodeDefaults;
     const hasNodeDefaults =
       nodeDefaults.retryPolicy !== undefined ||
       nodeDefaults.cachePolicy !== undefined ||
-      nodeDefaults.timeout !== undefined;
+      nodeDefaults.timeout !== undefined ||
+      defaultErrorHandlerNode !== undefined;
     for (const [key, node] of Object.entries<StateGraphNodeSpec<S, U>>(
       this.nodes
     )) {
+      const isErrorHandlerNode = node.isErrorHandler === true;
       const resolvedNode = hasNodeDefaults
         ? {
             ...node,
             retryPolicy: node.retryPolicy ?? nodeDefaults.retryPolicy,
-            cachePolicy:
-              node.cachePolicy === false
+            cachePolicy: isErrorHandlerNode
+              ? undefined
+              : node.cachePolicy === false
                 ? undefined
                 : (node.cachePolicy ?? nodeDefaults.cachePolicy),
             timeout: node.timeout ?? nodeDefaults.timeout,
+            errorHandlerNode:
+              !isErrorHandlerNode &&
+              defaultErrorHandlerNode !== undefined &&
+              node.errorHandlerNode === undefined
+                ? defaultErrorHandlerNode
+                : node.errorHandlerNode,
           }
         : node;
       compiled.attachNode(key as N, resolvedNode);

--- a/libs/langgraph-core/src/graph/state.ts
+++ b/libs/langgraph-core/src/graph/state.ts
@@ -1088,7 +1088,9 @@ export class StateGraph<
         errorHandlerNode = `__error_handler__${key}`;
         if (errorHandlerNode in this.nodes) {
           throw new Error(
-            `Auto-generated error handler node \`${errorHandlerNode}\` already exists.`
+            `Cannot add error handler to node \`${key}\`: the reserved name \`${errorHandlerNode}\` is already in use. ` +
+              `StateGraph registers \`__error_handler__<nodeName>\` when you pass \`errorHandler\` in addNode options. ` +
+              `Remove or rename the existing node with that name (for example, you may have added it manually).`
           );
         }
         const userHandler = options.errorHandler;

--- a/libs/langgraph-core/src/graph/state.ts
+++ b/libs/langgraph-core/src/graph/state.ts
@@ -721,8 +721,15 @@ export class StateGraph<
        * `addNode(..., { errorHandler })`. Runs only after the failing node's
        * retry policy is exhausted. It is never invoked when an error-handler
        * node itself raises — handler failures fail the run.
+       *
+       * Because a single shared handler serves every node, its `state`
+       * argument is typed as `unknown`: at runtime it receives the **failing
+       * node's input** (see `addNode(..., { input })`), which may be a subset
+       * of the graph state and differs per node. Narrow it yourself before
+       * reading fields. The handler may still return a graph-level update (`U`)
+       * or route via `new Command({ goto })` to any node (`N`).
        */
-      errorHandler?: NodeErrorHandler<S, U, N>;
+      errorHandler?: NodeErrorHandler<unknown, U, N>;
     }
   ): this {
     if (defaults.retryPolicy !== undefined) {
@@ -764,11 +771,13 @@ export class StateGraph<
     const handlerRunnable = new RunnableCallable({
       func: (state: unknown, config: LangGraphRunnableConfig) => {
         // Per-task failure context, injected when the handler task is prepared
-        // (see _prepareNodeErrorHandlerTask).
+        // (see _prepareNodeErrorHandlerTask). `state` is the failing node's
+        // input, which may be a per-node subset of the graph state — hence the
+        // handler's `state` parameter is typed `unknown`.
         const nodeError = config?.configurable?.[CONFIG_KEY_NODE_ERROR] as
           | NodeError
           | undefined;
-        return userHandler(state as S, nodeError as NodeError, config);
+        return userHandler(state, nodeError as NodeError, config);
       },
       name: DEFAULT_ERROR_HANDLER_NODE,
       trace: false,

--- a/libs/langgraph-core/src/graph/state.ts
+++ b/libs/langgraph-core/src/graph/state.ts
@@ -53,9 +53,11 @@ import {
   isInterrupted,
   Interrupt,
   INTERRUPT,
+  CONFIG_KEY_NODE_ERROR,
 } from "../constants.js";
 import {
   InvalidUpdateError,
+  NodeError,
   ParentCommand,
   StateGraphInputError,
 } from "../errors.js";
@@ -1036,6 +1038,40 @@ export class StateGraph<
             : rawCachePolicy;
       }
 
+      // If an error handler is provided, register an auto-generated handler
+      // node that runs only after this node's retry policy is exhausted.
+      let errorHandlerNode: string | undefined;
+      if (options?.errorHandler !== undefined) {
+        errorHandlerNode = `__error_handler__${key}`;
+        if (errorHandlerNode in this.nodes) {
+          throw new Error(
+            `Auto-generated error handler node \`${errorHandlerNode}\` already exists.`
+          );
+        }
+        const userHandler = options.errorHandler;
+        const handlerRunnable = new RunnableCallable({
+          func: (state: unknown, config: LangGraphRunnableConfig) => {
+            // Per-task failure context, injected when the handler task is
+            // prepared (see _prepareNodeErrorHandlerTask).
+            const nodeError = config?.configurable?.[CONFIG_KEY_NODE_ERROR] as
+              | NodeError
+              | undefined;
+            return userHandler(state, nodeError as NodeError, config);
+          },
+          name: errorHandlerNode,
+          trace: false,
+        });
+        const handlerSpec: StateGraphNodeSpec<S, U> = {
+          runnable: handlerRunnable as unknown as Runnable<S, U>,
+          metadata: undefined,
+          input: inputSpec ?? this._schemaDefinition,
+          retryPolicy: undefined,
+          cachePolicy: undefined,
+          isErrorHandler: true,
+        };
+        this.nodes[errorHandlerNode as unknown as N] = handlerSpec;
+      }
+
       const nodeSpec: StateGraphNodeSpec<S, U> = {
         runnable: runnable as unknown as Runnable<S, U>,
         retryPolicy: options?.retryPolicy,
@@ -1049,6 +1085,7 @@ export class StateGraph<
           : options?.subgraphs,
         ends: options?.ends,
         defer: options?.defer,
+        errorHandlerNode,
       };
 
       this.nodes[key as unknown as N] = nodeSpec;
@@ -1613,6 +1650,8 @@ export class CompiledStateGraph<
         timeout: node?.timeout,
         subgraphs: node?.subgraphs,
         ends: node?.ends,
+        isErrorHandler: node?.isErrorHandler,
+        errorHandlerNode: node?.errorHandlerNode,
       });
     }
   }

--- a/libs/langgraph-core/src/graph/state.ts
+++ b/libs/langgraph-core/src/graph/state.ts
@@ -181,12 +181,16 @@ export type StateGraphNodeSpec<RunInput, RunOutput> = NodeSpec<
  *
  * @template Nodes - Node name constraints
  * @template InputSchema - Per-node input schema type (inferred from options.input)
+ * @template HandlerState - State type passed to the node-level error handler
  */
 export type StateGraphAddNodeOptions<
   Nodes extends string = string,
   InputSchema extends StateDefinitionInit | undefined =
     | StateDefinitionInit
     | undefined,
+  HandlerState = InputSchema extends StateDefinitionInit
+    ? ExtractStateType<InputSchema>
+    : unknown,
 > = {
   input?: InputSchema;
   /**
@@ -194,9 +198,18 @@ export type StateGraphAddNodeOptions<
    * {@link RetryPolicy} is exhausted. Receives a {@link NodeError} with the
    * failed node name and error, and may return a state update or `Command`.
    */
-  errorHandler?: NodeErrorHandler;
+  errorHandler?: NodeErrorHandler<HandlerState>;
 } & NodePolicyOptions &
   AddNodeOptions<Nodes>;
+
+type StateGraphAddNodeOptionsWithNodeInput<
+  Nodes extends string,
+  NodeInput,
+> = StateGraphAddNodeOptions<
+  Nodes,
+  StateDefinitionInit | undefined,
+  NodeInput
+>;
 
 export type StateGraphArgsWithStateSchema<
   SD extends StateDefinition,
@@ -851,7 +864,7 @@ export class StateGraph<
     nodes: [
       key: K,
       action: NodeAction<NodeInput, NodeOutput, C, InterruptType, WriterType>,
-      options?: StateGraphAddNodeOptions,
+      options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput>,
     ][]
   ): StateGraph<
     SD,
@@ -917,7 +930,7 @@ export class StateGraph<
   override addNode<K extends string, NodeInput = S, NodeOutput extends U = U>(
     key: K,
     action: NodeAction<NodeInput, NodeOutput, C, InterruptType, WriterType>,
-    options?: StateGraphAddNodeOptions
+    options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput>
   ): StateGraph<
     SD,
     S,
@@ -932,7 +945,7 @@ export class StateGraph<
   override addNode<K extends string, NodeInput = S>(
     key: K,
     action: NodeAction<NodeInput, U, C, InterruptType, WriterType>,
-    options?: StateGraphAddNodeOptions
+    options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput>
   ): StateGraph<SD, S, U, N | K, I, O, C, NodeReturnType>;
 
   override addNode<K extends string, NodeInput = S, NodeOutput extends U = U>(
@@ -946,7 +959,7 @@ export class StateGraph<
             InterruptType,
             WriterType
           >,
-          options?: StateGraphAddNodeOptions,
+          options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput>,
         ]
       | [
           nodes:
@@ -954,7 +967,10 @@ export class StateGraph<
             | [
                 key: K,
                 action: NodeAction<NodeInput, U, C, InterruptType, WriterType>,
-                options?: StateGraphAddNodeOptions,
+                options?: StateGraphAddNodeOptionsWithNodeInput<
+                  N | K,
+                  NodeInput
+                >,
               ][],
         ]
   ): StateGraph<SD, S, U, N | K, I, O, C> {
@@ -966,7 +982,7 @@ export class StateGraph<
         | [
             key: K,
             action: NodeAction<NodeInput, U, C, InterruptType, WriterType>,
-            options?: StateGraphAddNodeOptions,
+            options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput>,
           ][],
     ] {
       return args.length >= 1 && typeof args[0] !== "string";
@@ -981,7 +997,7 @@ export class StateGraph<
     ) as [
       K,
       NodeAction<NodeInput, U, C, InterruptType, WriterType>,
-      StateGraphAddNodeOptions | undefined,
+      StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput> | undefined,
     ][];
 
     if (nodes.length === 0) {
@@ -1064,7 +1080,11 @@ export class StateGraph<
             const nodeError = config?.configurable?.[CONFIG_KEY_NODE_ERROR] as
               | NodeError
               | undefined;
-            return userHandler(state, nodeError as NodeError, config);
+            return userHandler(
+              state as NodeInput,
+              nodeError as NodeError,
+              config
+            );
           },
           name: errorHandlerNode,
           trace: false,
@@ -1141,7 +1161,7 @@ export class StateGraph<
     nodes: [
       key: K,
       action: NodeAction<NodeInput, NodeOutput, C, InterruptType, WriterType>,
-      options?: StateGraphAddNodeOptions,
+      options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput>,
     ][]
   ): StateGraph<
     SD,
@@ -1194,7 +1214,7 @@ export class StateGraph<
             InterruptType,
             WriterType
           >,
-          options?: StateGraphAddNodeOptions,
+          options?: StateGraphAddNodeOptionsWithNodeInput<N | K, NodeInput>,
         ][]
       | Record<
           K,
@@ -1226,8 +1246,14 @@ export class StateGraph<
 
       const validKey = key as unknown as N;
       this.addNode(
-        validKey,
-        action as NodeAction<S, U, C, InterruptType, WriterType>,
+        key as K,
+        action as NodeAction<
+          NodeInput,
+          NodeOutput,
+          C,
+          InterruptType,
+          WriterType
+        >,
         options
       );
       if (previousNode != null) {

--- a/libs/langgraph-core/src/graph/state.ts
+++ b/libs/langgraph-core/src/graph/state.ts
@@ -24,6 +24,7 @@ import {
   Branch,
   AddNodeOptions,
   NodeSpec,
+  NodeErrorHandler,
 } from "./graph.js";
 import {
   ChannelWrite,
@@ -96,6 +97,7 @@ import {
   type StateDefinitionInit,
 } from "./types.js";
 import type { StreamTransformer } from "../stream/types.js";
+import type { Pregel } from "../pregel/index.js";
 
 const ROOT = "__root__";
 
@@ -187,6 +189,12 @@ export type StateGraphAddNodeOptions<
     | undefined,
 > = {
   input?: InputSchema;
+  /**
+   * Optional node-level error handler. Runs only after this node's
+   * {@link RetryPolicy} is exhausted. Receives a {@link NodeError} with the
+   * failed node name and error, and may return a state update or `Command`.
+   */
+  errorHandler?: NodeErrorHandler;
 } & NodePolicyOptions &
   AddNodeOptions<Nodes>;
 
@@ -958,7 +966,7 @@ export class StateGraph<
         | [
             key: K,
             action: NodeAction<NodeInput, U, C, InterruptType, WriterType>,
-            options?: AddNodeOptions,
+            options?: StateGraphAddNodeOptions,
           ][],
     ] {
       return args.length >= 1 && typeof args[0] !== "string";
@@ -1069,7 +1077,7 @@ export class StateGraph<
           cachePolicy: undefined,
           isErrorHandler: true,
         };
-        this.nodes[errorHandlerNode as unknown as N] = handlerSpec;
+        this.nodes[errorHandlerNode as N] = handlerSpec;
       }
 
       const nodeSpec: StateGraphNodeSpec<S, U> = {
@@ -1081,7 +1089,7 @@ export class StateGraph<
         input: inputSpec ?? this._schemaDefinition,
         subgraphs: isPregelLike(runnable)
           ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            [runnable as any]
+            [runnable as Pregel<any, any>]
           : options?.subgraphs,
         ends: options?.ends,
         defer: options?.defer,

--- a/libs/langgraph-core/src/pregel/algo.ts
+++ b/libs/langgraph-core/src/pregel/algo.ts
@@ -49,11 +49,13 @@ import {
   CONFIG_KEY_SCRATCHPAD,
   RETURN,
   ERROR,
+  ERROR_SOURCE_NODE,
   NO_WRITES,
   CONFIG_KEY_PREVIOUS_STATE,
   PREVIOUS,
   CACHE_NS_WRITES,
   CONFIG_KEY_RESUME_MAP,
+  CONFIG_KEY_NODE_ERROR,
   START,
 } from "../constants.js";
 import {
@@ -66,7 +68,7 @@ import {
   TaskPath,
   VariadicTaskPath,
 } from "./types.js";
-import { EmptyChannelError, InvalidUpdateError } from "../errors.js";
+import { EmptyChannelError, InvalidUpdateError, NodeError } from "../errors.js";
 import { getNullChannelVersion } from "./utils/index.js";
 import { ExecutionInfo, LangGraphRunnableConfig } from "./runnable_types.js";
 import { getRunnableForFunc } from "./call.js";
@@ -240,6 +242,7 @@ const IGNORE = new Set<string | number | symbol>([
   INTERRUPT,
   RETURN,
   ERROR,
+  ERROR_SOURCE_NODE,
 ]);
 
 const RESERVED_SET: ReadonlySet<string> = new Set(RESERVED);
@@ -1142,6 +1145,168 @@ export function _prepareSingleTask<
     }
   }
   return undefined;
+}
+
+/**
+ * Prepare an immediate node-level error handler task for a failed task.
+ *
+ * The handler runs only after the failed node's retry policy is exhausted (the
+ * runner schedules it once a non-bubble-up error settles). It is prepared like
+ * a PUSH task targeting the auto-generated handler node, receives the failed
+ * node's input, and is injected with a {@link NodeError} under
+ * {@link CONFIG_KEY_NODE_ERROR} so the handler can inspect the failure
+ * provenance (and route via `Command({ goto })`).
+ *
+ * @internal
+ */
+export function _prepareNodeErrorHandlerTask<
+  Nn extends StrRecord<string, PregelNode>,
+  Cc extends StrRecord<string, BaseChannel>,
+>(
+  failedTask: PregelExecutableTask<keyof Nn, keyof Cc>,
+  handlerNodeName: string,
+  error: Error,
+  checkpoint: ReadonlyCheckpoint,
+  pendingWrites: CheckpointPendingWrite[] | undefined,
+  processes: Nn,
+  channels: Cc,
+  config: LangGraphRunnableConfig,
+  extra: NextTaskExtraFieldsWithStore
+): PregelExecutableTask<keyof Nn, keyof Cc> | undefined {
+  const { step, checkpointer, manager } = extra;
+  const proc = processes[handlerNodeName as keyof Nn];
+  if (proc === undefined) {
+    return undefined;
+  }
+  const node = proc.getNode();
+  if (node === undefined) {
+    return undefined;
+  }
+
+  const configurable = config.configurable ?? {};
+  const parentNamespace = configurable.checkpoint_ns ?? "";
+  const triggers = [PUSH];
+  const checkpointNamespace =
+    parentNamespace === ""
+      ? handlerNodeName
+      : `${parentNamespace}${CHECKPOINT_NAMESPACE_SEPARATOR}${handlerNodeName}`;
+  // Deterministic task id (includes the failed task id) so resuming from a
+  // checkpoint reconstructs the same handler task.
+  const taskId = uuid5(
+    JSON.stringify([
+      checkpointNamespace,
+      step.toString(),
+      handlerNodeName,
+      PUSH,
+      "node_error_handler",
+      failedTask.id,
+    ]),
+    checkpoint.id
+  );
+  const taskCheckpointNamespace = `${checkpointNamespace}${CHECKPOINT_NAMESPACE_END}${taskId}`;
+  // Last path element is a string (not `true`), so interrupts raised by the
+  // handler are surfaced normally rather than deferred to a parent call.
+  const taskPath = [
+    PUSH,
+    String(failedTask.name),
+    handlerNodeName,
+    false,
+  ] as VariadicTaskPath;
+
+  let metadata = {
+    langgraph_step: step,
+    langgraph_node: handlerNodeName,
+    langgraph_triggers: triggers,
+    langgraph_path: taskPath,
+    langgraph_checkpoint_ns: taskCheckpointNamespace,
+    checkpoint_ns: taskCheckpointNamespace,
+  };
+  if (proc.metadata !== undefined) {
+    metadata = { ...metadata, ...proc.metadata };
+  }
+
+  const writes: [keyof Cc, unknown][] = [];
+  const executionInfo: ExecutionInfo = {
+    checkpointId: checkpoint.id,
+    checkpointNs: taskCheckpointNamespace,
+    taskId,
+    threadId: configurable.thread_id as string | undefined,
+    runId: config.runId != null ? String(config.runId) : undefined,
+    nodeAttempt: 1,
+  };
+
+  return {
+    name: handlerNodeName as keyof Nn,
+    input: failedTask.input,
+    proc: node,
+    subgraphs: proc.subgraphs,
+    writes,
+    config: {
+      ...patchConfig(
+        mergeConfigs(config, {
+          metadata,
+          tags: proc.tags,
+          store: extra.store ?? config.store,
+        }),
+        {
+          runName: handlerNodeName,
+          callbacks: manager?.getChild(`graph:step:${step}`),
+          configurable: {
+            [CONFIG_KEY_TASK_ID]: taskId,
+            [CONFIG_KEY_SEND]: (writes_: PendingWrite[]) =>
+              _localWrite(
+                (items: PendingWrite<keyof Cc>[]) => writes.push(...items),
+                processes,
+                writes_
+              ),
+            [CONFIG_KEY_READ]: (
+              select_: Array<keyof Cc> | keyof Cc,
+              fresh_: boolean = false
+            ) =>
+              _localRead(
+                checkpoint,
+                channels,
+                {
+                  name: handlerNodeName,
+                  writes: writes as PendingWrite[],
+                  triggers,
+                  path: taskPath,
+                },
+                select_,
+                fresh_
+              ),
+            [CONFIG_KEY_CHECKPOINTER]:
+              checkpointer ?? configurable[CONFIG_KEY_CHECKPOINTER],
+            [CONFIG_KEY_CHECKPOINT_MAP]: {
+              ...configurable[CONFIG_KEY_CHECKPOINT_MAP],
+              [parentNamespace]: checkpoint.id,
+            },
+            [CONFIG_KEY_SCRATCHPAD]: _scratchpad({
+              pendingWrites: pendingWrites ?? [],
+              taskId,
+              currentTaskInput: failedTask.input,
+              resumeMap: config.configurable?.[CONFIG_KEY_RESUME_MAP],
+              namespaceHash: XXH3(taskCheckpointNamespace),
+            }),
+            [CONFIG_KEY_PREVIOUS_STATE]: checkpoint.channel_values[PREVIOUS],
+            [CONFIG_KEY_NODE_ERROR]: new NodeError(
+              String(failedTask.name),
+              error
+            ),
+            checkpoint_id: undefined,
+            checkpoint_ns: taskCheckpointNamespace,
+          },
+        }
+      ),
+      executionInfo,
+    },
+    triggers,
+    retry_policy: proc.retryPolicy,
+    cache_key: undefined,
+    id: taskId,
+    path: taskPath,
+    writers: proc.getWriters(),
+  } satisfies PregelExecutableTask<keyof Nn, keyof Cc>;
 }
 
 /**

--- a/libs/langgraph-core/src/pregel/loop.ts
+++ b/libs/langgraph-core/src/pregel/loop.ts
@@ -41,6 +41,7 @@ import {
   CONFIG_KEY_RESUMING,
   CONFIG_KEY_STREAM,
   ERROR,
+  ERROR_SOURCE_NODE,
   INPUT,
   INTERRUPT,
   NULL_TASK_ID,
@@ -58,6 +59,7 @@ import {
 import {
   _applyWrites,
   _prepareNextTasks,
+  _prepareNodeErrorHandlerTask,
   _prepareSingleTask,
   increment,
   shouldInterrupt,
@@ -817,7 +819,7 @@ export class PregelLoop {
       }
     );
     this.tasks = nextTasks;
-    const taskList = Object.values(this.tasks);
+    let taskList = Object.values(this.tasks);
 
     // Full-state checkpoint snapshots are expensive; skip unless a consumer
     // subscribed to "checkpoints" or the legacy "debug" wrapper mode.
@@ -851,7 +853,12 @@ export class PregelLoop {
     // if there are pending writes from a previous loop, apply them
     if (this.skipDoneTasks && this.checkpointPendingWrites.length > 0) {
       for (const [tid, k, v] of this.checkpointPendingWrites) {
-        if (k === ERROR || k === INTERRUPT || k === RESUME) {
+        if (
+          k === ERROR ||
+          k === ERROR_SOURCE_NODE ||
+          k === INTERRUPT ||
+          k === RESUME
+        ) {
           continue;
         }
         const task = taskList.find((t) => t.id === tid);
@@ -859,6 +866,13 @@ export class PregelLoop {
           task.writes.push([k, v]);
         }
       }
+      // On resume, re-schedule error handlers for nodes that failed in a prior
+      // run (recorded via ERROR_SOURCE_NODE) before they completed handling.
+      this._resumeErrorHandlersIfApplicable();
+      // Re-scheduling can add handler tasks to `this.tasks`, so refresh the
+      // cached task list before emitting writes and the downstream re-tick /
+      // interrupt / debug checks see the newly scheduled handlers.
+      taskList = Object.values(this.tasks);
       for (const task of taskList) {
         if (task.writes.length > 0) {
           this._outputWrites(task.id, task.writes, true);
@@ -1002,6 +1016,103 @@ export class PregelLoop {
     }
 
     return pushed;
+  }
+
+  /**
+   * Returns the name of the error handler node registered for `nodeName`, or
+   * `undefined` if none is configured.
+   */
+  getErrorHandlerNode(nodeName: string): string | undefined {
+    return this.nodes[nodeName]?.errorHandlerNode;
+  }
+
+  /**
+   * Whether `nodeName` is itself an auto-generated error handler node.
+   */
+  isErrorHandlerNode(nodeName: string): boolean {
+    return this.nodes[nodeName]?.isErrorHandler === true;
+  }
+
+  /**
+   * Schedule a node-level error handler task for a task that failed after its
+   * retry policy was exhausted. Prepares the handler task (injecting a
+   * {@link NodeError}), registers it so the runner executes it within the
+   * current step, and returns it (or `undefined` if no handler applies).
+   *
+   * The failure provenance (`ERROR` + `ERROR_SOURCE_NODE`) is checkpointed by
+   * the runner via {@link PregelLoop#putWrites} so handlers observe the same
+   * context after a resume.
+   */
+  scheduleErrorHandler(
+    failedTask: PregelExecutableTask<string, string>,
+    error: Error
+  ): PregelExecutableTask<string, string> | undefined {
+    const handlerNode = this.getErrorHandlerNode(String(failedTask.name));
+    if (!handlerNode) return undefined;
+
+    const handlerTask = _prepareNodeErrorHandlerTask(
+      failedTask,
+      handlerNode,
+      error,
+      this.checkpoint,
+      this.checkpointPendingWrites,
+      this.nodes,
+      this.channels,
+      failedTask.config ?? this.config,
+      {
+        step: this.step,
+        checkpointer: this.checkpointer,
+        manager: this.manager,
+        store: this.store,
+        stream: this.stream,
+      }
+    ) as PregelExecutableTask<string, string> | undefined;
+
+    if (handlerTask === undefined) return undefined;
+
+    this.tasks[handlerTask.id] = handlerTask;
+
+    this._emit(
+      gatherIteratorSync(prefixGenerator(mapDebugTasks([handlerTask]), "tasks"))
+    );
+    if (this.debug) printStepTasks(this.step, [handlerTask]);
+
+    return handlerTask;
+  }
+
+  /**
+   * On resume, re-schedule error handlers for tasks that failed in a prior run
+   * but had not finished being handled. Scans pending writes for
+   * `ERROR_SOURCE_NODE` markers (paired with `ERROR`), marks the originating
+   * task as done (so the runner won't re-run it), and prepares a fresh handler
+   * task so the runner picks it up.
+   */
+  protected _resumeErrorHandlersIfApplicable() {
+    // Collect failed task ids with both ERROR_SOURCE_NODE and ERROR writes.
+    const failed = new Map<string, Error>();
+    for (const [tid, chan] of this.checkpointPendingWrites) {
+      if (chan !== ERROR_SOURCE_NODE) continue;
+      const errorWrite = this.checkpointPendingWrites.find(
+        ([t, c]) => t === tid && c === ERROR
+      );
+      if (errorWrite === undefined) continue;
+      const value = errorWrite[2] as { message?: string; name?: string };
+      const error = new Error(value?.message ?? String(value));
+      if (value?.name) error.name = value.name;
+      failed.set(tid, error);
+    }
+
+    for (const [tid, error] of failed) {
+      const task = this.tasks[tid];
+      if (task === undefined) continue;
+      const handlerNode = this.getErrorHandlerNode(String(task.name));
+      if (!handlerNode) continue;
+      // Non-empty writes => runner's `writes.length === 0` filter skips it.
+      if (task.writes.length === 0) {
+        task.writes.push([ERROR, { message: error.message, name: error.name }]);
+      }
+      this.scheduleErrorHandler(task, error);
+    }
   }
 
   protected _suppressInterrupt(e?: Error): boolean {

--- a/libs/langgraph-core/src/pregel/read.ts
+++ b/libs/langgraph-core/src/pregel/read.ts
@@ -89,6 +89,10 @@ interface PregelNodeArgs<RunInput, RunOutput> extends Partial<
   timeout?: TimeoutPolicy;
   subgraphs?: Runnable[];
   ends?: string[];
+  /** Whether this node is an auto-generated node-level error handler. */
+  isErrorHandler?: boolean;
+  /** Name of the error handler node to run if this node's execution fails. */
+  errorHandlerNode?: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -131,6 +135,10 @@ export class PregelNode<
 
   ends?: string[];
 
+  isErrorHandler?: boolean;
+
+  errorHandlerNode?: string;
+
   constructor(fields: PregelNodeArgs<RunInput, RunOutput>) {
     const {
       channels,
@@ -146,6 +154,8 @@ export class PregelNode<
       tags,
       subgraphs,
       ends,
+      isErrorHandler,
+      errorHandlerNode,
     } = fields;
     const mergedTags = [
       ...(fields.config?.tags ? fields.config.tags : []),
@@ -176,6 +186,8 @@ export class PregelNode<
     this.timeout = timeout;
     this.subgraphs = subgraphs;
     this.ends = ends;
+    this.isErrorHandler = isErrorHandler;
+    this.errorHandlerNode = errorHandlerNode;
   }
 
   getWriters(): Array<Runnable> {

--- a/libs/langgraph-core/src/pregel/retry.ts
+++ b/libs/langgraph-core/src/pregel/retry.ts
@@ -61,12 +61,6 @@ export type SettledPregelTask = {
   task: PregelExecutableTask<any, any>;
   error: Error;
   signalAborted?: boolean;
-  /**
-   * Set when this task's error was routed to a node-level error handler. When
-   * true, the runner records failure provenance but does not treat the error
-   * as fatal to the run.
-   */
-  errorHandled?: boolean;
 };
 
 export async function _runWithRetry<

--- a/libs/langgraph-core/src/pregel/retry.ts
+++ b/libs/langgraph-core/src/pregel/retry.ts
@@ -80,10 +80,6 @@ export async function _runWithRetry<
   signalAborted?: boolean;
 }> {
   const resolvedRetryPolicy = pregelTask.retry_policy ?? retryPolicy;
-  let interval =
-    resolvedRetryPolicy !== undefined
-      ? (resolvedRetryPolicy.initialInterval ?? DEFAULT_INITIAL_INTERVAL)
-      : 0;
   let attempts = 0;
   let error;
   let result;
@@ -166,17 +162,21 @@ export async function _runWithRetry<
       if (!retryOn(error)) {
         break;
       }
-      interval = Math.min(
+      const initialInterval =
+        resolvedRetryPolicy.initialInterval ?? DEFAULT_INITIAL_INTERVAL;
+      const interval = Math.min(
         resolvedRetryPolicy.maxInterval ?? DEFAULT_MAX_INTERVAL,
-        interval * (resolvedRetryPolicy.backoffFactor ?? DEFAULT_BACKOFF_FACTOR)
+        initialInterval *
+          (resolvedRetryPolicy.backoffFactor ?? DEFAULT_BACKOFF_FACTOR) **
+            (attempts - 1)
       );
-      const intervalWithJitter =
+      const sleepMs =
         (resolvedRetryPolicy.jitter ?? DEFAULT_JITTER)
-          ? Math.floor(interval + Math.random() * 1000)
+          ? interval + Math.random() * 1000
           : interval;
       // sleep before retrying
       // eslint-disable-next-line no-promise-executor-return
-      await new Promise((resolve) => setTimeout(resolve, intervalWithJitter));
+      await new Promise((resolve) => setTimeout(resolve, sleepMs));
       // log the retry
       const errorName =
         (error as Error).name ??
@@ -185,7 +185,7 @@ export async function _runWithRetry<
         (error as Error).constructor.name;
       if (resolvedRetryPolicy?.logWarning ?? true) {
         console.log(
-          `Retrying task "${String(pregelTask.name)}" after ${interval.toFixed(
+          `Retrying task "${String(pregelTask.name)}" after ${sleepMs.toFixed(
             2
           )}ms (attempt ${attempts}) after ${errorName}: ${error}`
         );

--- a/libs/langgraph-core/src/pregel/retry.ts
+++ b/libs/langgraph-core/src/pregel/retry.ts
@@ -61,6 +61,12 @@ export type SettledPregelTask = {
   task: PregelExecutableTask<any, any>;
   error: Error;
   signalAborted?: boolean;
+  /**
+   * Set when this task's error was routed to a node-level error handler. When
+   * true, the runner records failure provenance but does not treat the error
+   * as fatal to the run.
+   */
+  errorHandled?: boolean;
 };
 
 export async function _runWithRetry<

--- a/libs/langgraph-core/src/pregel/retry.ts
+++ b/libs/langgraph-core/src/pregel/retry.ts
@@ -10,6 +10,7 @@ export const DEFAULT_INITIAL_INTERVAL = 500;
 export const DEFAULT_BACKOFF_FACTOR = 2;
 export const DEFAULT_MAX_INTERVAL = 128000;
 export const DEFAULT_MAX_RETRIES = 3;
+export const DEFAULT_JITTER = true;
 
 const DEFAULT_STATUS_NO_RETRY = [
   400, // Bad Request
@@ -169,9 +170,10 @@ export async function _runWithRetry<
         resolvedRetryPolicy.maxInterval ?? DEFAULT_MAX_INTERVAL,
         interval * (resolvedRetryPolicy.backoffFactor ?? DEFAULT_BACKOFF_FACTOR)
       );
-      const intervalWithJitter = resolvedRetryPolicy.jitter
-        ? Math.floor(interval + Math.random() * 1000)
-        : interval;
+      const intervalWithJitter =
+        (resolvedRetryPolicy.jitter ?? DEFAULT_JITTER)
+          ? Math.floor(interval + Math.random() * 1000)
+          : interval;
       // sleep before retrying
       // eslint-disable-next-line no-promise-executor-return
       await new Promise((resolve) => setTimeout(resolve, intervalWithJitter));

--- a/libs/langgraph-core/src/pregel/runner.ts
+++ b/libs/langgraph-core/src/pregel/runner.ts
@@ -88,6 +88,12 @@ export class PregelRunner {
   private loop: PregelLoop;
 
   /**
+   * Exceptions already routed to a node-level error handler. Consulted when
+   * deciding whether a failed task should abort the run.
+   */
+  private handledExceptions = new WeakSet<Error>();
+
+  /**
    * Construct a new PregelRunner, which executes tasks from the provided PregelLoop.
    * @param loop - The PregelLoop that produces tasks for this runner to execute.
    */
@@ -135,16 +141,11 @@ export class PregelRunner {
       maxConcurrency,
     });
 
-    for await (const {
-      task,
-      error,
-      signalAborted,
-      errorHandled,
-    } of taskStream) {
-      this._commit(task, error, errorHandled);
-      if (errorHandled) {
-        // Error was routed to a node-level error handler (scheduled within this
-        // same tick). Provenance has been checkpointed; the error is not fatal.
+    for await (const { task, error, signalAborted } of taskStream) {
+      this._commit(task, error);
+      if (error !== undefined && this.handledExceptions.has(error)) {
+        // Routed to a node-level error handler in this tick; provenance is
+        // checkpointed and the error must not abort the run.
         continue;
       }
       if (isGraphInterrupt(error)) {
@@ -361,7 +362,6 @@ export class PregelRunner {
           settledError
         );
         if (handlerTask !== undefined) {
-          settled.errorHandled = true;
           executingTasksMap[handlerTask.id] = _runWithRetry(
             handlerTask,
             retryPolicy,
@@ -390,6 +390,19 @@ export class PregelRunner {
   }
 
   /**
+   * Whether a failed task should record {@link ERROR_SOURCE_NODE} provenance.
+   */
+  private _shouldRouteToErrorHandler(
+    task: PregelExecutableTask<string, string>
+  ): boolean {
+    const name = String(task.name);
+    if (this.loop.isErrorHandlerNode(name)) {
+      return false;
+    }
+    return this.loop.getErrorHandlerNode(name) !== undefined;
+  }
+
+  /**
    * Determines what writes to apply based on whether the task completed successfully, and what type of error occurred.
    *
    * Throws an error if the error is a {@link GraphBubbleUp} error and {@link PregelLoop}#isNested is true.
@@ -397,11 +410,7 @@ export class PregelRunner {
    * @param task - The task to commit.
    * @param error - The error that occurred, if any.
    */
-  private _commit(
-    task: PregelExecutableTask<string, string>,
-    error?: Error,
-    errorHandled = false
-  ) {
+  private _commit(task: PregelExecutableTask<string, string>, error?: Error) {
     if (error !== undefined) {
       if (isGraphInterrupt(error)) {
         if (error.interrupts.length) {
@@ -416,22 +425,13 @@ export class PregelRunner {
         }
       } else if (isGraphBubbleUp(error) && task.writes.length) {
         this.loop.putWrites(task.id, task.writes);
-      } else if (errorHandled) {
-        // The error was routed to a node-level error handler. Record failure
-        // provenance (ERROR + ERROR_SOURCE_NODE) so the originating task counts
-        // as "done" for this superstep and handlers see the same context after
-        // a checkpoint resume. The handler task (scheduled separately) carries
-        // the recovery state update / routing.
-        task.writes.splice(0, task.writes.length);
-        task.writes.push(
-          [ERROR, { message: error.message, name: error.name }],
-          [ERROR_SOURCE_NODE, String(task.name)]
-        );
-        this.loop.putWrites(task.id, task.writes);
       } else {
-        this.loop.putWrites(task.id, [
-          [ERROR, { message: error.message, name: error.name }],
-        ]);
+        task.writes.push([ERROR, { message: error.message, name: error.name }]);
+        if (this._shouldRouteToErrorHandler(task)) {
+          task.writes.push([ERROR_SOURCE_NODE, String(task.name)]);
+          this.handledExceptions.add(error);
+        }
+        this.loop.putWrites(task.id, task.writes);
       }
     } else {
       if (

--- a/libs/langgraph-core/src/pregel/runner.ts
+++ b/libs/langgraph-core/src/pregel/runner.ts
@@ -15,6 +15,7 @@ import {
 import {
   CONFIG_KEY_SCRATCHPAD,
   ERROR,
+  ERROR_SOURCE_NODE,
   INTERRUPT,
   RESUME,
   NO_WRITES,
@@ -134,8 +135,18 @@ export class PregelRunner {
       maxConcurrency,
     });
 
-    for await (const { task, error, signalAborted } of taskStream) {
-      this._commit(task, error);
+    for await (const {
+      task,
+      error,
+      signalAborted,
+      errorHandled,
+    } of taskStream) {
+      this._commit(task, error, errorHandled);
+      if (errorHandled) {
+        // Error was routed to a node-level error handler (scheduled within this
+        // same tick). Provenance has been checkpointed; the error is not fatal.
+        continue;
+      }
       if (isGraphInterrupt(error)) {
         graphBubbleUp = error;
       } else if (isGraphBubbleUp(error) && !isGraphInterrupt(graphBubbleUp)) {
@@ -331,7 +342,43 @@ export class PregelRunner {
         continue;
       }
 
-      yield settledTask as SettledPregelTask;
+      const settled = settledTask as SettledPregelTask;
+      const { task: settledPregelTask, error: settledError } = settled;
+
+      // If the task failed (after exhausting its retry policy) and the node has
+      // a registered error handler, schedule that handler to run within this
+      // same tick instead of aborting the run. GraphBubbleUp errors (e.g.
+      // interrupts / parent commands) are never routed to error handlers.
+      if (
+        settledError !== undefined &&
+        !isGraphBubbleUp(settledError) &&
+        !this.loop.isErrorHandlerNode(String(settledPregelTask.name)) &&
+        this.loop.getErrorHandlerNode(String(settledPregelTask.name)) !==
+          undefined
+      ) {
+        const handlerTask = this.loop.scheduleErrorHandler(
+          settledPregelTask,
+          settledError
+        );
+        if (handlerTask !== undefined) {
+          settled.errorHandled = true;
+          executingTasksMap[handlerTask.id] = _runWithRetry(
+            handlerTask,
+            retryPolicy,
+            { [CONFIG_KEY_CALL]: call?.bind(thisCall, this, handlerTask) },
+            signals?.composedAbortSignal
+          ).catch((error) => {
+            return {
+              task: handlerTask,
+              error,
+              signalAborted: signals?.composedAbortSignal?.aborted,
+            };
+          });
+          barrier.next();
+        }
+      }
+
+      yield settled;
 
       if (listener != null) {
         timeoutOrCancelSignal.signal?.removeEventListener("abort", listener);
@@ -350,7 +397,11 @@ export class PregelRunner {
    * @param task - The task to commit.
    * @param error - The error that occurred, if any.
    */
-  private _commit(task: PregelExecutableTask<string, string>, error?: Error) {
+  private _commit(
+    task: PregelExecutableTask<string, string>,
+    error?: Error,
+    errorHandled = false
+  ) {
     if (error !== undefined) {
       if (isGraphInterrupt(error)) {
         if (error.interrupts.length) {
@@ -364,6 +415,18 @@ export class PregelRunner {
           this.loop.putWrites(task.id, interrupts);
         }
       } else if (isGraphBubbleUp(error) && task.writes.length) {
+        this.loop.putWrites(task.id, task.writes);
+      } else if (errorHandled) {
+        // The error was routed to a node-level error handler. Record failure
+        // provenance (ERROR + ERROR_SOURCE_NODE) so the originating task counts
+        // as "done" for this superstep and handlers see the same context after
+        // a checkpoint resume. The handler task (scheduled separately) carries
+        // the recovery state update / routing.
+        task.writes.splice(0, task.writes.length);
+        task.writes.push(
+          [ERROR, { message: error.message, name: error.name }],
+          [ERROR_SOURCE_NODE, String(task.name)]
+        );
         this.loop.putWrites(task.id, task.writes);
       } else {
         this.loop.putWrites(task.id, [

--- a/libs/langgraph-core/src/pregel/utils/index.ts
+++ b/libs/langgraph-core/src/pregel/utils/index.ts
@@ -78,7 +78,10 @@ export type RetryPolicy = {
    */
   maxAttempts?: number;
 
-  /** Whether to add random jitter to the interval between retries. */
+  /**
+   * Whether to add random jitter to the interval between retries.
+   * @default true
+   */
   jitter?: boolean;
 
   /** A function that returns True for exceptions that should trigger a retry. */

--- a/libs/langgraph-core/src/tests/diagrams.test.ts
+++ b/libs/langgraph-core/src/tests/diagrams.test.ts
@@ -1,8 +1,17 @@
 import { test, expect } from "vitest";
+import { z } from "zod/v4";
 import { createReactAgent } from "../prebuilt/index.js";
 import { FakeSearchTool } from "./utils.js";
 import { FakeToolCallingChatModel } from "./utils.models.js";
-import { Annotation, StateGraph } from "../web.js";
+import {
+  Annotation,
+  Command,
+  END,
+  NodeError,
+  START,
+  StateGraph,
+  StateSchema,
+} from "../web.js";
 
 test("prebuilt agent", async () => {
   // Define the tools for the agent to use
@@ -28,6 +37,37 @@ graph TD;
 \tclassDef first fill-opacity:0;
 \tclassDef last fill:#bfb6fc;
 `);
+});
+
+test("implicit end edge for terminal nodes", async () => {
+  const State = new StateSchema({ status: z.string() });
+
+  const graph = new StateGraph(State)
+    .addNode(
+      "riskyNode",
+      (state: typeof State.State) => {
+        if (state.status === "fail") {
+          throw new Error("fail");
+        }
+        return { status: "ok" };
+      },
+      {
+        errorHandler: (_state: typeof State.State, _error: NodeError) =>
+          new Command({ update: { status: "recovered" }, goto: "recover" }),
+      }
+    )
+    .addNode("recover", (state: typeof State.State) => ({
+      status: `${state.status}_final`,
+    }))
+    .addEdge(START, "riskyNode")
+    .addEdge("recover", END)
+    .compile();
+
+  const mermaid = graph.getGraph().drawMermaid();
+  expect(mermaid).toContain("__start__ --> riskyNode;");
+  expect(mermaid).toContain("riskyNode --> __end__;");
+  expect(mermaid).toContain("recover --> __end__;");
+  expect(mermaid).not.toContain("__error_handler__riskyNode --> __end__;");
 });
 
 test("graph with multiple sinks", async () => {

--- a/libs/langgraph-core/src/tests/node_error_handler.test.ts
+++ b/libs/langgraph-core/src/tests/node_error_handler.test.ts
@@ -17,7 +17,7 @@ import { START } from "../constants.js";
 import { Command } from "../constants.js";
 import { NodeError } from "../errors.js";
 import { interrupt } from "../interrupt.js";
-import { initializeAsyncLocalStorageSingleton } from "../setup/async_local_storage.js";
+import { initializeAsyncLocalStorageSingleton } from "../node.js";
 
 beforeAll(() => {
   // Need to initialize the AsyncLocalStorage singleton for interrupt() to work.

--- a/libs/langgraph-core/src/tests/node_error_handler.test.ts
+++ b/libs/langgraph-core/src/tests/node_error_handler.test.ts
@@ -1,7 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { it, expect, describe, beforeAll, afterAll, vi } from "vitest";
+import { z } from "zod/v4";
 import { MemorySaver } from "@langchain/langgraph-checkpoint";
-import { Annotation, StateGraph } from "../graph/index.js";
+import { StateGraph } from "../graph/index.js";
+import { StateSchema } from "../state/schema.js";
+import { ReducedValue } from "../state/values/reduced.js";
 import { START } from "../constants.js";
 import { Command } from "../constants.js";
 import { NodeError } from "../errors.js";
@@ -27,7 +30,7 @@ describe("Node-level error handlers", () => {
   });
 
   it("runs the error handler only after the retry policy is exhausted", async () => {
-    const State = Annotation.Root({ foo: Annotation<string> });
+    const State = new StateSchema({ foo: z.string() });
 
     let attempts = 0;
     const captured: { node?: string; error?: Error } = {};
@@ -72,7 +75,7 @@ describe("Node-level error handlers", () => {
   });
 
   it("lets the handler route to a recovery branch via Command(goto)", async () => {
-    const State = Annotation.Root({ foo: Annotation<string> });
+    const State = new StateSchema({ foo: z.string() });
 
     let attempts = 0;
     const graph = new StateGraph(State)
@@ -100,7 +103,7 @@ describe("Node-level error handlers", () => {
   });
 
   it("fails the run when the error handler itself throws", async () => {
-    const State = Annotation.Root({ foo: Annotation<string> });
+    const State = new StateSchema({ foo: z.string() });
 
     const graph = new StateGraph(State)
       .addNode(
@@ -121,8 +124,8 @@ describe("Node-level error handlers", () => {
   });
 
   it("handles a failure that occurs inside a subgraph node", async () => {
-    const SubState = Annotation.Root({ foo: Annotation<string> });
-    const ParentState = Annotation.Root({ foo: Annotation<string> });
+    const SubState = new StateSchema({ foo: z.string() });
+    const ParentState = new StateSchema({ foo: z.string() });
 
     const captured: { node?: string; error?: Error } = {};
 
@@ -151,7 +154,7 @@ describe("Node-level error handlers", () => {
   });
 
   it("preserves the failure context across a checkpoint resume", async () => {
-    const State = Annotation.Root({ foo: Annotation<string> });
+    const State = new StateSchema({ foo: z.string() });
     const captured: { node?: string; error?: Error } = {};
 
     const checkpointer = new MemorySaver();
@@ -186,7 +189,7 @@ describe("Node-level error handlers", () => {
   });
 
   it("does not swallow a concurrent interrupt()", async () => {
-    const State = Annotation.Root({ foo: Annotation<string> });
+    const State = new StateSchema({ foo: z.string() });
 
     const checkpointer = new MemorySaver();
     const graph = new StateGraph(State)
@@ -216,11 +219,10 @@ describe("Node-level error handlers", () => {
   });
 
   it("routes a failure to the matching node's handler", async () => {
-    const State = Annotation.Root({
-      route: Annotation<string>,
-      foo: Annotation<string[]>({
-        reducer: (a, b) => a.concat(b),
-        default: () => [],
+    const State = new StateSchema({
+      route: z.string(),
+      foo: new ReducedValue(z.array(z.string()).default(() => []), {
+        reducer: (a: string[], b: string[]) => a.concat(b),
       }),
     });
 
@@ -264,7 +266,7 @@ describe("Node-level error handlers", () => {
   });
 
   it("still fails the run for a node without an error handler", async () => {
-    const State = Annotation.Root({ foo: Annotation<string> });
+    const State = new StateSchema({ foo: z.string() });
 
     const graph = new StateGraph(State)
       .addNode("failWithoutHandler", () => {
@@ -277,7 +279,7 @@ describe("Node-level error handlers", () => {
   });
 
   it("exposes the NodeError to handlers registered as plain functions", async () => {
-    const State = Annotation.Root({ foo: Annotation<string> });
+    const State = new StateSchema({ foo: z.string() });
 
     let attempts = 0;
     const captured: { node?: string; error?: Error } = {};

--- a/libs/langgraph-core/src/tests/node_error_handler.test.ts
+++ b/libs/langgraph-core/src/tests/node_error_handler.test.ts
@@ -1,5 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { it, expect, describe, beforeAll, afterAll, vi } from "vitest";
+import {
+  it,
+  expect,
+  describe,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
 import { z } from "zod/v4";
 import { MemorySaver } from "@langchain/langgraph-checkpoint";
 import { StateGraph } from "../graph/index.js";
@@ -17,16 +25,12 @@ beforeAll(() => {
 });
 
 describe("Node-level error handlers", () => {
-  // Speed up retry backoff sleeps.
-  beforeAll(() => {
-    vi.spyOn(global, "setTimeout").mockImplementation(((fn: () => void) => {
-      fn();
-      return 0 as unknown as ReturnType<typeof setTimeout>;
-    }) as unknown as typeof setTimeout);
+  beforeEach(() => {
+    vi.useFakeTimers();
   });
 
-  afterAll(() => {
-    vi.restoreAllMocks();
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("runs the error handler only after the retry policy is exhausted", async () => {
@@ -65,7 +69,9 @@ describe("Node-level error handlers", () => {
       .addEdge(START, "alwaysFailing")
       .compile();
 
-    const result = await graph.invoke({ foo: "" });
+    const resultPromise = graph.invoke({ foo: "" });
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
 
     expect(attempts).toBe(2);
     expect(result.foo).toBe("handled_after");
@@ -308,7 +314,9 @@ describe("Node-level error handlers", () => {
       .addEdge(START, "alwaysFailing")
       .compile();
 
-    const result = await graph.invoke({ foo: "" });
+    const resultPromise = graph.invoke({ foo: "" });
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
     expect(attempts).toBe(2);
     expect(result.foo).toBe("handled_async");
     expect(captured.node).toBe("alwaysFailing");

--- a/libs/langgraph-core/src/tests/node_error_handler.test.ts
+++ b/libs/langgraph-core/src/tests/node_error_handler.test.ts
@@ -1,0 +1,315 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { it, expect, describe, beforeAll, afterAll, vi } from "vitest";
+import { MemorySaver } from "@langchain/langgraph-checkpoint";
+import { Annotation, StateGraph } from "../graph/index.js";
+import { START } from "../constants.js";
+import { Command } from "../constants.js";
+import { NodeError } from "../errors.js";
+import { interrupt } from "../interrupt.js";
+import { initializeAsyncLocalStorageSingleton } from "../setup/async_local_storage.js";
+
+beforeAll(() => {
+  // Need to initialize the AsyncLocalStorage singleton for interrupt() to work.
+  initializeAsyncLocalStorageSingleton();
+});
+
+describe("Node-level error handlers", () => {
+  // Speed up retry backoff sleeps.
+  beforeAll(() => {
+    vi.spyOn(global, "setTimeout").mockImplementation(((fn: () => void) => {
+      fn();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as unknown as typeof setTimeout);
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("runs the error handler only after the retry policy is exhausted", async () => {
+    const State = Annotation.Root({ foo: Annotation<string> });
+
+    let attempts = 0;
+    const captured: { node?: string; error?: Error } = {};
+
+    const graph = new StateGraph(State)
+      .addNode(
+        "alwaysFailing",
+        () => {
+          attempts += 1;
+          throw new Error("Always fails");
+        },
+        {
+          retryPolicy: {
+            maxAttempts: 2,
+            initialInterval: 1,
+            jitter: false,
+            retryOn: () => true,
+          },
+          errorHandler: (_state, error: NodeError) => {
+            captured.node = error.node;
+            captured.error = error.error;
+            return new Command({
+              update: { foo: "handled" },
+              goto: "afterHandler",
+            });
+          },
+        }
+      )
+      .addNode("afterHandler", (state: typeof State.State) => ({
+        foo: `${state.foo}_after`,
+      }))
+      .addEdge(START, "alwaysFailing")
+      .compile();
+
+    const result = await graph.invoke({ foo: "" });
+
+    expect(attempts).toBe(2);
+    expect(result.foo).toBe("handled_after");
+    expect(captured.node).toBe("alwaysFailing");
+    expect(captured.error).toBeInstanceOf(Error);
+    expect(captured.error?.message).toBe("Always fails");
+  });
+
+  it("lets the handler route to a recovery branch via Command(goto)", async () => {
+    const State = Annotation.Root({ foo: Annotation<string> });
+
+    let attempts = 0;
+    const graph = new StateGraph(State)
+      .addNode(
+        "alwaysFailing",
+        () => {
+          attempts += 1;
+          throw new Error("Always fails");
+        },
+        {
+          retryPolicy: { maxAttempts: 1, initialInterval: 1, jitter: false },
+          errorHandler: () =>
+            new Command({ update: { foo: "handled" }, goto: "nextNode" }),
+        }
+      )
+      .addNode("nextNode", (state: typeof State.State) => ({
+        foo: `${state.foo}_next`,
+      }))
+      .addEdge(START, "alwaysFailing")
+      .compile();
+
+    const result = await graph.invoke({ foo: "" });
+    expect(attempts).toBe(1);
+    expect(result.foo).toBe("handled_next");
+  });
+
+  it("fails the run when the error handler itself throws", async () => {
+    const State = Annotation.Root({ foo: Annotation<string> });
+
+    const graph = new StateGraph(State)
+      .addNode(
+        "alwaysFailing",
+        () => {
+          throw new Error("Always fails");
+        },
+        {
+          errorHandler: () => {
+            throw new Error("handler failed");
+          },
+        }
+      )
+      .addEdge(START, "alwaysFailing")
+      .compile();
+
+    await expect(graph.invoke({ foo: "" })).rejects.toThrow("handler failed");
+  });
+
+  it("handles a failure that occurs inside a subgraph node", async () => {
+    const SubState = Annotation.Root({ foo: Annotation<string> });
+    const ParentState = Annotation.Root({ foo: Annotation<string> });
+
+    const captured: { node?: string; error?: Error } = {};
+
+    const subgraph = new StateGraph(SubState)
+      .addNode("subFail", () => {
+        throw new Error("subgraph boom");
+      })
+      .addEdge(START, "subFail")
+      .compile();
+
+    const parent = new StateGraph(ParentState)
+      .addNode("subgraphNode", subgraph, {
+        errorHandler: (_state, error: NodeError) => {
+          captured.node = error.node;
+          captured.error = error.error;
+          return { foo: "handled_by_parent" };
+        },
+      })
+      .addEdge(START, "subgraphNode")
+      .compile();
+
+    const result = await parent.invoke({ foo: "" });
+    expect(result.foo).toBe("handled_by_parent");
+    expect(captured.node).toBe("subgraphNode");
+    expect(captured.error).toBeInstanceOf(Error);
+  });
+
+  it("preserves the failure context across a checkpoint resume", async () => {
+    const State = Annotation.Root({ foo: Annotation<string> });
+    const captured: { node?: string; error?: Error } = {};
+
+    const checkpointer = new MemorySaver();
+    const graph = new StateGraph(State)
+      .addNode(
+        "alwaysFailing",
+        () => {
+          throw new Error("failed before handler");
+        },
+        {
+          errorHandler: (_state, error: NodeError) => {
+            captured.node = error.node;
+            captured.error = error.error;
+            return { foo: "handled_after_resume" };
+          },
+        }
+      )
+      .addEdge(START, "alwaysFailing")
+      .compile({
+        checkpointer,
+        interruptBefore: ["__error_handler__alwaysFailing" as any],
+      });
+
+    const config = { configurable: { thread_id: "graph-error-resume" } };
+
+    await graph.invoke({ foo: "" }, config);
+    const result = await graph.invoke(null, config);
+
+    expect(result.foo).toBe("handled_after_resume");
+    expect(captured.node).toBe("alwaysFailing");
+    expect(captured.error).toBeInstanceOf(Error);
+  });
+
+  it("does not swallow a concurrent interrupt()", async () => {
+    const State = Annotation.Root({ foo: Annotation<string> });
+
+    const checkpointer = new MemorySaver();
+    const graph = new StateGraph(State)
+      .addNode(
+        "nodeA",
+        (_state: typeof State.State) => {
+          const val = interrupt("need human input");
+          return { foo: `a_${val}` };
+        },
+        { errorHandler: () => ({ foo: "handled" }) }
+      )
+      .addNode("nodeB", () => ({}))
+      .addEdge(START, "nodeA")
+      .addEdge(START, "nodeB")
+      .compile({ checkpointer });
+
+    const config = { configurable: { thread_id: "test-interrupt-concurrent" } };
+
+    await graph.invoke({ foo: "" }, config);
+
+    const state = await graph.getState(config);
+    expect(state.tasks.length).toBeGreaterThan(0);
+    const interrupts = state.tasks.filter(
+      (t) => t.interrupts && t.interrupts.length > 0
+    );
+    expect(interrupts.length).toBeGreaterThan(0);
+  });
+
+  it("routes a failure to the matching node's handler", async () => {
+    const State = Annotation.Root({
+      route: Annotation<string>,
+      foo: Annotation<string[]>({
+        reducer: (a, b) => a.concat(b),
+        default: () => [],
+      }),
+    });
+
+    const graph = new StateGraph(State)
+      .addNode("routeNode", () => ({ foo: [] }))
+      .addNode(
+        "failA",
+        () => {
+          throw new Error("a failed");
+        },
+        {
+          errorHandler: (_state, error: NodeError) => {
+            expect(error.node).toBe("failA");
+            return { foo: ["handled_a"] };
+          },
+        }
+      )
+      .addNode(
+        "failB",
+        () => {
+          throw new Error("b failed");
+        },
+        {
+          errorHandler: (_state, error: NodeError) => {
+            expect(error.node).toBe("failB");
+            return { foo: ["handled_b"] };
+          },
+        }
+      )
+      .addEdge(START, "routeNode")
+      .addConditionalEdges("routeNode", (state: typeof State.State) => state.route, [
+        "failA",
+        "failB",
+      ])
+      .compile();
+
+    const resultA = await graph.invoke({ route: "failA", foo: [] });
+    const resultB = await graph.invoke({ route: "failB", foo: [] });
+    expect(resultA.foo).toEqual(["handled_a"]);
+    expect(resultB.foo).toEqual(["handled_b"]);
+  });
+
+  it("still fails the run for a node without an error handler", async () => {
+    const State = Annotation.Root({ foo: Annotation<string> });
+
+    const graph = new StateGraph(State)
+      .addNode("failWithoutHandler", () => {
+        throw new Error("no handler");
+      })
+      .addEdge(START, "failWithoutHandler")
+      .compile();
+
+    await expect(graph.invoke({ foo: "" })).rejects.toThrow("no handler");
+  });
+
+  it("exposes the NodeError to handlers registered as plain functions", async () => {
+    const State = Annotation.Root({ foo: Annotation<string> });
+
+    let attempts = 0;
+    const captured: { node?: string; error?: Error } = {};
+
+    const graph = new StateGraph(State)
+      .addNode(
+        "alwaysFailing",
+        () => {
+          attempts += 1;
+          throw new Error("Always fails async");
+        },
+        {
+          retryPolicy: {
+            maxAttempts: 2,
+            initialInterval: 1,
+            jitter: false,
+            retryOn: () => true,
+          },
+          errorHandler: async (_state, error: NodeError) => {
+            captured.node = error.node;
+            captured.error = error.error;
+            return { foo: "handled_async" };
+          },
+        }
+      )
+      .addEdge(START, "alwaysFailing")
+      .compile();
+
+    const result = await graph.invoke({ foo: "" });
+    expect(attempts).toBe(2);
+    expect(result.foo).toBe("handled_async");
+    expect(captured.node).toBe("alwaysFailing");
+    expect(captured.error).toBeInstanceOf(Error);
+  });
+});

--- a/libs/langgraph-core/src/tests/pregel/retry.test.ts
+++ b/libs/langgraph-core/src/tests/pregel/retry.test.ts
@@ -1,0 +1,94 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { _runWithRetry } from "../../pregel/retry.js";
+import type { PregelExecutableTask } from "../../pregel/types.js";
+
+function makeTask(
+  invoke: ReturnType<typeof vi.fn>,
+  retryPolicy: NonNullable<PregelExecutableTask<string, string>["retry_policy"]>
+): PregelExecutableTask<string, string> {
+  return {
+    id: "task-1",
+    name: "test_node",
+    input: {},
+    proc: { invoke } as any,
+    writes: [],
+    writers: [],
+    triggers: [],
+    retry_policy: retryPolicy,
+  };
+}
+
+describe("_runWithRetry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("uses backoff: initial * backoff^(attempts - 1)", async () => {
+    const invoke = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("fail 1"))
+      .mockRejectedValueOnce(new Error("fail 2"))
+      .mockResolvedValueOnce("ok");
+
+    const sleepSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const task = makeTask(invoke, {
+      maxAttempts: 3,
+      initialInterval: 10,
+      backoffFactor: 2,
+      jitter: false,
+      retryOn: () => true,
+      logWarning: false,
+    });
+
+    const resultPromise = _runWithRetry(task);
+    await vi.runAllTimersAsync();
+    const { result, error } = await resultPromise;
+
+    expect(error).toBeUndefined();
+    expect(result).toBe("ok");
+    expect(invoke).toHaveBeenCalledTimes(3);
+
+    const sleepDelays = sleepSpy.mock.calls.map((call) => call[1]);
+    expect(sleepDelays).toEqual([10, 20]);
+  });
+
+  it("applies jitter: interval + uniform(0, 1s) in ms", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.05);
+
+    const invoke = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockResolvedValueOnce("ok");
+
+    const sleepSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const task = makeTask(invoke, {
+      maxAttempts: 2,
+      initialInterval: 10,
+      jitter: true,
+      retryOn: () => true,
+      logWarning: false,
+    });
+
+    const resultPromise = _runWithRetry(task);
+    await vi.runAllTimersAsync();
+    await resultPromise;
+
+    const sleepDelays = sleepSpy.mock.calls.map((call) => call[1]);
+    expect(sleepDelays).toEqual([60]);
+  });
+});

--- a/libs/langgraph-core/src/tests/set_node_defaults.test.ts
+++ b/libs/langgraph-core/src/tests/set_node_defaults.test.ts
@@ -480,4 +480,45 @@ describe("StateGraph.setNodeDefaults — errorHandler", () => {
     const result = await graph.invoke({ foo: "" });
     expect(result.foo).toBe("handled");
   });
+
+  it("receives the failing node's input, not the full graph state", async () => {
+    // A single shared default handler serves nodes with differing input
+    // schemas, so at runtime it sees the failing node's input (here a subset
+    // that omits `b`). This is why its `state` parameter is typed `unknown`
+    // rather than the full graph state.
+    const FullState = Annotation.Root({
+      a: Annotation<string>(),
+      b: Annotation<string>(),
+      handled: Annotation<boolean>(),
+    });
+    const NodeInput = Annotation.Root({
+      a: Annotation<string>(),
+    });
+
+    let received: Record<string, unknown> | undefined;
+    const graph = new StateGraph(FullState)
+      .setNodeDefaults({
+        errorHandler: (state) => {
+          received = state as Record<string, unknown>;
+          return { handled: true };
+        },
+      })
+      .addNode(
+        "fail",
+        () => {
+          throw new Error("boom");
+        },
+        { input: NodeInput }
+      )
+      .addEdge(START, "fail")
+      .compile();
+
+    const result = await graph.invoke({ a: "x", b: "y", handled: false });
+
+    expect(result.handled).toBe(true);
+    // The handler saw the node's input subset: `a` is present, the graph-only
+    // field `b` is absent — matching the `unknown` typing.
+    expect(received?.a).toBe("x");
+    expect(received?.b).toBeUndefined();
+  });
 });

--- a/libs/langgraph-core/src/tests/set_node_defaults.test.ts
+++ b/libs/langgraph-core/src/tests/set_node_defaults.test.ts
@@ -1,15 +1,16 @@
 /* eslint-disable no-promise-executor-return */
 import { it, expect, describe, vi, beforeAll } from "vitest";
+import { z } from "zod/v4";
 import { InMemoryCache, MemorySaver } from "@langchain/langgraph-checkpoint";
-import { Annotation, StateGraph } from "../graph/index.js";
+import { StateGraph } from "../graph/index.js";
+import { StateSchema } from "../state/schema.js";
+import { ReducedValue } from "../state/values/reduced.js";
 import { START, Command } from "../constants.js";
 import { NodeError } from "../errors.js";
 import { initializeAsyncLocalStorageSingleton } from "../node.js";
 import type { RetryPolicy } from "../pregel/utils/index.js";
 
-const State = Annotation.Root({
-  foo: Annotation<string>(),
-});
+const State = new StateSchema({ foo: z.string() });
 
 const fastRetry: RetryPolicy = {
   maxAttempts: 3,
@@ -232,11 +233,10 @@ describe("StateGraph.setNodeDefaults", () => {
 
 const RECOVERY_NODE = "__default_error_handler__";
 
-const RoutedState = Annotation.Root({
-  route: Annotation<string>(),
-  foo: Annotation<string[]>({
-    reducer: (a, b) => a.concat(b),
-    default: () => [],
+const RoutedState = new StateSchema({
+  route: z.string(),
+  foo: new ReducedValue(z.array(z.string()).default(() => []), {
+    reducer: (a: string[], b: string[]) => a.concat(b),
   }),
 });
 
@@ -486,13 +486,13 @@ describe("StateGraph.setNodeDefaults — errorHandler", () => {
     // schemas, so at runtime it sees the failing node's input (here a subset
     // that omits `b`). This is why its `state` parameter is typed `unknown`
     // rather than the full graph state.
-    const FullState = Annotation.Root({
-      a: Annotation<string>(),
-      b: Annotation<string>(),
-      handled: Annotation<boolean>(),
+    const FullState = new StateSchema({
+      a: z.string(),
+      b: z.string(),
+      handled: z.boolean(),
     });
-    const NodeInput = Annotation.Root({
-      a: Annotation<string>(),
+    const NodeInput = new StateSchema({
+      a: z.string(),
     });
 
     let received: Record<string, unknown> | undefined;

--- a/libs/langgraph-core/src/tests/set_node_defaults.test.ts
+++ b/libs/langgraph-core/src/tests/set_node_defaults.test.ts
@@ -1,20 +1,11 @@
 /* eslint-disable no-promise-executor-return */
-import { it, expect, describe, vi } from "vitest";
-import { InMemoryCache } from "@langchain/langgraph-checkpoint";
+import { it, expect, describe, vi, beforeAll } from "vitest";
+import { InMemoryCache, MemorySaver } from "@langchain/langgraph-checkpoint";
 import { Annotation, StateGraph } from "../graph/index.js";
-import { START } from "../constants.js";
+import { START, Command } from "../constants.js";
+import { NodeError } from "../errors.js";
+import { initializeAsyncLocalStorageSingleton } from "../node.js";
 import type { RetryPolicy } from "../pregel/utils/index.js";
-
-// ---------------------------------------------------------------------------
-// setNodeDefaults()
-//
-// Ports the parity behavior from langchain-ai/langgraph#7747
-// (`feat(langgraph): add set_node_defaults() to StateGraph`).
-//
-// Note: JS only supports the `retryPolicy` and `cachePolicy` node policies
-// today; the Python PR's `error_handler`/`timeout` defaults are intentionally
-// out of scope here because those node features do not yet exist in JS.
-// ---------------------------------------------------------------------------
 
 const State = Annotation.Root({
   foo: Annotation<string>(),
@@ -236,5 +227,257 @@ describe("StateGraph.setNodeDefaults", () => {
   it("returns the same builder instance for chaining", () => {
     const builder = new StateGraph(State);
     expect(builder.setNodeDefaults({ retryPolicy: fastRetry })).toBe(builder);
+  });
+});
+
+const RECOVERY_NODE = "__default_error_handler__";
+
+const RoutedState = Annotation.Root({
+  route: Annotation<string>(),
+  foo: Annotation<string[]>({
+    reducer: (a, b) => a.concat(b),
+    default: () => [],
+  }),
+});
+
+describe("StateGraph.setNodeDefaults — errorHandler", () => {
+  beforeAll(() => {
+    initializeAsyncLocalStorageSingleton();
+  });
+
+  it("applies the default error handler to every regular node lacking its own", async () => {
+    const captured: string[] = [];
+    const graph = new StateGraph(RoutedState)
+      .setNodeDefaults({
+        errorHandler: (_state, error: NodeError) => {
+          captured.push(error.node);
+          return { foo: [`handled_${error.node}`] };
+        },
+      })
+      .addNode(
+        "routeNode",
+        (state: typeof RoutedState.State) => new Command({ goto: state.route }),
+        { ends: ["failA", "failB"] }
+      )
+      .addNode("failA", () => {
+        throw new Error("a failed");
+      })
+      .addNode("failB", () => {
+        throw new Error("b failed");
+      })
+      .addEdge(START, "routeNode")
+      .compile();
+
+    const resultA = await graph.invoke({ route: "failA", foo: [] });
+    const resultB = await graph.invoke({ route: "failB", foo: [] });
+
+    expect(resultA.foo).toEqual(["handled_failA"]);
+    expect(resultB.foo).toEqual(["handled_failB"]);
+    expect(captured).toContain("failA");
+    expect(captured).toContain("failB");
+  });
+
+  it("lets a per-node errorHandler override the default", async () => {
+    const captured: string[] = [];
+    const graph = new StateGraph(RoutedState)
+      .setNodeDefaults({
+        errorHandler: (_state, error: NodeError) => {
+          captured.push(`default:${error.node}`);
+          return { foo: [`default_handled_${error.node}`] };
+        },
+      })
+      .addNode(
+        "routeNode",
+        (state: typeof RoutedState.State) => new Command({ goto: state.route }),
+        { ends: ["failA", "failB"] }
+      )
+      .addNode(
+        "failA",
+        () => {
+          throw new Error("a failed");
+        },
+        {
+          errorHandler: (_state, error: NodeError) => {
+            captured.push(`node:${error.node}`);
+            return { foo: [`node_handled_${error.node}`] };
+          },
+        }
+      )
+      .addNode("failB", () => {
+        throw new Error("b failed");
+      })
+      .addEdge(START, "routeNode")
+      .compile();
+
+    const resultA = await graph.invoke({ route: "failA", foo: [] });
+    expect(resultA.foo).toEqual(["node_handled_failA"]);
+    expect(captured).toContain("node:failA");
+    expect(captured).not.toContain("default:failA");
+
+    const resultB = await graph.invoke({ route: "failB", foo: [] });
+    expect(resultB.foo).toEqual(["default_handled_failB"]);
+    expect(captured).toContain("default:failB");
+  });
+
+  it("does not catch a failure raised by a per-node error handler", async () => {
+    const graph = new StateGraph(State)
+      .setNodeDefaults({
+        errorHandler: () => ({ foo: "default recovered" }),
+      })
+      .addNode(
+        "alwaysFailing",
+        () => {
+          throw new Error("node boom");
+        },
+        {
+          errorHandler: () => {
+            throw new Error("handler boom");
+          },
+        }
+      )
+      .addEdge(START, "alwaysFailing")
+      .compile();
+
+    await expect(graph.invoke({ foo: "" })).rejects.toThrow("handler boom");
+  });
+
+  it("fails the run when the default error handler itself throws", async () => {
+    const graph = new StateGraph(State)
+      .setNodeDefaults({
+        errorHandler: () => {
+          throw new Error("default handler boom");
+        },
+      })
+      .addNode("alwaysFailing", () => {
+        throw new Error("node boom");
+      })
+      .addEdge(START, "alwaysFailing")
+      .compile();
+
+    await expect(graph.invoke({ foo: "" })).rejects.toThrow(
+      "default handler boom"
+    );
+  });
+
+  it("passes the runnable config to the default error handler", async () => {
+    const captured: { threadId?: string } = {};
+    const graph = new StateGraph(State)
+      .setNodeDefaults({
+        errorHandler: (_state, _error, config) => {
+          captured.threadId = config?.configurable?.thread_id as string;
+          return { foo: "handled" };
+        },
+      })
+      .addNode("alwaysFailing", () => {
+        throw new Error("boom");
+      })
+      .addEdge(START, "alwaysFailing")
+      .compile({ checkpointer: new MemorySaver() });
+
+    const result = await graph.invoke(
+      { foo: "" },
+      { configurable: { thread_id: "thread-xyz" } }
+    );
+
+    expect(result.foo).toBe("handled");
+    expect(captured.threadId).toBe("thread-xyz");
+  });
+
+  it("throws at compile when a node uses the reserved default-handler name", () => {
+    const builder = new StateGraph(State)
+      .setNodeDefaults({ errorHandler: () => ({ foo: "handled" }) })
+      .addNode(RECOVERY_NODE, (state) => state)
+      .addEdge(START, RECOVERY_NODE);
+
+    expect(() => builder.compile()).toThrow(RECOVERY_NODE);
+  });
+
+  it("runs the default handler only after the default retryPolicy is exhausted", async () => {
+    let attempts = 0;
+    const captured: { error?: string } = {};
+    const graph = new StateGraph(State)
+      .setNodeDefaults({
+        retryPolicy: fastRetry,
+        errorHandler: (_state, error: NodeError) => {
+          captured.error = error.error.message;
+          return { foo: "handled" };
+        },
+      })
+      .addNode("fail", () => {
+        attempts += 1;
+        throw new Error("Always fails");
+      })
+      .addEdge(START, "fail")
+      .compile();
+
+    const result = await graph.invoke({ foo: "" });
+    expect(result.foo).toBe("handled");
+    expect(attempts).toBe(fastRetry.maxAttempts);
+    expect(captured.error).toBe("Always fails");
+  });
+
+  it("applies retry/timeout to the shared handler node but never cachePolicy", () => {
+    const graph = new StateGraph(State)
+      .setNodeDefaults({
+        retryPolicy: fastRetry,
+        cachePolicy: { ttl: 60 },
+        timeout: 1_000,
+        errorHandler: () => ({ foo: "handled" }),
+      })
+      .addNode("a", () => ({ foo: "a" }))
+      .addEdge(START, "a")
+      .compile({ cache: new InMemoryCache() });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const nodes = graph.nodes as Record<string, any>;
+    const handler = nodes[RECOVERY_NODE];
+    expect(handler).toBeDefined();
+    // retry + timeout defaults apply to the handler node too...
+    expect(handler.retryPolicy).toEqual(fastRetry);
+    expect(handler.timeout).toBeDefined();
+    // ...but cachePolicy must never be applied to a handler.
+    expect(handler.cachePolicy).toBeUndefined();
+    // regular node gets the cache default and routes to the shared handler.
+    expect(nodes.a.cachePolicy).toEqual({ ttl: 60 });
+    expect(nodes.a.errorHandlerNode).toBe(RECOVERY_NODE);
+  });
+
+  it("does not inherit the default error handler into subgraphs", () => {
+    const inner = new StateGraph(State)
+      .addNode("innerNode", () => ({ foo: "inner" }))
+      .addEdge(START, "innerNode")
+      .compile();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const innerNodes = inner.nodes as Record<string, any>;
+    expect(innerNodes[RECOVERY_NODE]).toBeUndefined();
+    expect(innerNodes.innerNode.errorHandlerNode).toBeUndefined();
+
+    const outer = new StateGraph(State)
+      .setNodeDefaults({ errorHandler: () => ({ foo: "handled" }) })
+      .addNode("sub", inner)
+      .addEdge(START, "sub")
+      .compile();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const outerNodes = outer.nodes as Record<string, any>;
+    // The outer graph materializes its own shared handler and routes `sub` to it...
+    expect(outerNodes[RECOVERY_NODE]).toBeDefined();
+    expect(outerNodes.sub.errorHandlerNode).toBe(RECOVERY_NODE);
+    // ...but the inner compiled graph is unaffected.
+    expect(innerNodes[RECOVERY_NODE]).toBeUndefined();
+  });
+
+  it("is order-independent (errorHandler set after addNode)", async () => {
+    const graph = new StateGraph(State)
+      .addNode("fail", () => {
+        throw new Error("boom");
+      })
+      .addEdge(START, "fail")
+      .setNodeDefaults({ errorHandler: () => ({ foo: "handled" }) })
+      .compile();
+
+    const result = await graph.invoke({ foo: "" });
+    expect(result.foo).toBe("handled");
   });
 });

--- a/libs/langgraph-core/src/tests/types.test-d.ts
+++ b/libs/langgraph-core/src/tests/types.test-d.ts
@@ -653,6 +653,29 @@ describe("StateGraph.addNode errorHandler", () => {
 
     expect(graph).toBeDefined();
   });
+
+  it("accepts handlers that return Command with typed goto and update", () => {
+    const State = new StateSchema({
+      count: z.number().default(0),
+      name: z.string(),
+    });
+
+    const graph = new StateGraph(State)
+      .addNode("recovery", (_state: typeof State.State) => ({ count: 0 }))
+      .addNode(
+        "fails",
+        (_state: typeof State.State) => {
+          throw new Error("boom");
+        },
+        {
+          ends: ["recovery"],
+          errorHandler: (_state, _error) =>
+            new Command({ update: { count: 1 }, goto: "recovery" }),
+        }
+      );
+
+    expect(graph).toBeDefined();
+  });
 });
 
 describe("ConditionalEdgeRouter", () => {

--- a/libs/langgraph-core/src/tests/types.test-d.ts
+++ b/libs/langgraph-core/src/tests/types.test-d.ts
@@ -13,6 +13,7 @@ import {
   type OverwriteValue,
 } from "../constants.js";
 import type { LangGraphRunnableConfig } from "../pregel/runnable_types.js";
+import type { NodeError } from "../errors.js";
 import type {
   GraphNode,
   ConditionalEdgeRouter,
@@ -603,6 +604,54 @@ describe("GraphNode", () => {
         expect(node).toBeDefined();
       });
     });
+  });
+});
+
+describe("StateGraph.addNode errorHandler", () => {
+  it("accepts handlers with the typed graph state", () => {
+    const State = new StateSchema({
+      count: z.number().default(0),
+      name: z.string(),
+    });
+
+    const typedHandler = (state: typeof State.State, _error: NodeError) => {
+      expectTypeOf(state.count).toEqualTypeOf<number>();
+      expectTypeOf(state.name).toEqualTypeOf<string>();
+      return { count: state.count + 1 };
+    };
+
+    const graph = new StateGraph(State).addNode(
+      "fails",
+      (_state: typeof State.State) => {
+        throw new Error("boom");
+      },
+      { errorHandler: typedHandler }
+    );
+
+    expect(graph).toBeDefined();
+  });
+
+  it("accepts handlers with typed per-node input state", () => {
+    const State = new StateSchema({
+      count: z.number().default(0),
+      name: z.string(),
+    });
+    const InputState = new StateSchema({
+      query: z.string(),
+    });
+
+    const typedHandler = (state: typeof InputState.State) => {
+      expectTypeOf(state.query).toEqualTypeOf<string>();
+      return { name: state.query };
+    };
+
+    const graph = new StateGraph(State).addNode(
+      "usesInput",
+      (state: typeof InputState.State) => ({ count: state.query.length }),
+      { input: InputState, errorHandler: typedHandler }
+    );
+
+    expect(graph).toBeDefined();
   });
 });
 


### PR DESCRIPTION
`StateGraph.addNode(name, fn, { errorHandler })` now accepts a first-class node-level error handler. The handler runs ONLY after the failing node's `retryPolicy` is exhausted, so retry and handling stay decoupled. It receives a typed `NodeError { node, error }`, can return a state update, and can route to a recovery branch via `new Command({ goto })` (saga / compensation flows).

Failure provenance is checkpointed (via a reserved `ERROR_SOURCE_NODE` write) so handlers observe the same context after a checkpoint resume. Uncaught node errors without a handler still abort the run as before, and `GraphBubbleUp` errors (such as `interrupt()`) are never swallowed by a handler.

Ports the Python feature from langchain-ai/langgraph#7233.