### PR TITLE
fix(langgraph): pass context with stateful RemoteGraph runs

### DIFF
--- a/.changeset/fix-remote-graph-context-stateful-runs.md
+++ b/.changeset/fix-remote-graph-context-stateful-runs.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(langgraph): pass context with stateful RemoteGraph runs
+
+Pop `thread_id` from run `config.configurable` and forward `context` to the SDK so checkpointed remote runs accept user context without a 400 from ambiguous parameters. Closes #1922.

--- a/libs/langgraph-core/src/pregel/remote.ts
+++ b/libs/langgraph-core/src/pregel/remote.ts
@@ -169,7 +169,8 @@ export class RemoteGraph<
     PregelOutputType,
     PregelOptions<Nn, Cc, ContextType>
   >
-  implements PregelInterface<Nn, Cc, ContextType> {
+  implements PregelInterface<Nn, Cc, ContextType>
+{
   static lc_name() {
     return "RemoteGraph";
   }
@@ -264,8 +265,8 @@ export class RemoteGraph<
         ) {
           const metadata =
             typeof record.metadata === "object" &&
-              record.metadata != null &&
-              !Array.isArray(record.metadata)
+            record.metadata != null &&
+            !Array.isArray(record.metadata)
               ? (record.metadata as Record<string, unknown>)
               : undefined;
           record.metadata =
@@ -410,11 +411,11 @@ export class RemoteGraph<
         // eslint-disable-next-line no-nested-ternary
         state: task.state
           ? this._createStateSnapshot(
-            task.state,
-            task.checkpoint
-              ? this._checkpointToConfig(task.checkpoint)
-              : fallbackConfig
-          )
+              task.state,
+              task.checkpoint
+                ? this._checkpointToConfig(task.checkpoint)
+                : fallbackConfig
+            )
           : task.checkpoint
             ? { configurable: task.checkpoint }
             : undefined,

--- a/libs/langgraph-core/src/pregel/remote.ts
+++ b/libs/langgraph-core/src/pregel/remote.ts
@@ -169,8 +169,7 @@ export class RemoteGraph<
     PregelOutputType,
     PregelOptions<Nn, Cc, ContextType>
   >
-  implements PregelInterface<Nn, Cc, ContextType>
-{
+  implements PregelInterface<Nn, Cc, ContextType> {
   static lc_name() {
     return "RemoteGraph";
   }
@@ -265,8 +264,8 @@ export class RemoteGraph<
         ) {
           const metadata =
             typeof record.metadata === "object" &&
-            record.metadata != null &&
-            !Array.isArray(record.metadata)
+              record.metadata != null &&
+              !Array.isArray(record.metadata)
               ? (record.metadata as Record<string, unknown>)
               : undefined;
           record.metadata =
@@ -300,6 +299,33 @@ export class RemoteGraph<
       metadata: sanitizedConfig.metadata ?? {},
       configurable: newConfigurable,
       recursion_limit: sanitizedConfig.recursionLimit,
+    };
+  }
+
+  /**
+   * Prepare config and thread ID for remote run API calls.
+   *
+   * `thread_id` is passed via the URL path, not in `config.configurable`, so the
+   * server can accept a separate `context` payload for stateful runs.
+   */
+  #prepareRunRequest(mergedConfig: LangGraphRunnableConfig): {
+    threadId: string | undefined;
+    context: unknown;
+    config: ReturnType<RemoteGraph["_sanitizeConfig"]>;
+  } {
+    const context = mergedConfig.context;
+    const sanitizedConfig = this._sanitizeConfig(mergedConfig);
+    const configurable = { ...sanitizedConfig.configurable };
+    const threadId = configurable.thread_id as string | undefined;
+    delete configurable.thread_id;
+
+    return {
+      threadId,
+      context,
+      config: {
+        ...sanitizedConfig,
+        configurable,
+      },
     };
   }
 
@@ -384,11 +410,11 @@ export class RemoteGraph<
         // eslint-disable-next-line no-nested-ternary
         state: task.state
           ? this._createStateSnapshot(
-              task.state,
-              task.checkpoint
-                ? this._checkpointToConfig(task.checkpoint)
-                : fallbackConfig
-            )
+            task.state,
+            task.checkpoint
+              ? this._checkpointToConfig(task.checkpoint)
+              : fallbackConfig
+          )
           : task.checkpoint
             ? { configurable: task.checkpoint }
             : undefined,
@@ -462,8 +488,15 @@ export class RemoteGraph<
     input: PregelInputType,
     options?: Partial<PregelOptions<Nn, Cc, ContextType>>
   ): AsyncGenerator<PregelOutputType> {
-    const mergedConfig = mergeConfigs(this.config, options);
-    const sanitizedConfig = this._sanitizeConfig(mergedConfig);
+    const mergedConfig = mergeConfigs(
+      this.config,
+      options
+    ) as LangGraphRunnableConfig;
+    const {
+      threadId,
+      context,
+      config: sanitizedConfig,
+    } = this.#prepareRunRequest(mergedConfig);
 
     const streamProtocolInstance = options?.configurable?.[CONFIG_KEY_STREAM];
 
@@ -497,22 +530,26 @@ export class RemoteGraph<
       serializedInput = _serializeInputs(input);
     }
 
-    for await (const chunk of this.client.runs.stream(
-      sanitizedConfig.configurable.thread_id as string,
-      this.graphId,
-      {
-        command,
-        input: serializedInput,
-        config: sanitizedConfig,
-        streamMode: extendedStreamModes,
-        interruptBefore: interruptBefore as string[],
-        interruptAfter: interruptAfter as string[],
-        streamSubgraphs,
-        ifNotExists: "create",
-        signal: mergedConfig.signal,
-        streamResumable: this.streamResumable,
-      }
-    )) {
+    const streamPayload = {
+      command,
+      input: serializedInput,
+      config: sanitizedConfig,
+      context,
+      streamMode: extendedStreamModes,
+      interruptBefore: interruptBefore as string[],
+      interruptAfter: interruptAfter as string[],
+      streamSubgraphs,
+      ifNotExists: "create" as const,
+      signal: mergedConfig.signal,
+      streamResumable: this.streamResumable,
+    };
+
+    const runStream =
+      threadId != null
+        ? this.client.runs.stream(threadId, this.graphId, streamPayload)
+        : this.client.runs.stream(null, this.graphId, streamPayload);
+
+    for await (const chunk of runStream) {
       let mode;
       let namespace: string[];
       if (chunk.event.includes(CHECKPOINT_NAMESPACE_SEPARATOR)) {

--- a/libs/langgraph-core/src/tests/pregel.stream.test.ts
+++ b/libs/langgraph-core/src/tests/pregel.stream.test.ts
@@ -12,7 +12,12 @@ import { StateSchema } from "../state/schema.js";
 import { ReducedValue } from "../state/values/reduced.js";
 import { StreamChannel } from "../stream/stream-channel.js";
 import type { ProtocolEvent, StreamTransformer } from "../stream/types.js";
-import { LangGraphRunnableConfig } from "../pregel/runnable_types.js";
+import { AIMessage } from "@langchain/core/messages";
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { MessagesAnnotation } from "../graph/messages_annotation.js";
+import { ToolNode } from "../prebuilt/tool_node.js";
+import type { ToolsEventData } from "../stream/types.js";
+import type { LangGraphRunnableConfig } from "../pregel/runnable_types.js";
 
 beforeAll(() => {
   initializeAsyncLocalStorageSingleton();
@@ -720,6 +725,84 @@ describe("streamEvents version v3", () => {
       expect(customEvents.length).toBeGreaterThanOrEqual(1);
       expect(customEvents[0].params.data).toEqual({
         payload: { hello: "world" },
+      });
+    });
+  });
+
+  describe("tool errors", () => {
+    const errorTool = new DynamicStructuredTool({
+      name: "error_tool",
+      description: "Always throws",
+      schema: z.object({}),
+      func: async () => {
+        throw new Error("test error");
+      },
+    });
+
+    function buildErrorToolGraph(handleToolErrors: boolean) {
+      return new StateGraph(MessagesAnnotation)
+        .addNode("tools", new ToolNode([errorTool], { handleToolErrors }))
+        .addEdge(START, "tools")
+        .addEdge("tools", END)
+        .compile({ checkpointer: new MemorySaver() });
+    }
+
+    async function collectToolEvents(handleToolErrors: boolean) {
+      const graph = buildErrorToolGraph(handleToolErrors);
+      const toolEvents: ToolsEventData[] = [];
+
+      try {
+        const run = await graph.streamEvents(
+          {
+            messages: [
+              new AIMessage({
+                tool_calls: [{ id: "call_1", name: "error_tool", args: {} }],
+              }),
+            ],
+          },
+          {
+            version: "v3",
+            configurable: {
+              thread_id: `tool-error-${handleToolErrors}-${Date.now()}`,
+            },
+          }
+        );
+
+        for await (const event of run) {
+          if (event.method === "tools") {
+            toolEvents.push(event.params.data as ToolsEventData);
+          }
+        }
+
+        await run.output;
+      } catch {
+        // Expected when handleToolErrors=false — the error propagates from invoke().
+      }
+
+      return toolEvents;
+    }
+
+    it("emits tool-started and tool-error when handleToolErrors=false", async () => {
+      const toolEvents = await collectToolEvents(false);
+
+      expect(toolEvents.some((e) => e.event === "tool-started")).toBe(true);
+      expect(toolEvents.some((e) => e.event === "tool-error")).toBe(true);
+      const err = toolEvents.find((e) => e.event === "tool-error");
+      expect(err).toMatchObject({
+        tool_call_id: "call_1",
+        message: "test error",
+      });
+    });
+
+    it("emits tool-started and tool-error when handleToolErrors=true", async () => {
+      const toolEvents = await collectToolEvents(true);
+
+      expect(toolEvents.some((e) => e.event === "tool-started")).toBe(true);
+      expect(toolEvents.some((e) => e.event === "tool-error")).toBe(true);
+      const err = toolEvents.find((e) => e.event === "tool-error");
+      expect(err).toMatchObject({
+        tool_call_id: "call_1",
+        message: "test error",
       });
     });
   });

--- a/libs/langgraph-core/src/tests/remote.test.ts
+++ b/libs/langgraph-core/src/tests/remote.test.ts
@@ -645,9 +645,45 @@ describe("RemoteGraph", () => {
       expect.objectContaining({
         signal: config.signal,
         config: expect.objectContaining({
-          configurable: config.configurable,
+          configurable: { custom_key: "custom_value" },
           recursion_limit: config.recursionLimit,
           tags: config.tags,
+        }),
+      }),
+    ]);
+  });
+
+  test("stream passes context separately from config for stateful runs", async () => {
+    const client = new Client({});
+    let streamArgs: unknown[] | undefined;
+    vi.spyOn(client.runs, "stream").mockImplementation(async function* (
+      ...args
+    ) {
+      streamArgs = args;
+      yield { event: "values", data: { ok: true } };
+    });
+
+    const remotePregel = new RemoteGraph({
+      client,
+      graphId: "test_graph_id",
+    });
+
+    const context = { userId: "user-1", tenantId: "tenant-1" };
+    await remotePregel.invoke(
+      { messages: [{ type: "human", content: "hello" }] },
+      {
+        configurable: { thread_id: "thread_1" },
+        context,
+      }
+    );
+
+    expect(streamArgs).toEqual([
+      "thread_1",
+      "test_graph_id",
+      expect.objectContaining({
+        context,
+        config: expect.objectContaining({
+          configurable: {},
         }),
       }),
     ]);
@@ -686,7 +722,6 @@ describe("RemoteGraph", () => {
           configurable: {
             circular: "[Circular]",
             bigint: "123",
-            thread_id: "thread_1",
           },
           metadata: {
             source: "test",


### PR DESCRIPTION
## Summary
- Fix [#1922](https://github.com/langchain-ai/langgraphjs/issues/1922) by porting the Python [langgraph#6497](https://github.com/langchain-ai/langgraph/pull/6497) behavior: `RemoteGraph` pops `thread_id` from `config.configurable` (it stays in the URL path) and passes `context` as a top-level field to `client.runs.stream()`.
- Stateful remote runs can now combine checkpointing (`thread_id`) with `context` for middleware / `contextSchema` without the server rejecting ambiguous parameters.

fixes #1922
