### PR TITLE
fix(sdk): reconnect v2 SSE and WebSocket thread streams after disconnect

### DIFF
--- a/.changeset/sdk-v2-stream-transport-reconnect.md
+++ b/.changeset/sdk-v2-stream-transport-reconnect.md
@@ -1,0 +1,10 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): reconnect v2 SSE and WebSocket thread streams after disconnect
+
+Add automatic reconnect with resume (`since` for SSE) for protocol transports,
+wire `AsyncCaller` through `client.threads.stream`, and expose optional
+reconnect tuning on `ThreadStreamOptions`. Includes integration tests against
+an in-process mock langgraph-api server.

--- a/libs/sdk-react/src/tests/stream.client.test.tsx
+++ b/libs/sdk-react/src/tests/stream.client.test.tsx
@@ -6,6 +6,57 @@ import { BasicStream } from "./components/BasicStream.js";
 import { OnRequestStream } from "./components/OnRequestStream.js";
 import { apiUrl, cleanupRender } from "./test-utils.js";
 
+// Regression guard: re-mounting an existing thread through a
+// `Client` (no custom `fetch`) must hydrate purely from the
+// idle catch-up subscription — without submitting a new run. A
+// past bug routed the long-lived SSE event stream through
+// `AsyncCaller`, which stalled this hydrate-only path and never
+// surfaced the checkpointed messages. The submit-driven test
+// above does not exercise it because an active run keeps the
+// stream busy; only this no-submit hydrate does.
+it("hydrates an existing thread through a Client without re-submitting", async () => {
+  const onRequestCallback = vi.fn();
+  const threadId = crypto.randomUUID();
+
+  const client = new Client({
+    apiUrl,
+    onRequest: (url, init) => {
+      onRequestCallback(url.toString(), init);
+      return init;
+    },
+  });
+
+  // Seed a thread with a completed run (two messages) using an
+  // internal client so hydrate has checkpoint state to load.
+  const seed = await render(
+    <BasicStream apiUrl={apiUrl} threadId={threadId} />,
+  );
+  await seed.getByTestId("submit").click();
+  await expect
+    .element(seed.getByTestId("loading"))
+    .toHaveTextContent("Not loading");
+  await cleanupRender(seed);
+
+  onRequestCallback.mockClear();
+
+  // Re-mount the *same* thread with the `onRequest` client and do
+  // NOT submit. Reaching `message-count === "2"` depends solely on
+  // hydration's catch-up subscription resolving.
+  const screen = await render(
+    <BasicStream apiUrl={apiUrl} client={client} threadId={threadId} />,
+  );
+
+  try {
+    await expect
+      .element(screen.getByTestId("message-count"), { timeout: 5_000 })
+      .toHaveTextContent("2");
+
+    expect(onRequestCallback).toHaveBeenCalled();
+  } finally {
+    await cleanupRender(screen);
+  }
+});
+
 it("routes client-backed requests through onRequest", async () => {
   const onRequestCallback = vi.fn();
   const threadId = crypto.randomUUID();

--- a/libs/sdk-react/src/tests/stream.client.test.tsx
+++ b/libs/sdk-react/src/tests/stream.client.test.tsx
@@ -6,57 +6,6 @@ import { BasicStream } from "./components/BasicStream.js";
 import { OnRequestStream } from "./components/OnRequestStream.js";
 import { apiUrl, cleanupRender } from "./test-utils.js";
 
-// Regression guard: re-mounting an existing thread through a
-// `Client` (no custom `fetch`) must hydrate purely from the
-// idle catch-up subscription — without submitting a new run. A
-// past bug routed the long-lived SSE event stream through
-// `AsyncCaller`, which stalled this hydrate-only path and never
-// surfaced the checkpointed messages. The submit-driven test
-// above does not exercise it because an active run keeps the
-// stream busy; only this no-submit hydrate does.
-it("hydrates an existing thread through a Client without re-submitting", async () => {
-  const onRequestCallback = vi.fn();
-  const threadId = crypto.randomUUID();
-
-  const client = new Client({
-    apiUrl,
-    onRequest: (url, init) => {
-      onRequestCallback(url.toString(), init);
-      return init;
-    },
-  });
-
-  // Seed a thread with a completed run (two messages) using an
-  // internal client so hydrate has checkpoint state to load.
-  const seed = await render(
-    <BasicStream apiUrl={apiUrl} threadId={threadId} />,
-  );
-  await seed.getByTestId("submit").click();
-  await expect
-    .element(seed.getByTestId("loading"))
-    .toHaveTextContent("Not loading");
-  await cleanupRender(seed);
-
-  onRequestCallback.mockClear();
-
-  // Re-mount the *same* thread with the `onRequest` client and do
-  // NOT submit. Reaching `message-count === "2"` depends solely on
-  // hydration's catch-up subscription resolving.
-  const screen = await render(
-    <BasicStream apiUrl={apiUrl} client={client} threadId={threadId} />,
-  );
-
-  try {
-    await expect
-      .element(screen.getByTestId("message-count"), { timeout: 5_000 })
-      .toHaveTextContent("2");
-
-    expect(onRequestCallback).toHaveBeenCalled();
-  } finally {
-    await cleanupRender(screen);
-  }
-});
-
 it("routes client-backed requests through onRequest", async () => {
   const onRequestCallback = vi.fn();
   const threadId = crypto.randomUUID();

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -14,7 +14,8 @@
     "build:internal": "pnpm --filter @langchain/build compile @langchain/langgraph-sdk",
     "prepublish": "pnpm build",
     "lint:eslint": "NODE_OPTIONS=--max-old-space-size=4096 eslint --cache --ext .ts,.js,.jsx,.tsx src/",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:int": "vitest run --mode int"
   },
   "license": "MIT",
   "dependencies": {
@@ -32,6 +33,7 @@
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
     "@types/uuid": "^9.0.1",
+    "@types/ws": "^8.18.1",
     "deepagents": "^1.8.3",
     "langchain": "^1.4.4",
     "react": "^19.2.7",
@@ -40,6 +42,7 @@
     "typescript": "^4.9.5 || ^5.4.5",
     "vitest": "^4.1.0",
     "vue": "^3.5.35",
+    "ws": "^8.18.3",
     "zod": "^4.3.5"
   },
   "peerDependencies": {

--- a/libs/sdk/src/client/stream/error.ts
+++ b/libs/sdk/src/client/stream/error.ts
@@ -14,3 +14,25 @@ export class ProtocolError extends Error {
     this.response = response;
   }
 }
+
+/**
+ * Thrown when the v2 WebSocket transport exhausts its automatic reconnect
+ * budget (`maxReconnectAttempts`) after an unexpected socket close or error.
+ *
+ * The transport closes its event queue with this error so consumers of
+ * `events()` can treat the stream as terminally failed. Set
+ * `maxReconnectAttempts` to `0` on `client.threads.stream({ transport:
+ * "websocket" })` to disable reconnect and fail fast on the first drop
+ * instead.
+ */
+export class MaxWebSocketReconnectAttemptsError extends Error {
+  /** The configured `maxReconnectAttempts` value that was exceeded. */
+  readonly maxAttempts: number;
+
+  constructor(maxAttempts: number, cause: unknown) {
+    super(`Exceeded maximum WebSocket reconnection attempts (${maxAttempts})`);
+    this.name = "MaxWebSocketReconnectAttemptsError";
+    this.maxAttempts = maxAttempts;
+    this.cause = cause;
+  }
+}

--- a/libs/sdk/src/client/stream/index.ts
+++ b/libs/sdk/src/client/stream/index.ts
@@ -2481,10 +2481,7 @@ export type {
 export { inferChannel, matchesSubscription } from "./subscription.js";
 export type { TransportAdapter, AgentServerAdapter } from "./transport.js";
 export type * from "./types.js";
-export {
-  ProtocolError,
-  MaxWebSocketReconnectAttemptsError,
-} from "./error.js";
+export { ProtocolError, MaxWebSocketReconnectAttemptsError } from "./error.js";
 export { MediaAssembler, MediaAssemblyError } from "./media.js";
 export type {
   AnyMediaHandle,

--- a/libs/sdk/src/client/stream/index.ts
+++ b/libs/sdk/src/client/stream/index.ts
@@ -761,6 +761,12 @@ export class ThreadStream<
     // SSE transports deliver events via openEventStream — the events()
     // iterable is inert. Skip the consumer loop in that case.
     if (this.#transportAdapter.openEventStream == null) {
+      const wsTransport = this.#transportAdapter as {
+        setOnReconnected?: (handler: () => void | Promise<void>) => void;
+      };
+      wsTransport.setOnReconnected?.(() =>
+        this.#resubscribeWebSocketSubscriptions()
+      );
       void this.#consumeEvents();
     }
   }
@@ -2186,6 +2192,46 @@ export class ThreadStream<
     return handle as SubscriptionHandle<Event>;
   }
 
+  /**
+   * Re-issue `subscription.subscribe` for every active WS subscription
+   * after the transport reconnects. The server replays buffered events on
+   * the new socket; client-side `event_id` dedup suppresses duplicates.
+   */
+  async #resubscribeWebSocketSubscriptions(): Promise<void> {
+    if (this.#transportAdapter.openEventStream != null || this.#closed) {
+      return;
+    }
+
+    const entries = [...this.#subscriptions.entries()];
+    await Promise.all(
+      entries.map(async ([id, subscription]) => {
+        if (id.startsWith("pending:")) {
+          return;
+        }
+        try {
+          const result = await this.#send(
+            "subscription.subscribe",
+            subscription.filter
+          );
+          const nextId = result.subscription_id;
+          if (nextId === id) {
+            return;
+          }
+          this.#subscriptions.delete(id);
+          (
+            subscription as unknown as SubscriptionHandle<Event>
+          ).subscriptionId = nextId;
+          this.#subscriptions.set(nextId, subscription);
+          if (this.#lifecycleSubId === id) {
+            this.#lifecycleSubId = nextId;
+          }
+        } catch {
+          // Best-effort; the content pump may still receive replayed events.
+        }
+      })
+    );
+  }
+
   async #consumeEvents(): Promise<void> {
     try {
       for await (const message of this.#transportAdapter.events()) {
@@ -2435,7 +2481,10 @@ export type {
 export { inferChannel, matchesSubscription } from "./subscription.js";
 export type { TransportAdapter, AgentServerAdapter } from "./transport.js";
 export type * from "./types.js";
-export { ProtocolError } from "./error.js";
+export {
+  ProtocolError,
+  MaxWebSocketReconnectAttemptsError,
+} from "./error.js";
 export { MediaAssembler, MediaAssemblyError } from "./media.js";
 export type {
   AnyMediaHandle,

--- a/libs/sdk/src/client/stream/test/mock-protocol-server.ts
+++ b/libs/sdk/src/client/stream/test/mock-protocol-server.ts
@@ -1,0 +1,364 @@
+/**
+ * Minimal in-process mock of the v2 LangGraph protocol surface used by
+ * {@link ProtocolSseTransportAdapter} and {@link ProtocolWebSocketTransportAdapter}.
+ *
+ * Mirrors the replay semantics of `langgraph-api` embed protocol: events are
+ * buffered per thread, SSE subscriptions honour `since` in the POST body, and
+ * WebSocket connections replay the full buffer on each connect.
+ *
+ * WebSocket serving uses the `ws` package; clients use the Node.js 22+ global
+ * {@link WebSocket} API.
+ */
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { WebSocketServer, type WebSocket } from "ws";
+
+export type MockProtocolEvent = {
+  type: "event";
+  method: string;
+  event_id: string;
+  seq: number;
+  params?: { namespace?: string[]; data?: unknown };
+};
+
+export interface MockProtocolServerOptions {
+  threadId?: string;
+  events: MockProtocolEvent[];
+  /** Drop the first SSE connection after delivering this many matching events. */
+  failSseAfterDelivered?: number;
+  /** Close the first WebSocket after delivering this many events. */
+  failWsAfterDelivered?: number;
+}
+
+export interface MockProtocolServer {
+  readonly apiUrl: string;
+  readonly threadId: string;
+  readonly sseConnectionCount: () => number;
+  readonly wsConnectionCount: () => number;
+  /** Forcibly close a prior WebSocket connection (1-based index). */
+  closeWebSocketConnection(connectionIndex: number): void;
+  close(): Promise<void>;
+}
+
+const MIN_NODE_MAJOR = 22;
+
+function assertNodeWebSocketGlobal(): void {
+  const major = Number(process.versions.node.split(".")[0] ?? "0");
+  if (major < MIN_NODE_MAJOR || typeof globalThis.WebSocket !== "function") {
+    throw new Error(
+      `Mock protocol server requires Node.js ${MIN_NODE_MAJOR}+ with a global WebSocket (found Node ${process.versions.node}).`
+    );
+  }
+}
+
+function serialise(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function matchesChannels(
+  event: MockProtocolEvent,
+  channels: string[] | undefined
+): boolean {
+  if (channels == null || channels.length === 0) {
+    return true;
+  }
+  return channels.includes(event.method);
+}
+
+function filterEvents(
+  events: MockProtocolEvent[],
+  channels: string[] | undefined,
+  since: number | undefined
+): MockProtocolEvent[] {
+  return events.filter(
+    (event) =>
+      matchesChannels(event, channels) &&
+      (since == null || event.seq > since)
+  );
+}
+
+function writeSseFrame(
+  res: import("node:http").ServerResponse,
+  event: MockProtocolEvent
+): void {
+  const payload = serialise(event);
+  res.write(`id: ${event.event_id}\n`);
+  res.write(`event: ${event.method}\n`);
+  res.write(`data: ${payload}\n\n`);
+}
+
+export async function startMockProtocolServer(
+  options: MockProtocolServerOptions
+): Promise<MockProtocolServer> {
+  assertNodeWebSocketGlobal();
+
+  const threadId = options.threadId ?? "thread_mock";
+  const events = [...options.events].sort((a, b) => a.seq - b.seq);
+
+  let sseConnections = 0;
+  let wsConnections = 0;
+  const wsSocketsByConnection = new Map<number, WebSocket>();
+
+  const wss = new WebSocketServer({ noServer: true });
+
+  const httpServer: Server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+
+    if (
+      req.method === "POST" &&
+      url.pathname === `/threads/${threadId}/commands`
+    ) {
+      void handleCommand(req, res);
+      return;
+    }
+
+    if (
+      req.method === "POST" &&
+      url.pathname === `/threads/${threadId}/stream/events`
+    ) {
+      void handleSse(req, res);
+      return;
+    }
+
+    res.statusCode = 404;
+    res.end("not found");
+  });
+
+  httpServer.on("upgrade", (request, socket, head) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (url.pathname !== `/threads/${threadId}/stream/events`) {
+      socket.destroy();
+      return;
+    }
+    wss.handleUpgrade(request, socket, head, (ws) => {
+      wss.emit("connection", ws, request);
+    });
+  });
+
+  function buildCommandResponse(command: {
+    id?: number;
+    method?: string;
+  }): Record<string, unknown> {
+    if (command.method === "subscription.subscribe") {
+      return {
+        type: "success",
+        id: command.id,
+        result: { subscription_id: `sub_${command.id}` },
+      };
+    }
+
+    if (command.method === "run.start") {
+      return {
+        type: "success",
+        id: command.id,
+        result: { run_id: "run_mock" },
+        meta: { applied_through_seq: 0 },
+      };
+    }
+
+    return {
+      type: "success",
+      id: command.id,
+      result: {},
+    };
+  }
+
+  wss.on("connection", (ws) => {
+    wsConnections += 1;
+    const connectionIndex = wsConnections;
+    wsSocketsByConnection.set(connectionIndex, ws);
+
+    ws.on("close", () => {
+      wsSocketsByConnection.delete(connectionIndex);
+    });
+
+    let delivered = 0;
+    let disconnectScheduled = false;
+
+    const push = (event: MockProtocolEvent): boolean => {
+      if (ws.readyState !== ws.OPEN || disconnectScheduled) {
+        return false;
+      }
+      ws.send(serialise(event));
+      delivered += 1;
+      if (
+        connectionIndex === 1 &&
+        options.failWsAfterDelivered != null &&
+        delivered >= options.failWsAfterDelivered
+      ) {
+        disconnectScheduled = true;
+        queueMicrotask(() => ws.close(1011, "mock disconnect"));
+      }
+      return true;
+    };
+
+    const replayEvents = (): void => {
+      for (const event of events) {
+        if (!push(event)) {
+          break;
+        }
+      }
+    };
+
+    // Subsequent sockets simulate server-side replay after reconnect.
+    if (connectionIndex > 1) {
+      queueMicrotask(() => replayEvents());
+    }
+
+    ws.on("message", (raw) => {
+      let command: { id?: number; method?: string };
+      try {
+        command = JSON.parse(String(raw)) as {
+          id?: number;
+          method?: string;
+        };
+      } catch {
+        return;
+      }
+      if (typeof command.id !== "number" || typeof command.method !== "string") {
+        return;
+      }
+      if (ws.readyState === ws.OPEN) {
+        ws.send(serialise(buildCommandResponse(command)));
+      }
+      // Mirror server replay: buffered events are delivered when the
+      // client subscribes, not at socket connect (avoids racing
+      // `run.start` / command round-trips on the same connection).
+      if (command.method === "subscription.subscribe") {
+        replayEvents();
+      }
+    });
+  });
+
+  async function handleCommand(
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse
+  ) {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(chunk as Buffer);
+    }
+    let command: { id?: number; method?: string };
+    try {
+      command = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+        id?: number;
+        method?: string;
+      };
+    } catch {
+      res.statusCode = 400;
+      res.end("invalid json");
+      return;
+    }
+
+    res.statusCode = 200;
+    res.setHeader("content-type", "application/json");
+    res.end(serialise(buildCommandResponse(command)));
+  }
+
+  async function handleSse(
+    req: import("node:http").IncomingMessage,
+    res: import("node:http").ServerResponse
+  ) {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(chunk as Buffer);
+    }
+    let body: {
+      channels?: string[];
+      since?: number;
+    };
+    try {
+      body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+        channels?: string[];
+        since?: number;
+      };
+    } catch {
+      res.statusCode = 400;
+      res.end("invalid json");
+      return;
+    }
+
+    sseConnections += 1;
+    const connectionIndex = sseConnections;
+    const toDeliver = filterEvents(events, body.channels, body.since);
+
+    res.statusCode = 200;
+    res.setHeader("content-type", "text/event-stream");
+    res.setHeader("cache-control", "no-cache");
+    res.setHeader("connection", "close");
+
+    const failAfterDelivered =
+      connectionIndex === 1 ? options.failSseAfterDelivered : undefined;
+
+    if (failAfterDelivered != null) {
+      // Truncated Content-Length forces the fetch body to error once the
+      // socket closes before the declared length is reached.
+      res.setHeader("content-length", "65536");
+    }
+
+    res.flushHeaders?.();
+
+    let delivered = 0;
+
+    try {
+      for (const event of toDeliver) {
+        writeSseFrame(res, event);
+        if (typeof res.flush === "function") {
+          res.flush();
+        }
+        delivered += 1;
+
+        if (
+          failAfterDelivered != null &&
+          delivered >= failAfterDelivered
+        ) {
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, 50);
+          });
+          res.socket?.destroy(new Error("mock SSE disconnect"));
+          return;
+        }
+      }
+      res.end();
+    } catch {
+      res.destroy();
+    }
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.listen(0, "127.0.0.1", () => resolve());
+    httpServer.on("error", reject);
+  });
+
+  const address = httpServer.address() as AddressInfo;
+  const apiUrl = `http://127.0.0.1:${address.port}`;
+
+  return {
+    apiUrl,
+    threadId,
+    sseConnectionCount: () => sseConnections,
+    wsConnectionCount: () => wsConnections,
+    closeWebSocketConnection: (connectionIndex: number) => {
+      const ws = wsSocketsByConnection.get(connectionIndex);
+      if (ws != null && ws.readyState === ws.OPEN) {
+        ws.close(1011, "mock disconnect");
+      }
+    },
+    close: () =>
+      new Promise((resolve, reject) => {
+        for (const client of wss.clients) {
+          client.close(1000, "server shutdown");
+        }
+        wss.close((wsErr) => {
+          if (wsErr) {
+            reject(wsErr);
+            return;
+          }
+          httpServer.close((httpErr) => {
+            if (httpErr) reject(httpErr);
+            else resolve();
+          });
+        });
+      }),
+  };
+}

--- a/libs/sdk/src/client/stream/test/mock-protocol-server.ts
+++ b/libs/sdk/src/client/stream/test/mock-protocol-server.ts
@@ -9,7 +9,7 @@
  * WebSocket serving uses the `ws` package; clients use the Node.js 22+ global
  * {@link WebSocket} API.
  */
-import { createServer, type Server } from "node:http";
+import { createServer, type Server, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { WebSocketServer, type WebSocket } from "ws";
 
@@ -39,6 +39,10 @@ export interface MockProtocolServer {
   closeWebSocketConnection(connectionIndex: number): void;
   close(): Promise<void>;
 }
+
+type FlushableServerResponse = ServerResponse & {
+  flush?: () => void;
+};
 
 const MIN_NODE_MAJOR = 22;
 
@@ -77,7 +81,7 @@ function filterEvents(
 }
 
 function writeSseFrame(
-  res: import("node:http").ServerResponse,
+  res: FlushableServerResponse,
   event: MockProtocolEvent
 ): void {
   const payload = serialise(event);
@@ -259,7 +263,7 @@ export async function startMockProtocolServer(
 
   async function handleSse(
     req: import("node:http").IncomingMessage,
-    res: import("node:http").ServerResponse
+    res: FlushableServerResponse
   ) {
     const chunks: Buffer[] = [];
     for await (const chunk of req) {

--- a/libs/sdk/src/client/stream/test/mock-protocol-server.ts
+++ b/libs/sdk/src/client/stream/test/mock-protocol-server.ts
@@ -72,8 +72,7 @@ function filterEvents(
 ): MockProtocolEvent[] {
   return events.filter(
     (event) =>
-      matchesChannels(event, channels) &&
-      (since == null || event.seq > since)
+      matchesChannels(event, channels) && (since == null || event.seq > since)
   );
 }
 
@@ -215,7 +214,10 @@ export async function startMockProtocolServer(
       } catch {
         return;
       }
-      if (typeof command.id !== "number" || typeof command.method !== "string") {
+      if (
+        typeof command.id !== "number" ||
+        typeof command.method !== "string"
+      ) {
         return;
       }
       if (ws.readyState === ws.OPEN) {
@@ -308,10 +310,7 @@ export async function startMockProtocolServer(
         }
         delivered += 1;
 
-        if (
-          failAfterDelivered != null &&
-          delivered >= failAfterDelivered
-        ) {
+        if (failAfterDelivered != null && delivered >= failAfterDelivered) {
           await new Promise<void>((resolve) => {
             setTimeout(resolve, 50);
           });

--- a/libs/sdk/src/client/stream/test/reconnect.int.test.ts
+++ b/libs/sdk/src/client/stream/test/reconnect.int.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const nodeMajor = Number(process.versions.node.split(".")[0] ?? "0");
+const hasGlobalWebSocket =
+  nodeMajor >= 22 && typeof globalThis.WebSocket === "function";
+
+import { Client } from "../../index.js";
+import {
+  startMockProtocolServer,
+  type MockProtocolEvent,
+  type MockProtocolServer,
+} from "./mock-protocol-server.js";
+
+const TEST_EVENTS: MockProtocolEvent[] = [
+  {
+    type: "event",
+    method: "values",
+    event_id: "evt_1",
+    seq: 1,
+    params: { namespace: [], data: { step: 1 } },
+  },
+  {
+    type: "event",
+    method: "values",
+    event_id: "evt_2",
+    seq: 2,
+    params: { namespace: [], data: { step: 2 } },
+  },
+  {
+    type: "event",
+    method: "values",
+    event_id: "evt_3",
+    seq: 3,
+    params: { namespace: [], data: { step: 3 } },
+  },
+  {
+    type: "event",
+    method: "values",
+    event_id: "evt_4",
+    seq: 4,
+    params: { namespace: [], data: { step: 4 } },
+  },
+];
+
+function collectSeqsFromThread(
+  thread: ReturnType<Client["threads"]["stream"]>
+): { seqs: number[]; off: () => void } {
+  const seqs: number[] = [];
+  const off = thread.onEvent((event) => {
+    if (event.type === "event" && typeof event.seq === "number") {
+      seqs.push(event.seq);
+    }
+  });
+  return { seqs, off };
+}
+
+describe.skipIf(!hasGlobalWebSocket)(
+  "client.threads.stream reconnection (mock langgraph-api)",
+  () => {
+    let server: MockProtocolServer;
+
+    afterEach(async () => {
+      await server?.close();
+    });
+
+    it("SSE: run.start streams all values after the server drops the connection", async () => {
+      server = await startMockProtocolServer({
+        threadId: "thread_sse_client_reconnect",
+        events: TEST_EVENTS,
+        failSseAfterDelivered: 2,
+      });
+
+      const onReconnect = vi.fn();
+      const client = new Client({ apiUrl: server.apiUrl, apiKey: null });
+      const thread = client.threads.stream(server.threadId, {
+        assistantId: "assistant_mock",
+        transport: "sse",
+        maxReconnectAttempts: 3,
+        reconnectDelayMs: () => 0,
+        onReconnect,
+      });
+
+      const { seqs, off } = collectSeqsFromThread(thread);
+      try {
+        const run = await thread.run.start({ input: { prompt: "hi" } });
+        expect(run).toBeDefined();
+
+        await vi.waitFor(
+          () => {
+            expect(onReconnect).toHaveBeenCalledTimes(1);
+            expect(server.sseConnectionCount()).toBeGreaterThanOrEqual(2);
+            expect(thread.ordering.lastSeenSeq).toBe(4);
+          },
+          { timeout: 10_000 }
+        );
+
+        expect([...new Set(seqs)].sort((a, b) => a - b)).toEqual([1, 2, 3, 4]);
+      } finally {
+        off();
+        await thread.close();
+      }
+    });
+
+    it("WebSocket: run.start streams all values after the server drops the connection", async () => {
+      server = await startMockProtocolServer({
+        threadId: "thread_ws_client_reconnect",
+        events: TEST_EVENTS,
+        failWsAfterDelivered: 2,
+      });
+
+      const onReconnect = vi.fn();
+      const client = new Client({ apiUrl: server.apiUrl, apiKey: null });
+      const thread = client.threads.stream(server.threadId, {
+        assistantId: "assistant_mock",
+        transport: "websocket",
+        maxReconnectAttempts: 3,
+        reconnectDelayMs: () => 0,
+        onReconnect,
+      });
+
+      const { seqs, off } = collectSeqsFromThread(thread);
+      try {
+        const run = await thread.run.start({ input: { prompt: "hi" } });
+        expect(run).toBeDefined();
+
+        await vi.waitFor(
+          () => {
+            expect(onReconnect).toHaveBeenCalledTimes(1);
+            expect(server.wsConnectionCount()).toBeGreaterThanOrEqual(2);
+            expect(thread.ordering.lastSeenSeq).toBe(4);
+          },
+          { timeout: 10_000 }
+        );
+
+        // Replay on reconnect may redeliver early seqs; unique set is enough.
+        expect([...new Set(seqs)].sort((a, b) => a - b)).toEqual([1, 2, 3, 4]);
+      } finally {
+        off();
+        await thread.close();
+      }
+    });
+  }
+);

--- a/libs/sdk/src/client/stream/transport/agent-server.ts
+++ b/libs/sdk/src/client/stream/transport/agent-server.ts
@@ -27,6 +27,7 @@ import type {
   Message,
   SubscribeParams,
 } from "@langchain/protocol";
+import type { AsyncCaller } from "../../../utils/async_caller.js";
 import { ProtocolSseTransportAdapter } from "./http.js";
 import { ProtocolWebSocketTransportAdapter } from "./websocket.js";
 import type {
@@ -50,6 +51,12 @@ export interface HttpAgentServerAdapterOptions {
    * mocks. Ignored when `webSocketFactory` is also supplied.
    */
   fetch?: typeof fetch;
+  /**
+   * Retries and concurrency for SSE/command HTTP. When omitted, requests
+   * use raw `fetch` with no automatic retries (same as constructing
+   * {@link ProtocolSseTransportAdapter} without this option).
+   */
+  asyncCaller?: AsyncCaller;
   /**
    * Optional WebSocket factory. Supplying it flips the adapter into
    * WebSocket mode — SSE is bypassed entirely.
@@ -89,6 +96,7 @@ export class HttpAgentServerAdapter implements AgentServerAdapter {
             defaultHeaders: options.defaultHeaders,
             onRequest: options.onRequest,
             fetch: options.fetch,
+            asyncCaller: options.asyncCaller,
             paths: options.paths,
           });
 

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -181,4 +181,54 @@ describe("ProtocolSseTransportAdapter AsyncCaller", () => {
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
+
+  it("routes commands through asyncCaller but bypasses it for the SSE event stream", async () => {
+    // Long-lived event streams must not run through AsyncCaller (its
+    // p-queue/p-retry semantics stall a streaming response). Commands must
+    // still go through it for retry/backoff parity with REST.
+    const sseFrame =
+      'event: values\ndata: {"type":"event","method":"values","seq":1,"event_id":"e1"}\n\n';
+    const fetchImpl = vi.fn((input: URL | RequestInfo) => {
+      if (String(input).includes("/stream/events")) {
+        return Promise.resolve(
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode(sseFrame));
+                controller.close();
+              },
+            }),
+            { status: 200, headers: { "content-type": "text/event-stream" } }
+          )
+        );
+      }
+      return Promise.resolve(protocolSuccessResponse());
+    }) as unknown as typeof fetch;
+
+    const asyncCaller = new AsyncCaller({ maxRetries: 0, maxConcurrency: 1 });
+    const callSpy = vi.spyOn(asyncCaller, "call");
+
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: THREAD_ID,
+      fetch: fetchImpl,
+      asyncCaller,
+    });
+
+    await transport.send({ id: 1, method: "state.get", params: { namespace: [] } });
+    expect(callSpy).toHaveBeenCalledTimes(1);
+
+    const callsAfterCommand = callSpy.mock.calls.length;
+
+    const handle = transport.openEventStream({ channels: ["values"] });
+    await handle.ready;
+    const iterator = handle.events[Symbol.asyncIterator]();
+    const first = await iterator.next();
+
+    expect(first.value).toMatchObject({ event_id: "e1", seq: 1 });
+    // The event stream must NOT have gone through asyncCaller.
+    expect(callSpy.mock.calls.length).toBe(callsAfterCommand);
+
+    await transport.close();
+  });
 });

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -1,11 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
+import { AsyncCaller } from "../../../utils/async_caller.js";
 import { ProtocolSseTransportAdapter } from "./http.js";
 import {
   LANGGRAPH_PROXY_API_URL,
   PROXIED_API_URL,
   THREAD_ID,
   createFetchRecorder,
+  protocolSuccessResponse,
 } from "./test-helpers.js";
 
 describe("ProtocolSseTransportAdapter URL resolution", () => {
@@ -122,5 +124,61 @@ describe("ProtocolSseTransportAdapter URL resolution", () => {
     });
 
     await expect(transport.getState()).resolves.toBeNull();
+  });
+});
+
+describe("ProtocolSseTransportAdapter AsyncCaller", () => {
+  it("retries transient command failures when asyncCaller is provided", async () => {
+    let attempts = 0;
+    const fetchImpl = vi.fn(() => {
+      attempts += 1;
+      if (attempts < 3) {
+        return Promise.resolve(
+          new Response("unavailable", { status: 503, statusText: "Unavailable" })
+        );
+      }
+      return Promise.resolve(protocolSuccessResponse());
+    }) as typeof fetch;
+
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: THREAD_ID,
+      fetch: fetchImpl,
+      asyncCaller: new AsyncCaller({ maxRetries: 4, maxConcurrency: 1 }),
+    });
+
+    await transport.send({
+      id: 1,
+      method: "state.get",
+      params: { namespace: [] },
+    });
+
+    expect(attempts).toBe(3);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry non-retryable status codes when asyncCaller is provided", async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(
+        new Response("not found", { status: 404, statusText: "Not Found" })
+      )
+    ) as typeof fetch;
+
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: THREAD_ID,
+      fetch: fetchImpl,
+      asyncCaller: new AsyncCaller({ maxRetries: 4, maxConcurrency: 1 }),
+    });
+
+    await expect(
+      transport.send({
+        id: 1,
+        method: "state.get",
+        params: { namespace: [] },
+      })
+    ).rejects.toThrow(/HTTP 404/);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 });

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -7,6 +7,7 @@ import type {
   ErrorResponse,
 } from "@langchain/protocol";
 
+import type { AsyncCaller } from "../../../utils/async_caller.js";
 import type {
   HeaderValue,
   ProtocolRequestHook,
@@ -22,6 +23,7 @@ import {
 } from "./utils.js";
 import { BytesLineDecoder, SSEDecoder } from "../../../utils/sse.js";
 import { IterableReadableStream } from "../../../utils/stream.js";
+import { webSocketReconnectDelayMs } from "./websocket.js";
 
 /**
  * Transport adapter that speaks the thread-centric protocol over HTTP
@@ -44,6 +46,14 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
 
   private readonly fetchFactory?: () => typeof fetch | Promise<typeof fetch>;
 
+  private readonly asyncCaller?: AsyncCaller;
+
+  private readonly maxReconnectAttempts: number;
+
+  private readonly onReconnect?: ProtocolSseTransportOptions["onReconnect"];
+
+  private readonly reconnectDelayMs: (attempt: number) => number;
+
   private readonly commandsUrl: string;
 
   private readonly streamUrl: string;
@@ -62,6 +72,15 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
     this.defaultHeaders = options.defaultHeaders ?? {};
     this.onRequest = options.onRequest;
     this.fetchFactory = options.fetchFactory;
+    this.asyncCaller = options.asyncCaller;
+    // Custom fetch (tests/mocks) must not auto-reconnect — same policy as skipping AsyncCaller.
+    this.maxReconnectAttempts =
+      options.fetch != null
+        ? 0
+        : (options.maxReconnectAttempts ?? 5);
+    this.onReconnect = options.onReconnect;
+    this.reconnectDelayMs =
+      options.reconnectDelayMs ?? webSocketReconnectDelayMs;
     this.threadId = options.threadId;
     this.commandsUrl =
       options.paths?.commands ?? `/threads/${this.threadId}/commands`;
@@ -189,60 +208,102 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
       rejectReady = reject;
     });
 
-    const since = (params as SubscribeParams & { since?: unknown }).since;
+    let resumeAfterSeq =
+      typeof (params as SubscribeParams & { since?: unknown }).since ===
+      "number"
+        ? (params as SubscribeParams & { since: number }).since
+        : undefined;
+
+    let readySettled = false;
 
     const startStream = async () => {
-      try {
-        const response = await this.request(streamUrl, {
-          method: "POST",
-          headers: {
-            "content-type": "application/json",
-            accept: "text/event-stream",
-          },
-          body: JSON.stringify({
-            channels: params.channels,
-            ...(params.namespaces ? { namespaces: params.namespaces } : {}),
-            ...(params.depth != null ? { depth: params.depth } : {}),
-            ...(typeof since === "number" ? { since } : {}),
-          }),
-          signal: ac.signal,
-        });
+      let attempt = 0;
+      let lastError: unknown;
 
-        resolveReady();
-
-        const readable =
-          response.body ??
-          new ReadableStream<Uint8Array>({
-            start(controller) {
-              controller.close();
+      while (!ac.signal.aborted && !this.closed) {
+        try {
+          const response = await this.request(streamUrl, {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              accept: "text/event-stream",
             },
+            body: JSON.stringify({
+              channels: params.channels,
+              ...(params.namespaces ? { namespaces: params.namespaces } : {}),
+              ...(params.depth != null ? { depth: params.depth } : {}),
+              ...(resumeAfterSeq != null ? { since: resumeAfterSeq } : {}),
+            }),
+            signal: ac.signal,
           });
 
-        const stream = readable
-          .pipeThrough(BytesLineDecoder())
-          .pipeThrough(SSEDecoder());
-        const iterable = IterableReadableStream.fromReadableStream(stream);
+          if (!readySettled) {
+            readySettled = true;
+            resolveReady();
+          }
 
-        for await (const event of iterable) {
-          if (ac.signal.aborted || this.closed) {
-            break;
+          const readable =
+            response.body ??
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.close();
+              },
+            });
+
+          const stream = readable
+            .pipeThrough(BytesLineDecoder())
+            .pipeThrough(SSEDecoder());
+          const iterable = IterableReadableStream.fromReadableStream(stream);
+
+          for await (const event of iterable) {
+            if (ac.signal.aborted || this.closed) {
+              break;
+            }
+            if (isRecord(event.data)) {
+              const msg = event.data as Message & {
+                seq?: number;
+                method?: string;
+              };
+              if (typeof msg.seq === "number") {
+                resumeAfterSeq = msg.seq;
+              }
+              streamQueue.push(msg);
+            }
           }
-          if (isRecord(event.data)) {
-            const msg = event.data as Message & {
-              seq?: number;
-              method?: string;
-            };
-            streamQueue.push(msg);
-          }
-        }
-        streamQueue.close();
-      } catch (error) {
-        rejectReady(error);
-        if (ac.signal.aborted || this.closed) {
           streamQueue.close();
           return;
+        } catch (error) {
+          lastError = error;
+          if (ac.signal.aborted || this.closed) {
+            if (!readySettled) {
+              rejectReady(error);
+            }
+            streamQueue.close();
+            return;
+          }
+          if (this.maxReconnectAttempts <= 0) {
+            if (!readySettled) {
+              rejectReady(error);
+            }
+            streamQueue.close(toError(error));
+            return;
+          }
+          attempt += 1;
+          if (attempt > this.maxReconnectAttempts) {
+            if (!readySettled) {
+              rejectReady(error);
+            }
+            streamQueue.close(toError(error));
+            return;
+          }
+          this.onReconnect?.({ attempt, cause: error });
+          const delay = this.reconnectDelayMs(attempt);
+          if (delay > 0) {
+            await new Promise<void>((resolve) => {
+              setTimeout(resolve, delay);
+            });
+          }
         }
-        streamQueue.close(error);
       }
     };
 
@@ -291,10 +352,15 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
       requestInit = await this.onRequest(url, requestInit);
     }
 
-    try {
+    const execute = async (): Promise<Response> => {
       const fetchImpl = await this.resolveFetch();
       const response = await fetchImpl(url.toString(), requestInit);
       if (!response.ok) {
+        // Reject with the Response so AsyncCaller maps it to HTTPError and
+        // applies STATUS_NO_RETRY / retry policy consistently with REST.
+        if (this.asyncCaller) {
+          throw response;
+        }
         let detail = "";
         try {
           const body = await response.text();
@@ -315,6 +381,12 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
         throw new Error(message);
       }
       return response;
+    };
+
+    try {
+      return this.asyncCaller
+        ? await this.asyncCaller.call(execute)
+        : await execute();
     } catch (error) {
       throw toError(error);
     }

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -216,7 +216,6 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
 
     const startStream = async () => {
       let attempt = 0;
-      let lastError: unknown;
 
       while (!ac.signal.aborted && !this.closed) {
         try {
@@ -271,7 +270,6 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
           streamQueue.close();
           return;
         } catch (error) {
-          lastError = error;
           if (ac.signal.aborted || this.closed) {
             if (!readySettled) {
               rejectReady(error);

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -75,9 +75,7 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
     this.asyncCaller = options.asyncCaller;
     // Custom fetch (tests/mocks) must not auto-reconnect — same policy as skipping AsyncCaller.
     this.maxReconnectAttempts =
-      options.fetch != null
-        ? 0
-        : (options.maxReconnectAttempts ?? 5);
+      options.fetch != null ? 0 : (options.maxReconnectAttempts ?? 5);
     this.onReconnect = options.onReconnect;
     this.reconnectDelayMs =
       options.reconnectDelayMs ?? webSocketReconnectDelayMs;

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -219,20 +219,24 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
 
       while (!ac.signal.aborted && !this.closed) {
         try {
-          const response = await this.request(streamUrl, {
-            method: "POST",
-            headers: {
-              "content-type": "application/json",
-              accept: "text/event-stream",
+          const response = await this.request(
+            streamUrl,
+            {
+              method: "POST",
+              headers: {
+                "content-type": "application/json",
+                accept: "text/event-stream",
+              },
+              body: JSON.stringify({
+                channels: params.channels,
+                ...(params.namespaces ? { namespaces: params.namespaces } : {}),
+                ...(params.depth != null ? { depth: params.depth } : {}),
+                ...(resumeAfterSeq != null ? { since: resumeAfterSeq } : {}),
+              }),
+              signal: ac.signal,
             },
-            body: JSON.stringify({
-              channels: params.channels,
-              ...(params.namespaces ? { namespaces: params.namespaces } : {}),
-              ...(params.depth != null ? { depth: params.depth } : {}),
-              ...(resumeAfterSeq != null ? { since: resumeAfterSeq } : {}),
-            }),
-            signal: ac.signal,
-          });
+            { stream: true }
+          );
 
           if (!readySettled) {
             readySettled = true;
@@ -337,7 +341,11 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
     this.queue.close();
   }
 
-  private async request(path: string, init: RequestInit): Promise<Response> {
+  private async request(
+    path: string,
+    init: RequestInit,
+    options?: { stream?: boolean }
+  ): Promise<Response> {
     const url = toAbsoluteUrl(this.apiUrl, path);
     let requestInit: RequestInit = {
       ...init,
@@ -348,13 +356,20 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
       requestInit = await this.onRequest(url, requestInit);
     }
 
+    // Long-lived SSE event streams must not run through AsyncCaller: its
+    // p-queue/p-retry semantics are designed for discrete request/response
+    // calls, and wrapping a streaming response stalls the call (and can
+    // leak retries). Stream resilience is handled separately by the
+    // reconnect loop in `openEventStream`.
+    const useAsyncCaller = this.asyncCaller != null && !options?.stream;
+
     const execute = async (): Promise<Response> => {
       const fetchImpl = await this.resolveFetch();
       const response = await fetchImpl(url.toString(), requestInit);
       if (!response.ok) {
         // Reject with the Response so AsyncCaller maps it to HTTPError and
         // applies STATUS_NO_RETRY / retry policy consistently with REST.
-        if (this.asyncCaller) {
+        if (useAsyncCaller) {
           throw response;
         }
         let detail = "";
@@ -380,8 +395,8 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
     };
 
     try {
-      return this.asyncCaller
-        ? await this.asyncCaller.call(execute)
+      return useAsyncCaller
+        ? await this.asyncCaller!.call(execute)
         : await execute();
     } catch (error) {
       throw toError(error);

--- a/libs/sdk/src/client/stream/transport/index.ts
+++ b/libs/sdk/src/client/stream/transport/index.ts
@@ -1,5 +1,8 @@
 export { ProtocolSseTransportAdapter } from "./http.js";
-export { ProtocolWebSocketTransportAdapter, webSocketReconnectDelayMs } from "./websocket.js";
+export {
+  ProtocolWebSocketTransportAdapter,
+  webSocketReconnectDelayMs,
+} from "./websocket.js";
 export { MaxWebSocketReconnectAttemptsError } from "../error.js";
 export type { WebSocketReconnectOptions } from "./websocket.js";
 export {

--- a/libs/sdk/src/client/stream/transport/index.ts
+++ b/libs/sdk/src/client/stream/transport/index.ts
@@ -1,5 +1,7 @@
 export { ProtocolSseTransportAdapter } from "./http.js";
-export { ProtocolWebSocketTransportAdapter } from "./websocket.js";
+export { ProtocolWebSocketTransportAdapter, webSocketReconnectDelayMs } from "./websocket.js";
+export { MaxWebSocketReconnectAttemptsError } from "../error.js";
+export type { WebSocketReconnectOptions } from "./websocket.js";
 export {
   HttpAgentServerAdapter,
   type HttpAgentServerAdapterOptions,

--- a/libs/sdk/src/client/stream/transport/types.ts
+++ b/libs/sdk/src/client/stream/transport/types.ts
@@ -1,4 +1,5 @@
 import type { CommandResponse, ErrorResponse } from "@langchain/protocol";
+import type { AsyncCaller } from "../../../utils/async_caller.js";
 
 export type ProtocolRequestHook = (
   url: URL,
@@ -19,7 +20,25 @@ export interface ProtocolSseTransportOptions {
   onRequest?: ProtocolRequestHook;
   fetch?: typeof fetch;
   fetchFactory?: () => typeof fetch | Promise<typeof fetch>;
+  /**
+   * When set, command and SSE subscription HTTP requests are executed
+   * through {@link AsyncCaller} (retries, concurrency). Typically wired
+   * from {@link BaseClient} via `client.threads.stream()`.
+   */
+  asyncCaller?: AsyncCaller;
   paths?: ProtocolTransportPaths;
+  /**
+   * Maximum reconnect attempts after an unexpected SSE disconnect.
+   * Defaults to 5. Set to 0 to disable automatic reconnection.
+   */
+  maxReconnectAttempts?: number;
+  /** Called before each SSE reconnect attempt (after backoff delay). */
+  onReconnect?: (options: { attempt: number; cause: unknown }) => void;
+  /**
+   * Backoff before each SSE reconnect attempt. Defaults to
+   * {@link webSocketReconnectDelayMs} from `./websocket.js`.
+   */
+  reconnectDelayMs?: (attempt: number) => number;
 }
 
 export interface ProtocolWebSocketTransportOptions {
@@ -29,6 +48,25 @@ export interface ProtocolWebSocketTransportOptions {
   onRequest?: ProtocolRequestHook;
   webSocketFactory?: (url: string) => WebSocket;
   paths?: Pick<ProtocolTransportPaths, "stream">;
+  /**
+   * Maximum reconnect attempts after an unexpected socket close.
+   * Defaults to 5. Set to 0 to disable automatic reconnection.
+   */
+  maxReconnectAttempts?: number;
+  /**
+   * Called before each reconnect attempt (after backoff delay).
+   */
+  onReconnect?: (options: { attempt: number; cause: unknown }) => void;
+  /**
+   * Invoked after the socket has been re-established. Use to restore
+   * server-side subscription state (see `ThreadStream`).
+   */
+  onReconnected?: () => void | Promise<void>;
+  /**
+   * Backoff before each reconnect attempt. Defaults to
+   * {@link webSocketReconnectDelayMs}.
+   */
+  reconnectDelayMs?: (attempt: number) => number;
 }
 
 export type HeaderValue = string | undefined | null;

--- a/libs/sdk/src/client/stream/transport/websocket.test.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.test.ts
@@ -1,11 +1,101 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ProtocolWebSocketTransportAdapter } from "./websocket.js";
+import {
+  ProtocolWebSocketTransportAdapter,
+  webSocketReconnectDelayMs,
+} from "./websocket.js";
 import {
   PROXIED_API_URL,
   THREAD_ID,
   createWebSocketUrlRecorder,
 } from "./test-helpers.js";
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readonly url: string;
+  readyState = FakeWebSocket.CONNECTING;
+  private readonly listeners = new Map<
+    string,
+    Set<EventListenerOrEventListenerObject>
+  >();
+
+  constructor(url: string) {
+    this.url = url;
+    queueMicrotask(() => {
+      if (this.readyState === FakeWebSocket.CLOSED) return;
+      this.readyState = FakeWebSocket.OPEN;
+      this.dispatch("open", new Event("open"));
+    });
+  }
+
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: AddEventListenerOptions | boolean
+  ): void {
+    if (options && typeof options === "object" && options.once) {
+      const wrapper: EventListener = (event) => {
+        this.removeEventListener(type, wrapper);
+        if (typeof listener === "function") {
+          listener.call(this, event);
+        } else {
+          listener.handleEvent(event);
+        }
+      };
+      this.listenersFor(type).add(wrapper);
+      return;
+    }
+    this.listenersFor(type).add(listener);
+  }
+
+  removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject
+  ): void {
+    this.listenersFor(type).delete(listener);
+  }
+
+  send(_data: string): void {
+    // no-op for tests
+  }
+
+  close(): void {
+    if (this.readyState === FakeWebSocket.CLOSED) return;
+    this.readyState = FakeWebSocket.CLOSED;
+    this.dispatch("close", new Event("close"));
+  }
+
+  simulateUnexpectedClose(): void {
+    this.close();
+  }
+
+  simulateMessage(payload: unknown): void {
+    this.dispatch("message", { data: JSON.stringify(payload) } as MessageEvent);
+  }
+
+  private listenersFor(type: string): Set<EventListenerOrEventListenerObject> {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    return set;
+  }
+
+  private dispatch(type: string, event: Event): void {
+    for (const listener of [...this.listenersFor(type)]) {
+      if (typeof listener === "function") {
+        listener.call(this, event);
+      } else {
+        listener.handleEvent(event);
+      }
+    }
+  }
+}
 
 describe("ProtocolWebSocketTransportAdapter URL resolution", () => {
   it("preserves apiUrl path prefix when opening the stream socket", async () => {
@@ -40,5 +130,119 @@ describe("ProtocolWebSocketTransportAdapter URL resolution", () => {
     expect(calls[0]).toBe(
       `ws://localhost:4100/api/chat-langchain${customStreamPath}`
     );
+  });
+});
+
+describe("webSocketReconnectDelayMs", () => {
+  it("caps exponential backoff", () => {
+    expect(webSocketReconnectDelayMs(1)).toBeLessThanOrEqual(6000);
+    expect(webSocketReconnectDelayMs(10)).toBeLessThanOrEqual(6000);
+  });
+});
+
+describe("ProtocolWebSocketTransportAdapter reconnection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reconnects after an unexpected close and keeps the events iterator alive", async () => {
+    let connections = 0;
+    const reconnected = vi.fn();
+
+    const transport = new ProtocolWebSocketTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: "thread-1",
+      maxReconnectAttempts: 3,
+      onReconnected: reconnected,
+      webSocketFactory: (url) => {
+        connections += 1;
+        const socket = new FakeWebSocket(url);
+        if (connections === 1) {
+          queueMicrotask(() => {
+            socket.simulateMessage({
+              type: "event",
+              method: "values",
+              event_id: "evt_1",
+              seq: 1,
+            });
+            socket.simulateUnexpectedClose();
+          });
+        } else {
+          queueMicrotask(() => {
+            socket.simulateMessage({
+              type: "event",
+              method: "values",
+              event_id: "evt_2",
+              seq: 2,
+            });
+          });
+        }
+        return socket as unknown as WebSocket;
+      },
+    });
+
+    await transport.open();
+    await Promise.resolve();
+    const iterator = transport.events()[Symbol.asyncIterator]();
+
+    const firstPromise = iterator.next();
+    await vi.runAllTimersAsync();
+    expect(connections).toBe(2);
+    expect(reconnected).toHaveBeenCalledTimes(1);
+
+    const first = await firstPromise;
+    expect(first.done).toBe(false);
+    expect(first.value).toMatchObject({ type: "event", event_id: "evt_1" });
+
+    const second = await iterator.next();
+    expect(second.value).toMatchObject({ type: "event", event_id: "evt_2" });
+
+    await transport.close();
+  });
+
+  it("closes the event queue when reconnection is disabled", async () => {
+    const transport = new ProtocolWebSocketTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: "thread-1",
+      maxReconnectAttempts: 0,
+      webSocketFactory: (url) => {
+        const socket = new FakeWebSocket(url);
+        queueMicrotask(() => socket.simulateUnexpectedClose());
+        return socket as unknown as WebSocket;
+      },
+    });
+
+    await transport.open();
+    await Promise.resolve();
+
+    await expect(
+      transport.events()[Symbol.asyncIterator]().next()
+    ).rejects.toThrow(/closed unexpectedly/);
+
+    await transport.close();
+  });
+
+  it("does not reconnect after an intentional close", async () => {
+    let connections = 0;
+    const transport = new ProtocolWebSocketTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: "thread-1",
+      webSocketFactory: (url) => {
+        connections += 1;
+        return new FakeWebSocket(url) as unknown as WebSocket;
+      },
+    });
+
+    await transport.open();
+    await transport.close();
+
+    expect(connections).toBe(1);
+
+    await vi.runAllTimersAsync();
+    expect(connections).toBe(1);
   });
 });

--- a/libs/sdk/src/client/stream/transport/websocket.test.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.test.ts
@@ -149,6 +149,51 @@ describe("ProtocolWebSocketTransportAdapter reconnection", () => {
     vi.useRealTimers();
   });
 
+  it("onReconnected can send commands without deadlocking on reconnectInFlight", async () => {
+    let connections = 0;
+    let resubscribed = false;
+
+    const transport = new ProtocolWebSocketTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: "thread-1",
+      maxReconnectAttempts: 3,
+      reconnectDelayMs: () => 0,
+      webSocketFactory: (url) => {
+        connections += 1;
+        const socket = new FakeWebSocket(url);
+        socket.send = (data: string) => {
+          const command = JSON.parse(data) as { id: number; method: string };
+          queueMicrotask(() => {
+            socket.simulateMessage({
+              type: "success",
+              id: command.id,
+              result: { subscription_id: `sub_${command.id}` },
+            });
+          });
+        };
+        if (connections === 1) {
+          queueMicrotask(() => socket.simulateUnexpectedClose());
+        }
+        return socket as unknown as WebSocket;
+      },
+      onReconnected: async () => {
+        await transport.send({
+          id: 42,
+          method: "subscription.subscribe",
+          params: { channels: ["values"] },
+        });
+        resubscribed = true;
+      },
+    });
+
+    await transport.open();
+    await vi.runAllTimersAsync();
+
+    expect(connections).toBe(2);
+    expect(resubscribed).toBe(true);
+    await transport.close();
+  });
+
   it("reconnects after an unexpected close and keeps the events iterator alive", async () => {
     let connections = 0;
     const reconnected = vi.fn();

--- a/libs/sdk/src/client/stream/transport/websocket.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.ts
@@ -20,11 +20,46 @@ import type {
   ProtocolWebSocketTransportOptions,
 } from "./types.js";
 import type { TransportAdapter } from "../transport.js";
+import { MaxWebSocketReconnectAttemptsError } from "../error.js";
+
+/**
+ * Reconnect tuning for {@link ProtocolWebSocketTransportAdapter}. A subset
+ * of {@link ProtocolWebSocketTransportOptions}.
+ */
+export interface WebSocketReconnectOptions {
+  /**
+   * Maximum reconnection attempts after an unexpected disconnect.
+   * Defaults to 5.
+   */
+  maxReconnectAttempts?: number;
+
+  /**
+   * Invoked before each reconnect attempt (after backoff).
+   */
+  onReconnect?: (options: { attempt: number; cause: unknown }) => void;
+}
+
+/**
+ * Exponential backoff with jitter for WebSocket reconnect. Mirrors
+ * {@link streamWithRetry} in `utils/stream.ts` (capped at 5s + 1s jitter).
+ */
+export function webSocketReconnectDelayMs(attempt: number): number {
+  const baseDelay = Math.min(1000 * 2 ** (attempt - 1), 5000);
+  const jitter = Math.random() * 1000;
+  return baseDelay + jitter;
+}
 
 /**
  * Transport adapter that speaks the thread-centric protocol over a
  * bidirectional WebSocket. Bound to a specific `threadId` — the socket
  * connects to `ws://.../threads/:thread_id/stream/events`.
+ *
+ * On unexpected disconnect the adapter reconnects with exponential
+ * backoff (see {@link ProtocolWebSocketTransportOptions.maxReconnectAttempts}).
+ * The server replays buffered events on the new socket; the SDK
+ * deduplicates by `event_id`. {@link ProtocolWebSocketTransportOptions.onReconnected}
+ * runs after each successful reconnect so `ThreadStream` can re-issue
+ * `subscription.subscribe` commands.
  */
 export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
   readonly threadId: string;
@@ -41,6 +76,14 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
 
   private readonly streamUrl: string;
 
+  private readonly maxReconnectAttempts: number;
+
+  private readonly onReconnect?: ProtocolWebSocketTransportOptions["onReconnect"];
+
+  private readonly reconnectDelayMs: (attempt: number) => number;
+
+  private onReconnected?: () => void | Promise<void>;
+
   private readonly pending = new Map<number, PendingResponse>();
 
   private socket: WebSocket | null = null;
@@ -48,6 +91,8 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
   private closed = false;
 
   private intentionalClose = false;
+
+  private reconnectInFlight: Promise<void> | null = null;
 
   constructor(options: ProtocolWebSocketTransportOptions) {
     this.apiUrl = options.apiUrl;
@@ -58,10 +103,34 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
       options.webSocketFactory ?? ((url) => new WebSocket(url));
     this.streamUrl =
       options.paths?.stream ?? `/threads/${this.threadId}/stream/events`;
+    this.maxReconnectAttempts = options.maxReconnectAttempts ?? 5;
+    this.onReconnect = options.onReconnect;
+    this.onReconnected = options.onReconnected;
+    this.reconnectDelayMs =
+      options.reconnectDelayMs ?? webSocketReconnectDelayMs;
+  }
+
+  /**
+   * Register a callback invoked after each successful reconnect. Used
+   * by {@link ThreadStream} to re-send active `subscription.subscribe`
+   * commands.
+   */
+  setOnReconnected(handler: () => void | Promise<void>): void {
+    this.onReconnected = handler;
   }
 
   async open(): Promise<void> {
-    if (this.socket != null) return;
+    if (this.closed) {
+      throw new Error("Protocol WebSocket transport is closed.");
+    }
+    if (this.socket?.readyState === WebSocket.OPEN) {
+      return;
+    }
+    if (this.socket != null) {
+      this.#detachSocket(this.socket);
+      this.socket = null;
+    }
+
     this.assertBrowserSafeTransportConfig();
 
     const wsUrl = toWebSocketUrl(
@@ -69,12 +138,9 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
     );
     const socket = this.webSocketFactory(wsUrl);
     this.socket = socket;
-    this.closed = false;
     this.intentionalClose = false;
 
-    socket.addEventListener("message", this.handleMessage);
-    socket.addEventListener("close", this.handleClose);
-    socket.addEventListener("error", this.handleSocketError);
+    this.#attachSocket(socket);
 
     await new Promise<void>((resolve, reject) => {
       const onOpen = () => {
@@ -133,6 +199,8 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
       return;
     }
 
+    this.#detachSocket(socket);
+
     await new Promise<void>((resolve) => {
       if (socket.readyState === WebSocket.CLOSED) {
         resolve();
@@ -167,6 +235,10 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
   private async sendCommand(
     command: Command
   ): Promise<CommandResponse | ErrorResponse> {
+    if (this.reconnectInFlight != null) {
+      await this.reconnectInFlight.catch(() => undefined);
+    }
+
     const socket = this.socket;
     if (socket == null || socket.readyState !== WebSocket.OPEN) {
       throw new Error("Protocol WebSocket is not open.");
@@ -184,6 +256,18 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
         }
       }
     );
+  }
+
+  #attachSocket(socket: WebSocket): void {
+    socket.addEventListener("message", this.handleMessage);
+    socket.addEventListener("close", this.handleClose);
+    socket.addEventListener("error", this.handleSocketError);
+  }
+
+  #detachSocket(socket: WebSocket): void {
+    socket.removeEventListener("message", this.handleMessage);
+    socket.removeEventListener("close", this.handleClose);
+    socket.removeEventListener("error", this.handleSocketError);
   }
 
   private readonly handleMessage = (event: MessageEvent): void => {
@@ -213,6 +297,10 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
   };
 
   private readonly handleClose = (): void => {
+    const socket = this.socket;
+    if (socket != null) {
+      this.#detachSocket(socket);
+    }
     this.socket = null;
 
     if (this.intentionalClose || this.closed) {
@@ -220,12 +308,9 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
       return;
     }
 
-    const error = new Error("Protocol WebSocket closed unexpectedly.");
-    for (const { reject } of this.pending.values()) {
-      reject(error);
-    }
-    this.pending.clear();
-    this.queue.close(error);
+    this.#handleUnexpectedDisconnect(
+      new Error("Protocol WebSocket closed unexpectedly.")
+    );
   };
 
   private readonly handleSocketError = (): void => {
@@ -233,11 +318,76 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
       return;
     }
 
-    const error = new Error("Protocol WebSocket encountered an error.");
+    this.#handleUnexpectedDisconnect(
+      new Error("Protocol WebSocket encountered an error.")
+    );
+  };
+
+  #handleUnexpectedDisconnect(cause: unknown): void {
+    const error = toError(cause);
     for (const { reject } of this.pending.values()) {
       reject(error);
     }
     this.pending.clear();
-    this.queue.close(error);
-  };
+
+    if (this.maxReconnectAttempts <= 0) {
+      this.queue.close(error);
+      return;
+    }
+
+    this.#scheduleReconnect(cause);
+  }
+
+  #scheduleReconnect(cause: unknown): void {
+    if (this.closed || this.intentionalClose) {
+      return;
+    }
+    if (this.reconnectInFlight != null) {
+      return;
+    }
+
+    this.reconnectInFlight = this.#runReconnectLoop(cause).finally(() => {
+      this.reconnectInFlight = null;
+    });
+  }
+
+  async #runReconnectLoop(initialCause: unknown): Promise<void> {
+    let lastError: unknown = initialCause;
+
+    for (let attempt = 1; attempt <= this.maxReconnectAttempts; attempt += 1) {
+      if (this.closed || this.intentionalClose) {
+        return;
+      }
+
+      this.onReconnect?.({ attempt, cause: lastError });
+
+      const delay = this.reconnectDelayMs(attempt);
+      if (delay > 0) {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, delay);
+        });
+      }
+
+      if (this.closed || this.intentionalClose) {
+        return;
+      }
+
+      try {
+        await this.open();
+        if (this.onReconnected) {
+          await this.onReconnected();
+        }
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    this.queue.close(
+      new MaxWebSocketReconnectAttemptsError(
+        this.maxReconnectAttempts,
+        lastError
+      )
+    );
+  }
 }

--- a/libs/sdk/src/client/stream/transport/websocket.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.ts
@@ -235,11 +235,19 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
   private async sendCommand(
     command: Command
   ): Promise<CommandResponse | ErrorResponse> {
-    if (this.reconnectInFlight != null) {
+    // Wait for an in-flight reconnect only when the socket is not usable.
+    // After `open()` succeeds, `#runReconnectLoop` may still be awaiting
+    // `onReconnected` (e.g. ThreadStream resubscribe). Those callbacks call
+    // `sendCommand` and must not await the same `reconnectInFlight` promise.
+    let socket = this.socket;
+    if (
+      this.reconnectInFlight != null &&
+      (socket == null || socket.readyState !== WebSocket.OPEN)
+    ) {
       await this.reconnectInFlight.catch(() => undefined);
+      socket = this.socket;
     }
 
-    const socket = this.socket;
     if (socket == null || socket.readyState !== WebSocket.OPEN) {
       throw new Error("Protocol WebSocket is not open.");
     }

--- a/libs/sdk/src/client/stream/transport/websocket.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.ts
@@ -22,6 +22,10 @@ import type {
 import type { TransportAdapter } from "../transport.js";
 import { MaxWebSocketReconnectAttemptsError } from "../error.js";
 
+const WEB_SOCKET_CONNECTING = 0;
+const WEB_SOCKET_OPEN = 1;
+const WEB_SOCKET_CLOSED = 3;
+
 /**
  * Reconnect tuning for {@link ProtocolWebSocketTransportAdapter}. A subset
  * of {@link ProtocolWebSocketTransportOptions}.
@@ -123,7 +127,7 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
     if (this.closed) {
       throw new Error("Protocol WebSocket transport is closed.");
     }
-    if (this.socket?.readyState === WebSocket.OPEN) {
+    if (this.socket?.readyState === WEB_SOCKET_OPEN) {
       return;
     }
     if (this.socket != null) {
@@ -202,7 +206,7 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
     this.#detachSocket(socket);
 
     await new Promise<void>((resolve) => {
-      if (socket.readyState === WebSocket.CLOSED) {
+      if (socket.readyState === WEB_SOCKET_CLOSED) {
         resolve();
         return;
       }
@@ -214,8 +218,8 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
 
       socket.addEventListener("close", onClose, { once: true });
       if (
-        socket.readyState === WebSocket.OPEN ||
-        socket.readyState === WebSocket.CONNECTING
+        socket.readyState === WEB_SOCKET_OPEN ||
+        socket.readyState === WEB_SOCKET_CONNECTING
       ) {
         socket.close();
       } else {
@@ -242,13 +246,13 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
     let socket = this.socket;
     if (
       this.reconnectInFlight != null &&
-      (socket == null || socket.readyState !== WebSocket.OPEN)
+      (socket == null || socket.readyState !== WEB_SOCKET_OPEN)
     ) {
       await this.reconnectInFlight.catch(() => undefined);
       socket = this.socket;
     }
 
-    if (socket == null || socket.readyState !== WebSocket.OPEN) {
+    if (socket == null || socket.readyState !== WEB_SOCKET_OPEN) {
       throw new Error("Protocol WebSocket is not open.");
     }
 

--- a/libs/sdk/src/client/stream/types.ts
+++ b/libs/sdk/src/client/stream/types.ts
@@ -126,6 +126,20 @@ export interface ThreadStreamOptions {
    * for the SSE transport and for custom {@link AgentServerAdapter}s.
    */
   webSocketFactory?: (url: string) => WebSocket;
+  /**
+   * Built-in `"sse"` / `"websocket"` transports only: max reconnect
+   * attempts after an unexpected disconnect. Defaults to 5.
+   */
+  maxReconnectAttempts?: number;
+  /**
+   * Built-in transports only: delay before each reconnect attempt.
+   * Defaults to exponential backoff with jitter.
+   */
+  reconnectDelayMs?: (attempt: number) => number;
+  /**
+   * Built-in transports only: invoked before each reconnect attempt.
+   */
+  onReconnect?: (options: { attempt: number; cause: unknown }) => void;
 }
 
 export interface SessionOrderingState {

--- a/libs/sdk/src/client/threads/index.ts
+++ b/libs/sdk/src/client/threads/index.ts
@@ -474,9 +474,9 @@ export class ThreadsClient<
     const { threadId, options } =
       typeof threadIdOrOptions === "string"
         ? {
-            threadId: threadIdOrOptions,
-            options: maybeOptions as ThreadStreamOptions,
-          }
+          threadId: threadIdOrOptions,
+          options: maybeOptions as ThreadStreamOptions,
+        }
         : { threadId: uuidv7(), options: threadIdOrOptions };
 
     // `transport` accepts either a preset string (`"sse"` / `"websocket"`)
@@ -484,6 +484,12 @@ export class ThreadsClient<
     // the built-in factories entirely — this is the seam that lets users
     // point `useStream` at any agent server (including the thin wrappers
     // produced by `HttpAgentServerAdapter`).
+    // When callers supply `fetch`, use it verbatim (tests, auth shims). Otherwise
+    // route protocol HTTP and media URL fetches through AsyncCaller like REST.
+    const userFetch = options.fetch;
+    const protocolFetch =
+      userFetch ?? this.asyncCaller.fetch.bind(this.asyncCaller);
+
     let transport: TransportAdapter;
     if (options.transport != null && typeof options.transport !== "string") {
       transport = options.transport;
@@ -491,24 +497,37 @@ export class ThreadsClient<
       const transportKind: ThreadStreamTransportKind =
         options.transport ??
         (this.streamProtocol === "v2-websocket" ? "websocket" : "sse");
+      const maxReconnectAttempts = options.maxReconnectAttempts ?? 5;
+
+      /**
+       * Common options for both transports.
+       */
+      const commonOpts = {
+        apiUrl: this.apiUrl,
+        threadId,
+        defaultHeaders: this.defaultHeaders,
+        onRequest: this.onRequest,
+        maxReconnectAttempts,
+        reconnectDelayMs: options.reconnectDelayMs,
+        onReconnect: options.onReconnect,
+      }
+
       transport =
         transportKind === "websocket"
           ? new ProtocolWebSocketTransportAdapter({
-              apiUrl: this.apiUrl,
-              threadId,
-              defaultHeaders: this.defaultHeaders,
-              onRequest: this.onRequest,
-              webSocketFactory: options.webSocketFactory,
-            })
+            ...commonOpts,
+            webSocketFactory: options.webSocketFactory,
+          })
           : new ProtocolSseTransportAdapter({
-              apiUrl: this.apiUrl,
-              threadId,
-              defaultHeaders: this.defaultHeaders,
-              onRequest: this.onRequest,
-              fetch: options.fetch,
-            });
+            ...commonOpts,
+            fetch: userFetch,
+            asyncCaller: userFetch ? undefined : this.asyncCaller,
+          });
     }
 
-    return new ThreadStream<TExtensions>(transport, options);
+    return new ThreadStream<TExtensions>(transport, {
+      ...options,
+      fetch: protocolFetch,
+    });
   }
 }

--- a/libs/sdk/src/client/threads/index.ts
+++ b/libs/sdk/src/client/threads/index.ts
@@ -474,9 +474,9 @@ export class ThreadsClient<
     const { threadId, options } =
       typeof threadIdOrOptions === "string"
         ? {
-          threadId: threadIdOrOptions,
-          options: maybeOptions as ThreadStreamOptions,
-        }
+            threadId: threadIdOrOptions,
+            options: maybeOptions as ThreadStreamOptions,
+          }
         : { threadId: uuidv7(), options: threadIdOrOptions };
 
     // `transport` accepts either a preset string (`"sse"` / `"websocket"`)
@@ -510,19 +510,19 @@ export class ThreadsClient<
         maxReconnectAttempts,
         reconnectDelayMs: options.reconnectDelayMs,
         onReconnect: options.onReconnect,
-      }
+      };
 
       transport =
         transportKind === "websocket"
           ? new ProtocolWebSocketTransportAdapter({
-            ...commonOpts,
-            webSocketFactory: options.webSocketFactory,
-          })
+              ...commonOpts,
+              webSocketFactory: options.webSocketFactory,
+            })
           : new ProtocolSseTransportAdapter({
-            ...commonOpts,
-            fetch: userFetch,
-            asyncCaller: userFetch ? undefined : this.asyncCaller,
-          });
+              ...commonOpts,
+              fetch: userFetch,
+              asyncCaller: userFetch ? undefined : this.asyncCaller,
+            });
     }
 
     return new ThreadStream<TExtensions>(transport, {

--- a/libs/sdk/vitest.config.js
+++ b/libs/sdk/vitest.config.js
@@ -25,6 +25,7 @@ export default defineConfig((env) => {
         exclude: configDefaults.exclude,
         include: ["**/*.int.test.ts"],
         name: "int",
+        // Global WebSocket (client) is available in Node.js 22+.
         environment: "node",
       },
     };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2325,6 +2325,9 @@ importers:
       '@types/uuid':
         specifier: ^9.0.1
         version: 9.0.8
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       deepagents:
         specifier: ^1.8.3
         version: 1.8.3(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
@@ -2349,6 +2352,9 @@ importers:
       vue:
         specifier: ^3.5.35
         version: 3.5.35(typescript@5.9.3)
+      ws:
+        specifier: ^8.18.3
+        version: 8.20.1
       zod:
         specifier: ^4.3.5
         version: 4.3.6


### PR DESCRIPTION
## Summary
- Add automatic reconnect for v2 `ProtocolSseTransportAdapter` and `ProtocolWebSocketTransportAdapter` (resume via `since` on SSE, full buffer replay on WebSocket, with `MaxWebSocketReconnectAttemptsError` when the budget is exceeded).
- Wire `AsyncCaller` and reconnect defaults through `client.threads.stream`, with optional `maxReconnectAttempts`, `reconnectDelayMs`, and `onReconnect` on `ThreadStreamOptions`.
- Disable auto-reconnect when a custom `fetch` is passed (test/mocks), and add `pnpm test:int` integration tests using `client.threads.stream` + `run.start` against an in-process mock server.
