### PR TITLE
fix(sdk): normalize OpenAI Responses function_call into tool_calls

### DIFF
--- a/.changeset/normalize-openai-function-call-tool-calls.md
+++ b/.changeset/normalize-openai-function-call-tool-calls.md
@@ -1,0 +1,9 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): normalize OpenAI Responses function_call blocks into tool_calls
+
+Promote provider-native `function_call` content blocks and
+`response_metadata.output` entries to LangChain `tool_calls` during
+message coercion so useStream consumers can rely on `message.tool_calls`.

--- a/libs/sdk/src/stream/assembled-to-message.ts
+++ b/libs/sdk/src/stream/assembled-to-message.ts
@@ -26,6 +26,10 @@ import {
 } from "@langchain/core/messages";
 import type { ContentBlock, MessageRole, UsageInfo } from "@langchain/protocol";
 import type { AssembledMessage } from "../client/stream/messages.js";
+import {
+  extractToolCallsFromBlocks,
+  stripProviderToolCallBlocks,
+} from "../utils/normalize-tool-calls.js";
 
 export type ExtendedMessageRole = MessageRole | "tool";
 
@@ -91,9 +95,10 @@ export function assembledToBaseMessage(
       // `content-block-finish` finally promotes the chunks to
       // finalized `tool_calls`). The chunk class is assignment-compatible
       // with `BaseMessage` and round-trips through the merge logic.
+      const contentBlocks = cloneContentBlocks(blocks);
       const payload = {
         ...(id != null ? { id } : {}),
-        content: cloneContentBlocks(blocks),
+        content: stripProviderToolCallBlocks(contentBlocks) as ContentBlock[],
         ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
         ...(toolCallChunks.length > 0
           ? { tool_call_chunks: toolCallChunks }
@@ -149,33 +154,8 @@ function cloneContentBlocks(blocks: ContentBlock[]): ContentBlock[] {
   return blocks.map((block) => structuredClone(block));
 }
 
-interface LooseToolCall {
-  id: string;
-  name: string;
-  args: Record<string, unknown>;
-  type: "tool_call";
-}
-
-function extractToolCalls(blocks: ContentBlock[]): LooseToolCall[] {
-  const out: LooseToolCall[] = [];
-  for (const block of blocks) {
-    if (block.type !== "tool_call" && block.type !== "tool_use") continue;
-    const tc = block as ToolCallLikeBlock;
-    out.push({
-      id: tc.id ?? "",
-      name: tc.name ?? "",
-      args: normalizeToolCallArgs(tc.args ?? tc.input),
-      type: "tool_call",
-    });
-  }
-  return out;
-}
-
-interface ToolCallLikeBlock {
-  id?: string;
-  name?: string;
-  args?: unknown;
-  input?: unknown;
+function extractToolCalls(blocks: ContentBlock[]) {
+  return extractToolCallsFromBlocks(blocks);
 }
 
 interface LooseToolCallChunk {
@@ -205,25 +185,4 @@ function extractToolCallChunks(blocks: ContentBlock[]): LooseToolCallChunk[] {
     });
   }
   return out;
-}
-
-function normalizeToolCallArgs(value: unknown): Record<string, unknown> {
-  if (value != null && typeof value === "object" && !Array.isArray(value)) {
-    return value as Record<string, unknown>;
-  }
-  if (typeof value === "string" && value.length > 0) {
-    try {
-      const parsed = JSON.parse(value);
-      if (
-        parsed != null &&
-        typeof parsed === "object" &&
-        !Array.isArray(parsed)
-      ) {
-        return parsed as Record<string, unknown>;
-      }
-    } catch {
-      // Partial streaming input is represented via tool_call_chunks.
-    }
-  }
-  return {};
 }

--- a/libs/sdk/src/stream/message-reconciliation.ts
+++ b/libs/sdk/src/stream/message-reconciliation.ts
@@ -1,4 +1,5 @@
 import type { BaseMessage } from "@langchain/core/messages";
+import { extractToolCallsFromBlocks } from "../utils/normalize-tool-calls.js";
 
 export interface ReconcileMessagesFromValuesOptions {
   /**
@@ -229,12 +230,27 @@ function normalizedMessageId(message: BaseMessage): string | undefined {
 function getMessageToolCalls(
   message: BaseMessage
 ): Array<{ id?: string; name?: string; args?: unknown }> {
-  const raw = (message as unknown as { tool_calls?: unknown }).tool_calls;
-  if (!Array.isArray(raw)) return [];
-  return raw.filter(
-    (toolCall): toolCall is { id?: string; name?: string; args?: unknown } =>
-      toolCall != null && typeof toolCall === "object"
-  );
+  const record = message as unknown as {
+    tool_calls?: unknown;
+    content?: unknown;
+    response_metadata?: { output?: unknown };
+  };
+  const raw = record.tool_calls;
+  if (Array.isArray(raw) && raw.length > 0) {
+    return raw.filter(
+      (toolCall): toolCall is { id?: string; name?: string; args?: unknown } =>
+        toolCall != null && typeof toolCall === "object"
+    );
+  }
+
+  const fromContent = extractToolCallsFromBlocks(record.content);
+  if (fromContent.length > 0) return fromContent;
+
+  if (Array.isArray(record.response_metadata?.output)) {
+    return extractToolCallsFromBlocks(record.response_metadata.output);
+  }
+
+  return [];
 }
 
 function jsonishEqual(previous: unknown, next: unknown): boolean {

--- a/libs/sdk/src/ui/manager.ts
+++ b/libs/sdk/src/ui/manager.ts
@@ -15,6 +15,7 @@ import type {
   ValuesStreamEvent,
 } from "../types.stream.js";
 import { MessageTupleManager, toMessageDict } from "./messages.js";
+import { normalizePlainAIMessageFields } from "../utils/normalize-tool-calls.js";
 import { StreamError } from "./errors.js";
 import type { Message } from "../types.messages.js";
 import type { BagTemplate } from "../types.template.js";
@@ -601,23 +602,10 @@ export class StreamManager<
           const messages = latestState.values[messagesKey];
           if (!Array.isArray(messages) || messages.length === 0) return;
 
-          /**
-           * Normalize messages: promote tool_calls from additional_kwargs to top
-           * level when the checkpointer serialized them in the legacy format.
-           */
           const normalizedMessages = messages.map((msg) => {
             const m = msg as Record<string, unknown>;
-            if (
-              m.type === "ai" &&
-              (!m.tool_calls || (m.tool_calls as unknown[]).length === 0)
-            ) {
-              const ak = m.additional_kwargs as
-                | Record<string, unknown>
-                | undefined;
-              const legacy = ak?.tool_calls;
-              if (Array.isArray(legacy) && legacy.length > 0) {
-                return { ...m, tool_calls: legacy };
-              }
+            if (m.type === "ai" || m.type === "assistant") {
+              return normalizePlainAIMessageFields(m);
             }
             return m;
           });

--- a/libs/sdk/src/ui/messages.test.ts
+++ b/libs/sdk/src/ui/messages.test.ts
@@ -12,6 +12,7 @@ import type { Message } from "../types.messages.js";
 import {
   ensureMessageInstances,
   ensureHistoryMessageInstances,
+  MessageTupleManager,
 } from "./messages.js";
 import { getBranchContext } from "./branching.js";
 
@@ -112,6 +113,68 @@ describe("ensureMessageInstances", () => {
         id: "toolu_123",
         name: "fact_card",
         args: { worker: "worker-001", attempt: 0 },
+        type: "tool_call",
+      },
+    ]);
+  });
+
+  it("promotes OpenAI Responses function_call content blocks to AIMessage.tool_calls", () => {
+    const [result] = ensureMessageInstances([
+      {
+        type: "ai",
+        id: "msg_function_call",
+        content: [
+          {
+            type: "function_call",
+            name: "get_weather",
+            call_id: "call_demo_123",
+            arguments: JSON.stringify({ city: "San Francisco" }),
+          },
+        ],
+        tool_calls: [],
+        invalid_tool_calls: [],
+        response_metadata: { model_provider: "openai" },
+      } as unknown as Message,
+    ]);
+
+    expect(result).toBeInstanceOf(AIMessage);
+    expect((result as AIMessage).tool_calls).toEqual([
+      {
+        id: "call_demo_123",
+        name: "get_weather",
+        args: { city: "San Francisco" },
+        type: "tool_call",
+      },
+    ]);
+    expect(result.content).toEqual([]);
+  });
+
+  it("promotes function_call blocks via MessageTupleManager", () => {
+    const manager = new MessageTupleManager();
+    const message = {
+      type: "ai",
+      id: "msg_function_call",
+      content: [
+        {
+          type: "function_call",
+          name: "get_weather",
+          call_id: "call_demo_123",
+          arguments: JSON.stringify({ city: "San Francisco" }),
+        },
+      ],
+      tool_calls: [],
+      invalid_tool_calls: [],
+    } as unknown as Message;
+
+    manager.add(message, undefined);
+    const assembled = manager.get("msg_function_call")?.chunk;
+
+    expect(assembled).toBeInstanceOf(AIMessageChunk);
+    expect((assembled as AIMessage).tool_calls).toEqual([
+      {
+        id: "call_demo_123",
+        name: "get_weather",
+        args: { city: "San Francisco" },
         type: "tool_call",
       },
     ]);

--- a/libs/sdk/src/ui/messages.ts
+++ b/libs/sdk/src/ui/messages.ts
@@ -16,6 +16,7 @@ import {
 
 import type { Message } from "../types.messages.js";
 import type { ThreadState } from "../schema.js";
+import { normalizePlainAIMessageFields } from "../utils/normalize-tool-calls.js";
 
 /**
  * Replaces the `messages` property in a state type with `BaseMessage[]`.
@@ -99,77 +100,12 @@ function tryCoerceMessageLikeToChunk(
   return tryCoerceMessageLikeToMessage(message);
 }
 
-type ToolCallLike = {
-  id?: string;
-  name?: string;
-  args?: unknown;
-  input?: unknown;
-};
-
 function normalizeAIMessageToolCalls<
   T extends Omit<Message, "type"> & { type: string },
 >(message: T): T {
-  const record = message as T & {
-    content?: unknown;
-    tool_calls?: unknown;
-  };
-  if (Array.isArray(record.tool_calls) && record.tool_calls.length > 0) {
-    return message;
-  }
-
-  const toolCalls = extractToolCallsFromContent(record.content);
-  if (toolCalls.length === 0) return message;
-  return {
-    ...message,
-    tool_calls: toolCalls,
-  };
-}
-
-function extractToolCallsFromContent(content: unknown) {
-  if (!Array.isArray(content)) return [];
-  return content.flatMap(
-    (
-      block
-    ): Array<{
-      id: string;
-      name: string;
-      args: Record<string, unknown>;
-      type: "tool_call";
-    }> => {
-      if (block == null || typeof block !== "object") return [];
-      const record = block as ToolCallLike & { type?: unknown };
-      if (record.type !== "tool_call" && record.type !== "tool_use") return [];
-      return [
-        {
-          id: record.id ?? "",
-          name: record.name ?? "",
-          args: normalizeToolCallArgs(record.args ?? record.input),
-          type: "tool_call",
-        },
-      ];
-    }
-  );
-}
-
-function normalizeToolCallArgs(value: unknown): Record<string, unknown> {
-  if (value != null && typeof value === "object" && !Array.isArray(value)) {
-    return value as Record<string, unknown>;
-  }
-  if (typeof value === "string" && value.length > 0) {
-    try {
-      const parsed = JSON.parse(value);
-      if (
-        parsed != null &&
-        typeof parsed === "object" &&
-        !Array.isArray(parsed)
-      ) {
-        return parsed as Record<string, unknown>;
-      }
-    } catch {
-      // Streaming input fragments are expected to be invalid until finalized.
-    }
-  }
-  return {};
+  return normalizePlainAIMessageFields(
+    message as T & Record<string, unknown>
+  ) as T;
 }
 
 export class MessageTupleManager {

--- a/libs/sdk/src/utils/normalize-tool-calls.test.ts
+++ b/libs/sdk/src/utils/normalize-tool-calls.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractToolCallsFromBlocks,
+  normalizePlainAIMessageFields,
+  stripProviderToolCallBlocks,
+  toolCallFromProviderBlock,
+} from "./normalize-tool-calls.js";
+
+describe("toolCallFromProviderBlock", () => {
+  it("maps tool_call blocks", () => {
+    expect(
+      toolCallFromProviderBlock({
+        type: "tool_call",
+        id: "call_1",
+        name: "search",
+        args: { q: "test" },
+      })
+    ).toEqual({
+      type: "tool_call",
+      id: "call_1",
+      name: "search",
+      args: { q: "test" },
+    });
+  });
+
+  it("maps tool_use blocks", () => {
+    expect(
+      toolCallFromProviderBlock({
+        type: "tool_use",
+        id: "toolu_1",
+        name: "ls",
+        input: { path: "." },
+      })
+    ).toEqual({
+      type: "tool_call",
+      id: "toolu_1",
+      name: "ls",
+      args: { path: "." },
+    });
+  });
+
+  it("maps OpenAI Responses function_call blocks", () => {
+    expect(
+      toolCallFromProviderBlock({
+        type: "function_call",
+        name: "get_weather",
+        call_id: "call_123",
+        arguments: '{"city":"Paris"}',
+      })
+    ).toEqual({
+      type: "tool_call",
+      id: "call_123",
+      name: "get_weather",
+      args: { city: "Paris" },
+    });
+  });
+
+  it("handles invalid JSON in function_call arguments", () => {
+    expect(
+      toolCallFromProviderBlock({
+        type: "function_call",
+        name: "get_weather",
+        call_id: "call_456",
+        arguments: "not valid json",
+      })
+    ).toEqual({
+      type: "tool_call",
+      id: "call_456",
+      name: "get_weather",
+      args: { raw: "not valid json" },
+    });
+  });
+});
+
+describe("normalizePlainAIMessageFields", () => {
+  it("promotes function_call content blocks to tool_calls", () => {
+    const result = normalizePlainAIMessageFields({
+      type: "ai",
+      id: "msg_1",
+      content: [
+        {
+          type: "function_call",
+          name: "get_weather",
+          call_id: "call_123",
+          arguments: '{"city":"San Francisco"}',
+        },
+      ],
+      tool_calls: [],
+    });
+
+    expect(result.tool_calls).toEqual([
+      {
+        type: "tool_call",
+        id: "call_123",
+        name: "get_weather",
+        args: { city: "San Francisco" },
+      },
+    ]);
+    expect(result.content).toEqual([]);
+  });
+
+  it("falls back to response_metadata.output", () => {
+    const result = normalizePlainAIMessageFields({
+      type: "ai",
+      content: "",
+      tool_calls: [],
+      response_metadata: {
+        output: [
+          {
+            type: "function_call",
+            id: "fc_1",
+            call_id: "call_789",
+            name: "get_weather",
+            arguments: '{"city":"NYC"}',
+          },
+        ],
+      },
+    });
+
+    expect(result.tool_calls).toEqual([
+      {
+        type: "tool_call",
+        id: "call_789",
+        name: "get_weather",
+        args: { city: "NYC" },
+      },
+    ]);
+  });
+
+  it("promotes legacy additional_kwargs.tool_calls", () => {
+    const legacy = [
+      {
+        id: "call_legacy",
+        type: "function",
+        function: { name: "search", arguments: "{}" },
+      },
+    ];
+    const result = normalizePlainAIMessageFields({
+      type: "ai",
+      content: "",
+      tool_calls: [],
+      additional_kwargs: { tool_calls: legacy },
+    });
+
+    expect(result.tool_calls).toEqual(legacy);
+  });
+
+  it("leaves messages with existing tool_calls unchanged", () => {
+    const message = {
+      type: "ai",
+      content: [{ type: "function_call", name: "x", call_id: "y" }],
+      tool_calls: [{ type: "tool_call", id: "existing", name: "x", args: {} }],
+    };
+    expect(normalizePlainAIMessageFields(message)).toBe(message);
+  });
+});
+
+describe("stripProviderToolCallBlocks", () => {
+  it("removes function_call blocks but keeps other content", () => {
+    expect(
+      stripProviderToolCallBlocks([
+        { type: "text", text: "hello" },
+        { type: "function_call", name: "x", call_id: "y", arguments: "{}" },
+      ])
+    ).toEqual([{ type: "text", text: "hello" }]);
+  });
+});
+
+describe("extractToolCallsFromBlocks", () => {
+  it("extracts multiple tool calls in order", () => {
+    expect(
+      extractToolCallsFromBlocks([
+        { type: "tool_call", id: "a", name: "one", args: {} },
+        {
+          type: "function_call",
+          call_id: "b",
+          name: "two",
+          arguments: '{"k":1}',
+        },
+      ])
+    ).toEqual([
+      { type: "tool_call", id: "a", name: "one", args: {} },
+      { type: "tool_call", id: "b", name: "two", args: { k: 1 } },
+    ]);
+  });
+});

--- a/libs/sdk/src/utils/normalize-tool-calls.ts
+++ b/libs/sdk/src/utils/normalize-tool-calls.ts
@@ -1,0 +1,131 @@
+export type NormalizedToolCall = {
+  id: string;
+  name: string;
+  args: Record<string, unknown>;
+  type: "tool_call";
+};
+
+export function normalizeToolCallArgs(value: unknown): Record<string, unknown> {
+  if (value != null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  if (typeof value === "string" && value.length > 0) {
+    try {
+      const parsed = JSON.parse(value);
+      if (
+        parsed != null &&
+        typeof parsed === "object" &&
+        !Array.isArray(parsed)
+      ) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Streaming input fragments are expected to be invalid until finalized.
+    }
+  }
+  return {};
+}
+
+/**
+ * Map a provider-native content or output block to a LangChain tool call.
+ *
+ * Handles standard LangChain/Anthropic blocks (`tool_call`, `tool_use`) and
+ * OpenAI Responses API blocks (`function_call` with `call_id` + `arguments`).
+ */
+export function toolCallFromProviderBlock(
+  block: unknown
+): NormalizedToolCall | null {
+  if (block == null || typeof block !== "object") return null;
+  const record = block as Record<string, unknown>;
+
+  if (record.type === "tool_call" || record.type === "tool_use") {
+    return {
+      id: String(record.id ?? ""),
+      name: String(record.name ?? ""),
+      args: normalizeToolCallArgs(record.args ?? record.input),
+      type: "tool_call",
+    };
+  }
+
+  if (record.type === "function_call") {
+    const argsString =
+      typeof record.arguments === "string" ? record.arguments : "{}";
+    let args: Record<string, unknown>;
+    try {
+      args = JSON.parse(argsString) as Record<string, unknown>;
+    } catch {
+      args = { raw: argsString };
+    }
+    return {
+      id: String(record.call_id ?? record.id ?? ""),
+      name: String(record.name ?? "unknown"),
+      args,
+      type: "tool_call",
+    };
+  }
+
+  return null;
+}
+
+export function extractToolCallsFromBlocks(
+  blocks: unknown
+): NormalizedToolCall[] {
+  if (!Array.isArray(blocks)) return [];
+  const out: NormalizedToolCall[] = [];
+  for (const block of blocks) {
+    const toolCall = toolCallFromProviderBlock(block);
+    if (toolCall != null) out.push(toolCall);
+  }
+  return out;
+}
+
+/**
+ * Remove provider-native tool call blocks from message content after they
+ * have been promoted to top-level `tool_calls`.
+ */
+export function stripProviderToolCallBlocks(content: unknown): unknown {
+  if (!Array.isArray(content)) return content;
+  return content.filter((block) => {
+    if (block == null || typeof block !== "object") return true;
+    const type = (block as { type?: unknown }).type;
+    return type !== "function_call";
+  });
+}
+
+/**
+ * Normalize tool calls on a plain serialized AI message dict before
+ * constructing an `AIMessage` instance.
+ */
+export function normalizePlainAIMessageFields<
+  T extends Record<string, unknown>,
+>(message: T): T {
+  if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
+    return message;
+  }
+
+  const additionalKwargs = message.additional_kwargs as
+    | Record<string, unknown>
+    | undefined;
+  const legacyToolCalls = additionalKwargs?.tool_calls;
+  if (Array.isArray(legacyToolCalls) && legacyToolCalls.length > 0) {
+    return { ...message, tool_calls: legacyToolCalls };
+  }
+
+  let toolCalls = extractToolCallsFromBlocks(message.content);
+  if (toolCalls.length === 0) {
+    const responseMetadata = message.response_metadata as
+      | { output?: unknown }
+      | undefined;
+    if (Array.isArray(responseMetadata?.output)) {
+      toolCalls = extractToolCallsFromBlocks(responseMetadata.output);
+    }
+  }
+
+  if (toolCalls.length === 0) return message;
+
+  return {
+    ...message,
+    tool_calls: toolCalls,
+    content: stripProviderToolCallBlocks(message.content),
+  };
+}


### PR DESCRIPTION
## Summary
- Add shared `normalize-tool-calls` helpers in `@langchain/langgraph-sdk` to map OpenAI Responses `function_call` blocks (and existing `tool_call` / `tool_use` blocks) into LangChain `tool_calls`.
- Wire normalization through message coercion paths used by `useStream`: `ensureMessageInstances`, `MessageTupleManager`, v2 stream assembly, subagent history hydration, and stream/values reconciliation.
- Strip promoted `function_call` blocks from `content` after normalization so UIs inspecting both fields stay consistent.
