### PR TITLE
fix(sdk): keep subgraph status complete when values arrives late

### DIFF
--- a/.changeset/fix-subgraph-discovery-late-values-status.md
+++ b/.changeset/fix-subgraph-discovery-late-values-status.md
@@ -1,0 +1,11 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): keep subgraph status complete when values arrives late
+
+`SubgraphDiscovery` no longer downgrades a terminal subgraph back to
+`running` when a host-namespace `values` snapshot is observed after its
+`completed` or `failed` lifecycle event. The content pump and lifecycle
+watcher are independent streams, so this reordering could strand nodes as
+perpetually running in `useStream` subgraph UIs.

--- a/libs/sdk/src/stream/discovery/subgraphs.test.ts
+++ b/libs/sdk/src/stream/discovery/subgraphs.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { Event, LifecycleEvent } from "@langchain/protocol";
+import type { Event, LifecycleEvent, ValuesEvent } from "@langchain/protocol";
 
 import { SubgraphDiscovery } from "./subgraphs.js";
 
 function lifecycleEvent(
   namespace: readonly string[],
-  event: "started" | "completed",
+  event: "started" | "completed" | "failed",
   seq = 1
 ): Event {
   return {
@@ -20,6 +20,23 @@ function lifecycleEvent(
   } as LifecycleEvent & Event;
 }
 
+function valuesEvent(
+  namespace: readonly string[],
+  data: Record<string, unknown> = {},
+  seq = 1
+): Event {
+  return {
+    type: "event",
+    method: "values",
+    seq,
+    params: {
+      namespace,
+      timestamp: Date.now(),
+      data,
+    },
+  } as ValuesEvent & Event;
+}
+
 describe("SubgraphDiscovery", () => {
   it("promotes a host namespace when a deeper namespace is observed", () => {
     const discovery = new SubgraphDiscovery();
@@ -31,6 +48,42 @@ describe("SubgraphDiscovery", () => {
 
     expect([...discovery.snapshot.values()]).toMatchObject([
       { nodeName: "classify", status: "running" },
+    ]);
+  });
+
+  it("does not resurrect a completed subgraph from a late values snapshot", () => {
+    // The content pump (values) and lifecycle watcher (lifecycle) are
+    // independent streams, so a host namespace's final values snapshot
+    // can be delivered AFTER its terminal lifecycle event. A late values
+    // event must not downgrade the node back to "running".
+    const discovery = new SubgraphDiscovery();
+    const host = ["classify:u1"] as const;
+    const inner = ["classify:u1", "run:u2"] as const;
+
+    discovery.push(lifecycleEvent(host, "started", 1));
+    discovery.push(valuesEvent(host, {}, 2));
+    discovery.push(lifecycleEvent(inner, "started", 3));
+    discovery.push(lifecycleEvent(host, "completed", 4));
+    // Reordered: the host's final values snapshot lands after completed.
+    discovery.push(valuesEvent(host, {}, 5));
+
+    expect([...discovery.snapshot.values()]).toMatchObject([
+      { nodeName: "classify", status: "complete" },
+    ]);
+  });
+
+  it("does not resurrect a failed subgraph from a late values snapshot", () => {
+    const discovery = new SubgraphDiscovery();
+    const host = ["classify:u1"] as const;
+    const inner = ["classify:u1", "run:u2"] as const;
+
+    discovery.push(lifecycleEvent(host, "started", 1));
+    discovery.push(lifecycleEvent(inner, "started", 2));
+    discovery.push(lifecycleEvent(host, "failed", 3));
+    discovery.push(valuesEvent(host, {}, 4));
+
+    expect([...discovery.snapshot.values()]).toMatchObject([
+      { nodeName: "classify", status: "error" },
     ]);
   });
 

--- a/libs/sdk/src/stream/discovery/subgraphs.ts
+++ b/libs/sdk/src/stream/discovery/subgraphs.ts
@@ -200,7 +200,20 @@ export class SubgraphDiscovery {
     const lastSegment = namespace[namespace.length - 1] ?? "";
     const nodeName = parseNodeName(lastSegment);
     const entry = this.#ensureShadow(id, namespace, nodeName);
-    entry.status = "running";
+    // A `values` snapshot is a discovery/promotion signal, not a status
+    // transition — terminal status is owned by `lifecycle` events. The
+    // content pump (which carries `values`) and the lifecycle watcher
+    // (which carries `lifecycle`) are independent streams deduped through
+    // `onEvent`, so a host namespace's final `values` snapshot can be
+    // observed AFTER its terminal `completed`/`failed` lifecycle event.
+    // Unconditionally writing "running" here would resurrect a finished
+    // subgraph and strand it as perpetually running in the UI. New
+    // entries are already created as "running" by `#ensureShadow`, so we
+    // only need to avoid downgrading an entry that already reached a
+    // terminal state.
+    if (entry.status !== "complete" && entry.status !== "error") {
+      entry.status = "running";
+    }
 
     if (!this.#promoted.has(id)) {
       this.#promoted.add(id);


### PR DESCRIPTION
## Summary
- Fix `SubgraphDiscovery` so late host-namespace `values` snapshots do not reset subgraph status from `complete`/`error` back to `running`.
- Root cause: the SDK’s content pump (`values`) and lifecycle watcher (`lifecycle`) are separate streams; `onEvent` can deliver a final `values` event after terminal `lifecycle`, which left some nodes stuck as “running” in `useStream` subgraph UIs (e.g. graph-execution-cards).
- Add regression tests for completed and failed subgraphs receiving a late `values` event.
