### PR TITLE
fix(sdk): route headless tool resumes through respond on v1 stream

### DIFF
--- a/.changeset/fix-headless-tool-v1-resume.md
+++ b/.changeset/fix-headless-tool-v1-resume.md
@@ -1,0 +1,15 @@
+---
+"@langchain/langgraph-sdk": patch
+"@langchain/react": patch
+"@langchain/vue": patch
+"@langchain/angular": patch
+"@langchain/svelte": patch
+---
+
+fix(sdk): route headless tool resumes through respond on v1 stream
+
+`useStream` was calling `submit(null, { command })` for headless-tool resumes,
+which dispatches `run.start` without delivering the tool result. Add
+`applyHeadlessToolResumeCommand` to route payloads through `respond` /
+`respondAll`, and tighten headless-tool browser tests to assert end-to-end
+resume and graph completion.

--- a/libs/sdk-angular/src/tests/components/HeadlessToolStream.ts
+++ b/libs/sdk-angular/src/tests/components/HeadlessToolStream.ts
@@ -40,7 +40,7 @@ const TEMPLATE = `
     <div data-testid="tool-events">
       @for (event of toolEvents(); track $index) {
         <div [attr.data-testid]="'tool-event-' + $index">
-          {{ event.phase + ":" + event.name + (event.phase === "error" && event.error ? ":" + event.error.message : "") }}
+          {{ event.phase + ":" + event.name + (event.phase === "success" && event.result != null ? ":" + str(event.result) : "") + (event.phase === "error" && event.error ? ":" + event.error.message : "") }}
         </div>
       }
     </div>

--- a/libs/sdk-angular/src/tests/stream.headless-tools.test.ts
+++ b/libs/sdk-angular/src/tests/stream.headless-tools.test.ts
@@ -6,12 +6,15 @@ import {
   setHeadlessToolExecute,
 } from "./components/HeadlessToolStream.js";
 
+const LOCATION_RESULT =
+  '{"latitude":37.7749,"longitude":-122.4194}' as const;
+
 afterEach(() => {
   setHeadlessToolExecute(null);
 });
 
 it(
-  "invokes onTool with start + success phases on happy path",
+  "executes headless tool, resumes with result, and completes the run",
   { timeout: 20_000 },
   async () => {
     const screen = await render(HeadlessToolStreamComponent);
@@ -24,7 +27,15 @@ it(
 
     await expect
       .element(screen.getByTestId("tool-event-1"), { timeout: 5_000 })
-      .toHaveTextContent("success:get_location");
+      .toHaveTextContent(`success:get_location:${LOCATION_RESULT}`);
+
+    await expect
+      .element(screen.getByTestId("message-last"), { timeout: 5_000 })
+      .toHaveTextContent("Location received!");
+
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 5_000 })
+      .toHaveTextContent("idle");
 
     await expect
       .element(screen.getByTestId("interrupt-count"))
@@ -47,5 +58,9 @@ it(
     await expect
       .element(screen.getByTestId("tool-event-1"), { timeout: 5_000 })
       .toHaveTextContent("error:get_location:GPS unavailable");
+
+    await expect
+      .element(screen.getByTestId("message-last"), { timeout: 5_000 })
+      .toHaveTextContent("Location received!");
   },
 );

--- a/libs/sdk-angular/src/use-stream.ts
+++ b/libs/sdk-angular/src/use-stream.ts
@@ -11,6 +11,7 @@ import {
 import type { BaseMessage } from "@langchain/core/messages";
 import type { Client, Interrupt } from "@langchain/langgraph-sdk";
 import {
+  applyHeadlessToolResumeCommand,
   filterOutHeadlessToolInterrupts,
   flushPendingHeadlessToolInterrupts,
   scheduleCoalescedHeadlessToolFlush,
@@ -587,9 +588,7 @@ export function useStream<
                 void Promise.resolve().then(run);
               },
               resumeSubmit: (command) =>
-                controller.submit(null, {
-                  command,
-                } as StreamSubmitOptions<StateType, ConfigurableType>),
+                applyHeadlessToolResumeCommand(controller, command),
             }
           );
         });

--- a/libs/sdk-react/src/index.ts
+++ b/libs/sdk-react/src/index.ts
@@ -122,5 +122,6 @@ export {
   executeHeadlessTool,
   handleHeadlessToolInterrupt,
   headlessToolResumeCommand,
+  applyHeadlessToolResumeCommand,
   flushPendingHeadlessToolInterrupts,
 } from "@langchain/langgraph-sdk";

--- a/libs/sdk-react/src/tests/components/HeadlessToolStream.tsx
+++ b/libs/sdk-react/src/tests/components/HeadlessToolStream.tsx
@@ -22,7 +22,7 @@ export function HeadlessToolStream({ apiUrl, execute }: Props) {
       })),
   );
 
-  const { messages, isLoading, submit } = useStream<{
+  const { messages, isLoading, interrupts, submit } = useStream<{
     messages: BaseMessage[];
   }>({
     assistantId: "headless_tool_graph",
@@ -56,11 +56,15 @@ export function HeadlessToolStream({ apiUrl, execute }: Props) {
       </div>
 
       <div data-testid="loading">{isLoading ? "loading" : "idle"}</div>
+      <div data-testid="interrupt-count">{interrupts.length}</div>
 
       <div data-testid="tool-events">
         {toolEvents.map((event, i) => (
           <div key={i} data-testid={`tool-event-${i}`}>
             {`${event.phase}:${event.name}`}
+            {event.phase === "success" &&
+              event.result != null &&
+              `:${JSON.stringify(event.result)}`}
             {event.phase === "error" && `:${event.error?.message}`}
           </div>
         ))}

--- a/libs/sdk-react/src/tests/stream.headless-tools.test.tsx
+++ b/libs/sdk-react/src/tests/stream.headless-tools.test.tsx
@@ -4,8 +4,11 @@ import { render } from "vitest-browser-react";
 import { HeadlessToolStream } from "./components/HeadlessToolStream.js";
 import { apiUrl, cleanupRender } from "./test-utils.js";
 
+const LOCATION_RESULT =
+  '{"latitude":37.7749,"longitude":-122.4194}' as const;
+
 it(
-  "invokes onTool with start + success phases on happy path",
+  "executes headless tool, resumes with result, and completes the run",
   { timeout: 20_000 },
   async () => {
     const screen = await render(<HeadlessToolStream apiUrl={apiUrl} />);
@@ -19,7 +22,19 @@ it(
 
       await expect
         .element(screen.getByTestId("tool-event-1"), { timeout: 5_000 })
-        .toHaveTextContent("success:get_location");
+        .toHaveTextContent(`success:get_location:${LOCATION_RESULT}`);
+
+      await expect
+        .element(screen.getByTestId("message-last"), { timeout: 5_000 })
+        .toHaveTextContent("Location received!");
+
+      await expect
+        .element(screen.getByTestId("loading"), { timeout: 5_000 })
+        .toHaveTextContent("idle");
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"))
+        .toHaveTextContent("0");
     } finally {
       await cleanupRender(screen);
     }
@@ -44,6 +59,10 @@ it(
       await expect
         .element(screen.getByTestId("tool-event-1"), { timeout: 5_000 })
         .toHaveTextContent("error:get_location:GPS unavailable");
+
+      await expect
+        .element(screen.getByTestId("message-last"), { timeout: 5_000 })
+        .toHaveTextContent("Location received!");
     } finally {
       await cleanupRender(screen);
     }

--- a/libs/sdk-react/src/use-stream.ts
+++ b/libs/sdk-react/src/use-stream.ts
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 import type { BaseMessage } from "@langchain/core/messages";
 import type { Client, Interrupt } from "@langchain/langgraph-sdk";
 import {
+  applyHeadlessToolResumeCommand,
   filterOutHeadlessToolInterrupts,
   flushPendingHeadlessToolInterrupts,
 } from "@langchain/langgraph-sdk";
@@ -600,9 +601,7 @@ export function useStream<
           void Promise.resolve().then(run);
         },
         resumeSubmit: (command) =>
-          controller.submit(null, {
-            command,
-          } as StreamSubmitOptions<StateType, ConfigurableType>),
+          applyHeadlessToolResumeCommand(controller, command),
       }
     );
   }, [controller, tools, onTool, rootValuesForTools, rootInterruptsForTools]);

--- a/libs/sdk-svelte/src/tests/components/HeadlessToolStream.svelte
+++ b/libs/sdk-svelte/src/tests/components/HeadlessToolStream.svelte
@@ -52,11 +52,14 @@
   </div>
 
   <div data-testid="loading">{stream.isLoading ? "loading" : "idle"}</div>
+  <div data-testid="interrupt-count">{stream.interrupts.length}</div>
 
   <div data-testid="tool-events">
     {#each toolEvents as event, i}
       <div data-testid={`tool-event-${i}`}>
-        {event.phase}:{event.name}{event.phase === "error" && event.error
+        {event.phase}:{event.name}{event.phase === "success" && event.result != null
+          ? `:${JSON.stringify(event.result)}`
+          : ""}{event.phase === "error" && event.error
           ? `:${event.error.message}`
           : ""}
       </div>

--- a/libs/sdk-svelte/src/tests/stream.headless-tools.test.ts
+++ b/libs/sdk-svelte/src/tests/stream.headless-tools.test.ts
@@ -5,8 +5,11 @@ import HeadlessToolStream from "./components/HeadlessToolStream.svelte";
 
 const serverUrl = inject("serverUrl");
 
+const LOCATION_RESULT =
+  '{"latitude":37.7749,"longitude":-122.4194}' as const;
+
 it(
-  "invokes onTool with start + success phases on happy path",
+  "executes headless tool, resumes with result, and completes the run",
   { timeout: 20_000 },
   async () => {
     const screen = render(HeadlessToolStream, { apiUrl: serverUrl });
@@ -19,7 +22,19 @@ it(
 
     await expect
       .element(screen.getByTestId("tool-event-1"), { timeout: 5_000 })
-      .toHaveTextContent("success:get_location");
+      .toHaveTextContent(`success:get_location:${LOCATION_RESULT}`);
+
+    await expect
+      .element(screen.getByTestId("message-last"), { timeout: 5_000 })
+      .toHaveTextContent("Location received!");
+
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 5_000 })
+      .toHaveTextContent("idle");
+
+    await expect
+      .element(screen.getByTestId("interrupt-count"))
+      .toHaveTextContent("0");
   },
 );
 
@@ -39,5 +54,9 @@ it(
     await expect
       .element(screen.getByTestId("tool-event-1"), { timeout: 5_000 })
       .toHaveTextContent("error:get_location:GPS unavailable");
+
+    await expect
+      .element(screen.getByTestId("message-last"), { timeout: 5_000 })
+      .toHaveTextContent("Location received!");
   },
 );

--- a/libs/sdk-svelte/src/use-stream.svelte.ts
+++ b/libs/sdk-svelte/src/use-stream.svelte.ts
@@ -2,6 +2,7 @@ import { onDestroy } from "svelte";
 import type { BaseMessage } from "@langchain/core/messages";
 import type { Client, Interrupt } from "@langchain/langgraph-sdk";
 import {
+  applyHeadlessToolResumeCommand,
   flushPendingHeadlessToolInterrupts,
   scheduleCoalescedHeadlessToolFlush,
   type AnyHeadlessToolImplementation,
@@ -570,9 +571,7 @@ export function useStream<
               void Promise.resolve().then(run);
             },
             resumeSubmit: (command) =>
-              controller.submit(null, {
-                command,
-              } as StreamSubmitOptions<StateType, ConfigurableType>),
+              applyHeadlessToolResumeCommand(controller, command),
           }
         );
       });

--- a/libs/sdk-vue/src/tests/components/HeadlessToolStream.tsx
+++ b/libs/sdk-vue/src/tests/components/HeadlessToolStream.tsx
@@ -51,7 +51,16 @@ export const HeadlessToolStream = defineComponent({
         const err = event.error as { message?: string } | undefined;
         return err?.message ? `:${err.message}` : "";
       }
+      if (event.phase === "success" && event.result != null) {
+        return `:${JSON.stringify(event.result)}`;
+      }
       return "";
+    };
+
+    const lastMessage = (): string => {
+      const msgs = stream.messages.value;
+      if (msgs.length === 0) return "";
+      return formatContent(msgs[msgs.length - 1]);
     };
 
     return () => (
@@ -76,6 +85,9 @@ export const HeadlessToolStream = defineComponent({
               {formatContent(msg)}
             </div>
           ))}
+          {stream.messages.value.length > 0 && (
+            <div data-testid="message-last">{lastMessage()}</div>
+          )}
         </div>
 
         <button

--- a/libs/sdk-vue/src/tests/stream.headless-tools.test.tsx
+++ b/libs/sdk-vue/src/tests/stream.headless-tools.test.tsx
@@ -7,12 +7,15 @@ import {
 } from "./components/HeadlessToolStream.js";
 import { apiUrl } from "./test-utils.js";
 
+const LOCATION_RESULT =
+  '{"latitude":37.7749,"longitude":-122.4194}' as const;
+
 afterEach(() => {
   setHeadlessToolExecute(null);
 });
 
 it(
-  "invokes onTool with start + success phases on happy path",
+  "executes headless tool, resumes with result, and completes the run",
   { timeout: 20_000 },
   async () => {
     const screen = await render(HeadlessToolStream, { props: { apiUrl } });
@@ -26,7 +29,16 @@ it(
 
       await expect
         .element(screen.getByTestId("tool-event-1"), { timeout: 5_000 })
-        .toHaveTextContent("success:get_location");
+        .toHaveTextContent(`success:get_location:${LOCATION_RESULT}`);
+
+      await expect
+        .element(screen.getByTestId("message-last"), { timeout: 5_000 })
+        .toHaveTextContent("Location received!");
+
+      await expect
+        .element(screen.getByTestId("loading"), { timeout: 5_000 })
+        .toHaveTextContent("idle");
+
       await expect
         .element(screen.getByTestId("interrupt-count"))
         .toHaveTextContent("0");
@@ -52,6 +64,10 @@ it(
       await expect
         .element(screen.getByTestId("tool-event-1"), { timeout: 5_000 })
         .toHaveTextContent("error:get_location:GPS unavailable");
+
+      await expect
+        .element(screen.getByTestId("message-last"), { timeout: 5_000 })
+        .toHaveTextContent("Location received!");
     } finally {
       await screen.unmount();
     }

--- a/libs/sdk-vue/src/use-stream.ts
+++ b/libs/sdk-vue/src/use-stream.ts
@@ -12,6 +12,7 @@ import {
 import type { BaseMessage } from "@langchain/core/messages";
 import type { Client, Interrupt } from "@langchain/langgraph-sdk";
 import {
+  applyHeadlessToolResumeCommand,
   filterOutHeadlessToolInterrupts,
   flushPendingHeadlessToolInterrupts,
   scheduleCoalescedHeadlessToolFlush,
@@ -626,9 +627,7 @@ export function useStream<
                 void Promise.resolve().then(run);
               },
               resumeSubmit: (command) =>
-                controller.submit(null, {
-                  command,
-                } as StreamSubmitOptions<StateType, ConfigurableType>),
+                applyHeadlessToolResumeCommand(controller, command),
             }
           );
         });

--- a/libs/sdk/src/headless-tools.test.ts
+++ b/libs/sdk/src/headless-tools.test.ts
@@ -82,6 +82,7 @@ describe("headless tool resume helpers", () => {
           toolu_01A: { key: "user_name" },
         },
       },
+      keyedByInterruptId: true,
     });
 
     expect(
@@ -102,6 +103,7 @@ describe("headless tool resume helpers", () => {
         "4b704fd4b473bfd68df40c9979bffe1b": { toolu_01A: { key: "user_name" } },
         "c485a7b6c996d3ace440d2afd6f292a3": { toolu_01B: { key: "user_role" } },
       },
+      keyedByInterruptId: true,
     });
 
     expect(isInterruptIdKeyedResume({})).toBe(false);
@@ -110,6 +112,22 @@ describe("headless tool resume helpers", () => {
         "4b704fd4b473bfd68df40c9979bffe1b": { toolu_01A: {} },
       })
     ).toBe(true);
+    expect(
+      isInterruptIdKeyedResume({
+        "int-1": { toolu_01A: { success: true } },
+      })
+    ).toBe(false);
+    expect(
+      isInterruptIdKeyedResume(
+        { "int-1": { toolu_01A: { success: true } } },
+        [{ interruptId: "int-1", namespace: [], payload: {} }]
+      )
+    ).toBe(true);
+    expect(
+      isInterruptIdKeyedResume({
+        toolu_01A: { latitude: 1, longitude: 2 },
+      })
+    ).toBe(false);
   });
 
   it("wraps tool-call keyed resume input under the matching interrupt id", () => {
@@ -151,6 +169,37 @@ describe("headless tool resume helpers", () => {
       "4b704fd4b473bfd68df40c9979bffe1b": { toolu_01A: { success: true } },
       "c485a7b6c996d3ace440d2afd6f292a3": { toolu_01B: { success: true } },
     });
+
+    expect(
+      buildResumeRunInput(
+        {
+          "int-1": { toolu_01A: { success: true } },
+          "int-2": { toolu_01B: { success: true } },
+        },
+        [
+          {
+            interruptId: "int-1",
+            namespace: [] as string[],
+            payload: {
+              type: "tool",
+              toolCall: { id: "toolu_01A", name: "memory_put", args: {} },
+            },
+          },
+          {
+            interruptId: "int-2",
+            namespace: [] as string[],
+            payload: {
+              type: "tool",
+              toolCall: { id: "toolu_01B", name: "memory_put", args: {} },
+            },
+          },
+        ],
+        new Set()
+      )
+    ).toEqual({
+      "int-1": { toolu_01A: { success: true } },
+      "int-2": { toolu_01B: { success: true } },
+    });
   });
 
   it("routes interrupt-id keyed resumes through respondAll on v1 stream", async () => {
@@ -174,13 +223,51 @@ describe("headless tool resume helpers", () => {
     expect(respond).not.toHaveBeenCalled();
   });
 
+  it("routes non-hex interrupt-id keyed resumes through respondAll on v1 stream", async () => {
+    const respond = vi.fn().mockResolvedValue(undefined);
+    const respondAll = vi.fn().mockResolvedValue(undefined);
+    const command = headlessToolsBatchResumeCommand([
+      {
+        interruptId: "int-1",
+        toolCallId: "toolu_01A",
+        value: { success: true },
+      },
+    ]);
+
+    await applyHeadlessToolResumeCommand({ respond, respondAll }, command);
+
+    expect(respondAll).toHaveBeenCalledWith({
+      "int-1": { toolu_01A: { success: true } },
+    });
+    expect(respond).not.toHaveBeenCalled();
+  });
+
+  it("routes direct-value interrupt resumes through respondAll when keyedByInterruptId is set", async () => {
+    const respond = vi.fn().mockResolvedValue(undefined);
+    const respondAll = vi.fn().mockResolvedValue(undefined);
+    const command = headlessToolsBatchResumeCommand([
+      {
+        interruptId: "int-1",
+        toolCallId: "",
+        value: { latitude: 1, longitude: 2 },
+      },
+    ]);
+
+    await applyHeadlessToolResumeCommand({ respond, respondAll }, command);
+
+    expect(respondAll).toHaveBeenCalledWith({
+      "int-1": { latitude: 1, longitude: 2 },
+    });
+    expect(respond).not.toHaveBeenCalled();
+  });
+
   it("routes tool-call keyed resumes through respond on v1 stream", async () => {
     const respond = vi.fn().mockResolvedValue(undefined);
     const respondAll = vi.fn().mockResolvedValue(undefined);
 
     await applyHeadlessToolResumeCommand(
       { respond, respondAll },
-      { resume: { toolu_01A: { success: true } } }
+      { resume: { toolu_01A: { success: true } }, keyedByInterruptId: false }
     );
 
     expect(respond).toHaveBeenCalledWith({ toolu_01A: { success: true } });
@@ -240,6 +327,7 @@ describe("headless tool resume helpers", () => {
           toolu_01B: { success: true },
         },
       },
+      keyedByInterruptId: true,
     });
   });
 
@@ -323,6 +411,7 @@ describe("headless tool resume helpers", () => {
           toolu_01B: { success: true },
         },
       },
+      keyedByInterruptId: true,
     });
   });
 });

--- a/libs/sdk/src/headless-tools.test.ts
+++ b/libs/sdk/src/headless-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  applyHeadlessToolResumeCommand,
   buildResumeRunInput,
   flushPendingHeadlessToolInterrupts,
   headlessToolsBatchResumeCommand,
@@ -150,6 +151,40 @@ describe("headless tool resume helpers", () => {
       "4b704fd4b473bfd68df40c9979bffe1b": { toolu_01A: { success: true } },
       "c485a7b6c996d3ace440d2afd6f292a3": { toolu_01B: { success: true } },
     });
+  });
+
+  it("routes interrupt-id keyed resumes through respondAll on v1 stream", async () => {
+    const respond = vi.fn().mockResolvedValue(undefined);
+    const respondAll = vi.fn().mockResolvedValue(undefined);
+    const command = headlessToolsBatchResumeCommand([
+      {
+        interruptId: "4b704fd4b473bfd68df40c9979bffe1b",
+        toolCallId: "toolu_01A",
+        value: { success: true },
+      },
+    ]);
+
+    await applyHeadlessToolResumeCommand({ respond, respondAll }, command);
+
+    expect(respondAll).toHaveBeenCalledWith({
+      "4b704fd4b473bfd68df40c9979bffe1b": {
+        toolu_01A: { success: true },
+      },
+    });
+    expect(respond).not.toHaveBeenCalled();
+  });
+
+  it("routes tool-call keyed resumes through respond on v1 stream", async () => {
+    const respond = vi.fn().mockResolvedValue(undefined);
+    const respondAll = vi.fn().mockResolvedValue(undefined);
+
+    await applyHeadlessToolResumeCommand(
+      { respond, respondAll },
+      { resume: { toolu_01A: { success: true } } }
+    );
+
+    expect(respond).toHaveBeenCalledWith({ toolu_01A: { success: true } });
+    expect(respondAll).not.toHaveBeenCalled();
   });
 
   it("flushes all pending headless tools in one batch resume", async () => {

--- a/libs/sdk/src/headless-tools.ts
+++ b/libs/sdk/src/headless-tools.ts
@@ -249,6 +249,42 @@ export function headlessToolsBatchResumeCommand(
 }
 
 /**
+ * Minimal controller surface for servicing a headless-tool resume on the
+ * v1 stream protocol (`input.respond`).
+ */
+export interface HeadlessToolResumeController {
+  respond: (
+    response: unknown,
+    options?: { interruptId?: string }
+  ) => Promise<void>;
+  respondAll: (responsesById: Record<string, unknown>) => Promise<void>;
+}
+
+/**
+ * Resume a headless-tool batch on the v1 commands transport.
+ *
+ * {@link headlessToolsBatchResumeCommand} still returns a legacy
+ * `{ resume }` command shape for callers on the old runs/stream API.
+ * On v1 `StreamController`, that payload must be sent through
+ * {@link HeadlessToolResumeController.respond} /
+ * {@link HeadlessToolResumeController.respondAll} — not `submit(null,
+ * { command })`, which dispatches `run.start` without a resume value.
+ */
+export function applyHeadlessToolResumeCommand(
+  controller: HeadlessToolResumeController,
+  command: { resume: unknown }
+): Promise<void> {
+  const { resume } = command;
+  if (resume == null) return Promise.resolve();
+
+  if (isInterruptIdKeyedResume(resume)) {
+    return controller.respondAll(resume as Record<string, unknown>);
+  }
+
+  return controller.respond(resume);
+}
+
+/**
  * True when every top-level resume key is a graph task interrupt id
  * (32-char hex from `values.__interrupt__`).
  */

--- a/libs/sdk/src/headless-tools.ts
+++ b/libs/sdk/src/headless-tools.ts
@@ -199,14 +199,28 @@ export async function handleHeadlessToolInterrupt(
   };
 }
 
+/**
+ * Resume command produced by {@link headlessToolResumeCommand} /
+ * {@link headlessToolsBatchResumeCommand}.
+ */
+export interface HeadlessToolResumeCommand {
+  resume: unknown;
+  /**
+   * When true, top-level {@link resume} keys are protocol interrupt ids and
+   * must be sent through {@link HeadlessToolResumeController.respondAll}.
+   */
+  keyedByInterruptId?: boolean;
+}
+
 export function headlessToolResumeCommand(result: {
   toolCallId: string | undefined;
   value: unknown;
-}): { resume: unknown } {
+}): HeadlessToolResumeCommand {
   return {
     resume: result.toolCallId
       ? { [result.toolCallId]: result.value }
       : result.value,
+    keyedByInterruptId: false,
   };
 }
 
@@ -221,9 +235,9 @@ export function headlessToolsBatchResumeCommand(
     toolCallId: string | undefined;
     value: unknown;
   }>
-): { resume: unknown } {
+): HeadlessToolResumeCommand {
   if (entries.length === 0) {
-    return { resume: {} };
+    return { resume: {}, keyedByInterruptId: false };
   }
 
   const hasInterruptIds = entries.every(
@@ -245,7 +259,7 @@ export function headlessToolsBatchResumeCommand(
         ? { [entry.toolCallId]: entry.value }
         : entry.value;
   }
-  return { resume };
+  return { resume, keyedByInterruptId: true };
 }
 
 /**
@@ -272,12 +286,16 @@ export interface HeadlessToolResumeController {
  */
 export function applyHeadlessToolResumeCommand(
   controller: HeadlessToolResumeController,
-  command: { resume: unknown }
+  command: HeadlessToolResumeCommand
 ): Promise<void> {
-  const { resume } = command;
+  const { resume, keyedByInterruptId } = command;
   if (resume == null) return Promise.resolve();
 
-  if (isInterruptIdKeyedResume(resume)) {
+  const useRespondAll =
+    keyedByInterruptId === true ||
+    (keyedByInterruptId !== false && isInterruptIdKeyedResume(resume));
+
+  if (useRespondAll) {
     return controller.respondAll(resume as Record<string, unknown>);
   }
 
@@ -285,16 +303,36 @@ export function applyHeadlessToolResumeCommand(
 }
 
 /**
- * True when every top-level resume key is a graph task interrupt id
- * (32-char hex from `values.__interrupt__`).
+ * True when a resume payload is keyed by protocol interrupt id at the top
+ * level (for {@link HeadlessToolResumeController.respondAll}).
+ *
+ * Prefer {@link HeadlessToolResumeCommand.keyedByInterruptId} from
+ * {@link headlessToolsBatchResumeCommand} when ids are not inferable
+ * (for example `{ "int-1": result }` without a nested tool-call map).
+ *
+ * When `interrupts` is provided, a single top-level key that matches a
+ * known protocol interrupt id is treated as interrupt-keyed.
  */
-export function isInterruptIdKeyedResume(resume: unknown): boolean {
+export function isInterruptIdKeyedResume(
+  resume: unknown,
+  interrupts?: readonly ProtocolInterruptEntry[]
+): boolean {
   if (resume == null || typeof resume !== "object" || Array.isArray(resume)) {
     return false;
   }
-  const keys = Object.keys(resume as Record<string, unknown>);
+  const record = resume as Record<string, unknown>;
+  const keys = Object.keys(record);
   if (keys.length === 0) return false;
-  return keys.every((key) => /^[0-9a-f]{32}$/i.test(key));
+  if (keys.length > 1) return true;
+
+  const [key] = keys;
+  if (interrupts?.length) {
+    const knownIds = new Set(interrupts.map((entry) => entry.interruptId));
+    if (knownIds.has(key!)) return true;
+  }
+
+  // Legacy graph task ids from `values.__interrupt__`.
+  return /^[0-9a-f]{32}$/i.test(key!);
 }
 
 /**
@@ -309,7 +347,7 @@ export function buildResumeRunInput(
   resolvedInterruptIds: ReadonlySet<string>
 ): Record<string, unknown> | null {
   if (resume == null) return null;
-  if (isInterruptIdKeyedResume(resume)) {
+  if (isInterruptIdKeyedResume(resume, interrupts)) {
     return resume as Record<string, unknown>;
   }
 
@@ -390,7 +428,7 @@ export function resolveInterruptTargetForHeadlessResume(
 
 export interface FlushPendingHeadlessToolInterruptsOptions {
   onTool?: OnToolCallback;
-  resumeSubmit: (command: { resume: unknown }) => void | Promise<void>;
+  resumeSubmit: (command: HeadlessToolResumeCommand) => void | Promise<void>;
   defer?: (run: () => void) => void;
 }
 

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -118,6 +118,7 @@ export type {
   HeadlessToolInterrupt,
   OnToolCallback,
   FlushPendingHeadlessToolInterruptsOptions,
+  HeadlessToolResumeController,
 } from "./headless-tools.js";
 export {
   isHeadlessToolInterrupt,
@@ -127,6 +128,7 @@ export {
   executeHeadlessTool,
   handleHeadlessToolInterrupt,
   headlessToolResumeCommand,
+  applyHeadlessToolResumeCommand,
   flushPendingHeadlessToolInterrupts,
   scheduleCoalescedHeadlessToolFlush,
 } from "./headless-tools.js";

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -119,6 +119,7 @@ export type {
   OnToolCallback,
   FlushPendingHeadlessToolInterruptsOptions,
   HeadlessToolResumeController,
+  HeadlessToolResumeCommand,
 } from "./headless-tools.js";
 export {
   isHeadlessToolInterrupt,

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -207,17 +207,82 @@ describe("StreamController", () => {
 
     onEvent?.(inputRequestedEvent());
 
-    expect(controller.rootStore.getSnapshot().interrupt).toEqual({
-      id: "interrupt-1",
-      value: {
-        actionRequests: [
+    const interrupt = controller.rootStore.getSnapshot().interrupt;
+    expect(interrupt?.id).toBe("interrupt-1");
+    expect(
+      (interrupt?.value as { actionRequests?: unknown[] }).actionRequests
+    ).toEqual([
+      expect.objectContaining({
+        name: "send_release_update_email",
+        args: { to: "qa@example.com" },
+      }),
+    ]);
+
+    await controller.dispose();
+  });
+
+  it("normalizes Python snake_case HITL interrupt payloads in root state", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+
+    let onEvent: ((event: Event) => void) | undefined;
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        onEvent = listener;
+        return vi.fn();
+      }),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {} })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, unknown>({
+      assistantId: "human-in-the-loop",
+      client: client as never,
+      threadId: "thread-1",
+    });
+    await controller.hydrationPromise;
+
+    onEvent?.(
+      inputRequestedEvent("interrupt-py", {
+        action_requests: [
           {
-            name: "send_release_update_email",
-            args: { to: "qa@example.com" },
+            name: "send_email",
+            args: { to: "team@acme.com" },
+            description: "Review email before sending",
           },
         ],
-      },
-    });
+        review_configs: [
+          {
+            action_name: "send_email",
+            allowed_decisions: ["approve", "edit", "reject"],
+          },
+        ],
+      })
+    );
+
+    const value = controller.rootStore.getSnapshot().interrupt?.value as Record<
+      string,
+      unknown
+    >;
+    expect(value.actionRequests).toEqual([
+      expect.objectContaining({
+        name: "send_email",
+        args: { to: "team@acme.com" },
+        description: "Review email before sending",
+      }),
+    ]);
+    expect(value.reviewConfigs).toEqual([
+      expect.objectContaining({
+        allowedDecisions: ["approve", "edit", "reject"],
+      }),
+    ]);
 
     await controller.dispose();
   });

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -210,7 +210,8 @@ describe("StreamController", () => {
     const interrupt = controller.rootStore.getSnapshot().interrupt;
     expect(interrupt?.id).toBe("interrupt-1");
     expect(
-      (interrupt?.value as { actionRequests?: unknown[] }).actionRequests
+      (interrupt?.value as { actionRequests?: unknown[] } | undefined)
+        ?.actionRequests
     ).toEqual([
       expect.objectContaining({
         name: "send_release_update_email",

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -34,6 +34,7 @@ import type { ThreadStream } from "../client/stream/index.js";
 import type { SubscriptionHandle } from "../client/stream/index.js";
 import { ToolCallAssembler } from "../client/stream/handles/tools.js";
 import { ensureMessageInstances } from "../ui/messages.js";
+import { normalizeInterruptForClient } from "../ui/interrupts.js";
 import type { Message } from "../types.messages.js";
 import { StreamStore } from "./store.js";
 import { ChannelRegistry } from "./channel-registry.js";
@@ -481,10 +482,12 @@ export class StreamController<
             const id = typed?.id;
             if (typeof id !== "string" || activeIds.has(id)) continue;
             activeIds.add(id);
-            activeInterrupts.push({
-              id,
-              value: typed?.value as InterruptType,
-            });
+            activeInterrupts.push(
+              normalizeInterruptForClient({
+                id,
+                value: typed?.value as InterruptType,
+              })
+            );
           }
         }
         this.rootStore.setState((s) => ({
@@ -1543,10 +1546,10 @@ export class StreamController<
     ) {
       return;
     }
-    const interrupt: Interrupt<InterruptType> = {
+    const interrupt: Interrupt<InterruptType> = normalizeInterruptForClient({
       id: interruptId,
       value: data.payload as InterruptType,
-    };
+    });
     this.rootStore.setState((s) => {
       if (s.interrupts.some((entry) => entry.id === interruptId)) return s;
       const interrupts = [...s.interrupts, interrupt];

--- a/libs/sdk/src/ui/hitl-interrupt-payload.test.ts
+++ b/libs/sdk/src/ui/hitl-interrupt-payload.test.ts
@@ -201,6 +201,7 @@ describe("headless tool interrupt helpers", () => {
       resume: {
         "call-1": { latitude: 1, longitude: 2 },
       },
+      keyedByInterruptId: false,
     });
   });
 
@@ -251,6 +252,7 @@ describe("headless tool interrupt helpers", () => {
           "call-1": { latitude: 1, longitude: 2 },
         },
       },
+      keyedByInterruptId: true,
     });
 
     expect(handled.has("headless-1")).toBe(true);
@@ -328,6 +330,7 @@ describe("headless tool interrupt helpers", () => {
           "call-1": { latitude: 1, longitude: 2 },
         },
       },
+      keyedByInterruptId: true,
     });
     expect(handled.has("py-headless")).toBe(true);
     expect(onTool).toHaveBeenCalledTimes(2);
@@ -394,6 +397,7 @@ describe("headless tool interrupt helpers", () => {
           },
         },
       },
+      keyedByInterruptId: true,
     });
     expect(onTool).toHaveBeenCalledTimes(2);
   });


### PR DESCRIPTION
## Summary

- Fix headless-tool resume on the v1 stream protocol by routing resume payloads through `applyHeadlessToolResumeCommand` (`respond` / `respondAll`) instead of `submit(null, { command })`.
- Export `applyHeadlessToolResumeCommand` and `HeadlessToolResumeController` from `@langchain/langgraph-sdk` and re-export from `@langchain/react`.
- Strengthen headless-tool browser tests across React, Vue, Angular, and Svelte to assert tool result values, final agent message, idle loading state, and no lingering interrupts.
