### PR TITLE
fix(sdk): claim in-flight slot before root pump wait for enqueue

### DIFF
--- a/.changeset/fix-submit-enqueue-same-tick.md
+++ b/.changeset/fix-submit-enqueue-same-tick.md
@@ -1,0 +1,9 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): claim in-flight slot before root pump wait for enqueue
+
+Move `#runAbort` and `isLoading` setup ahead of `waitForRootPumpReady()` so
+`multitaskStrategy: "enqueue"` submits in the same tick land in `queueStore`
+instead of bypassing the client queue.

--- a/libs/sdk/src/stream/submit-coordinator.test.ts
+++ b/libs/sdk/src/stream/submit-coordinator.test.ts
@@ -479,6 +479,24 @@ describe("SubmitCoordinator", () => {
       await first;
     });
 
+    it("enqueues a follow-up fired in the same tick as dispatch", async () => {
+      const h = makeHarness();
+      const first = h.coordinator.submit({ count: 1 });
+      void h.coordinator.submit({ count: 2 }, { multitaskStrategy: "enqueue" });
+      await flush();
+
+      expect(h.queueStore.getSnapshot()).toHaveLength(1);
+      expect(h.queueStore.getSnapshot()[0].values).toEqual({ count: 2 });
+      expect(h.submitRun).toHaveBeenCalledTimes(1);
+      expect(h.submitRun.mock.calls[0]?.[0]?.input).toEqual({ count: 1 });
+
+      await h.terminalRegistered();
+      h.resolveSubmit({ run_id: "run-1" });
+      h.resolveTerminal({ event: "completed" });
+      await vi.runAllTimersAsync();
+      await first;
+    });
+
     it("drains the queue after the active run terminates", async () => {
       const h = makeHarness();
       const first = h.coordinator.submit({ count: 1 });

--- a/libs/sdk/src/stream/submit-coordinator.ts
+++ b/libs/sdk/src/stream/submit-coordinator.ts
@@ -302,10 +302,6 @@ export class SubmitCoordinator<
     // returns (see `#startDeferredRootPump` calls below).
     const thread = this.#ensureThread(currentThreadId, wasSelfCreated);
     const activeThreadId = currentThreadId;
-    // Wait for the root subscription to be live; otherwise the
-    // dispatch could resolve before we're listening for events and
-    // we'd miss the terminal that ends the run.
-    await this.#waitForRootPumpReady();
 
     const strategy = options?.multitaskStrategy ?? "rollback";
     // `wasSelfCreated` short-circuit: when this submit just minted a
@@ -336,9 +332,9 @@ export class SubmitCoordinator<
     const abort = new AbortController();
     this.#runAbort = abort;
 
-    // Optimistically clear interrupts/error and flip loading. The
-    // root pump's lifecycle listener will re-flip these as the run
-    // terminates.
+    // Claim the in-flight slot before awaiting the root pump so
+    // concurrent `enqueue` submits in the same tick observe
+    // `hasActiveRun` and land in {@link queueStore}.
     this.#rootStore.setState((s) => ({
       ...s,
       interrupts: [],
@@ -346,6 +342,11 @@ export class SubmitCoordinator<
       error: undefined,
       isLoading: true,
     }));
+
+    // Wait for the root subscription to be live; otherwise the
+    // dispatch could resolve before we're listening for events and
+    // we'd miss the terminal that ends the run.
+    await this.#waitForRootPumpReady();
 
     const boundConfig = bindThreadConfig(options?.config, currentThreadId);
     // Subscribe to the next terminal *before* dispatching so a fast


### PR DESCRIPTION
## Summary
- Fix a race in `SubmitCoordinator.submit()` where `multitaskStrategy: "enqueue"` follow-ups fired in the same tick as the first dispatch could miss `hasActiveRun` and skip the client `queueStore`.
- Claim the in-flight slot (`#runAbort`, `isLoading`) before `waitForRootPumpReady()` so concurrent enqueues are recorded client-side and drain sequentially as intended.
- Add a regression test for same-tick enqueue behavior.
