### PR TITLE
fix(sdk): normalize HITL edit decisions for Python servers

### DIFF
--- a/.changeset/fix-hitl-respond-edited-action-snake-case.md
+++ b/.changeset/fix-hitl-respond-edited-action-snake-case.md
@@ -1,0 +1,9 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): normalize HITL edit decisions for Python servers
+
+`StreamController.respond()` now mirrors camelCase and snake_case on edit
+decisions (`editedAction` / `edited_action`) so JS clients can resume
+human-in-the-loop interrupts against Python LangGraph servers.

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -876,6 +876,71 @@ describe("StreamController", () => {
     await controller.dispose();
   });
 
+  it("respond() normalizes camelCase HITL edit decisions for Python servers", async () => {
+    const respondInput = vi.fn(async () => undefined);
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [
+        {
+          interruptId: "int-hitl",
+          payload: { action_requests: [] },
+          namespace: [],
+        },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {} })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, unknown>({
+      assistantId: "human-in-the-loop",
+      client: client as never,
+      threadId: "thread-1",
+    });
+    await controller.hydrationPromise;
+
+    await controller.respond({
+      decisions: [
+        {
+          type: "edit",
+          editedAction: {
+            name: "send_email",
+            args: { to: "team@acme.com" },
+          },
+        },
+      ],
+    });
+
+    expect(respondInput).toHaveBeenCalledWith({
+      namespace: [],
+      interrupt_id: "int-hitl",
+      response: {
+        decisions: [
+          {
+            type: "edit",
+            editedAction: {
+              name: "send_email",
+              args: { to: "team@acme.com" },
+            },
+            edited_action: {
+              name: "send_email",
+              args: { to: "team@acme.com" },
+            },
+          },
+        ],
+      },
+    });
+
+    await controller.dispose();
+  });
+
   it("respond() removes only the targeted interrupt when several are pending", async () => {
     let onEvent: ((event: Event) => void) | undefined;
     const respondInput = vi.fn(async () => undefined);

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -35,6 +35,7 @@ import type { SubscriptionHandle } from "../client/stream/index.js";
 import { ToolCallAssembler } from "../client/stream/handles/tools.js";
 import { ensureMessageInstances } from "../ui/messages.js";
 import { normalizeInterruptForClient } from "../ui/interrupts.js";
+import { normalizeHitlResponseForServer } from "../ui/hitl-interrupt-payload.js";
 import type { Message } from "../types.messages.js";
 import { StreamStore } from "./store.js";
 import { ChannelRegistry } from "./channel-registry.js";
@@ -759,7 +760,7 @@ export class StreamController<
       await this.#thread.respondInput({
         namespace: resolved.namespace,
         interrupt_id: resolved.interruptId,
-        response,
+        response: normalizeHitlResponseForServer(response),
         config: options?.config,
         metadata: options?.metadata,
       });
@@ -827,7 +828,7 @@ export class StreamController<
     const pending = this.#thread.interrupts;
     const responses = entries.map(([interruptId, response]) => ({
       interrupt_id: interruptId,
-      response,
+      response: normalizeHitlResponseForServer(response),
       namespace: pending.find((entry) => entry.interruptId === interruptId)
         ?.namespace ?? [...ROOT_NAMESPACE],
     }));

--- a/libs/sdk/src/ui/hitl-interrupt-payload.test.ts
+++ b/libs/sdk/src/ui/hitl-interrupt-payload.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { normalizeHitlInterruptPayload } from "./hitl-interrupt-payload.js";
+import { normalizeHitlInterruptPayload, normalizeHitlResponseForServer } from "./hitl-interrupt-payload.js";
 import { normalizeInterruptForClient } from "./interrupts.js";
 import {
   filterOutHeadlessToolInterrupts,
@@ -87,6 +87,54 @@ describe("normalizeHitlInterruptPayload", () => {
     expect(normalizeHitlInterruptPayload({ foo: 1 })).toEqual({ foo: 1 });
     expect(normalizeHitlInterruptPayload(null)).toBeNull();
     expect(normalizeHitlInterruptPayload("x")).toBe("x");
+  });
+});
+
+describe("normalizeHitlResponseForServer", () => {
+  it("adds edited_action alias for camelCase edit decisions", () => {
+    const raw = {
+      decisions: [
+        { type: "approve" },
+        {
+          type: "edit",
+          editedAction: { name: "send_email", args: { to: "a@b.com" } },
+        },
+      ],
+    };
+    const out = normalizeHitlResponseForServer(raw) as {
+      decisions: Record<string, unknown>[];
+    };
+    expect(out.decisions[1]).toEqual({
+      type: "edit",
+      editedAction: { name: "send_email", args: { to: "a@b.com" } },
+      edited_action: { name: "send_email", args: { to: "a@b.com" } },
+    });
+  });
+
+  it("adds editedAction alias for snake_case edit decisions", () => {
+    const raw = {
+      decisions: [
+        {
+          type: "edit",
+          edited_action: { name: "send_email", args: { to: "a@b.com" } },
+        },
+      ],
+    };
+    const out = normalizeHitlResponseForServer(raw) as {
+      decisions: Record<string, unknown>[];
+    };
+    expect(out.decisions[0]).toEqual({
+      type: "edit",
+      editedAction: { name: "send_email", args: { to: "a@b.com" } },
+      edited_action: { name: "send_email", args: { to: "a@b.com" } },
+    });
+  });
+
+  it("passes through non-HITL responses", () => {
+    expect(normalizeHitlResponseForServer({ approved: true })).toEqual({
+      approved: true,
+    });
+    expect(normalizeHitlResponseForServer(null)).toBeNull();
   });
 });
 

--- a/libs/sdk/src/ui/hitl-interrupt-payload.ts
+++ b/libs/sdk/src/ui/hitl-interrupt-payload.ts
@@ -76,3 +76,41 @@ export function normalizeHitlInterruptPayload(value: unknown): unknown {
   }
   return next;
 }
+
+function normalizeDecisionForServer(decision: unknown): unknown {
+  if (decision === null || typeof decision !== "object" || Array.isArray(decision)) {
+    return decision;
+  }
+  const obj = decision as Record<string, unknown>;
+  if (obj.type !== "edit") {
+    return decision;
+  }
+  const edited = obj.editedAction ?? obj.edited_action;
+  if (edited === undefined) {
+    return decision;
+  }
+  return {
+    ...obj,
+    editedAction: edited,
+    edited_action: edited,
+  };
+}
+
+/**
+ * If `value` looks like a HITL resume payload from a JS client, expose both
+ * camelCase and snake_case decision fields so Python and JS runtimes accept it.
+ */
+export function normalizeHitlResponseForServer(value: unknown): unknown {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return value;
+  }
+  const obj = value as Record<string, unknown>;
+  const decisions = obj.decisions;
+  if (!Array.isArray(decisions)) {
+    return value;
+  }
+  return {
+    ...obj,
+    decisions: decisions.map(normalizeDecisionForServer),
+  };
+}

--- a/libs/sdk/src/ui/hitl-interrupt-payload.ts
+++ b/libs/sdk/src/ui/hitl-interrupt-payload.ts
@@ -78,7 +78,11 @@ export function normalizeHitlInterruptPayload(value: unknown): unknown {
 }
 
 function normalizeDecisionForServer(decision: unknown): unknown {
-  if (decision === null || typeof decision !== "object" || Array.isArray(decision)) {
+  if (
+    decision === null ||
+    typeof decision !== "object" ||
+    Array.isArray(decision)
+  ) {
     return decision;
   }
   const obj = decision as Record<string, unknown>;

--- a/libs/sdk/src/ui/index.ts
+++ b/libs/sdk/src/ui/index.ts
@@ -24,7 +24,10 @@ export {
   userFacingInterruptsFromValuesArray,
   userFacingInterruptsFromThreadTasks,
 } from "./interrupts.js";
-export { normalizeHitlInterruptPayload, normalizeHitlResponseForServer } from "./hitl-interrupt-payload.js";
+export {
+  normalizeHitlInterruptPayload,
+  normalizeHitlResponseForServer,
+} from "./hitl-interrupt-payload.js";
 export { FetchStreamTransport } from "./transport.js";
 export {
   unique,

--- a/libs/sdk/src/ui/index.ts
+++ b/libs/sdk/src/ui/index.ts
@@ -24,7 +24,7 @@ export {
   userFacingInterruptsFromValuesArray,
   userFacingInterruptsFromThreadTasks,
 } from "./interrupts.js";
-export { normalizeHitlInterruptPayload } from "./hitl-interrupt-payload.js";
+export { normalizeHitlInterruptPayload, normalizeHitlResponseForServer } from "./hitl-interrupt-payload.js";
 export { FetchStreamTransport } from "./transport.js";
 export {
   unique,


### PR DESCRIPTION
## Summary
- Normalize HITL resume payloads in `StreamController.respond()` and `respondAll()` so edit decisions include both `editedAction` and `edited_action`.
- Add `normalizeHitlResponseForServer` in the SDK UI layer and export it for direct use.
- Cover normalization with unit tests on the payload helper and on `respond()` wiring.
