### PR TITLE
feat(langgraph): add `StateGraph.setNodeDefaults()` for graph-wide node policy defaults

### DIFF
--- a/.changeset/tame-pugs-attack.md
+++ b/.changeset/tame-pugs-attack.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph": minor
+---
+
+Add `StateGraph.setNodeDefaults()` for setting graph-wide node policy defaults (`retryPolicy`, `cachePolicy`). Per-node values passed to `addNode` always take precedence, and defaults are resolved at `compile()` time so call order does not matter. Defaults are not inherited by subgraphs. Ports Python's `set_node_defaults()` (langchain-ai/langgraph#7747).

--- a/libs/langgraph-core/src/graph/index.ts
+++ b/libs/langgraph-core/src/graph/index.ts
@@ -21,7 +21,6 @@ export {
   type StateGraphNodeSpec,
   type StateGraphAddNodeOptions,
   type NodePolicyOptions,
-  type NodeDefaults,
   type StateGraphArgsWithStateSchema,
   type StateGraphArgsWithInputOutputSchemas,
 } from "./state.js";

--- a/libs/langgraph-core/src/graph/index.ts
+++ b/libs/langgraph-core/src/graph/index.ts
@@ -20,6 +20,7 @@ export {
   CompiledStateGraph,
   type StateGraphNodeSpec,
   type StateGraphAddNodeOptions,
+  type NodeDefaults,
   type StateGraphArgsWithStateSchema,
   type StateGraphArgsWithInputOutputSchemas,
 } from "./state.js";

--- a/libs/langgraph-core/src/graph/index.ts
+++ b/libs/langgraph-core/src/graph/index.ts
@@ -20,6 +20,7 @@ export {
   CompiledStateGraph,
   type StateGraphNodeSpec,
   type StateGraphAddNodeOptions,
+  type NodePolicyOptions,
   type NodeDefaults,
   type StateGraphArgsWithStateSchema,
   type StateGraphArgsWithInputOutputSchemas,

--- a/libs/langgraph-core/src/graph/state.ts
+++ b/libs/langgraph-core/src/graph/state.ts
@@ -110,8 +110,9 @@ export interface StateGraphArgs<Channels extends object | unknown> {
  *
  * Use with {@link StateGraph.addNode} for per-node overrides, or with
  * {@link StateGraph.setNodeDefaults} for graph-wide defaults applied at
- * `compile()` time. Per-node values always take precedence over defaults,
- * regardless of call order.
+ * `compile()` time. Per-node values always take precedence over defaults.
+ * `setNodeDefaults` may be called before or after `addNode`, including as the
+ * last step before `compile()`.
  */
 export type NodePolicyOptions = {
   /**
@@ -143,9 +144,8 @@ export type NodePolicyOptions = {
  */
 export type NodePolicies = {
   retryPolicy?: RetryPolicy;
-  cachePolicy?: CachePolicy;
-  /** Set when `addNode(..., { cachePolicy: false })` opts out of graph defaults. */
-  cachePolicyOptOut?: true;
+  /** `false` opts out of graph defaults set via {@link StateGraph.setNodeDefaults}. */
+  cachePolicy?: CachePolicy | false;
 };
 
 export type StateGraphNodeSpec<RunInput, RunOutput> = NodeSpec<
@@ -171,17 +171,6 @@ export type StateGraphAddNodeOptions<
   input?: InputSchema;
 } & NodePolicyOptions &
   AddNodeOptions<Nodes>;
-
-/**
- * Graph-wide default node policies set via {@link StateGraph.setNodeDefaults}.
- *
- * These are applied to every node at `compile()` time. Per-node values passed
- * to `addNode(...)` always take precedence, regardless of the order in which
- * `setNodeDefaults` and `addNode` are called.
- *
- * Defaults are **not** inherited by subgraphs.
- */
-export type NodeDefaults = NodePolicyOptions;
 
 export type StateGraphArgsWithStateSchema<
   SD extends StateDefinition,
@@ -613,17 +602,17 @@ export class StateGraph<
    * graph.
    *
    * Per-node values passed to {@link addNode} always take precedence over these
-   * defaults. Defaults are resolved at {@link compile} time, so this method can
-   * be called before or after `addNode` with the same result. Calling it
-   * multiple times merges the provided fields, with later calls overriding
-   * earlier ones on a per-field basis.
+   * defaults. Defaults are resolved at {@link compile} time, so call order does
+   * not matter — you may call this before or after `addNode`, including as the
+   * last step before `compile()`. Calling it multiple times merges the provided
+   * fields, with later calls overriding earlier ones on a per-field basis.
    *
    * Policies set here are **not** inherited by subgraphs.
    *
    * @param defaults - The default node policies to apply.
    * @returns The builder instance, for chaining.
    *
-   * @example
+   * @example Call before `addNode`
    * ```ts
    * const graph = new StateGraph(State)
    *   .setNodeDefaults({
@@ -635,8 +624,21 @@ export class StateGraph<
    *   .addEdge(START, "a")
    *   .compile();
    * ```
+   *
+   * @example Call after `addNode`, immediately before `compile()`
+   * ```ts
+   * const graph = new StateGraph(State)
+   *   .addNode("a", nodeA)
+   *   .addNode("b", nodeB, { retryPolicy: { maxAttempts: 5 } }) // overrides default
+   *   .addEdge(START, "a")
+   *   .setNodeDefaults({
+   *     retryPolicy: { maxAttempts: 3 },
+   *     cachePolicy: { ttl: 60 },
+   *   })
+   *   .compile();
+   * ```
    */
-  setNodeDefaults(defaults: NodeDefaults): this {
+  setNodeDefaults(defaults: NodePolicyOptions): this {
     if (defaults.retryPolicy !== undefined) {
       this._nodeDefaults.retryPolicy = defaults.retryPolicy;
     }
@@ -1003,22 +1005,21 @@ export class StateGraph<
         runnable = _coerceToRunnable(action);
       }
 
-      let cachePolicy = options?.cachePolicy;
-      let cachePolicyOptOut: true | undefined;
-      if (typeof cachePolicy === "boolean") {
-        if (cachePolicy) {
-          cachePolicy = {};
-        } else {
-          cachePolicy = undefined;
-          cachePolicyOptOut = true;
-        }
+      const rawCachePolicy = options?.cachePolicy;
+      let cachePolicy: CachePolicy | false | undefined;
+      if (rawCachePolicy !== undefined) {
+        cachePolicy =
+          typeof rawCachePolicy === "boolean"
+            ? rawCachePolicy
+              ? {}
+              : false
+            : rawCachePolicy;
       }
 
       const nodeSpec: StateGraphNodeSpec<S, U> = {
         runnable: runnable as unknown as Runnable<S, U>,
         retryPolicy: options?.retryPolicy,
         cachePolicy,
-        cachePolicyOptOut,
         metadata: options?.metadata,
         input: inputSpec ?? this._schemaDefinition,
         subgraphs: isPregelLike(runnable)
@@ -1290,9 +1291,10 @@ export class StateGraph<
         ? {
             ...node,
             retryPolicy: node.retryPolicy ?? nodeDefaults.retryPolicy,
-            cachePolicy: node.cachePolicyOptOut
-              ? undefined
-              : (node.cachePolicy ?? nodeDefaults.cachePolicy),
+            cachePolicy:
+              node.cachePolicy === false
+                ? undefined
+                : (node.cachePolicy ?? nodeDefaults.cachePolicy),
           }
         : node;
       compiled.attachNode(key as N, resolvedNode);
@@ -1376,6 +1378,10 @@ function _getChannels<Channels extends Record<string, unknown> | unknown>(
  *
  * @typeParam WriterType - The type for custom stream writers. Used with the `writer`
  *   option to enable typed custom streaming from within nodes.
+ *
+ * @typeParam TStreamTransformers - Stream transformer factories registered at
+ *   compile time via the `transformers` option. Used to type extensions on
+ *   `streamEvents(..., { version: "v3" })`.
  */
 export class CompiledStateGraph<
   S,
@@ -1560,6 +1566,9 @@ export class CompiledStateGraph<
       this.channels[branchChannel] = node?.defer
         ? new LastValueAfterFinish()
         : new EphemeralValue(false);
+      const nodeCachePolicy = node?.cachePolicy;
+      const cachePolicy =
+        nodeCachePolicy === false ? undefined : nodeCachePolicy;
       this.nodes[key] = new PregelNode<S, U>({
         triggers: [branchChannel],
         // read state keys
@@ -1577,7 +1586,7 @@ export class CompiledStateGraph<
         bound: node?.runnable,
         metadata: node?.metadata,
         retryPolicy: node?.retryPolicy,
-        cachePolicy: node?.cachePolicy,
+        cachePolicy,
         subgraphs: node?.subgraphs,
         ends: node?.ends,
       });

--- a/libs/langgraph-core/src/graph/state.ts
+++ b/libs/langgraph-core/src/graph/state.ts
@@ -131,6 +131,29 @@ export type StateGraphAddNodeOptions<
   input?: InputSchema;
 } & AddNodeOptions<Nodes>;
 
+/**
+ * Graph-wide default node policies set via {@link StateGraph.setNodeDefaults}.
+ *
+ * These are applied to every node at `compile()` time. Per-node values passed
+ * to `addNode(...)` always take precedence, regardless of the order in which
+ * `setNodeDefaults` and `addNode` are called.
+ *
+ * Defaults are **not** inherited by subgraphs.
+ */
+export type NodeDefaults = {
+  /**
+   * Default retry policy for nodes that don't specify their own via
+   * `addNode(..., { retryPolicy })`.
+   */
+  retryPolicy?: RetryPolicy;
+  /**
+   * Default cache policy for nodes that don't specify their own via
+   * `addNode(..., { cachePolicy })`. Pass `true` for default caching, `false`
+   * to disable.
+   */
+  cachePolicy?: CachePolicy | boolean;
+};
+
 export type StateGraphArgsWithStateSchema<
   SD extends StateDefinition,
   I extends StateDefinition,
@@ -350,6 +373,12 @@ export class StateGraph<
   /** @internal */
   _writer: WriterType;
 
+  /**
+   * Graph-wide default node policies, resolved at `compile()` time.
+   * @internal
+   */
+  _nodeDefaults: { retryPolicy?: RetryPolicy; cachePolicy?: CachePolicy } = {};
+
   declare Node: StrictNodeAction<S, U, C, N, InterruptType, WriterType>;
 
   /**
@@ -548,6 +577,49 @@ export class StateGraph<
     // Handle interrupt and writer
     this._interrupt = init.interrupt as InterruptType;
     this._writer = init.writer as WriterType;
+  }
+
+  /**
+   * Set graph-wide default node policies that apply to every node in this
+   * graph.
+   *
+   * Per-node values passed to {@link addNode} always take precedence over these
+   * defaults. Defaults are resolved at {@link compile} time, so this method can
+   * be called before or after `addNode` with the same result. Calling it
+   * multiple times merges the provided fields, with later calls overriding
+   * earlier ones on a per-field basis.
+   *
+   * Policies set here are **not** inherited by subgraphs.
+   *
+   * @param defaults - The default node policies to apply.
+   * @returns The builder instance, for chaining.
+   *
+   * @example
+   * ```ts
+   * const graph = new StateGraph(State)
+   *   .setNodeDefaults({
+   *     retryPolicy: { maxAttempts: 3 },
+   *     cachePolicy: { ttl: 60 },
+   *   })
+   *   .addNode("a", nodeA)
+   *   .addNode("b", nodeB, { retryPolicy: { maxAttempts: 5 } }) // overrides default
+   *   .addEdge(START, "a")
+   *   .compile();
+   * ```
+   */
+  setNodeDefaults(defaults: NodeDefaults): this {
+    if (defaults.retryPolicy !== undefined) {
+      this._nodeDefaults.retryPolicy = defaults.retryPolicy;
+    }
+    if (defaults.cachePolicy !== undefined) {
+      this._nodeDefaults.cachePolicy =
+        typeof defaults.cachePolicy === "boolean"
+          ? defaults.cachePolicy
+            ? {}
+            : undefined
+          : defaults.cachePolicy;
+    }
+    return this;
   }
 
   /**
@@ -1168,10 +1240,24 @@ export class StateGraph<
 
     // attach nodes, edges and branches
     compiled.attachNode(START);
+    // Resolve graph-wide node defaults. Per-node values always win. Defaults
+    // are merged into a copy of each spec so repeated `compile()` calls remain
+    // stable (the builder's node specs are never mutated).
+    const nodeDefaults = this._nodeDefaults;
+    const hasNodeDefaults =
+      nodeDefaults.retryPolicy !== undefined ||
+      nodeDefaults.cachePolicy !== undefined;
     for (const [key, node] of Object.entries<StateGraphNodeSpec<S, U>>(
       this.nodes
     )) {
-      compiled.attachNode(key as N, node);
+      const resolvedNode = hasNodeDefaults
+        ? {
+            ...node,
+            retryPolicy: node.retryPolicy ?? nodeDefaults.retryPolicy,
+            cachePolicy: node.cachePolicy ?? nodeDefaults.cachePolicy,
+          }
+        : node;
+      compiled.attachNode(key as N, resolvedNode);
     }
     compiled.attachBranch(START, SELF, _getControlBranch() as Branch<S, N>, {
       withReader: false,

--- a/libs/langgraph-core/src/graph/state.ts
+++ b/libs/langgraph-core/src/graph/state.ts
@@ -141,16 +141,18 @@ export type NodePolicyOptions = {
  *
  * @internal
  */
-export type ResolvedNodePolicies = {
+export type NodePolicies = {
   retryPolicy?: RetryPolicy;
   cachePolicy?: CachePolicy;
+  /** Set when `addNode(..., { cachePolicy: false })` opts out of graph defaults. */
+  cachePolicyOptOut?: true;
 };
 
 export type StateGraphNodeSpec<RunInput, RunOutput> = NodeSpec<
   RunInput,
   RunOutput
 > &
-  ResolvedNodePolicies & {
+  NodePolicies & {
     input?: StateDefinition;
   };
 
@@ -404,7 +406,7 @@ export class StateGraph<
    * Graph-wide default node policies, resolved at `compile()` time.
    * @internal
    */
-  _nodeDefaults: ResolvedNodePolicies = {};
+  _nodeDefaults: NodePolicies = {};
 
   declare Node: StrictNodeAction<S, U, C, N, InterruptType, WriterType>;
 
@@ -1002,14 +1004,21 @@ export class StateGraph<
       }
 
       let cachePolicy = options?.cachePolicy;
+      let cachePolicyOptOut: true | undefined;
       if (typeof cachePolicy === "boolean") {
-        cachePolicy = cachePolicy ? {} : undefined;
+        if (cachePolicy) {
+          cachePolicy = {};
+        } else {
+          cachePolicy = undefined;
+          cachePolicyOptOut = true;
+        }
       }
 
       const nodeSpec: StateGraphNodeSpec<S, U> = {
         runnable: runnable as unknown as Runnable<S, U>,
         retryPolicy: options?.retryPolicy,
         cachePolicy,
+        cachePolicyOptOut,
         metadata: options?.metadata,
         input: inputSpec ?? this._schemaDefinition,
         subgraphs: isPregelLike(runnable)
@@ -1281,7 +1290,9 @@ export class StateGraph<
         ? {
             ...node,
             retryPolicy: node.retryPolicy ?? nodeDefaults.retryPolicy,
-            cachePolicy: node.cachePolicy ?? nodeDefaults.cachePolicy,
+            cachePolicy: node.cachePolicyOptOut
+              ? undefined
+              : (node.cachePolicy ?? nodeDefaults.cachePolicy),
           }
         : node;
       compiled.attachNode(key as N, resolvedNode);

--- a/libs/langgraph-core/src/graph/state.ts
+++ b/libs/langgraph-core/src/graph/state.ts
@@ -105,14 +105,54 @@ export interface StateGraphArgs<Channels extends object | unknown> {
     : ChannelReducers<{ __root__: Channels }>;
 }
 
-export type StateGraphNodeSpec<RunInput, RunOutput> = NodeSpec<
-  RunInput,
-  RunOutput
-> & {
-  input?: StateDefinition;
+/**
+ * Retry and cache policies configurable on graph nodes.
+ *
+ * Use with {@link StateGraph.addNode} for per-node overrides, or with
+ * {@link StateGraph.setNodeDefaults} for graph-wide defaults applied at
+ * `compile()` time. Per-node values always take precedence over defaults,
+ * regardless of call order.
+ */
+export type NodePolicyOptions = {
+  /**
+   * Retry policy controlling backoff, max attempts, and which errors trigger
+   * a retry.
+   *
+   * @see {@link RetryPolicy}
+   */
+  retryPolicy?: RetryPolicy;
+  /**
+   * Cache policy controlling how node results are keyed and how long they
+   * persist.
+   *
+   * - Pass a {@link CachePolicy} object for fine-grained control (e.g. custom
+   *   `keyFunc`, `ttl`).
+   * - Pass `true` to enable caching with default settings.
+   * - Pass `false` to disable caching.
+   *
+   * @see {@link CachePolicy}
+   */
+  cachePolicy?: CachePolicy | boolean;
+};
+
+/**
+ * Resolved retry and cache policies stored on a node after boolean
+ * `cachePolicy` shorthand is normalized.
+ *
+ * @internal
+ */
+export type ResolvedNodePolicies = {
   retryPolicy?: RetryPolicy;
   cachePolicy?: CachePolicy;
 };
+
+export type StateGraphNodeSpec<RunInput, RunOutput> = NodeSpec<
+  RunInput,
+  RunOutput
+> &
+  ResolvedNodePolicies & {
+    input?: StateDefinition;
+  };
 
 /**
  * Options for StateGraph.addNode() method.
@@ -126,10 +166,9 @@ export type StateGraphAddNodeOptions<
     | StateDefinitionInit
     | undefined,
 > = {
-  retryPolicy?: RetryPolicy;
-  cachePolicy?: CachePolicy | boolean;
   input?: InputSchema;
-} & AddNodeOptions<Nodes>;
+} & NodePolicyOptions &
+  AddNodeOptions<Nodes>;
 
 /**
  * Graph-wide default node policies set via {@link StateGraph.setNodeDefaults}.
@@ -140,19 +179,7 @@ export type StateGraphAddNodeOptions<
  *
  * Defaults are **not** inherited by subgraphs.
  */
-export type NodeDefaults = {
-  /**
-   * Default retry policy for nodes that don't specify their own via
-   * `addNode(..., { retryPolicy })`.
-   */
-  retryPolicy?: RetryPolicy;
-  /**
-   * Default cache policy for nodes that don't specify their own via
-   * `addNode(..., { cachePolicy })`. Pass `true` for default caching, `false`
-   * to disable.
-   */
-  cachePolicy?: CachePolicy | boolean;
-};
+export type NodeDefaults = NodePolicyOptions;
 
 export type StateGraphArgsWithStateSchema<
   SD extends StateDefinition,
@@ -377,7 +404,7 @@ export class StateGraph<
    * Graph-wide default node policies, resolved at `compile()` time.
    * @internal
    */
-  _nodeDefaults: { retryPolicy?: RetryPolicy; cachePolicy?: CachePolicy } = {};
+  _nodeDefaults: ResolvedNodePolicies = {};
 
   declare Node: StrictNodeAction<S, U, C, N, InterruptType, WriterType>;
 

--- a/libs/langgraph-core/src/tests/set_node_defaults.test.ts
+++ b/libs/langgraph-core/src/tests/set_node_defaults.test.ts
@@ -1,0 +1,206 @@
+/* eslint-disable no-promise-executor-return */
+import { it, expect, describe, vi } from "vitest";
+import { InMemoryCache } from "@langchain/langgraph-checkpoint";
+import { Annotation, StateGraph } from "../graph/index.js";
+import { START } from "../constants.js";
+import type { RetryPolicy } from "../pregel/utils/index.js";
+
+// ---------------------------------------------------------------------------
+// setNodeDefaults()
+//
+// Ports the parity behavior from langchain-ai/langgraph#7747
+// (`feat(langgraph): add set_node_defaults() to StateGraph`).
+//
+// Note: JS only supports the `retryPolicy` and `cachePolicy` node policies
+// today; the Python PR's `error_handler`/`timeout` defaults are intentionally
+// out of scope here because those node features do not yet exist in JS.
+// ---------------------------------------------------------------------------
+
+const State = Annotation.Root({
+  foo: Annotation<string>(),
+});
+
+const fastRetry: RetryPolicy = {
+  maxAttempts: 3,
+  initialInterval: 1,
+  jitter: false,
+  logWarning: false,
+};
+
+describe("StateGraph.setNodeDefaults", () => {
+  it("applies the default retryPolicy to nodes without their own", async () => {
+    let attempts = 0;
+    const graph = new StateGraph(State)
+      .setNodeDefaults({ retryPolicy: fastRetry })
+      .addNode("flaky", () => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw new Error("not yet");
+        }
+        return { foo: "ok" };
+      })
+      .addEdge(START, "flaky")
+      .compile();
+
+    const result = await graph.invoke({ foo: "" });
+    expect(result.foo).toBe("ok");
+    expect(attempts).toBe(3);
+    expect(graph.nodes.flaky.retryPolicy).toEqual(fastRetry);
+  });
+
+  it("lets a per-node retryPolicy override the default", async () => {
+    let attempts = 0;
+    const perNode: RetryPolicy = {
+      maxAttempts: 5,
+      initialInterval: 1,
+      jitter: false,
+      logWarning: false,
+    };
+    const graph = new StateGraph(State)
+      .setNodeDefaults({ retryPolicy: { maxAttempts: 1, logWarning: false } })
+      .addNode(
+        "flaky",
+        () => {
+          attempts += 1;
+          if (attempts < 4) {
+            throw new Error("not yet");
+          }
+          return { foo: "ok" };
+        },
+        { retryPolicy: perNode }
+      )
+      .addEdge(START, "flaky")
+      .compile();
+
+    const result = await graph.invoke({ foo: "" });
+    expect(result.foo).toBe("ok");
+    expect(attempts).toBe(4);
+    expect(graph.nodes.flaky.retryPolicy).toEqual(perNode);
+  });
+
+  it("applies the default cachePolicy to nodes without their own", async () => {
+    const cache = new InMemoryCache();
+    const spy = vi.fn(() => ({ foo: "ok" }));
+    const graph = new StateGraph(State)
+      .setNodeDefaults({ cachePolicy: { ttl: 60 } })
+      .addNode("cached", spy)
+      .addEdge(START, "cached")
+      .compile({ cache });
+
+    expect(graph.nodes.cached.cachePolicy).toEqual({ ttl: 60 });
+
+    await graph.invoke({ foo: "" });
+    await graph.invoke({ foo: "" });
+    // Second invocation should be served from cache.
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts a boolean cachePolicy default", () => {
+    const enabled = new StateGraph(State)
+      .setNodeDefaults({ cachePolicy: true })
+      .addNode("a", () => ({ foo: "a" }))
+      .addEdge(START, "a")
+      .compile({ cache: new InMemoryCache() });
+    expect(enabled.nodes.a.cachePolicy).toEqual({});
+
+    const disabled = new StateGraph(State)
+      .setNodeDefaults({ cachePolicy: false })
+      .addNode("a", () => ({ foo: "a" }))
+      .addEdge(START, "a")
+      .compile();
+    expect(disabled.nodes.a.cachePolicy).toBeUndefined();
+  });
+
+  it("lets a per-node cachePolicy override the default", () => {
+    const graph = new StateGraph(State)
+      .setNodeDefaults({ cachePolicy: { ttl: 60 } })
+      .addNode("a", () => ({ foo: "a" }), { cachePolicy: { ttl: 5 } })
+      .addNode("b", () => ({ foo: "b" }))
+      .addEdge(START, "a")
+      .addEdge("a", "b")
+      .compile({ cache: new InMemoryCache() });
+
+    expect(graph.nodes.a.cachePolicy).toEqual({ ttl: 5 });
+    expect(graph.nodes.b.cachePolicy).toEqual({ ttl: 60 });
+  });
+
+  it("is chainable and order-independent (called after addNode)", () => {
+    const graph = new StateGraph(State)
+      .addNode("a", () => ({ foo: "a" }))
+      .addEdge(START, "a")
+      .setNodeDefaults({ retryPolicy: fastRetry, cachePolicy: { ttl: 60 } })
+      .compile({ cache: new InMemoryCache() });
+
+    expect(graph.nodes.a.retryPolicy).toEqual(fastRetry);
+    expect(graph.nodes.a.cachePolicy).toEqual({ ttl: 60 });
+  });
+
+  it("merges fields across multiple calls, later wins per-field", () => {
+    const graph = new StateGraph(State)
+      .setNodeDefaults({ retryPolicy: { maxAttempts: 2, logWarning: false } })
+      .setNodeDefaults({ cachePolicy: { ttl: 60 } })
+      .setNodeDefaults({ retryPolicy: fastRetry })
+      .addNode("a", () => ({ foo: "a" }))
+      .addEdge(START, "a")
+      .compile({ cache: new InMemoryCache() });
+
+    expect(graph.nodes.a.retryPolicy).toEqual(fastRetry);
+    expect(graph.nodes.a.cachePolicy).toEqual({ ttl: 60 });
+  });
+
+  it("applies defaults to all nodes that lack their own value", () => {
+    const perNode: RetryPolicy = { maxAttempts: 7, logWarning: false };
+    const graph = new StateGraph(State)
+      .setNodeDefaults({ retryPolicy: fastRetry })
+      .addNode("a", () => ({ foo: "a" }))
+      .addNode("b", () => ({ foo: "b" }), { retryPolicy: perNode })
+      .addNode("c", () => ({ foo: "c" }))
+      .addEdge(START, "a")
+      .addEdge("a", "b")
+      .addEdge("b", "c")
+      .compile();
+
+    expect(graph.nodes.a.retryPolicy).toEqual(fastRetry);
+    expect(graph.nodes.b.retryPolicy).toEqual(perNode);
+    expect(graph.nodes.c.retryPolicy).toEqual(fastRetry);
+  });
+
+  it("does not mutate builder state across repeated compiles", () => {
+    const builder = new StateGraph(State)
+      .setNodeDefaults({ retryPolicy: fastRetry })
+      .addNode("a", () => ({ foo: "a" }))
+      .addEdge(START, "a");
+
+    builder.compile();
+    builder.compile();
+
+    // The original spec stored on the builder must remain untouched.
+    expect(builder.nodes.a.retryPolicy).toBeUndefined();
+  });
+
+  it("does not inherit defaults into subgraphs", () => {
+    const inner = new StateGraph(State)
+      .addNode("innerNode", () => ({ foo: "inner" }))
+      .addEdge(START, "innerNode")
+      .compile();
+
+    // Inner graph was compiled without defaults.
+    expect(inner.nodes.innerNode.retryPolicy).toBeUndefined();
+
+    const outer = new StateGraph(State)
+      .setNodeDefaults({ retryPolicy: fastRetry })
+      .addNode("sub", inner)
+      .addEdge(START, "sub")
+      .compile();
+
+    // The subgraph node in the outer graph picks up the outer default...
+    expect(outer.nodes.sub.retryPolicy).toEqual(fastRetry);
+    // ...but the inner graph's own node is unaffected.
+    expect(inner.nodes.innerNode.retryPolicy).toBeUndefined();
+  });
+
+  it("returns the same builder instance for chaining", () => {
+    const builder = new StateGraph(State);
+    expect(builder.setNodeDefaults({ retryPolicy: fastRetry })).toBe(builder);
+  });
+});

--- a/libs/langgraph-core/src/tests/set_node_defaults.test.ts
+++ b/libs/langgraph-core/src/tests/set_node_defaults.test.ts
@@ -128,10 +128,14 @@ describe("StateGraph.setNodeDefaults", () => {
     const cache = new InMemoryCache();
     const cachedSpy = vi.fn(() => ({ foo: "cached" }));
     const uncachedSpy = vi.fn(() => ({ foo: "uncached" }));
-    const graph = new StateGraph(State)
+    const builder = new StateGraph(State)
       .setNodeDefaults({ cachePolicy: true })
       .addNode("cached", cachedSpy)
-      .addNode("uncached", uncachedSpy, { cachePolicy: false })
+      .addNode("uncached", uncachedSpy, { cachePolicy: false });
+
+    expect(builder.nodes.uncached.cachePolicy).toBe(false);
+
+    const graph = builder
       .addEdge(START, "cached")
       .addEdge("cached", "uncached")
       .compile({ cache });
@@ -145,15 +149,24 @@ describe("StateGraph.setNodeDefaults", () => {
     expect(uncachedSpy).toHaveBeenCalledTimes(2);
   });
 
-  it("is chainable and order-independent (called after addNode)", () => {
+  it("applies defaults when setNodeDefaults is called after all addNode calls", () => {
+    const perNode: RetryPolicy = { maxAttempts: 7, logWarning: false };
     const graph = new StateGraph(State)
       .addNode("a", () => ({ foo: "a" }))
+      .addNode("b", () => ({ foo: "b" }), { retryPolicy: perNode })
+      .addNode("c", () => ({ foo: "c" }))
       .addEdge(START, "a")
+      .addEdge("a", "b")
+      .addEdge("b", "c")
       .setNodeDefaults({ retryPolicy: fastRetry, cachePolicy: { ttl: 60 } })
       .compile({ cache: new InMemoryCache() });
 
     expect(graph.nodes.a.retryPolicy).toEqual(fastRetry);
     expect(graph.nodes.a.cachePolicy).toEqual({ ttl: 60 });
+    expect(graph.nodes.b.retryPolicy).toEqual(perNode);
+    expect(graph.nodes.b.cachePolicy).toEqual({ ttl: 60 });
+    expect(graph.nodes.c.retryPolicy).toEqual(fastRetry);
+    expect(graph.nodes.c.cachePolicy).toEqual({ ttl: 60 });
   });
 
   it("merges fields across multiple calls, later wins per-field", () => {

--- a/libs/langgraph-core/src/tests/set_node_defaults.test.ts
+++ b/libs/langgraph-core/src/tests/set_node_defaults.test.ts
@@ -124,6 +124,27 @@ describe("StateGraph.setNodeDefaults", () => {
     expect(graph.nodes.b.cachePolicy).toEqual({ ttl: 60 });
   });
 
+  it("lets a per-node cachePolicy: false opt out of the default", async () => {
+    const cache = new InMemoryCache();
+    const cachedSpy = vi.fn(() => ({ foo: "cached" }));
+    const uncachedSpy = vi.fn(() => ({ foo: "uncached" }));
+    const graph = new StateGraph(State)
+      .setNodeDefaults({ cachePolicy: true })
+      .addNode("cached", cachedSpy)
+      .addNode("uncached", uncachedSpy, { cachePolicy: false })
+      .addEdge(START, "cached")
+      .addEdge("cached", "uncached")
+      .compile({ cache });
+
+    expect(graph.nodes.cached.cachePolicy).toEqual({});
+    expect(graph.nodes.uncached.cachePolicy).toBeUndefined();
+
+    await graph.invoke({ foo: "" });
+    await graph.invoke({ foo: "" });
+    expect(cachedSpy).toHaveBeenCalledTimes(1);
+    expect(uncachedSpy).toHaveBeenCalledTimes(2);
+  });
+
   it("is chainable and order-independent (called after addNode)", () => {
     const graph = new StateGraph(State)
       .addNode("a", () => ({ foo: "a" }))

--- a/libs/langgraph-core/src/web.ts
+++ b/libs/langgraph-core/src/web.ts
@@ -33,7 +33,6 @@ export {
   type StateGraphNodeSpec,
   type StateGraphAddNodeOptions,
   type NodePolicyOptions,
-  type NodeDefaults,
   type StateGraphArgsWithStateSchema,
   type StateGraphArgsWithInputOutputSchemas,
 } from "./graph/index.js";

--- a/libs/langgraph-core/src/web.ts
+++ b/libs/langgraph-core/src/web.ts
@@ -32,6 +32,7 @@ export {
   type AddNodeOptions,
   type StateGraphNodeSpec,
   type StateGraphAddNodeOptions,
+  type NodePolicyOptions,
   type NodeDefaults,
   type StateGraphArgsWithStateSchema,
   type StateGraphArgsWithInputOutputSchemas,

--- a/libs/langgraph-core/src/web.ts
+++ b/libs/langgraph-core/src/web.ts
@@ -32,6 +32,7 @@ export {
   type AddNodeOptions,
   type StateGraphNodeSpec,
   type StateGraphAddNodeOptions,
+  type NodeDefaults,
   type StateGraphArgsWithStateSchema,
   type StateGraphArgsWithInputOutputSchemas,
 } from "./graph/index.js";


### PR DESCRIPTION
## Summary
- Add `StateGraph.setNodeDefaults({ retryPolicy?, cachePolicy? })` for graph-wide node policy defaults, resolved at `compile()` so call order does not matter; per-node `addNode` options always take precedence.
- Defaults are not inherited by subgraphs (parity with Python #7747).
- Consolidate duplicate `retryPolicy` / `cachePolicy` fields into exported `NodePolicyOptions` with shared TSDoc; `NodeDefaults` and `StateGraphAddNodeOptions` both use it; internal specs use `ResolvedNodePolicies` after boolean `cachePolicy` normalization.
