### PR TITLE
fix(sdk): prefer completed task's direct mapping over pending checkpoint's positional guess in fetchSubagentHistory

### DIFF
--- a/.changeset/brown-mice-listen.md
+++ b/.changeset/brown-mice-listen.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): prefer completed task's direct mapping over pending checkpoint's positional guess in fetchSubagentHistory

--- a/libs/sdk/src/ui/manager.test.ts
+++ b/libs/sdk/src/ui/manager.test.ts
@@ -1495,4 +1495,132 @@ describe("StreamManager", () => {
       expect(mgr.getSubagentsByMessage(streamingId)).toHaveLength(0);
     });
   });
+
+  describe("fetchSubagentHistory namespace resolution", () => {
+    it("prefers a completed task's direct mapping over a newer pending checkpoint's positional guess", async () => {
+      /**
+       * Regression test: the most recent checkpoint is a still-pending (e.g.
+       * interrupted) PUSH task. That head checkpoint has no task result, so it
+       * cannot produce a direct tool_call_id mapping — but its accumulated
+       * `values.messages` still contains the AI message whose subagent tool
+       * call already completed in an OLDER checkpoint.
+       *
+       * The positional fallback, run against the head checkpoint, would align
+       * that stale AI tool call to the head's unrelated pending push task and
+       * stop — never reaching the older checkpoint whose task result holds the
+       * correct namespace. Direct mappings must take precedence across the
+       * whole history, not just the first checkpoint that yields any mapping.
+       */
+      const sm = new StreamManager<TestState>(messageManager, {
+        throttle: false,
+        subagentToolNames: ["task"],
+      });
+
+      // AI message whose subagent tool call ("call-real") completed in an
+      // OLDER checkpoint. Registers a pending subagent with empty messages.
+      const aiMessage = {
+        type: "ai",
+        id: "ai-completed",
+        content: "",
+        tool_calls: [
+          {
+            id: "call-real",
+            name: "task",
+            args: {
+              subagent_type: "researcher",
+              description: "Research the real topic",
+            },
+          },
+        ],
+      };
+
+      sm.reconstructSubagents(
+        [aiMessage] as unknown as Parameters<typeof sm.reconstructSubagents>[0]
+      );
+      expect(sm.getSubagent("call-real")?.messages).toHaveLength(0);
+
+      // Main history is newest-first:
+      //   [0] head    — pending push task, no result; stale AI message in values
+      //   [1] older   — completed push task; result maps call-real -> task:uuid-real
+      const mainHistory = [
+        {
+          values: { messages: [aiMessage] },
+          tasks: [
+            {
+              id: "uuid-pending",
+              name: "task",
+              path: ["__pregel_push", 0],
+              checkpoint: null,
+            },
+          ],
+        },
+        {
+          values: { messages: [aiMessage] },
+          tasks: [
+            {
+              id: "uuid-real",
+              name: "task",
+              path: ["__pregel_push", 0],
+              checkpoint: null,
+              result: {
+                messages: [
+                  {
+                    type: "tool",
+                    tool_call_id: "call-real",
+                    content: "ok",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ];
+
+      const byNamespace: Record<string, Array<{ values: unknown }>> = {
+        // Correct namespace, derived from the completed task result.
+        "task:uuid-real": [
+          {
+            values: {
+              messages: [
+                { type: "human", id: "h-real", content: "Research the real topic" },
+                { type: "ai", id: "ai-real", content: "Correct research result" },
+              ],
+            },
+          },
+        ],
+        // Wrong namespace, returned only if the positional fallback mis-maps.
+        "task:uuid-pending": [
+          {
+            values: {
+              messages: [{ type: "ai", id: "ai-stale", content: "Stale pending result" }],
+            },
+          },
+        ],
+      };
+
+      const getHistory = vi.fn(
+        async (
+          _threadId: string,
+          opts?: { checkpoint?: { checkpoint_ns?: string } }
+        ) => {
+          const ns = opts?.checkpoint?.checkpoint_ns;
+          if (ns) return byNamespace[ns] ?? [];
+          return mainHistory;
+        }
+      );
+
+      await sm.fetchSubagentHistory(
+        { getHistory } as unknown as Parameters<
+          typeof sm.fetchSubagentHistory
+        >[0],
+        "thread-1"
+      );
+
+      const contents = (sm.getSubagent("call-real")?.messages ?? []).map(
+        (m) => (m as { content?: unknown }).content
+      );
+      expect(contents).toContain("Correct research result");
+      expect(contents).not.toContain("Stale pending result");
+    });
+  });
 });

--- a/libs/sdk/src/ui/manager.ts
+++ b/libs/sdk/src/ui/manager.ts
@@ -376,7 +376,7 @@ export class StreamManager<
      * derive the subgraph namespace for every tool call without any external
      * metadata on the ToolMessage itself.
      */
-    let toolCallIdToNamespace: Map<string, string> | undefined;
+    const toolCallIdToNamespace = new Map<string, string>();
 
     try {
       /**
@@ -388,30 +388,36 @@ export class StreamManager<
         { limit: options?.historyLimit ?? 20, signal }
       );
 
+      /**
+       * Phase 1: Direct mapping across ALL checkpoints (preferred).
+       *
+       * When a completed checkpoint contains task results, each task.result
+       * has a ToolMessage whose tool_call_id directly and unambiguously maps
+       * the task to the LLM tool call that triggered it. This is more robust
+       * than positional alignment: it works even when a step mixes subagent
+       * tool calls with other tool calls, and requires no assumptions about
+       * the ordering of tasks vs tool_calls.
+       *
+       * We collect these direct mappings across the entire history before
+       * attempting any positional fallback. Otherwise a more recent checkpoint
+       * whose task is still pending (e.g. an interrupted run) could produce a
+       * positional guess and stop the scan before reaching the older checkpoint
+       * that actually holds the correct, completed mapping.
+       *
+       * LangGraph v2 dispatches each parallel tool call as a separate PUSH
+       * task ("__pregel_push"). The subgraph checkpoint_ns is constructed as
+       * `task.name + ":" + task.id`, mirroring algo.ts:
+       *   taskCheckpointNamespace = checkpointNamespace + ":" + taskId
+       *   where checkpointNamespace = task.name for root-level tasks.
+       *
+       * task.checkpoint is always null for completed tasks, so we derive the
+       * namespace from task.name + task.id rather than task.checkpoint.checkpoint_ns.
+       */
       for (const checkpoint of mainHistory) {
         const { tasks } = checkpoint;
         if (!tasks || tasks.length === 0) {
           continue;
         }
-
-        /**
-         * When a completed checkpoint contains task results, each task.result
-         * has a ToolMessage whose tool_call_id directly and unambiguously maps
-         * the task to the LLM tool call that triggered it. This is more robust
-         * than positional alignment: it works even when a step mixes subagent
-         * tool calls with other tool calls, and requires no assumptions about
-         * the ordering of tasks vs tool_calls.
-         *
-         * LangGraph v2 dispatches each parallel tool call as a separate PUSH
-         * task ("__pregel_push"). The subgraph checkpoint_ns is constructed as
-         * `task.name + ":" + task.id`, mirroring algo.ts:
-         *   taskCheckpointNamespace = checkpointNamespace + ":" + taskId
-         *   where checkpointNamespace = task.name for root-level tasks.
-         *
-         * task.checkpoint is always null for completed tasks, so we derive the
-         * namespace from task.name + task.id rather than task.checkpoint.checkpoint_ns.
-         */
-        const directMap = new Map<string, string>();
 
         for (const task of tasks) {
           if (
@@ -430,101 +436,124 @@ export class StreamManager<
             task as unknown as { result?: { messages?: unknown[] } }
           ).result?.messages;
 
-          if (Array.isArray(resultMessages)) {
-            for (const msg of resultMessages) {
-              const m = msg as Record<string, unknown>;
-              if (
-                m.type === "tool" &&
-                typeof m.tool_call_id === "string" &&
-                toFetch.some(([id]) => id === m.tool_call_id)
-              ) {
-                directMap.set(m.tool_call_id, `${task.name}:${task.id}`);
-              }
+          if (!Array.isArray(resultMessages)) {
+            continue;
+          }
+
+          for (const msg of resultMessages) {
+            const m = msg as Record<string, unknown>;
+            if (
+              m.type === "tool" &&
+              typeof m.tool_call_id === "string" &&
+              toFetch.some(([id]) => id === m.tool_call_id) &&
+              !toolCallIdToNamespace.has(m.tool_call_id)
+            ) {
+              toolCallIdToNamespace.set(
+                m.tool_call_id,
+                `${task.name}:${task.id}`
+              );
             }
           }
         }
+      }
 
-        if (directMap.size > 0) {
-          toolCallIdToNamespace = directMap;
-          break;
-        }
+      /**
+       * Phase 2: Positional fallback, applied ONLY to tool calls that Phase 1
+       * could not resolve.
+       *
+       * This covers checkpoints whose task results are not yet populated (tasks
+       * still pending — the live or just-interrupted case). We align push tasks
+       * to the subagent tool calls of the triggering AI message by Send index
+       * (task.path[1]). Restricting this to still-unmapped tool calls guarantees
+       * a correct direct mapping from Phase 1 is never overwritten by a guess.
+       */
+      const hasUnmappedToolCalls = () =>
+        toFetch.some(([id]) => !toolCallIdToNamespace.has(id));
 
-        /**
-         * Fallback for checkpoints where task results are not yet populated
-         * (tasks are still pending). Use positional alignment via the Send
-         * index in task.path[1] as a secondary strategy.
-         */
-        const pushTasks = tasks.filter(
-          (t) =>
-            Array.isArray(t.path) &&
-            t.path[0] === "__pregel_push" &&
-            typeof t.path[1] === "number" &&
-            typeof t.id === "string" &&
-            typeof t.name === "string"
-        );
-        if (pushTasks.length === 0) continue;
+      if (hasUnmappedToolCalls()) {
+        for (const checkpoint of mainHistory) {
+          if (!hasUnmappedToolCalls()) break;
 
-        /**
-         * Find the AI message with subagent tool calls to align by Send index.
-         */
-        const msgs = checkpoint.values[messagesKey];
-        if (!Array.isArray(msgs)) continue;
+          const { tasks } = checkpoint;
+          if (!tasks || tasks.length === 0) {
+            continue;
+          }
 
-        let aiMessage: Record<string, unknown> | undefined;
-        for (let i = msgs.length - 1; i >= 0; i -= 1) {
-          const m = msgs[i] as Record<string, unknown>;
-          if (
-            m.type === "ai" &&
-            Array.isArray(m.tool_calls) &&
-            m.tool_calls.length > 0 &&
-            (m.tool_calls as Array<{ name: string }>).some((tc) =>
-              this.subagentManager.isSubagentToolCall(tc.name)
-            )
+          const pushTasks = tasks.filter(
+            (t) =>
+              Array.isArray(t.path) &&
+              t.path[0] === "__pregel_push" &&
+              typeof t.path[1] === "number" &&
+              typeof t.id === "string" &&
+              typeof t.name === "string"
+          );
+          if (pushTasks.length === 0) continue;
+
+          /**
+           * Find the AI message with subagent tool calls to align by Send index.
+           */
+          const msgs = checkpoint.values[messagesKey];
+          if (!Array.isArray(msgs)) continue;
+
+          let aiMessage: Record<string, unknown> | undefined;
+          for (let i = msgs.length - 1; i >= 0; i -= 1) {
+            const m = msgs[i] as Record<string, unknown>;
+            if (
+              m.type === "ai" &&
+              Array.isArray(m.tool_calls) &&
+              m.tool_calls.length > 0 &&
+              (m.tool_calls as Array<{ name: string }>).some((tc) =>
+                this.subagentManager.isSubagentToolCall(tc.name)
+              )
+            ) {
+              aiMessage = m;
+              break;
+            }
+          }
+          if (!aiMessage) {
+            continue;
+          }
+
+          /**
+           * Only consider subagent tool calls from the AI message — not all tool
+           * calls. This ensures regular tool calls (searchWeb, queryDatabase, etc.)
+           * are never mistaken for subagents even when they appear in the same step.
+           */
+          const subagentToolCalls = (
+            aiMessage.tool_calls as Array<{ id?: string; name: string }>
+          ).filter((tc) => this.subagentManager.isSubagentToolCall(tc.name));
+
+          if (subagentToolCalls.length === 0) {
+            continue;
+          }
+
+          /**
+           * Sort push tasks by Send index (path[1]) to align with tool_calls order
+           */
+          const sorted = [...pushTasks].sort((a, b) => {
+            const ai = Array.isArray(a.path) ? (a.path[1] as number) : 0;
+            const bi = Array.isArray(b.path) ? (b.path[1] as number) : 0;
+            return ai - bi;
+          });
+
+          for (
+            let i = 0;
+            i < sorted.length && i < subagentToolCalls.length;
+            i += 1
           ) {
-            aiMessage = m;
-            break;
+            const tc = subagentToolCalls[i];
+            const task = sorted[i];
+            if (
+              tc?.id &&
+              task.id &&
+              task.name &&
+              toFetch.some(([id]) => id === tc.id) &&
+              !toolCallIdToNamespace.has(tc.id)
+            ) {
+              toolCallIdToNamespace.set(tc.id, `${task.name}:${task.id}`);
+            }
           }
         }
-        if (!aiMessage) {
-          continue;
-        }
-
-        /**
-         * Only consider subagent tool calls from the AI message — not all tool
-         * calls. This ensures regular tool calls (searchWeb, queryDatabase, etc.)
-         * are never mistaken for subagents even when they appear in the same step.
-         */
-        const subagentToolCalls = (
-          aiMessage.tool_calls as Array<{ id?: string; name: string }>
-        ).filter((tc) => this.subagentManager.isSubagentToolCall(tc.name));
-
-        if (subagentToolCalls.length === 0) {
-          continue;
-        }
-
-        /**
-         * Sort push tasks by Send index (path[1]) to align with tool_calls order
-         */
-        const sorted = [...pushTasks].sort((a, b) => {
-          const ai = Array.isArray(a.path) ? (a.path[1] as number) : 0;
-          const bi = Array.isArray(b.path) ? (b.path[1] as number) : 0;
-          return ai - bi;
-        });
-
-        toolCallIdToNamespace = new Map();
-        for (
-          let i = 0;
-          i < sorted.length && i < subagentToolCalls.length;
-          i += 1
-        ) {
-          const tc = subagentToolCalls[i];
-          const task = sorted[i];
-          if (tc?.id && task.id && task.name) {
-            toolCallIdToNamespace.set(tc.id, `${task.name}:${task.id}`);
-          }
-        }
-
-        if (toolCallIdToNamespace.size > 0) break;
       }
     } catch {
       /**
@@ -544,7 +573,7 @@ export class StreamManager<
          *   3. Skip — we cannot reliably identify the namespace
          */
         const checkpointNs =
-          toolCallIdToNamespace?.get(toolCallId) ??
+          toolCallIdToNamespace.get(toolCallId) ??
           (subagent.namespace.length > 0
             ? subagent.namespace.join("|")
             : undefined);


### PR DESCRIPTION
Fixes #2454

## Problem

`StreamManager.fetchSubagentHistory` (`libs/sdk/src/ui/manager.ts`) restores each subagent's conversation from its subgraph checkpoint by first resolving every subagent `tool_call_id` to its subgraph `checkpoint_ns`. It scans the parent thread's history **newest-first** and, per checkpoint, tries two strategies:

1. **Direct mapping** — read the `tool_call_id` straight off a completed PUSH task's result `ToolMessage` (`task.name + ":" + task.id`). The code comments correctly call this *"more robust than positional alignment ... preferred"*.
2. **Positional fallback** — when task results aren't populated yet, align push tasks to the AI message's subagent tool calls by Send index (`task.path[1]`).

The loop **breaks on the first checkpoint that yields any mapping** (direct *or* positional). That break is the bug.

When the most recent checkpoint is a still-pending PUSH task — e.g. a run stopped at an interrupt — its task has no result, so the direct map is empty and the **positional fallback runs against the head checkpoint instead**. The fallback's backward scan of `values.messages` then latches onto a *stale* AI message whose subagent actually **completed in an older checkpoint**, positionally aligns it to the head's unrelated pending task, and breaks — before the loop ever reaches the older checkpoint whose task result holds the **correct** direct mapping.

Net effect: the subagent's history is reconstructed from the **wrong subgraph namespace** (or not at all). A newer, lower-confidence positional guess silently shadows an older, authoritative direct mapping — the opposite of the code's stated intent.

## Fix

Split namespace resolution into two phases:

1. **Phase 1 — direct mapping across the _entire_ history first.** Collect all `tool_call_id → namespace` mappings from completed task results before attempting any fallback. These are unambiguous, so no pending head checkpoint can pre-empt them.
2. **Phase 2 — positional fallback only for tool calls still unmapped** after phase 1 (the genuinely live/pending case). This preserves the existing behavior for in-flight runs while guaranteeing a correct direct mapping is never overwritten by a positional guess.

No backend/protocol change is required — the server already serializes the correct material (the completed task result with the matching `tool_call_id`); only the client-side resolution order was wrong.

## Testing

- Added a regression test (`fetchSubagentHistory namespace resolution`): a pending head checkpoint sitting in front of an older checkpoint that holds the correct completed mapping. Verified it **fails on the pre-fix code** (`expected [ 'Stale pending result' ] to include 'Correct research result'`) and **passes with this change**.
- `vitest run` (SDK): **595 passed**, no type errors.
- `oxlint`: 0 warnings / 0 errors · `oxfmt --check`: clean · `tsc -p libs/sdk/tsconfig.json --noEmit`: clean.
