### PR TITLE
perf(core): optimize applyWrites, interrupt seen, and channel errors

### DIFF
--- a/.changeset/perf-core-hot-paths.md
+++ b/.changeset/perf-core-hot-paths.md
@@ -1,0 +1,9 @@
+---
+"@langchain/langgraph": patch
+---
+
+perf(core): optimize applyWrites, interrupt seen, and channel errors
+
+Reduce allocations in _applyWrites, fix O(N²) interrupt versions_seen updates,
+skip stack traces on EmptyChannelError control flow, and cache task lists in
+the pregel loop and runner.

--- a/libs/langgraph-core/src/errors.ts
+++ b/libs/langgraph-core/src/errors.ts
@@ -130,7 +130,11 @@ export class EmptyInputError extends BaseLangGraphError {
 
 export class EmptyChannelError extends BaseLangGraphError {
   constructor(message?: string, fields?: BaseLangGraphErrorFields) {
+    // Skip expensive stack trace capture — used for control flow on channel reads.
+    const prevLimit = Error.stackTraceLimit;
+    Error.stackTraceLimit = 0;
     super(message, fields);
+    Error.stackTraceLimit = prevLimit;
     this.name = "EmptyChannelError";
   }
 

--- a/libs/langgraph-core/src/pregel/algo.ts
+++ b/libs/langgraph-core/src/pregel/algo.ts
@@ -242,6 +242,8 @@ const IGNORE = new Set<string | number | symbol>([
   ERROR,
 ]);
 
+const RESERVED_SET: ReadonlySet<string> = new Set(RESERVED);
+
 export function _applyWrites<Cc extends Record<string, BaseChannel>>(
   checkpoint: Checkpoint,
   channels: Cc,
@@ -250,11 +252,18 @@ export function _applyWrites<Cc extends Record<string, BaseChannel>>(
   getNextVersion: ((version: any) => any) | undefined,
   triggerToNodes: Record<string, string[]> | undefined
 ): Set<string> {
+  // Pre-compute paths once before sorting to avoid repeated .slice() allocations
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pathCache = new Map<WritesProtocol<keyof Cc>, any[]>();
+  for (const task of tasks) {
+    pathCache.set(task, task.path?.slice(0, 3) || []);
+  }
+
   // Sort tasks by first 3 path elements for deterministic order
   // Later path parts (like task IDs) are ignored for sorting
   tasks.sort((a, b) => {
-    const aPath = a.path?.slice(0, 3) || [];
-    const bPath = b.path?.slice(0, 3) || [];
+    const aPath = pathCache.get(a)!;
+    const bPath = pathCache.get(b)!;
 
     // Compare each path element
     for (let i = 0; i < Math.min(aPath.length, bPath.length); i += 1) {
@@ -266,33 +275,28 @@ export function _applyWrites<Cc extends Record<string, BaseChannel>>(
     return aPath.length - bPath.length;
   });
 
-  // if no task has triggers this is applying writes from the null task only
-  // so we don't do anything other than update the channels written to
-  const bumpStep = tasks.some((task) => task.triggers.length > 0);
-
   // Filter out non instances of BaseChannel
   const onlyChannels = getOnlyChannels(channels);
 
-  // Update seen versions
+  // Single pass: update seen versions, check for triggers, collect channels to consume
+  let bumpStep = false;
+  const channelsToConsume = new Set<string>();
   for (const task of tasks) {
+    if (task.triggers.length > 0) bumpStep = true;
     checkpoint.versions_seen[task.name] ??= {};
     for (const chan of task.triggers) {
       if (chan in checkpoint.channel_versions) {
         checkpoint.versions_seen[task.name][chan] =
           checkpoint.channel_versions[chan];
       }
+      if (!RESERVED_SET.has(chan)) {
+        channelsToConsume.add(chan);
+      }
     }
   }
 
   // Find the highest version of all channels
   let maxVersion = maxChannelMapVersion(checkpoint.channel_versions);
-
-  // Consume all channels that were read
-  const channelsToConsume = new Set(
-    tasks
-      .flatMap((task) => task.triggers)
-      .filter((chan) => !RESERVED.includes(chan))
-  );
 
   let usedNewVersion = false;
   for (const chan of channelsToConsume) {

--- a/libs/langgraph-core/src/pregel/loop.ts
+++ b/libs/langgraph-core/src/pregel/loop.ts
@@ -766,13 +766,14 @@ export class PregelLoop {
     } else if (
       Object.values(this.tasks).every((task) => task.writes.length > 0)
     ) {
+      const finishTaskList = Object.values(this.tasks);
       // finish superstep
-      const writes = Object.values(this.tasks).flatMap((t) => t.writes);
+      const writes = finishTaskList.flatMap((t) => t.writes);
       // All tasks have finished
       this.updatedChannels = _applyWrites(
         this.checkpoint,
         this.channels,
-        Object.values(this.tasks),
+        finishTaskList,
         this.checkpointerGetNextVersion,
         this.triggerToNodes
       );
@@ -791,13 +792,7 @@ export class PregelLoop {
       await this._putCheckpoint({ source: "loop" });
       this._emitValuesWithCheckpointMeta(valuesOutput);
       // after execution, check if we should interrupt
-      if (
-        shouldInterrupt(
-          this.checkpoint,
-          this.interruptAfter,
-          Object.values(this.tasks)
-        )
-      ) {
+      if (shouldInterrupt(this.checkpoint, this.interruptAfter, finishTaskList)) {
         this.status = "interrupt_after";
         throw new GraphInterrupt();
       }
@@ -833,6 +828,7 @@ export class PregelLoop {
       }
     );
     this.tasks = nextTasks;
+    const taskList = Object.values(this.tasks);
 
     // Produce debug output
     if (this.checkpointer) {
@@ -844,7 +840,7 @@ export class PregelLoop {
               this.channels,
               this.streamKeys,
               this.checkpointMetadata,
-              Object.values(this.tasks),
+              taskList,
               this.checkpointPendingWrites,
               this.prevCheckpointConfig,
               this.outputKeys
@@ -855,7 +851,7 @@ export class PregelLoop {
       );
     }
 
-    if (Object.values(this.tasks).length === 0) {
+    if (taskList.length === 0) {
       this.status = "done";
       return false;
     }
@@ -865,37 +861,31 @@ export class PregelLoop {
         if (k === ERROR || k === INTERRUPT || k === RESUME) {
           continue;
         }
-        const task = Object.values(this.tasks).find((t) => t.id === tid);
+        const task = taskList.find((t) => t.id === tid);
         if (task) {
           task.writes.push([k, v]);
         }
       }
-      for (const task of Object.values(this.tasks)) {
+      for (const task of taskList) {
         if (task.writes.length > 0) {
           this._outputWrites(task.id, task.writes, true);
         }
       }
     }
     // if all tasks have finished, re-tick
-    if (Object.values(this.tasks).every((task) => task.writes.length > 0)) {
+    if (taskList.every((task) => task.writes.length > 0)) {
       return this.tick({ inputKeys });
     }
 
     // Before execution, check if we should interrupt
-    if (
-      shouldInterrupt(
-        this.checkpoint,
-        this.interruptBefore,
-        Object.values(this.tasks)
-      )
-    ) {
+    if (shouldInterrupt(this.checkpoint, this.interruptBefore, taskList)) {
       this.status = "interrupt_before";
       throw new GraphInterrupt();
     }
 
     // Produce debug output
     const debugOutput = await gatherIterator(
-      prefixGenerator(mapDebugTasks(Object.values(this.tasks)), "tasks")
+      prefixGenerator(mapDebugTasks(taskList), "tasks")
     );
     this._emit(debugOutput);
 
@@ -1098,18 +1088,22 @@ export class PregelLoop {
     }
     const isCommandUpdateOrGoto =
       isCommand(this.input) && nullWrites.length > 0;
-    if (this.isResuming || isCommandUpdateOrGoto) {
+    const cachedIsResuming = this.isResuming;
+    if (cachedIsResuming || isCommandUpdateOrGoto) {
+      // One spread (O(N)) instead of O(N²) per-channel spreads. Must be a
+      // new object — copyCheckpoint shallow-copies versions_seen.
+      const interruptSeen: Record<string, string | number> = {
+        ...this.checkpoint.versions_seen[INTERRUPT],
+      };
       for (const channelName in this.channels) {
         if (!Object.prototype.hasOwnProperty.call(this.channels, channelName))
           continue;
         if (this.checkpoint.channel_versions[channelName] !== undefined) {
-          const version = this.checkpoint.channel_versions[channelName];
-          this.checkpoint.versions_seen[INTERRUPT] = {
-            ...this.checkpoint.versions_seen[INTERRUPT],
-            [channelName]: version,
-          };
+          interruptSeen[channelName] =
+            this.checkpoint.channel_versions[channelName];
         }
       }
+      this.checkpoint.versions_seen[INTERRUPT] = interruptSeen;
       // produce values output
       const valuesOutput = await gatherIterator(
         prefixGenerator(
@@ -1121,7 +1115,7 @@ export class PregelLoop {
       // `isResuming` and `isCommandUpdateOrGoto` are true (resuming from
       // an interrupt with a Command update/goto), the resume path wins
       // and no new input checkpoint is created here.
-      if (this.isResuming) {
+      if (cachedIsResuming) {
         this.input = INPUT_RESUMING;
       } else if (isCommandUpdateOrGoto) {
         // Persist the input checkpoint BEFORE emitting values so the

--- a/libs/langgraph-core/src/pregel/loop.ts
+++ b/libs/langgraph-core/src/pregel/loop.ts
@@ -792,7 +792,9 @@ export class PregelLoop {
       await this._putCheckpoint({ source: "loop" });
       this._emitValuesWithCheckpointMeta(valuesOutput);
       // after execution, check if we should interrupt
-      if (shouldInterrupt(this.checkpoint, this.interruptAfter, finishTaskList)) {
+      if (
+        shouldInterrupt(this.checkpoint, this.interruptAfter, finishTaskList)
+      ) {
         this.status = "interrupt_after";
         throw new GraphInterrupt();
       }

--- a/libs/langgraph-core/src/pregel/runner.ts
+++ b/libs/langgraph-core/src/pregel/runner.ts
@@ -118,10 +118,8 @@ export class PregelRunner {
       ? AbortSignal.timeout(timeout)
       : undefined;
 
-    // Start task execution
-    const pendingTasks = Object.values(this.loop.tasks).filter(
-      (t) => t.writes.length === 0
-    );
+    const allTasks = Object.values(this.loop.tasks);
+    const pendingTasks = allTasks.filter((t) => t.writes.length === 0);
 
     const { signals, disposeCombinedSignal } = this._initializeAbortSignals({
       exceptionSignal,
@@ -165,9 +163,7 @@ export class PregelRunner {
 
     onStepWrite?.(
       this.loop.step,
-      Object.values(this.loop.tasks)
-        .map((task) => task.writes)
-        .flat()
+      allTasks.map((task) => task.writes).flat()
     );
 
     if (nodeErrors.size === 1) {

--- a/libs/langgraph-core/src/pregel/runner.ts
+++ b/libs/langgraph-core/src/pregel/runner.ts
@@ -161,10 +161,7 @@ export class PregelRunner {
 
     disposeCombinedSignal?.();
 
-    onStepWrite?.(
-      this.loop.step,
-      allTasks.map((task) => task.writes).flat()
-    );
+    onStepWrite?.(this.loop.step, allTasks.map((task) => task.writes).flat());
 
     if (nodeErrors.size === 1) {
       throw Array.from(nodeErrors)[0];


### PR DESCRIPTION
## Summary
- Optimize `_applyWrites`: pre-compute sort paths, `RESERVED_SET`, and a single pass over tasks for version tracking and channel consumption.
- Fix `_first` interrupt `versions_seen` updates from O(N²) spreads to one object build (also avoids mutating shallow-copied checkpoint refs).
- Skip V8 stack capture for `EmptyChannelError` (control-flow throws on channel reads).
- Cache `Object.values(this.tasks)` in `tick()` and `Object.values(this.loop.tasks)` in the runner.
