### PR TITLE
docs(sdk): update event based streaming migration guide

### DIFF
--- a/libs/sdk-angular/docs/v1-migration.md
+++ b/libs/sdk-angular/docs/v1-migration.md
@@ -1,8 +1,8 @@
 # Migrating to `@langchain/angular` v1
 
 This guide walks application authors through the jump from the pre-v1
-`injectStream` / `useStream` API to the v2-native `injectStream` that
-ships with `@langchain/angular@^1.0.0`.
+`injectStream` / `useStream` API to the `injectStream` injector built for
+**new event-based streaming**, which ships with `@langchain/angular@^1.0.0`.
 
 Short version: **the `injectStream` import name does not change, but
 the return shape, option bag, and protocol semantics do.** Most chat
@@ -33,14 +33,14 @@ covered in their own sections.
 
 ## 1. Why the breaking change?
 
-The legacy `injectStream` was built against the v1 streaming protocol
+The legacy `injectStream` was built against the legacy streaming protocol
 and accreted a large surface of opt-in callbacks (`onUpdateEvent`,
 `onCustomEvent`, `onMetadataEvent`, `onStop`, …) plus derived state
 (`history`, `branch`, `experimental_branchTree`,
 `getMessagesMetadata`, `joinStream`) that had to be recomputed on every
 change-detection cycle.
 
-The v1 injector targets **protocol v2**. In practice that means:
+The v1 package injector uses **new event-based streaming**. In practice that means:
 
 - **Selector-based subscriptions.** Namespaced data (subagent
   messages, subgraph tool calls, media) is opened *only* when a
@@ -70,11 +70,15 @@ The net effect is a smaller, faster, more predictable API.
 For the typical chat app, this is the whole migration. Deeper changes
 are flagged in the later sections.
 
-- [ ] **Upgrade** `@langchain/angular` to `^1.0.0`.
+- [ ] **Upgrade** `@langchain/angular` to `^1.0.0` and
+      `@langchain/langgraph-sdk` to the matching new event-based streaming
+      runtime.
 - [ ] **Imports stay the same** — `import { injectStream } from "@langchain/angular"`
-      now resolves to the v2-native injector. A framework-agnostic
-      `useStream` factory is also exported for library code / advanced
-      callers (see §11); prefer `injectStream` in component code.
+      now resolves to the injector built for new event-based streaming.
+      `useStreamExperimental` is
+      not exported from this package. A framework-agnostic `useStream`
+      factory is also exported for library code / advanced callers (see §11);
+      prefer `injectStream` in component code.
 - [ ] **Remove these option-bag fields** (see §3):
       `onError`, `onFinish`, `onUpdateEvent`, `onCustomEvent`,
       `onMetadataEvent`, `onStop`, `fetchStateHistory`,
@@ -267,11 +271,11 @@ await this.stream.submit({ messages: new HumanMessage("hi") });
 | `context` | Fold into `config.configurable`. |
 | `checkpoint: { checkpoint_id }` | `forkFrom: "cp_123"` (direct checkpoint id string). The earlier non-functional `forkFrom: { checkpointId }` object form was removed. |
 | `command: { resume }` | Use `stream.respond()` instead. |
-| `interruptBefore`, `interruptAfter` | Drop — not supported in v2. |
+| `interruptBefore`, `interruptAfter` | Drop — not supported with new event-based streaming. |
 | `metadata` | Unchanged. |
 | `multitaskStrategy` | Unchanged. `"rollback"`, `"reject"`, and `"enqueue"` are honoured client-side today; `"interrupt"` falls back to `"rollback"` pending server support. |
 | `onCompletion` | Use the hook-level `onCompleted` option for run-completion side effects. |
-| `onDisconnect`, `feedbackKeys`, `streamMode`, `runId`, `optimisticValues`, `streamSubgraphs`, `streamResumable`, `checkpointDuring` | Drop from submit. Disconnect/cancel policy now lives on `stop()` / `disconnect()` instead of per-submit options (§5.3). Other fields map to protocol-v2 defaults. |
+| `onDisconnect`, `feedbackKeys`, `streamMode`, `runId`, `optimisticValues`, `streamSubgraphs`, `streamResumable`, `checkpointDuring` | Drop from submit. Disconnect/cancel policy now lives on `stop()` / `disconnect()` instead of per-submit options (§5.3). Other fields map to new event-based streaming defaults. |
 | **(new submit option)** `onError` | Per-submit fire-and-forget error callback. There is no hook-level `onError` option; transport-level `stream.error()` updates still happen in parallel. |
 | **(new)** `threadId` | Per-submit thread override. Rebinds the controller to that thread before dispatching and keeps it bound until the `threadId` option changes again. |
 
@@ -556,13 +560,15 @@ It returns the same `StreamApi` shape as `injectStream`.
 
 ## 12. Type helpers
 
-| Legacy | v1 |
-|---|---|
-| `UseStream<T>` | `StreamApi<T>` for Angular code. |
-| `UseStreamOptions<T>` | `UseStreamOptions<T>` — now a discriminated union of the LGP and custom-adapter branches. |
-| `UseStreamTransport` | `AgentServerAdapter` (re-exported from `@langchain/angular` and `@langchain/langgraph-sdk`). |
-| `CustomStreamTransport` | Dropped. |
-| `StreamOrchestrator` | Dropped. |
+| Legacy                         | v1                                                                                      |
+| ------------------------------ | --------------------------------------------------------------------------------------- |
+| `UseStream<T>`                 | `StreamApi<T>` / `UseStreamReturn<T>` for Angular code (prefer `StreamApi<T>`).         |
+| `UseStreamOptions<State, Bag>` | `UseStreamOptions<State>` — discriminated union of the LGP and custom-adapter branches. |
+| `UseStreamTransport`           | `AgentServerAdapter` (re-exported from `@langchain/angular` and `@langchain/langgraph-sdk`). |
+| `CustomStreamTransport`        | Dropped.                                                                                |
+| `StreamOrchestrator`           | Dropped.                                                                                |
+| —                              | `AnyStream` — type-erased handle (`UseStreamReturn<any, any, any>`) for prop-drilling. |
+| —                              | `InjectSubmissionQueueReturn` — return shape of `injectSubmissionQueue(stream)`.        |
 
 `StreamApi<T>` and `UseStreamResult<T>` are aliases for the same stream
 handle. Prefer `StreamApi<T>` when writing Angular components,

--- a/libs/sdk-react/docs/v1-migration.md
+++ b/libs/sdk-react/docs/v1-migration.md
@@ -2,8 +2,9 @@
 
 This guide walks application authors through the jump from the pre-v1
 `useStream` hook (previously shipped as `@langchain/langgraph-sdk/react`
-and later re-exported as `@langchain/react`) to the v2-native `useStream`
-that ships with `@langchain/react` **v1**.
+and later re-exported as `@langchain/react`) to the `useStream` hook built
+for **new event-based streaming**, which ships with `@langchain/react`
+**v1**.
 
 Short version: **the `useStream` import name does not change, but the
 return shape, option bag, and protocol semantics do.** Most chat apps
@@ -35,7 +36,7 @@ dedicated sections.
 
 ## 1. Why the breaking change?
 
-The legacy `useStream` was built against the v1 streaming protocol and
+The legacy `useStream` was built against the legacy streaming protocol and
 accreted a large surface of opt-in callbacks (`onUpdateEvent`,
 `onCustomEvent`, `onMetadataEvent`, `onLangChainEvent`, `onDebugEvent`,
 `onCheckpointEvent`, `onTaskEvent`, `onToolEvent`, `onStop`, …) plus
@@ -43,7 +44,7 @@ derived state (`history`, `branch`, `experimental_branchTree`,
 `getMessagesMetadata`, `joinStream`) that had to be recomputed on every
 render.
 
-The v1 hook targets protocol v2. In practice that means:
+The v1 package hook uses new event-based streaming. In practice that means:
 
 - **Selector-based subscriptions.** Namespaced data (subagent messages,
   subgraph tool calls, media) is opened _only_ when a component actually
@@ -74,11 +75,12 @@ For the typical app this is the whole migration. Deeper changes are
 flagged in the later sections.
 
 - [ ] **Upgrade** `@langchain/react` to `^1.0.0` and
-      `@langchain/langgraph-sdk` to the matching v2 runtime.
+      `@langchain/langgraph-sdk` to the matching new event-based streaming
+      runtime.
 - [ ] **Imports stay the same** — `import { useStream } from "@langchain/react"`
-      now resolves to the v2-native hook. `useStreamExperimental` is
-      kept as an alias for one minor for call sites that were on the
-      preview; new code should import `useStream`.
+      now resolves to the hook built for new event-based streaming.
+      `useStreamExperimental` is not
+      exported from this package.
 - [ ] **Remove these option-bag fields** (they are gone; see §3):
       `onError`, `onFinish`, `onUpdateEvent`, `onCustomEvent`,
       `onMetadataEvent`, `onLangChainEvent`, `onDebugEvent`,
@@ -150,14 +152,14 @@ These keep working without changes:
 | ------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `onError` (hook-level)                                                                                                                     | Read `stream.error` directly, or pass a per-submit `onError` via `submit(input, { onError })` — the v1 per-submit callback is fire-and-forget and scoped to the one submission it was passed to.                                                    |
 | `onFinish`                                                                                                                                 | Use `onCompleted` for imperative side effects, or derive render state from `isLoading` / `useValues(stream)`.                                                                                                                                       |
-| `onUpdateEvent`, `onCustomEvent`, `onMetadataEvent`, `onLangChainEvent`, `onDebugEvent`, `onCheckpointEvent`, `onTaskEvent`, `onToolEvent` | Drop. The v2 protocol delivers these as structured store updates; read them via selector hooks (`useChannel`, `useExtension`) when you genuinely need raw events.                                                                                   |
+| `onUpdateEvent`, `onCustomEvent`, `onMetadataEvent`, `onLangChainEvent`, `onDebugEvent`, `onCheckpointEvent`, `onTaskEvent`, `onToolEvent` | Drop. New event-based streaming delivers these as structured store updates; read them via selector hooks (`useChannel`, `useExtension`) when you genuinely need raw events.                                                                                   |
 | `onStop`                                                                                                                                   | Drop. Use `stream.stop()` to cancel the active run (default) or `stream.disconnect()` to leave the agent running server-side. See §5.3. |
 | `fetchStateHistory`                                                                                                                        | Drop. Fork/edit flows use `useMessageMetadata` + `submit({}, { forkFrom })` instead (§5).                                                                                                                                                           |
 | `reconnectOnMount`                                                                                                                         | Drop. Re-attach is automatic: remounting the hook with the same `threadId` attaches to the in-flight run.                                                                                                                                           |
 | `throttle`                                                                                                                                 | Drop. The hook batches state updates natively; call sites that need render throttling can memoize at the selector site.                                                                                                                             |
 | `thread`                                                                                                                                   | Drop. External thread managers should drive the hook by controlling `threadId` and `initialValues`.                                                                                                                                                 |
 | `filterSubagentMessages`                                                                                                                   | Drop. Subagent messages are already absent from `stream.messages`; they live on per-subagent selector hooks (§7).                                                                                                                                   |
-| `subagentToolNames`                                                                                                                        | Drop. Subagent classification is driven by protocol-v2 lifecycle events, not by a client-side tool-name list.                                                                                                                                       |
+| `subagentToolNames`                                                                                                                        | Drop. Subagent classification is driven by new event-based streaming lifecycle events, not by a client-side tool-name list.                                                                                                                                       |
 
 Any previously silent callback-based side effects should migrate into
 effects that watch the relevant projection:
@@ -283,7 +285,7 @@ reach for it unless you're typing an intermediate variable.
 | `context`                                                                                                                           | Drop — fold into `config.configurable`.                                                                                                                                   |
 | `checkpoint: { checkpoint_id }`                                                                                                     | `forkFrom: "cp_123"` (direct checkpoint id string). The earlier non-functional `forkFrom: { checkpointId }` object form was removed.                                      |
 | `command: { resume }`                                                                                                               | Use `stream.respond()` instead.                                                                                                                                           |
-| `interruptBefore`, `interruptAfter`                                                                                                 | Drop — not supported in v2.                                                                                                                                               |
+| `interruptBefore`, `interruptAfter`                                                                                                 | Drop — not supported with new event-based streaming.                                                                                                                                               |
 | `metadata`                                                                                                                          | Unchanged.                                                                                                                                                                |
 | `multitaskStrategy`                                                                                                                 | Unchanged. `"rollback"` (default), `"reject"`, and `"enqueue"` are honoured client-side today; `"interrupt"` falls back to `"rollback"` pending server support (see §13). |
 | `onCompletion`                                                                                                                      | Use the hook-level `onCompleted` option for run-completion side effects.                                                                                                  |
@@ -562,7 +564,7 @@ class FetchStreamTransport implements UseStreamTransport { ... }
 
 v1 replaces this with `AgentServerAdapter`, a richer interface that
 owns the **entire** transport — both commands and the event stream —
-and matches the v2 protocol's request shape. There is a convenience
+and matches the new event-based streaming protocol's request shape. There is a convenience
 class `HttpAgentServerAdapter` that covers the common case (SSE + WS
 with injectable `fetch` / `webSocketFactory` / `defaultHeaders`).
 
@@ -670,7 +672,8 @@ union; pass `transport: adapter` to route through a custom
 
 ## 11. `useSuspenseStream`
 
-`useSuspenseStream` is now a slim v1-native port built on top of
+`useSuspenseStream` is now a slim port aligned with the v1 package API,
+built on top of
 `useStream` and the controller's `hydrationPromise`. The legacy
 implementation prefetched `threads.getHistory(threadId)` into an
 external `SuspenseCache`; v1 drops `history` entirely and uses the
@@ -741,7 +744,7 @@ prop-drilling a stream handle:
 | Helper                                                                                                                 | Use                                                                                                                              |
 | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `UseStreamReturn<T>`                                                                                                   | The fully-resolved return type of `useStream<T>`. Prop-drill as `{ stream: UseStreamReturn<typeof agent> }`.                     |
-| `AnyStream`                                                                                                            | Type-erased handle (`UseStreamExperimentalReturn<any, any, any>`) for components that only forward the stream to selector hooks. |
+| `AnyStream`                                                                                                            | Type-erased handle (`UseStreamReturn<any, any, any>`) for components that only forward the stream to selector hooks. |
 | `InferStateType<T>`                                                                                                    | Unwraps a compiled graph / agent brand / agent tool array into its state shape.                                                  |
 | `InferToolCalls<T>`                                                                                                    | Derives a discriminated union of tool-call shapes from tools array, agent brand, or an explicit shape.                           |
 | `InferSubagentStates<T>`                                                                                               | `{ name: State, … }` map derived from a DeepAgent brand.                                                                         |
@@ -749,7 +752,7 @@ prop-drilling a stream handle:
 | `StreamSubmitOptions<State, Configurable>`                                                                             | Options shape accepted by `submit()`.                                                                                            |
 | `AgentServerAdapter`                                                                                                   | Interface for custom transports (see §9).                                                                                        |
 | `HttpAgentServerAdapter`, `HttpAgentServerAdapterOptions`                                                              | Convenience adapter (see §9).                                                                                                    |
-| `UseStreamExperimentalOptions`, `AgentServerOptions`, `CustomAdapterOptions`                                           | Discriminated options union; rarely needed at call sites.                                                                        |
+| `UseStreamOptions`, `AgentServerOptions`, `CustomAdapterOptions`                                                       | Discriminated options union; rarely needed at call sites.                                                                        |
 | `SelectorTarget`, `SubagentDiscoverySnapshot`, `SubgraphDiscoverySnapshot`                                             | For components that render per-subagent/subgraph views.                                                                          |
 | `AssembledToolCall`, `ToolCallStatus`                                                                                  | For rendering tool-call UI.                                                                                                      |
 | `MessageMetadata`, `MessageMetadataMap`, `UseSubmissionQueueReturn`, `SubmissionQueueEntry`, `SubmissionQueueSnapshot` | Companion-hook return shapes.                                                                                                    |
@@ -778,11 +781,11 @@ Migrate each call site to the v1 name:
 | Legacy name                                 | v1 replacement                                                      |
 | ------------------------------------------- | ------------------------------------------------------------------- |
 | `UseStream<State, Bag>`                     | `UseStreamReturn<State>` (or `UseStreamReturn<typeof agent>`).      |
-| `UseStreamOptions<State, Bag>`              | `UseStreamExperimentalOptions<State>` (or just let the hook infer). |
+| `UseStreamOptions<State, Bag>`              | `UseStreamOptions<State>` (or just let the hook infer).            |
 | `UseStreamTransport`                        | `AgentServerAdapter` (§9).                                          |
 | `FetchStreamTransport`                      | `HttpAgentServerAdapter` (§9).                                      |
 | `GetToolCallsType<State>`                   | `InferToolCalls<typeof agent>`.                                     |
-| `UseSuspenseStream<…>`                      | `UseSuspenseStreamReturn<T>` (v1-native shape — see §11).           |
+| `UseSuspenseStream<…>`                      | `UseSuspenseStreamReturn<T>` (v1 package API shape — see §11).           |
 | `QueueEntry`, `QueueInterface`              | `SubmissionQueueEntry`, `UseSubmissionQueueReturn` (§6).            |
 | `SubagentStream`, `SubagentStreamInterface` | `SubagentDiscoverySnapshot` + `useMessages(stream, subagent)` (§7). |
 
@@ -851,7 +854,8 @@ concern; the React layer faithfully renders whatever the server sends.
 
 ### Q. We pinned `@langchain/langgraph-sdk` in app code. Do we need to bump it?
 
-Yes. `@langchain/react` v1 depends on the v2 stream runtime in
+Yes. `@langchain/react` v1 depends on the new event-based streaming
+runtime in
 `@langchain/langgraph-sdk`. Bumping the SDK is mandatory, but the
 public v1 type helpers (`InferStateType`, `AgentServerAdapter`, …)
 are re-exported from `@langchain/react` so app imports rarely need to
@@ -875,30 +879,25 @@ useStream<MyState, { InterruptType: MyInterrupt }>({ ... });
 useStream<MyState, MyInterrupt>({ ... });
 ```
 
-### Q. Is the `useStreamExperimental` name going away?
-
-Yes — but not in v1.0. `useStreamExperimental` is kept as a thin
-alias of `useStream` so apps that adopted the preview can bump to
-v1 without touching imports. It will be removed in the next minor;
-new code should import `useStream`.
-
 ### Q. Where did the legacy `useStream` / `FetchStreamTransport` surface go?
 
-The legacy source files (`stream.tsx`, `stream.lgp.tsx`,
-`stream.custom.tsx`, `types.tsx`, `suspense-stream.tsx`) and every
-legacy type re-export have been removed from `@langchain/react` v1.
-In particular:
+The pre-v1 hook implementations (`stream.tsx`, `stream.lgp.tsx`,
+`stream.custom.tsx`, `types.tsx`, and the old `useSuspenseStream`
+implementation) have been removed from `@langchain/react` v1. In
+particular:
 
 - `import { FetchStreamTransport } from "@langchain/react"` no longer
   resolves — use `HttpAgentServerAdapter` from the same package (§9).
 - The legacy type aliases (`UseStream`, `UseStreamOptions`,
   `UseStreamTransport`, `QueueEntry`, `SubagentStream`, …) are no
   longer re-exported; use the v1 names from §12.
-- `useSuspenseStream` is now a slim v1-native port (§11).
+- `useSuspenseStream` **is still exported** — it is a slim port aligned
+  with the v1 package API, built on `useStream` (§11), not the pre-v1
+  implementation.
 
 Apps that still need the legacy types mid-migration can import them
-directly from `@langchain/langgraph-sdk/ui`. No runtime code in the
-legacy surface remains in the `@langchain/react` bundle.
+directly from `@langchain/langgraph-sdk/ui`. No pre-v1 runtime code
+remains in the `@langchain/react` bundle.
 
 ### Q. Does `multitaskStrategy: "enqueue"` work today?
 

--- a/libs/sdk-svelte/docs/v1-migration.md
+++ b/libs/sdk-svelte/docs/v1-migration.md
@@ -1,10 +1,10 @@
 # Migrating from `@langchain/svelte` v0 to v1
 
-`@langchain/svelte` **v1** targets the v2 streaming protocol. The `useStream` import stays the same, but the option bag, return shape, and how you subscribe to scoped data all change. Most chat apps migrate in well under an hour.
+`@langchain/svelte` **v1** targets **new event-based streaming**. The `useStream` import stays the same, but the option bag, return shape, and how you subscribe to scoped data all change. Most chat apps migrate in well under an hour.
 
 ## Why the breaking change
 
-The v0 binding was built on the v1 protocol and accreted a large surface of opt-in callbacks (`onUpdateEvent`, `onCustomEvent`, `onDebugEvent`, `onCheckpointEvent`, …) and derived state (`history`, `branch`, `experimental_branchTree`, `activeSubagents`, `subagents`) that had to be recomputed on every update — whether or not any component was rendering it.
+The v0 binding was built on the legacy streaming protocol and accreted a large surface of opt-in callbacks (`onUpdateEvent`, `onCustomEvent`, `onDebugEvent`, `onCheckpointEvent`, …) and derived state (`history`, `branch`, `experimental_branchTree`, `activeSubagents`, `subagents`) that had to be recomputed on every update — whether or not any component was rendering it.
 
 v1 flips that around:
 
@@ -16,7 +16,10 @@ v1 flips that around:
 
 ## TL;DR checklist
 
-- [ ] Upgrade `@langchain/svelte` to `^1.0.0`.
+- [ ] Upgrade `@langchain/svelte` to `^1.0.0` and
+      `@langchain/langgraph-sdk` to the matching new event-based streaming
+      runtime.
+- [ ] Import `useStream` only — `useStreamExperimental` is not exported from this package.
 - [ ] Remove the following options — they are gone: `onFinish`, `onUpdateEvent`, `onCustomEvent`, `onMetadataEvent`, `onLangChainEvent`, `onDebugEvent`, `onCheckpointEvent`, `onTaskEvent`, `onStop`, `onError`, `fetchStateHistory`, `throttle`, `filterSubagentMessages`, `subagentToolNames`.
 - [ ] Replace `transport: new FetchStreamTransport(…)` with `transport: new HttpAgentServerAdapter(…)` from `@langchain/svelte` (or `@langchain/langgraph-sdk`). The adapter is bound to a concrete `threadId`.
 - [ ] Stop destructuring and reading the following from the return — they moved or were dropped: `branch`, `setBranch`, `history`, `experimental_branchTree`, `getMessagesMetadata`, `joinStream`, `switchThread`, `queue`, `activeSubagents`, `getSubagent`, `getSubagentsByType`, `getSubagentsByMessage`.
@@ -65,7 +68,7 @@ v1 flips that around:
 | `subagents`, `subgraphs`, `subgraphsByNode`                                     | **new** — discovery snapshots (namespaces). Use them as the `target` argument to selector composables                                                                 |
 | `respond(response, options?)` / `respondAll(responsesById, options?)`           | **new** — resume the agent after an interrupt (`respondAll` resumes several at the same checkpoint)                                                                    |
 | `getThread()`                                                                   | **new** — returns the bound `ThreadStream` for low-level protocol access                                                                                              |
-| `branch`, `setBranch`                                                           | removed — there is no global branch pointer in v2. Fork flows use `submit(input, { forkFrom })` and `parentCheckpointId` from `useMessageMetadata`. |
+| `branch`, `setBranch`                                                           | removed — there is no global branch pointer with new event-based streaming. Fork flows use `submit(input, { forkFrom })` and `parentCheckpointId` from `useMessageMetadata`. |
 | `history`, `experimental_branchTree`                                            | removed — pull history via the `Client` directly when needed                                                                                                          |
 | `getMessagesMetadata(msg)`                                                      | `useMessageMetadata(stream, () => msg.id)` → `{ parentCheckpointId }`                                                                                                 |
 | `joinStream(...)`                                                               | removed — `useStream` attaches automatically on mount                                                                                                                 |
@@ -194,3 +197,13 @@ until server-side interrupt semantics land.
 ```
 
 Each mounted `useMessages(stream, sub)` opens a ref-counted namespace subscription on demand and releases it on unmount.
+
+## Type helpers
+
+| Helper              | Use                                                                                                                              |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `UseStreamReturn<T>` | Fully-resolved return type of `useStream<T>`.                                                                                    |
+| `AnyStream`         | Type-erased handle (`UseStreamReturn<any, any, any>`) for components that only forward the stream to selector hooks.             |
+| `UseStreamOptions`  | Discriminated options union (LGP branch vs custom `AgentServerAdapter`); rarely needed at call sites.                            |
+| `InferStateType<T>` | Unwraps a compiled graph / agent brand into its state shape.                                                                     |
+| `UseSubmissionQueueReturn` | Return shape of `useSubmissionQueue(stream)` (`entries`, `size`, `cancel`, `clear`).                                      |

--- a/libs/sdk-vue/docs/v1-migration.md
+++ b/libs/sdk-vue/docs/v1-migration.md
@@ -1,8 +1,8 @@
 # Migrating to `@langchain/vue` v1
 
 This guide walks Vue application authors through the jump from the
-pre-v1 `useStream` composable to the v2-native `useStream` that ships
-with `@langchain/vue` **v1**.
+pre-v1 `useStream` composable to the `useStream` composable built for
+**new event-based streaming**, which ships with `@langchain/vue` **v1**.
 
 Short version: **the `useStream` import name does not change, but the
 return shape, option bag, and protocol semantics do.** Most chat apps
@@ -57,14 +57,14 @@ refs instead of React hooks).
 
 ## 1. Why the breaking change?
 
-The legacy `useStream` was built against the v1 streaming protocol and
+The legacy `useStream` was built against the legacy streaming protocol and
 accreted a large surface of opt-in callbacks (`onUpdateEvent`,
 `onCustomEvent`, `onMetadataEvent`, `onCheckpointEvent`, `onTaskEvent`,
 `onToolEvent`, `onStop`, …) plus derived state (`branch`,
 `experimental_branchTree`, `getMessagesMetadata`, `joinStream`,
 `switchThread`) that had to be recomputed on every render.
 
-The v1 composable targets protocol v2. In practice that means:
+The v1 package composable uses new event-based streaming. In practice that means:
 
 - **Selector-based subscriptions.** Namespaced data (subagent messages,
   subgraph tool calls, media) is opened *only* when a component
@@ -94,12 +94,18 @@ covers every scenario the legacy composable supported.
 For the typical app this is the whole migration. Deeper changes are
 flagged in the later sections.
 
-- [ ] **Upgrade** `@langchain/vue` to `^1.0.0` and `vue` to `^3.4`.
+- [ ] **Upgrade** `@langchain/vue` to `^1.0.0`, `vue` to `^3.4`, and
+      `@langchain/langgraph-sdk` to the matching new event-based streaming
+      runtime.
 - [ ] **Imports stay the same** — `import { useStream } from "@langchain/vue"`
-      now resolves to the v2-native composable.
+      now resolves to the composable built for new event-based streaming.
+      `useStreamExperimental` is
+      not exported from this package.
 - [ ] **Read reactive state via `.value`** (or directly in templates
-      where Vue auto-unwraps). `messages`, `values`, `toolCalls`,
-      `interrupts`, `isLoading`, `error`, `threadId` are all refs now.
+      where Vue auto-unwraps). Root fields are Vue refs:
+      `messages` / `values` / `toolCalls` / `interrupts` are
+      `ShallowRef`s; `isLoading`, `isThreadLoading`, `error`,
+      `threadId`, and `interrupt` are `ComputedRef`s.
 - [ ] **Remove these option-bag fields** (they are gone; see §3):
       `onError`, `onFinish`, `onUpdateEvent`, `onCustomEvent`,
       `onMetadataEvent`, `onLangChainEvent`, `onDebugEvent`,
@@ -166,14 +172,14 @@ These keep working without changes:
 | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `onError`                                                                                                                                  | Read `stream.error.value` directly, or pass a per-submit `onError` via `submit(input, { onError })` for a one-off side effect.                                          |
 | `onFinish`                                                                                                                                 | Derive from `isLoading` transitioning `true → false`, or observe the thread via `useValues(stream)`.                                                                    |
-| `onUpdateEvent`, `onCustomEvent`, `onMetadataEvent`, `onLangChainEvent`, `onDebugEvent`, `onCheckpointEvent`, `onTaskEvent`, `onToolEvent` | Drop. The v2 protocol delivers these as structured store updates; read them via selector composables (`useChannel`, `useExtension`) when you genuinely need raw events. |
+| `onUpdateEvent`, `onCustomEvent`, `onMetadataEvent`, `onLangChainEvent`, `onDebugEvent`, `onCheckpointEvent`, `onTaskEvent`, `onToolEvent` | Drop. New event-based streaming delivers these as structured store updates; read them via selector composables (`useChannel`, `useExtension`) when you genuinely need raw events. |
 | `onStop`                                                                                                                                   | Drop. Use `stream.stop()` to cancel the active run (default) or `stream.disconnect()` for join/rejoin. See §5.3.                                                            |
 | `fetchStateHistory`                                                                                                                        | Drop. Fork/edit flows use `useMessageMetadata` + `submit({}, { forkFrom })` instead (§5).                                                                               |
 | `reconnectOnMount`                                                                                                                         | Drop. Re-attach is automatic: remounting the composable with the same `threadId` attaches to the in-flight run.                                                         |
 | `throttle`                                                                                                                                 | Drop. The composable batches state updates natively; call sites that need render throttling can memoize at the selector site.                                           |
 | `thread`                                                                                                                                   | Drop. External thread managers should drive the composable by controlling `threadId` and `initialValues`.                                                               |
 | `filterSubagentMessages`                                                                                                                   | Drop. Subagent messages are already absent from `stream.messages`; they live on per-subagent selector composables (§7).                                                 |
-| `subagentToolNames`                                                                                                                        | Drop. Subagent classification is driven by protocol-v2 lifecycle events, not by a client-side tool-name list.                                                           |
+| `subagentToolNames`                                                                                                                        | Drop. Subagent classification is driven by new event-based streaming lifecycle events, not by a client-side tool-name list.                                                           |
 
 Migrate silent callback side effects into `watch()` / `watchEffect()`:
 
@@ -316,11 +322,11 @@ await submit({ messages: new HumanMessage("hi") });
 | `context`                                                                                                                                           | Drop — fold into `config.configurable`.                                                                                                                  |
 | `checkpoint: { checkpoint_id }`                                                                                                                     | `forkFrom: "cp_123"` (direct checkpoint id string). The earlier non-functional `forkFrom: { checkpointId }` object form was removed.                     |
 | `command: { resume }`                                                                                                                               | Use `stream.respond()` instead.                                                                                                                          |
-| `interruptBefore`, `interruptAfter`                                                                                                                 | Drop — not supported in v2.                                                                                                                              |
+| `interruptBefore`, `interruptAfter`                                                                                                                 | Drop — not supported with new event-based streaming.                                                                                                                              |
 | `metadata`                                                                                                                                          | Unchanged.                                                                                                                                               |
 | `multitaskStrategy`                                                                                                                                 | Unchanged. `"rollback"`, `"reject"`, and `"enqueue"` are honoured client-side today; `"interrupt"` falls back to `"rollback"` pending server support (see §13). |
 | `onCompletion`                                                                                                                                     | Use the composable-level `onCompleted` option for run-completion side effects.                                                                            |
-| `onDisconnect`, `feedbackKeys`, `streamMode`, `runId`, `optimisticValues`, `streamSubgraphs`, `streamResumable`, `checkpointDuring`                 | Drop from submit. Disconnect/cancel policy now lives on `stop()` / `disconnect()` instead of per-submit options (§5.3). Most other fields map to protocol-v2 defaults.                                                                                                                  |
+| `onDisconnect`, `feedbackKeys`, `streamMode`, `runId`, `optimisticValues`, `streamSubgraphs`, `streamResumable`, `checkpointDuring`                 | Drop from submit. Disconnect/cancel policy now lives on `stop()` / `disconnect()` instead of per-submit options (§5.3). Most other fields map to new event-based streaming defaults.                                                                                                                  |
 | **(new submit option)** `onError`                                                                                                                   | Per-submit fire-and-forget error callback. There is no composable-level `onError` option; transport-level `stream.error` updates still happen in parallel. |
 | **(new)** `threadId`                                                                                                                                | Per-submit thread override. Rebinds the controller to that thread before dispatching and keeps it bound until the reactive `threadId` option changes again. |
 
@@ -656,11 +662,12 @@ fallback until hydration completes.
 
 ## 12. Type helpers
 
-| Legacy         | v1                                             |
-| -------------- | ---------------------------------------------- |
-| `UseStream<T>` | `UseStreamReturn<T>`                           |
-| `StateOf<T>`   | `InferStateType<T>`                            |
-| —              | `AnyStream` — erased handle for prop-drilling. |
+| Legacy                         | v1                                                                                      |
+| ------------------------------ | --------------------------------------------------------------------------------------- |
+| `UseStream<T>`                 | `UseStreamReturn<T>`                                                                    |
+| `UseStreamOptions<State, Bag>` | `UseStreamOptions<State>` (or let the composable infer).                                |
+| `StateOf<T>`                   | `InferStateType<T>`                                                                     |
+| —                              | `AnyStream` — type-erased handle (`UseStreamReturn<any, any, any>`) for prop-drilling. |
 
 ```ts
 import type { UseStreamReturn, AnyStream } from "@langchain/vue";
@@ -678,16 +685,16 @@ function renderMessages(stream: AnyStream) {
   honoured client-side. `"interrupt"` currently falls back to
   `"rollback"` until server-side interrupt semantics land.
 - `forkFrom` + `submit()` requires a server release that supports
-  protocol v2 checkpoints.
+  new event-based streaming checkpoints.
 
 ---
 
 ## 14. FAQ
 
 **Q: Can I use the v1 binding with a LangGraph server that still
-speaks protocol v1?**
-No. v1 is strictly v2-native. Stay on `@langchain/vue@0.x` until your
-server is upgraded.
+uses the legacy streaming protocol?**
+No. The v1 package requires new event-based streaming. Stay on
+`@langchain/vue@0.x` until your server is upgraded.
 
 **Q: Why does `stream.values` show stale data during a run?**
 It doesn't — `values` reflects the server's authoritative state


### PR DESCRIPTION
This patch updates the migration docs to the new event based streaming mechanism. Improves wording and correctness.