### PR TITLE
perf(core): index pending writes for O(1) task-prep lookups

### DIFF
--- a/.changeset/index-pending-writes.md
+++ b/.changeset/index-pending-writes.md
@@ -1,0 +1,8 @@
+---
+"@langchain/langgraph": patch
+---
+
+perf(core): index pending writes for O(1) task-prep lookups
+
+Build a PendingWritesIndex once per _prepareNextTasks call so resume and
+skip-done-task checks avoid repeated linear scans over checkpointPendingWrites.

--- a/libs/langgraph-core/src/pregel/algo.test.ts
+++ b/libs/langgraph-core/src/pregel/algo.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import type { Checkpoint } from "@langchain/langgraph-checkpoint";
+import { LastValue } from "../channels/last_value.js";
+import { ERROR, RESUME, RETURN } from "../constants.js";
+import { _indexPendingWrites, _prepareNextTasks } from "./algo.js";
+import { PregelNode } from "./read.js";
+
+function buildPendingWrites(
+  count: number
+): [string, string, unknown][] {
+  const writes: [string, string, unknown][] = [];
+  for (let i = 0; i < count; i += 1) {
+    const taskId = `task-${i % 500}`;
+    if (i % 4 === 0) {
+      writes.push([taskId, RESUME, i]);
+    } else if (i % 11 === 0) {
+      writes.push([taskId, ERROR, "err"]);
+    } else {
+      writes.push([taskId, RETURN, i]);
+    }
+  }
+  return writes;
+}
+
+function linearScanSuccessfulWrite(
+  pendingWrites: [string, string, unknown][],
+  taskId: string
+): boolean {
+  return pendingWrites.some((w) => w[0] === taskId && w[1] !== ERROR);
+}
+
+describe("pending writes index", () => {
+  it("index successfulWriteTaskIds matches linear scan for many task ids", () => {
+    const pendingWrites = buildPendingWrites(12_000);
+    const index = _indexPendingWrites(pendingWrites);
+
+    for (let i = 0; i < 500; i += 1) {
+      const taskId = `task-${i}`;
+      expect(index.successfulWriteTaskIds.has(taskId)).toBe(
+        linearScanSuccessfulWrite(pendingWrites, taskId)
+      );
+    }
+  });
+
+  it("index resume values match filter/flatMap for many task ids", () => {
+    const pendingWrites = buildPendingWrites(8_000);
+    const index = _indexPendingWrites(pendingWrites);
+
+    for (let i = 0; i < 200; i += 1) {
+      const taskId = `task-${i}`;
+      const expected = pendingWrites
+        .filter(([tid, chan]) => tid === taskId && chan === RESUME)
+        .flatMap(([, , v]) => v);
+      expect((index.resumeByTaskId.get(taskId) ?? []).flat()).toEqual(expected);
+    }
+  });
+
+  it("_prepareNextTasks is unchanged with a pre-built index", () => {
+    const nodeCount = 30;
+    const channelVersions: Record<string, number> = {};
+    const versionsSeen: Record<string, Record<string, number>> = {};
+    const processes: Record<string, PregelNode> = {};
+    const channels: Record<string, LastValue<number>> = {};
+
+    for (let i = 0; i < nodeCount; i += 1) {
+      const name = `node${i}`;
+      const chan = `channel${i}`;
+      channelVersions[chan] = 2;
+      versionsSeen[name] = { [chan]: 1 };
+      processes[name] = new PregelNode({
+        channels: [chan],
+        triggers: [chan],
+      });
+      const channel = new LastValue<number>();
+      channel.update([i]);
+      channels[chan] = channel;
+    }
+
+    const checkpoint: Checkpoint = {
+      v: 1,
+      id: "00000000-0000-0000-0000-000000000002",
+      ts: "2026-01-01T00:00:00.000Z",
+      channel_values: Object.fromEntries(
+        Object.keys(channels).map((k) => [k, channels[k].get()])
+      ),
+      channel_versions: channelVersions,
+      versions_seen: versionsSeen,
+    };
+
+    const pendingWrites = buildPendingWrites(6_000);
+    const config = { configurable: { thread_id: "algo-test" } };
+    const extra = { step: 2 };
+
+    const withoutPrebuilt = _prepareNextTasks(
+      checkpoint,
+      pendingWrites,
+      processes,
+      channels,
+      config,
+      false,
+      extra
+    );
+
+    const withPrebuilt = _prepareNextTasks(
+      checkpoint,
+      pendingWrites,
+      processes,
+      channels,
+      config,
+      false,
+      { ...extra, pendingWritesIndex: _indexPendingWrites(pendingWrites) }
+    );
+
+    expect(Object.keys(withPrebuilt).sort()).toEqual(
+      Object.keys(withoutPrebuilt).sort()
+    );
+    for (const id of Object.keys(withoutPrebuilt)) {
+      expect(withPrebuilt[id]).toEqual(withoutPrebuilt[id]);
+    }
+  });
+});

--- a/libs/langgraph-core/src/pregel/algo.ts
+++ b/libs/langgraph-core/src/pregel/algo.ts
@@ -432,6 +432,48 @@ function* candidateNodes(
   }
 }
 
+/**
+ * Pre-indexed pending writes for O(1) lookups, avoiding repeated
+ * linear scans in _prepareSingleTask and _scratchpad.
+ */
+export type PendingWritesIndex = {
+  nullResume: unknown | undefined;
+  resumeByTaskId: Map<string, unknown[]>;
+  successfulWriteTaskIds: Set<string>;
+};
+
+/**
+ * Build an index over pendingWrites for O(1) lookups.
+ *
+ * @internal Exported for benchmarks and regression tests only.
+ */
+export function _indexPendingWrites(
+  pendingWrites: [string, string, unknown][] | undefined
+): PendingWritesIndex {
+  let nullResume: unknown | undefined;
+  const resumeByTaskId = new Map<string, unknown[]>();
+  const successfulWriteTaskIds = new Set<string>();
+  if (pendingWrites) {
+    for (const [tid, chan, val] of pendingWrites) {
+      if (tid === NULL_TASK_ID && chan === RESUME && nullResume === undefined) {
+        nullResume = val;
+      }
+      if (chan === RESUME && tid !== NULL_TASK_ID) {
+        let arr = resumeByTaskId.get(tid);
+        if (!arr) {
+          arr = [];
+          resumeByTaskId.set(tid, arr);
+        }
+        arr.push(val);
+      }
+      if (chan !== ERROR) {
+        successfulWriteTaskIds.add(tid);
+      }
+    }
+  }
+  return { nullResume, resumeByTaskId, successfulWriteTaskIds };
+}
+
 export type NextTaskExtraFields = {
   step: number;
   isResuming?: boolean;
@@ -441,6 +483,7 @@ export type NextTaskExtraFields = {
   stream?: IterableReadableWritableStream;
   triggerToNodes?: Record<string, string[]>;
   updatedChannels?: Set<string>;
+  pendingWritesIndex?: PendingWritesIndex;
 };
 
 export type NextTaskExtraFieldsWithStore = NextTaskExtraFields & {
@@ -500,6 +543,11 @@ export function _prepareNextTasks<
     | Record<string, PregelExecutableTask<keyof Nn, keyof Cc>>
     | Record<string, PregelTaskDescription> = {};
 
+  // Pre-index pendingWrites once for O(1) lookups in _prepareSingleTask/_scratchpad
+  const indexedExtra: typeof extra = extra.pendingWritesIndex
+    ? extra
+    : { ...extra, pendingWritesIndex: _indexPendingWrites(pendingWrites) };
+
   // Consume pending tasks
   const tasksChannel = channels[TASKS] as Topic<SendProtocol> | undefined;
 
@@ -514,7 +562,7 @@ export function _prepareNextTasks<
         channels,
         config,
         forExecution,
-        extra
+        indexedExtra
       );
       if (task !== undefined) {
         tasks[task.id] = task;
@@ -524,7 +572,7 @@ export function _prepareNextTasks<
 
   // Check if any processes should be run in next step
   // If so, prepare the values to be passed to them
-  for (const name of candidateNodes(checkpoint, processes, extra)) {
+  for (const name of candidateNodes(checkpoint, processes, indexedExtra)) {
     const task = _prepareSingleTask(
       [PULL, name],
       checkpoint,
@@ -533,7 +581,7 @@ export function _prepareNextTasks<
       channels,
       config,
       forExecution,
-      extra
+      indexedExtra
     );
     if (task !== undefined) {
       tasks[task.id] = task;
@@ -700,6 +748,7 @@ export function _prepareSingleTask<
                   currentTaskInput: call.input,
                   resumeMap: config.configurable?.[CONFIG_KEY_RESUME_MAP],
                   namespaceHash: XXH3(taskCheckpointNamespace),
+                  pendingWritesIndex: extra.pendingWritesIndex,
                 }),
                 [CONFIG_KEY_PREVIOUS_STATE]:
                   checkpoint.channel_values[PREVIOUS],
@@ -857,6 +906,7 @@ export function _prepareSingleTask<
                     currentTaskInput: packet.args,
                     resumeMap: config.configurable?.[CONFIG_KEY_RESUME_MAP],
                     namespaceHash: XXH3(taskCheckpointNamespace),
+                    pendingWritesIndex: extra.pendingWritesIndex,
                   }),
                   [CONFIG_KEY_PREVIOUS_STATE]:
                     checkpoint.channel_values[PREVIOUS],
@@ -917,12 +967,10 @@ export function _prepareSingleTask<
         checkpoint.id
       );
 
-      // Check if there are successful writes (not ERROR) for this task ID
-      const hasSuccessfulWrites = pendingWrites.some(
-        (w) => w[0] === taskId && w[1] !== ERROR
-      );
+      const hasSuccessfulWrites = extra.pendingWritesIndex
+        ? extra.pendingWritesIndex.successfulWriteTaskIds.has(taskId)
+        : pendingWrites.some((w) => w[0] === taskId && w[1] !== ERROR);
 
-      // If task completed successfully, don't include it in next tasks
       if (hasSuccessfulWrites) {
         return undefined;
       }
@@ -1042,6 +1090,7 @@ export function _prepareSingleTask<
                       currentTaskInput: val,
                       resumeMap: config.configurable?.[CONFIG_KEY_RESUME_MAP],
                       namespaceHash: XXH3(taskCheckpointNamespace),
+                      pendingWritesIndex: extra.pendingWritesIndex,
                     }),
                     [CONFIG_KEY_PREVIOUS_STATE]:
                       checkpoint.channel_values[PREVIOUS],
@@ -1193,23 +1242,30 @@ function _scratchpad({
   currentTaskInput,
   resumeMap,
   namespaceHash,
+  pendingWritesIndex,
 }: {
   pendingWrites: CheckpointPendingWrite[];
   taskId: string;
   currentTaskInput: unknown;
   resumeMap: Record<string, unknown> | undefined;
   namespaceHash: string;
+  pendingWritesIndex?: PendingWritesIndex;
 }): PregelScratchpad {
-  const nullResume = pendingWrites.find(
-    ([writeTaskId, chan]) => writeTaskId === NULL_TASK_ID && chan === RESUME
-  )?.[2];
+  const nullResume = pendingWritesIndex
+    ? pendingWritesIndex.nullResume
+    : pendingWrites.find(
+        ([writeTaskId, chan]) => writeTaskId === NULL_TASK_ID && chan === RESUME
+      )?.[2];
 
   const resume = (() => {
-    const result = pendingWrites
-      .filter(
-        ([writeTaskId, chan]) => writeTaskId === taskId && chan === RESUME
-      )
-      .flatMap(([_writeTaskId, _chan, resume]) => resume);
+    // flatMap flattens array resume values one level; mirror that with .flat()
+    const result: unknown[] = pendingWritesIndex
+      ? (pendingWritesIndex.resumeByTaskId.get(taskId) ?? []).flat()
+      : pendingWrites
+          .filter(
+            ([writeTaskId, chan]) => writeTaskId === taskId && chan === RESUME
+          )
+          .flatMap(([_writeTaskId, _chan, resume]) => resume);
 
     if (resumeMap != null && namespaceHash in resumeMap) {
       const mappedResume = resumeMap[namespaceHash];


### PR DESCRIPTION
## Summary
- Add `PendingWritesIndex` built once in `_prepareNextTasks` with maps for null resume, per-task resume values, and task IDs with successful writes.
- Use the index in `_scratchpad` and PULL early-exit checks instead of repeated `find`/`filter`/`some` over `pendingWrites`.
- Preserve linear-scan fallbacks when `_prepareSingleTask` is invoked without a pre-built index.

This is a performance-only change: task preparation and resume behavior are unchanged.
