### PR TITLE
fix(sdk): surface resumed run failures on stream.error

### DIFF
--- a/.changeset/fix-respond-resume-stream-error.md
+++ b/.changeset/fix-respond-resume-stream-error.md
@@ -1,0 +1,11 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): surface resumed run failures on stream.error
+
+Route `respond()` and `respondAll()` through a coordinator dispatch path that
+writes the reactive `rootStore.error` slot when a resumed run reaches a failed
+terminal or when `input.respond` dispatch fails, matching submit() behavior so
+framework consumers (e.g. API-key retry UIs) observe resume failures via
+`stream.error` instead of only `isLoading` transitions.

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -1100,4 +1100,162 @@ describe("StreamController", () => {
 
     await controller.dispose();
   });
+
+  it("respond() surfaces a failed resumed run on rootStore.error", async () => {
+    let onEvent: ((event: Event) => void) | undefined;
+    const respondInput = vi.fn(async () => undefined);
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        onEvent = listener;
+        return vi.fn();
+      }),
+      close: vi.fn(async () => undefined),
+      interrupts: [
+        { interruptId: "int-1", payload: { prompt: "Approve?" }, namespace: [] },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {} })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, { prompt: string }>({
+      assistantId: "interrupt_graph",
+      client: client as never,
+      threadId: "thread-1",
+    });
+    await controller.hydrationPromise;
+    onEvent?.(inputRequestedEvent("int-1", { prompt: "Approve?" }));
+
+    await controller.respond({ approved: true });
+
+    // The resumed run later fails (e.g. a missing model key surfaced after
+    // the user approved the interrupt). respond() dispatches the resume
+    // directly rather than via submit(), so without the background terminal
+    // watch this `failed` lifecycle would only flip isLoading and never
+    // populate the reactive rootStore.error slot.
+    onEvent?.({
+      type: "event",
+      event_id: "lifecycle-failed-2",
+      seq: 2,
+      method: "lifecycle",
+      params: {
+        namespace: [],
+        timestamp: 0,
+        data: { event: "failed", error: "missing OPENAI_API_KEY" },
+      },
+    } as Event);
+
+    await waitForExpectation(() => {
+      expect(
+        (controller.rootStore.getSnapshot().error as Error | undefined)?.message
+      ).toBe("missing OPENAI_API_KEY");
+    });
+
+    await controller.dispose();
+  });
+
+  it("respond() surfaces an input.respond dispatch failure on rootStore.error", async () => {
+    let onEvent: ((event: Event) => void) | undefined;
+    const dispatchError = new Error("network down");
+    const respondInput = vi.fn(async () => {
+      throw dispatchError;
+    });
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        onEvent = listener;
+        return vi.fn();
+      }),
+      close: vi.fn(async () => undefined),
+      interrupts: [
+        { interruptId: "int-1", payload: { prompt: "Approve?" }, namespace: [] },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {} })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, { prompt: string }>({
+      assistantId: "interrupt_graph",
+      client: client as never,
+      threadId: "thread-1",
+    });
+    await controller.hydrationPromise;
+    onEvent?.(inputRequestedEvent("int-1", { prompt: "Approve?" }));
+
+    await expect(controller.respond({ approved: true })).rejects.toThrow(
+      "network down"
+    );
+    expect(controller.rootStore.getSnapshot().error).toBe(dispatchError);
+
+    await controller.dispose();
+  });
+
+  it("respondAll() surfaces a failed batched resume on rootStore.error", async () => {
+    let onEvent: ((event: Event) => void) | undefined;
+    const respondInput = vi.fn(async () => undefined);
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        onEvent = listener;
+        return vi.fn();
+      }),
+      close: vi.fn(async () => undefined),
+      interrupts: [
+        { interruptId: "int-1", payload: {}, namespace: [] },
+        { interruptId: "int-2", payload: {}, namespace: [] },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {} })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, unknown>({
+      assistantId: "human-in-the-loop",
+      client: client as never,
+      threadId: "thread-1",
+    });
+    await controller.hydrationPromise;
+
+    await controller.respondAll({
+      "int-1": { approved: true },
+      "int-2": { approved: false },
+    });
+
+    onEvent?.({
+      type: "event",
+      event_id: "lifecycle-failed-2",
+      seq: 2,
+      method: "lifecycle",
+      params: {
+        namespace: [],
+        timestamp: 0,
+        data: { event: "failed", error: "tool authorization rejected" },
+      },
+    } as Event);
+
+    await waitForExpectation(() => {
+      expect(
+        (controller.rootStore.getSnapshot().error as Error | undefined)?.message
+      ).toBe("tool authorization rejected");
+    });
+
+    await controller.dispose();
+  });
 });

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -1101,6 +1101,86 @@ describe("StreamController", () => {
     await controller.dispose();
   });
 
+  it("respond() ignores stale interrupted before resumed run running", async () => {
+    let onEvent: ((event: Event) => void) | undefined;
+    let releaseRespondInput!: () => void;
+    const respondInput = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseRespondInput = resolve;
+        })
+    );
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        onEvent = listener;
+        return vi.fn();
+      }),
+      close: vi.fn(async () => undefined),
+      interrupts: [
+        { interruptId: "int-1", payload: { prompt: "Approve?" }, namespace: [] },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {} })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, { prompt: string }>({
+      assistantId: "interrupt_graph",
+      client: client as never,
+      threadId: "thread-1",
+    });
+    await controller.hydrationPromise;
+    onEvent?.(inputRequestedEvent("int-1", { prompt: "Approve?" }));
+
+    const respondPromise = controller.respond({ approved: true });
+
+    // Stale `interrupted` from the run being resumed (can land after
+    // input.requested but before respondInput's #prepareForNextRun).
+    onEvent?.({
+      type: "event",
+      event_id: "lifecycle-interrupted-stale",
+      seq: 2,
+      method: "lifecycle",
+      params: {
+        namespace: [],
+        timestamp: 0,
+        data: { event: "interrupted" },
+      },
+    } as Event);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(controller.rootStore.getSnapshot().error).toBeUndefined();
+
+    releaseRespondInput();
+    await respondPromise;
+
+    onEvent?.({
+      type: "event",
+      event_id: "lifecycle-failed-3",
+      seq: 3,
+      method: "lifecycle",
+      params: {
+        namespace: [],
+        timestamp: 0,
+        data: { event: "failed", error: "missing OPENAI_API_KEY" },
+      },
+    } as Event);
+
+    await waitForExpectation(() => {
+      expect(
+        (controller.rootStore.getSnapshot().error as Error | undefined)?.message
+      ).toBe("missing OPENAI_API_KEY");
+    });
+
+    await controller.dispose();
+  });
+
   it("respond() surfaces a failed resumed run on rootStore.error", async () => {
     let onEvent: ((event: Event) => void) | undefined;
     const respondInput = vi.fn(async () => undefined);

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -293,6 +293,8 @@ export class StreamController<
       },
       waitForRootPumpReady: () => this.#rootPumpReady,
       awaitNextTerminal: (signal) => this.#awaitNextTerminal(signal),
+      awaitResumedRunTerminal: (signal) =>
+        this.#awaitResumedRunTerminal(signal),
       onSubmitStart: () => {
         // Clear the hydrate-window allowlist so genuinely-new live
         // interrupts on the just-started run aren't filtered. Bump
@@ -1614,8 +1616,38 @@ export class StreamController<
     event: "completed" | "failed" | "interrupted" | "aborted";
     error?: string;
   }> {
+    return this.#awaitRootTerminal(signal, { skipInterruptedUntilRunning: false });
+  }
+
+  /**
+   * Resolve on the resumed run's root terminal lifecycle.
+   *
+   * Unlike {@link #awaitNextTerminal}, ignores `interrupted` events until a
+   * root `running` lifecycle has been observed. Headless-tool flows can emit
+   * a stale `interrupted` for the run being resumed after `input.requested`
+   * but before `respondInput` calls `#prepareForNextRun`; accepting that
+   * terminal would unsubscribe the watcher before the resumed run's `failed`
+   * terminal arrives.
+   */
+  #awaitResumedRunTerminal(signal: AbortSignal): Promise<{
+    event: "completed" | "failed" | "interrupted" | "aborted";
+    error?: string;
+  }> {
+    return this.#awaitRootTerminal(signal, {
+      skipInterruptedUntilRunning: true,
+    });
+  }
+
+  #awaitRootTerminal(
+    signal: AbortSignal,
+    options: { skipInterruptedUntilRunning: boolean }
+  ): Promise<{
+    event: "completed" | "failed" | "interrupted" | "aborted";
+    error?: string;
+  }> {
     return new Promise((resolve) => {
       let settled = false;
+      let sawRunning = false;
       function finish(result: {
         event: "completed" | "failed" | "interrupted" | "aborted";
         error?: string;
@@ -1636,6 +1668,10 @@ export class StreamController<
           event?: string;
           error?: string;
         };
+        if (lifecycle?.event === "running") {
+          sawRunning = true;
+          return;
+        }
         if (lifecycle?.event === "completed") {
           setTimeout(() => finish({ event: "completed" }), 0);
         } else if (lifecycle?.event === "failed") {
@@ -1644,6 +1680,12 @@ export class StreamController<
             0
           );
         } else if (lifecycle?.event === "interrupted") {
+          if (
+            options.skipInterruptedUntilRunning &&
+            !sawRunning
+          ) {
+            return;
+          }
           setTimeout(() => finish({ event: "interrupted" }), 0);
         }
       };

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -756,15 +756,24 @@ export class StreamController<
     if (resolved == null) {
       throw new Error("No pending interrupt to respond to.");
     }
+    const thread = this.#thread;
     try {
-      await this.#thread.respondInput({
-        namespace: resolved.namespace,
-        interrupt_id: resolved.interruptId,
-        response: normalizeHitlResponseForServer(response),
-        config: options?.config,
-        metadata: options?.metadata,
+      // Route through the coordinator so a resumed run that fails (e.g. a
+      // missing model key surfaced after the user answers) lands in the
+      // reactive `rootStore.error` slot, exactly like a `submit()` failure.
+      // The dispatch (`respondInput` + interrupt-resolved bookkeeping) is
+      // what's awaited; the resumed run's terminal is watched in the
+      // background (see {@link SubmitCoordinator.dispatchResume}).
+      await this.#submitter.dispatchResume(async () => {
+        await thread.respondInput({
+          namespace: resolved.namespace,
+          interrupt_id: resolved.interruptId,
+          response: normalizeHitlResponseForServer(response),
+          config: options?.config,
+          metadata: options?.metadata,
+        });
+        this.#markInterruptResolvedInRootStore(resolved.interruptId);
       });
-      this.#markInterruptResolvedInRootStore(resolved.interruptId);
     } catch (error) {
       if (this.#disposed && isAbortLikeError(error)) {
         return;
@@ -825,7 +834,8 @@ export class StreamController<
     if (entries.length === 0) {
       throw new Error("respondAll() requires at least one response.");
     }
-    const pending = this.#thread.interrupts;
+    const thread = this.#thread;
+    const pending = thread.interrupts;
     const responses = entries.map(([interruptId, response]) => ({
       interrupt_id: interruptId,
       response: normalizeHitlResponseForServer(response),
@@ -833,14 +843,19 @@ export class StreamController<
         ?.namespace ?? [...ROOT_NAMESPACE],
     }));
     try {
-      await this.#thread.respondInput({
-        responses,
-        config: options?.config,
-        metadata: options?.metadata,
+      // See `respond()` — route through the coordinator so the single run
+      // that services the batched resume surfaces failures on the reactive
+      // `rootStore.error` slot.
+      await this.#submitter.dispatchResume(async () => {
+        await thread.respondInput({
+          responses,
+          config: options?.config,
+          metadata: options?.metadata,
+        });
+        for (const { interrupt_id: interruptId } of responses) {
+          this.#markInterruptResolvedInRootStore(interruptId);
+        }
       });
-      for (const { interrupt_id: interruptId } of responses) {
-        this.#markInterruptResolvedInRootStore(interruptId);
-      }
     } catch (error) {
       if (this.#disposed && isAbortLikeError(error)) {
         return;

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -1616,7 +1616,9 @@ export class StreamController<
     event: "completed" | "failed" | "interrupted" | "aborted";
     error?: string;
   }> {
-    return this.#awaitRootTerminal(signal, { skipInterruptedUntilRunning: false });
+    return this.#awaitRootTerminal(signal, {
+      skipInterruptedUntilRunning: false,
+    });
   }
 
   /**
@@ -1680,10 +1682,7 @@ export class StreamController<
             0
           );
         } else if (lifecycle?.event === "interrupted") {
-          if (
-            options.skipInterruptedUntilRunning &&
-            !sawRunning
-          ) {
+          if (options.skipInterruptedUntilRunning && !sawRunning) {
             return;
           }
           setTimeout(() => finish({ event: "interrupted" }), 0);

--- a/libs/sdk/src/stream/submit-coordinator.test.ts
+++ b/libs/sdk/src/stream/submit-coordinator.test.ts
@@ -179,6 +179,7 @@ function makeHarness(initial: { threadId?: string | null } = {}): Harness {
     abandonDeferredRootPump,
     waitForRootPumpReady: () => Promise.resolve(),
     awaitNextTerminal,
+    awaitResumedRunTerminal: awaitNextTerminal,
     onRunStart,
     onRunCreated,
     onRunCompleted,

--- a/libs/sdk/src/stream/submit-coordinator.ts
+++ b/libs/sdk/src/stream/submit-coordinator.ts
@@ -480,6 +480,83 @@ export class SubmitCoordinator<
   }
 
   /**
+   * Surface a *resumed* run's failure the same way {@link submit} surfaces
+   * a fresh run's failure — by writing it to the reactive
+   * {@link RootSnapshot.error} slot.
+   *
+   * `respond()` / `respondAll()` dispatch their `input.respond` command on
+   * the controller directly (they target a specific interrupt, so they
+   * cannot go through {@link submit}, which only does `run.start`). The
+   * resumed run therefore never passed through the submit lifecycle that
+   * populates `rootStore.error` — only the persistent lifecycle listener
+   * observed it, and that listener drives `isLoading` alone. Without this,
+   * a resumed run that fails (e.g. a missing model key surfaced after the
+   * user approves an interrupt) would flip `isLoading` back to `false`
+   * with `error` left untouched, so `stream.error`-driven UIs (error
+   * banners, API-key retry prompts) would silently miss it.
+   *
+   * The `dispatch` thunk is awaited, so a dispatch failure rejects the
+   * caller's `respond()` *and* lands in `rootStore.error`. The resumed
+   * run's terminal is watched in the **background** so the returned promise
+   * still settles on dispatch — preserving the resume command's
+   * resolve-on-dispatch contract (and avoiding a hang when no terminal is
+   * ever emitted, e.g. in unit tests).
+   *
+   * Reuses the shared {@link #runAbort} slot, so `stop()`, `dispose()`, and
+   * a rollback `submit()` all cancel the terminal watch (no spurious error
+   * on user-initiated cancel) and treat the resumed run as the active run.
+   *
+   * @param dispatch - Sends the `input.respond` command (and marks the
+   *   targeted interrupt resolved). Invoked after the terminal watch is
+   *   armed.
+   */
+  async dispatchResume(dispatch: () => Promise<void>): Promise<void> {
+    if (this.#getDisposed()) return;
+
+    // Rollback any run still tracked as active (mirrors submit()), then
+    // claim the in-flight slot so stop()/dispose()/a concurrent submit
+    // cancels the terminal watch armed below.
+    this.#runAbort?.abort();
+    const abort = new AbortController();
+    this.#runAbort = abort;
+
+    // Optimistically clear a stale error from a previous run, matching
+    // submit()'s reset, so the resume starts from a clean error slot.
+    this.#rootStore.setState((s) =>
+      s.error === undefined ? s : { ...s, error: undefined }
+    );
+
+    const reportError = (error: unknown): void => {
+      if (abort.signal.aborted) return;
+      this.#rootStore.setState((s) => ({ ...s, error }));
+    };
+
+    // Subscribe to the next terminal *before* dispatching so a fast run's
+    // `failed` event can't race us. Watched in the background — we never
+    // gate the returned promise on the resumed run's terminal.
+    const terminalPromise = this.#awaitNextTerminal(abort.signal);
+    void terminalPromise.then((terminal) => {
+      if (this.#runAbort === abort) this.#runAbort = undefined;
+      if (terminal.event === "failed" && !abort.signal.aborted) {
+        reportError(
+          new Error(terminal.error ?? "Run failed with no error message")
+        );
+      }
+      // Drain any submission enqueued while the resumed run was active.
+      setTimeout(() => this.#drainQueue(), 0);
+    });
+
+    try {
+      await dispatch();
+    } catch (error) {
+      // The `input.respond` send itself failed, before any run started.
+      reportError(error);
+      if (this.#runAbort === abort) this.#runAbort = undefined;
+      throw error;
+    }
+  }
+
+  /**
    * Abort the current run (if any) and force `isLoading=false`.
    *
    * Client-side only — server-side cancel is handled by

--- a/libs/sdk/src/stream/submit-coordinator.ts
+++ b/libs/sdk/src/stream/submit-coordinator.ts
@@ -170,6 +170,13 @@ export class SubmitCoordinator<
   readonly #waitForRootPumpReady: () => Promise<void> | undefined;
   /** Resolves on the next root terminal lifecycle (or on abort). */
   readonly #awaitNextTerminal: (signal: AbortSignal) => Promise<TerminalResult>;
+  /**
+   * Resolves on the resumed run's terminal, skipping stale `interrupted`
+   * events from the run being resumed (see {@link dispatchResume}).
+   */
+  readonly #awaitResumedRunTerminal: (
+    signal: AbortSignal
+  ) => Promise<TerminalResult>;
   /** Called once at the start of every {@link submit} invocation. */
   readonly #onSubmitStart: () => void;
   /** Marks that a local run dispatch is now active. */
@@ -208,6 +215,7 @@ export class SubmitCoordinator<
     abandonDeferredRootPump: () => void;
     waitForRootPumpReady: () => Promise<void> | undefined;
     awaitNextTerminal: (signal: AbortSignal) => Promise<TerminalResult>;
+    awaitResumedRunTerminal: (signal: AbortSignal) => Promise<TerminalResult>;
     onSubmitStart?: () => void;
     onRunStart?: () => void;
     onRunCreated?: (runId: string) => void;
@@ -228,6 +236,7 @@ export class SubmitCoordinator<
     this.#abandonDeferredRootPump = params.abandonDeferredRootPump;
     this.#waitForRootPumpReady = params.waitForRootPumpReady;
     this.#awaitNextTerminal = params.awaitNextTerminal;
+    this.#awaitResumedRunTerminal = params.awaitResumedRunTerminal;
     this.#onSubmitStart = params.onSubmitStart ?? (() => undefined);
     this.#onRunStart = params.onRunStart ?? (() => undefined);
     this.#onRunCreated = params.onRunCreated ?? (() => undefined);
@@ -506,6 +515,12 @@ export class SubmitCoordinator<
    * a rollback `submit()` all cancel the terminal watch (no spurious error
    * on user-initiated cancel) and treat the resumed run as the active run.
    *
+   * The terminal watch uses {@link #awaitResumedRunTerminal}, which skips
+   * stale `interrupted` terminals from the run being resumed (they can reach
+   * the pump after `input.requested` but before `respondInput` calls
+   * `#prepareForNextRun`) and only accepts a later `interrupted` once a
+   * root `running` lifecycle for the resumed run has been observed.
+   *
    * @param dispatch - Sends the `input.respond` command (and marks the
    *   targeted interrupt resolved). Invoked after the terminal watch is
    *   armed.
@@ -531,10 +546,12 @@ export class SubmitCoordinator<
       this.#rootStore.setState((s) => ({ ...s, error }));
     };
 
-    // Subscribe to the next terminal *before* dispatching so a fast run's
-    // `failed` event can't race us. Watched in the background — we never
-    // gate the returned promise on the resumed run's terminal.
-    const terminalPromise = this.#awaitNextTerminal(abort.signal);
+    // Subscribe to the resumed run's terminal *before* dispatching so a fast
+    // `failed` can't race us. Unlike `#awaitNextTerminal`, the resume watcher
+    // ignores stale `interrupted` events until root `running` is seen.
+    // Watched in the background — we never gate the returned promise on the
+    // resumed run's terminal.
+    const terminalPromise = this.#awaitResumedRunTerminal(abort.signal);
     void terminalPromise.then((terminal) => {
       if (this.#runAbort === abort) this.#runAbort = undefined;
       if (terminal.event === "failed" && !abort.signal.aborted) {


### PR DESCRIPTION
## Summary
- Route `respond()` / `respondAll()` through `SubmitCoordinator.dispatchResume()` so resumed runs write failures to the reactive `rootStore.error` slot (same path `submit()` uses), instead of only toggling `isLoading` via the lifecycle listener.
- Arm a background terminal watch before dispatch so `respond()` still resolves on `input.respond` while a later `failed` lifecycle populates `stream.error`.
- Add controller tests for failed resume, dispatch failure, and batched `respondAll()` failure.
