### PR TITLE
fix(sdk): revive automatic optimistic submit echo

### DIFF
--- a/.changeset/feat-optimistic-submit-echo.md
+++ b/.changeset/feat-optimistic-submit-echo.md
@@ -1,0 +1,16 @@
+---
+"@langchain/langgraph-sdk": patch
+"@langchain/react": patch
+"@langchain/vue": patch
+"@langchain/svelte": patch
+"@langchain/angular": patch
+---
+
+fix(sdk): revive automatic optimistic submit echo
+
+Echo `submit()` input into `values` / `messages` immediately with client-side
+id minting and id-based reconciliation as the server streams back. Expose
+per-message `optimisticStatus` via message metadata (`pending` → `sent` /
+`failed`), shallow-merge non-message keys with rollback when no `values`
+arrive, and add an `optimistic: false` hook opt-out. Plumb through React,
+Vue, Svelte, and Angular with browser e2e coverage.

--- a/libs/sdk-angular/src/tests/components/OptimisticStream.ts
+++ b/libs/sdk-angular/src/tests/components/OptimisticStream.ts
@@ -1,0 +1,207 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+} from "@angular/core";
+import { HumanMessage, type BaseMessage } from "@langchain/core/messages";
+
+import { injectStream, type StreamApi } from "../../index.js";
+import { injectMessageMetadata } from "../../selectors-metadata.js";
+import { apiUrl } from "./apiUrl.js";
+
+interface StreamState {
+  messages: BaseMessage[];
+}
+
+const TEMPLATE = `
+  <div data-testid="message-count">{{ stream.messages().length }}</div>
+  <div data-testid="messages">
+    @for (msg of stream.messages(); track msg.id ?? $index) {
+      <div [attr.data-testid]="'message-' + $index">
+        <span [attr.data-testid]="'message-' + $index + '-content'">{{
+          str(msg.content)
+        }}</span>
+        @if ($index === 0) {
+          <span data-testid="message-0-status">{{ firstStatus() }}</span>
+        }
+      </div>
+    }
+  </div>
+  <div data-testid="loading">
+    {{ stream.isLoading() ? "Loading..." : "Not loading" }}
+  </div>
+  @if (stream.error()) {
+    <div data-testid="error">{{ stream.error() }}</div>
+  }
+  <button data-testid="submit" (click)="onSubmit()">Send</button>
+`;
+
+abstract class OptimisticBaseComponent {
+  abstract readonly stream: StreamApi<StreamState>;
+  abstract readonly firstMetadata: ReturnType<typeof injectMessageMetadata>;
+
+  str(value: unknown): string {
+    return typeof value === "string" ? value : JSON.stringify(value);
+  }
+
+  firstStatus(): string {
+    return this.firstMetadata()?.optimisticStatus ?? "none";
+  }
+
+  onSubmit(): void {
+    void this.stream.submit({ messages: [new HumanMessage("Hello")] });
+  }
+}
+
+/** Optimistic (default) against the slow graph for pending → sent. */
+@Component({
+  selector: "lg-optimistic-slow-stream",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: TEMPLATE,
+})
+export class OptimisticSlowStreamComponent extends OptimisticBaseComponent {
+  readonly stream = injectStream<StreamState>({
+    assistantId: "slow_graph",
+    apiUrl,
+  });
+
+  private readonly firstId = computed(() => this.stream.messages()[0]?.id);
+  readonly firstMetadata = injectMessageMetadata(this.stream, this.firstId);
+}
+
+/** Optimistic (default) against the fast graph for id reconciliation. */
+@Component({
+  selector: "lg-optimistic-default-stream",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: TEMPLATE,
+})
+export class OptimisticDefaultStreamComponent extends OptimisticBaseComponent {
+  readonly stream = injectStream<StreamState>({
+    assistantId: "agent",
+    apiUrl,
+  });
+
+  private readonly firstId = computed(() => this.stream.messages()[0]?.id);
+  readonly firstMetadata = injectMessageMetadata(this.stream, this.firstId);
+}
+
+/** Optimistic (default) against the error graph for failed rollback. */
+@Component({
+  selector: "lg-optimistic-error-stream",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: TEMPLATE,
+})
+export class OptimisticErrorStreamComponent extends OptimisticBaseComponent {
+  readonly stream = injectStream<StreamState>({
+    assistantId: "errorAgent",
+    apiUrl,
+  });
+
+  private readonly firstId = computed(() => this.stream.messages()[0]?.id);
+  readonly firstMetadata = injectMessageMetadata(this.stream, this.firstId);
+}
+
+/** Optimistic disabled — server-authoritative only. */
+@Component({
+  selector: "lg-optimistic-disabled-stream",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: TEMPLATE,
+})
+export class OptimisticDisabledStreamComponent extends OptimisticBaseComponent {
+  readonly stream = injectStream<StreamState>({
+    assistantId: "slow_graph",
+    apiUrl,
+    optimistic: false,
+  });
+
+  private readonly firstId = computed(() => this.stream.messages()[0]?.id);
+  readonly firstMetadata = injectMessageMetadata(this.stream, this.firstId);
+}
+
+interface StreamValuesState {
+  messages: BaseMessage[];
+  status?: string;
+}
+
+const VALUES_TEMPLATE = `
+  <div data-testid="message-count">{{ stream.messages().length }}</div>
+  <div data-testid="messages">
+    @for (msg of stream.messages(); track msg.id ?? $index) {
+      <div [attr.data-testid]="'message-' + $index">{{ str(msg.content) }}</div>
+    }
+  </div>
+  <div data-testid="status">{{ status() }}</div>
+  <div data-testid="loading">
+    {{ stream.isLoading() ? "Loading..." : "Not loading" }}
+  </div>
+  @if (stream.error()) {
+    <div data-testid="error">{{ stream.error() }}</div>
+  }
+  <button data-testid="submit" (click)="onSubmit()">Send</button>
+`;
+
+abstract class OptimisticValuesBaseComponent {
+  abstract readonly stream: StreamApi<StreamValuesState>;
+
+  str(value: unknown): string {
+    return typeof value === "string" ? value : JSON.stringify(value);
+  }
+
+  status(): string {
+    return (this.stream.values() as StreamValuesState).status ?? "none";
+  }
+
+  onSubmit(): void {
+    void this.stream.submit({
+      messages: [new HumanMessage("Hello")],
+      status: "draft",
+    });
+  }
+}
+
+/** Optimistic (default) non-message state convergence. */
+@Component({
+  selector: "lg-optimistic-values-stream",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: VALUES_TEMPLATE,
+})
+export class OptimisticValuesStreamComponent extends OptimisticValuesBaseComponent {
+  readonly stream = injectStream<StreamValuesState>({
+    assistantId: "stateful_values_graph",
+    apiUrl,
+  });
+}
+
+/** Optimistic non-message state against an unknown assistant (rollback). */
+@Component({
+  selector: "lg-optimistic-values-missing-stream",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: VALUES_TEMPLATE,
+})
+export class OptimisticValuesMissingStreamComponent extends OptimisticValuesBaseComponent {
+  readonly stream = injectStream<StreamValuesState>({
+    assistantId: "missing_graph",
+    apiUrl,
+  });
+}
+
+/** Non-message state with optimistic disabled. */
+@Component({
+  selector: "lg-optimistic-values-disabled-stream",
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: VALUES_TEMPLATE,
+})
+export class OptimisticValuesDisabledStreamComponent extends OptimisticValuesBaseComponent {
+  readonly stream = injectStream<StreamValuesState>({
+    assistantId: "stateful_values_graph",
+    apiUrl,
+    optimistic: false,
+  });
+}

--- a/libs/sdk-angular/src/tests/fixtures/mock-server.ts
+++ b/libs/sdk-angular/src/tests/fixtures/mock-server.ts
@@ -25,6 +25,7 @@ import {
 import {
   StateGraph,
   MessagesAnnotation,
+  Annotation,
   Command,
   interrupt,
   pushMessage,
@@ -120,6 +121,27 @@ const slowGraph = new StateGraph(MessagesAnnotation)
       setTimeout(resolve, 400);
     });
     return { messages: [new AIMessage("Done.")] };
+  })
+  .addEdge(START, "agent")
+  .compile();
+
+// State with a non-message channel alongside `messages`, used to
+// exercise optimistic handling of non-message input keys. Sleeps
+// before overwriting `status` with the server-authoritative value.
+const StatefulState = Annotation.Root({
+  ...MessagesAnnotation.spec,
+  status: Annotation<string>({
+    reducer: (_prev, next) => next,
+    default: () => "idle",
+  }),
+});
+
+const statefulValuesGraph = new StateGraph(StatefulState)
+  .addNode("agent", async () => {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 400);
+    });
+    return { messages: [new AIMessage("Done.")], status: "final" };
   })
   .addEdge(START, "agent")
   .compile();
@@ -533,6 +555,7 @@ const graphs: Record<string, AnyPregel> = {
   multi_interrupt_graph: multiInterruptGraph as unknown as AnyPregel,
   parentAgent,
   slow_graph: slowGraph,
+  stateful_values_graph: statefulValuesGraph,
   customChannelAgent,
   namedCustomChannelAgent,
   embeddedSubgraphAgent,

--- a/libs/sdk-angular/src/tests/stream.optimistic.test.ts
+++ b/libs/sdk-angular/src/tests/stream.optimistic.test.ts
@@ -1,0 +1,164 @@
+import { expect, it } from "vitest";
+import { render } from "vitest-browser-angular";
+
+import {
+  OptimisticSlowStreamComponent,
+  OptimisticDefaultStreamComponent,
+  OptimisticErrorStreamComponent,
+  OptimisticDisabledStreamComponent,
+  OptimisticValuesStreamComponent,
+  OptimisticValuesMissingStreamComponent,
+  OptimisticValuesDisabledStreamComponent,
+} from "./components/OptimisticStream.js";
+
+it("echoes the submitted message immediately as pending, then marks it sent", async () => {
+  // The slow graph sleeps before emitting, giving us a stable window to
+  // observe the optimistic (pending) message while the run is in flight.
+  const screen = await render(OptimisticSlowStreamComponent);
+
+  await screen.getByTestId("submit").click();
+
+  await expect
+    .element(screen.getByTestId("message-0-content"))
+    .toHaveTextContent("Hello");
+  await expect
+    .element(screen.getByTestId("message-0-status"))
+    .toHaveTextContent("pending");
+  await expect
+    .element(screen.getByTestId("loading"))
+    .toHaveTextContent("Loading...");
+
+  await expect
+    .element(screen.getByTestId("loading"), { timeout: 5_000 })
+    .toHaveTextContent("Not loading");
+  await expect
+    .element(screen.getByTestId("message-0-status"))
+    .toHaveTextContent("sent");
+  await expect
+    .element(screen.getByTestId("message-1-content"))
+    .toHaveTextContent("Done.");
+});
+
+it("reconciles the server echo by id without duplicating the message", async () => {
+  const screen = await render(OptimisticDefaultStreamComponent);
+
+  await screen.getByTestId("submit").click();
+
+  await expect
+    .element(screen.getByTestId("loading"), { timeout: 5_000 })
+    .toHaveTextContent("Not loading");
+
+  await expect
+    .element(screen.getByTestId("message-count"))
+    .toHaveTextContent("2");
+  await expect
+    .element(screen.getByTestId("message-0-content"))
+    .toHaveTextContent("Hello");
+  await expect
+    .element(screen.getByTestId("message-0-status"))
+    .toHaveTextContent("sent");
+  await expect
+    .element(screen.getByTestId("message-1-content"))
+    .toHaveTextContent("Hey");
+});
+
+it("keeps the optimistic message and marks it failed when the run errors", async () => {
+  const screen = await render(OptimisticErrorStreamComponent);
+
+  await screen.getByTestId("submit").click();
+
+  await expect
+    .element(screen.getByTestId("loading"), { timeout: 5_000 })
+    .toHaveTextContent("Not loading");
+
+  await expect.element(screen.getByTestId("error")).toBeInTheDocument();
+
+  await expect
+    .element(screen.getByTestId("message-count"))
+    .toHaveTextContent("1");
+  await expect
+    .element(screen.getByTestId("message-0-content"))
+    .toHaveTextContent("Hello");
+  await expect
+    .element(screen.getByTestId("message-0-status"))
+    .toHaveTextContent("failed");
+});
+
+it("does not echo optimistically when optimistic is disabled", async () => {
+  const screen = await render(OptimisticDisabledStreamComponent);
+
+  await screen.getByTestId("submit").click();
+
+  await expect
+    .element(screen.getByTestId("loading"))
+    .toHaveTextContent("Loading...");
+  await expect
+    .element(screen.getByTestId("message-count"))
+    .toHaveTextContent("0");
+
+  await expect
+    .element(screen.getByTestId("loading"), { timeout: 5_000 })
+    .toHaveTextContent("Not loading");
+  await expect
+    .element(screen.getByTestId("message-count"))
+    .toHaveTextContent("2");
+  await expect
+    .element(screen.getByTestId("message-0-content"))
+    .toHaveTextContent("Hello");
+  await expect
+    .element(screen.getByTestId("message-0-status"))
+    .toHaveTextContent("none");
+});
+
+it("merges non-message state optimistically and converges to server truth", async () => {
+  const screen = await render(OptimisticValuesStreamComponent);
+
+  await screen.getByTestId("submit").click();
+
+  await expect.element(screen.getByTestId("status")).toHaveTextContent("draft");
+  await expect
+    .element(screen.getByTestId("loading"))
+    .toHaveTextContent("Loading...");
+
+  await expect
+    .element(screen.getByTestId("loading"), { timeout: 5_000 })
+    .toHaveTextContent("Not loading");
+  await expect.element(screen.getByTestId("status")).toHaveTextContent("final");
+  await expect
+    .element(screen.getByTestId("message-1"))
+    .toHaveTextContent("Done.");
+});
+
+it("rolls back an optimistic non-message key when the run never starts", async () => {
+  // An unknown assistant id makes dispatch reject before any `values`
+  // snapshot streams back — the one case where the optimistic
+  // non-message key is reverted rather than converged to server truth.
+  const screen = await render(OptimisticValuesMissingStreamComponent);
+
+  await screen.getByTestId("submit").click();
+
+  await expect
+    .element(screen.getByTestId("loading"), { timeout: 5_000 })
+    .toHaveTextContent("Not loading");
+  await expect.element(screen.getByTestId("error")).toBeInTheDocument();
+
+  // No server `values` ever landed, so the optimistic `status` is
+  // reverted to its pre-submit state (absent).
+  await expect.element(screen.getByTestId("status")).toHaveTextContent("none");
+});
+
+it("does not merge non-message state when optimistic is disabled", async () => {
+  const screen = await render(OptimisticValuesDisabledStreamComponent);
+
+  await screen.getByTestId("submit").click();
+
+  await expect
+    .element(screen.getByTestId("loading"))
+    .toHaveTextContent("Loading...");
+  await expect.element(screen.getByTestId("status")).toHaveTextContent("none");
+
+  await expect
+    .element(screen.getByTestId("loading"), { timeout: 5_000 })
+    .toHaveTextContent("Not loading");
+  await expect.element(screen.getByTestId("status")).toHaveTextContent("final");
+});

--- a/libs/sdk-angular/src/use-stream.ts
+++ b/libs/sdk-angular/src/use-stream.ts
@@ -412,6 +412,7 @@ export function useStream<
     messagesKey?: string;
     tools?: AnyHeadlessToolImplementation[];
     onTool?: OnToolCallback;
+    optimistic?: boolean;
   }
   const asBag = options as OptionsBag;
 
@@ -466,6 +467,7 @@ export function useStream<
     onCompleted: options.onCompleted,
     initialValues: options.initialValues,
     messagesKey: options.messagesKey,
+    optimistic: asBag.optimistic,
   });
 
   // Deferred dispose — matches the React `useEffect(() =>

--- a/libs/sdk-react/docs/use-stream.md
+++ b/libs/sdk-react/docs/use-stream.md
@@ -37,6 +37,7 @@ The option bag is a discriminated union on `transport`:
 | `onCompleted`   | `(info: { runId?: string; reason: "success" \| "error" \| "interrupt" \| "stopped" }) => void` | Convenience callback fired when a run's active streaming phase ends. `runId` may be omitted for re-attached in-flight runs. |
 | `tools`         | `HeadlessToolImplementation[]`                                                            | Headless tools. Matching interrupts are auto-resolved with the handler's return value. See [Interrupts](./interrupts.md).   |
 | `onTool`        | `OnToolCallback`                                                                          | Observe headless-tool lifecycle events (`start` / `success` / `error`).                                                     |
+| `optimistic`    | `boolean`                                                                                 | Echo `submit()` input into `values` / `messages` immediately and reconcile by id as the server streams back. Defaults to `true`. Set `false` for server-authoritative-only. See [v1 migration §5.4](./v1-migration.md). |
 
 ### Agent Server branch (`AgentServerOptions`)
 

--- a/libs/sdk-react/docs/v1-migration.md
+++ b/libs/sdk-react/docs/v1-migration.md
@@ -289,7 +289,7 @@ reach for it unless you're typing an intermediate variable.
 | `metadata`                                                                                                                          | Unchanged.                                                                                                                                                                |
 | `multitaskStrategy`                                                                                                                 | Unchanged. `"rollback"` (default), `"reject"`, and `"enqueue"` are honoured client-side today; `"interrupt"` falls back to `"rollback"` pending server support (see §13). |
 | `onCompletion`                                                                                                                      | Use the hook-level `onCompleted` option for run-completion side effects.                                                                                                  |
-| `onDisconnect`, `feedbackKeys`, `streamMode`, `runId`, `optimisticValues`, `streamSubgraphs`, `streamResumable`, `checkpointDuring` | Drop from submit. Disconnect/cancel policy now lives on `stop()` / `disconnect()` instead of per-submit options (§5.3). `optimisticValues` has no client-side analogue — reconcile via `values` after the run settles. |
+| `onDisconnect`, `feedbackKeys`, `streamMode`, `runId`, `optimisticValues`, `streamSubgraphs`, `streamResumable`, `checkpointDuring` | Drop from submit. Disconnect/cancel policy now lives on `stop()` / `disconnect()` instead of per-submit options (§5.3). `optimisticValues` is **no longer needed**: v1 echoes the `submit()` input optimistically and reconciles it by id automatically — see §5.4. |
 | **(new submit option)** `onError`                                                                                                   | Per-submit fire-and-forget error callback. There is no hook-level `onError` option; transport-level `stream.error` updates still happen in parallel.                      |
 | **(new)** `threadId`                                                                                                                | Per-submit thread override — rebinds the controller to the given thread before dispatching, then keeps it bound until the hook's `threadId` prop changes again.           |
 
@@ -309,6 +309,62 @@ await submit(
   { messages: [new HumanMessage("retry")] },
   { forkFrom: "cp_123", multitaskStrategy: "rollback" },
 );
+```
+
+### 5.4 Optimistic updates (replaces `optimisticValues`)
+
+Legacy `optimisticValues` let you hand-merge state into the visible
+`values` before a run streamed back — most commonly to show the user's
+own message instantly. v1 makes this automatic: the input you pass to
+`submit()` is reflected in `values` / `messages` immediately and then
+reconciled against the authoritative server state as it streams in. No
+per-submit option, no callback.
+
+```tsx
+// Legacy: manually echo the user's message via a callback.
+await submit(
+  { messages: [new HumanMessage("hi")] },
+  { optimisticValues: (prev) => ({ messages: [...prev.messages, new HumanMessage("hi")] }) },
+);
+
+// v1: just submit. The human message appears at once.
+await submit({ messages: [new HumanMessage("hi")] });
+```
+
+How it works:
+
+- **Messages** in the input are appended right away. Any message
+  without an `id` gets a stable client id (sent to the server, which
+  `add_messages` preserves) so the server echo reconciles by id instead
+  of duplicating.
+- **Other input keys** are shallow-merged into `values` and converge to
+  server truth on the first `values` event (or are rolled back if the
+  run fails before any echo).
+- **Per-message status** is exposed via
+  `useMessageMetadata(stream, message.id).optimisticStatus`
+  (`"pending"` → `"sent"`, or `"failed"` if the run errors before the
+  message is echoed). Failed optimistic messages are kept (so you can
+  render a retry affordance) and dropped on the next `hydrate()` /
+  reload.
+
+```tsx
+function Bubble({ stream, message }: { stream: AnyStream; message: BaseMessage }) {
+  const { optimisticStatus } = useMessageMetadata(stream, message.id) ?? {};
+  return (
+    <div data-pending={optimisticStatus === "pending"}>
+      {message.text}
+      {optimisticStatus === "failed" && <RetryButton />}
+    </div>
+  );
+}
+```
+
+Opt out per hook with `optimistic: false` (dispatch input verbatim,
+server-authoritative only) — useful for non-chat state graphs or
+deterministic SSR/tests:
+
+```tsx
+const stream = useStream({ assistantId: "agent", optimistic: false });
 ```
 
 ### 5.3 Stop / disconnect

--- a/libs/sdk-react/src/tests/components/OptimisticStream.tsx
+++ b/libs/sdk-react/src/tests/components/OptimisticStream.tsx
@@ -1,0 +1,75 @@
+import { HumanMessage, type BaseMessage } from "@langchain/core/messages";
+
+import { useStream, useMessageMetadata } from "../../index.js";
+import type { UseStreamReturn } from "../../index.js";
+import { formatMessage } from "./format.js";
+
+type StreamState = { messages: BaseMessage[] };
+
+function MessageRow({
+  stream,
+  index,
+  message,
+}: {
+  stream: UseStreamReturn<StreamState>;
+  index: number;
+  message: BaseMessage;
+}) {
+  const metadata = useMessageMetadata(stream, message.id);
+  return (
+    <div data-testid={`message-${index}`}>
+      <span data-testid={`message-${index}-content`}>
+        {formatMessage(message)}
+      </span>
+      <span data-testid={`message-${index}-status`}>
+        {metadata?.optimisticStatus ?? "none"}
+      </span>
+    </div>
+  );
+}
+
+interface Props {
+  apiUrl: string;
+  assistantId?: string;
+  optimistic?: boolean;
+  submitText?: string;
+}
+
+export function OptimisticStream({
+  apiUrl,
+  assistantId = "stategraph_text",
+  optimistic,
+  submitText = "Hello",
+}: Props) {
+  const stream = useStream<StreamState>({ assistantId, apiUrl, optimistic });
+
+  return (
+    <div>
+      <div data-testid="message-count">{stream.messages.length}</div>
+      <div data-testid="messages">
+        {stream.messages.map((msg, i) => (
+          <MessageRow
+            key={msg.id ?? i}
+            stream={stream}
+            index={i}
+            message={msg}
+          />
+        ))}
+      </div>
+      <div data-testid="loading">
+        {stream.isLoading ? "Loading..." : "Not loading"}
+      </div>
+      {stream.error ? (
+        <div data-testid="error">{String(stream.error)}</div>
+      ) : null}
+      <button
+        data-testid="submit"
+        onClick={() =>
+          void stream.submit({ messages: [new HumanMessage(submitText)] })
+        }
+      >
+        Send
+      </button>
+    </div>
+  );
+}

--- a/libs/sdk-react/src/tests/components/OptimisticValuesStream.tsx
+++ b/libs/sdk-react/src/tests/components/OptimisticValuesStream.tsx
@@ -1,0 +1,59 @@
+import { HumanMessage, type BaseMessage } from "@langchain/core/messages";
+
+import { useStream } from "../../index.js";
+
+interface StreamState {
+  messages: BaseMessage[];
+  status?: string;
+  [key: string]: unknown;
+}
+
+interface Props {
+  apiUrl: string;
+  assistantId?: string;
+  optimistic?: boolean;
+  submitStatus?: string;
+}
+
+export function OptimisticValuesStream({
+  apiUrl,
+  assistantId = "stateful_values_graph",
+  optimistic,
+  submitStatus = "draft",
+}: Props) {
+  const stream = useStream<StreamState>({ assistantId, apiUrl, optimistic });
+  const status = (stream.values as StreamState).status;
+
+  return (
+    <div>
+      <div data-testid="message-count">{stream.messages.length}</div>
+      <div data-testid="messages">
+        {stream.messages.map((msg, i) => (
+          <div key={msg.id ?? i} data-testid={`message-${i}`}>
+            {typeof msg.content === "string"
+              ? msg.content
+              : JSON.stringify(msg.content)}
+          </div>
+        ))}
+      </div>
+      <div data-testid="status">{status ?? "none"}</div>
+      <div data-testid="loading">
+        {stream.isLoading ? "Loading..." : "Not loading"}
+      </div>
+      {stream.error ? (
+        <div data-testid="error">{String(stream.error)}</div>
+      ) : null}
+      <button
+        data-testid="submit"
+        onClick={() =>
+          void stream.submit({
+            messages: [new HumanMessage("Hello")],
+            status: submitStatus,
+          })
+        }
+      >
+        Send
+      </button>
+    </div>
+  );
+}

--- a/libs/sdk-react/src/tests/fixtures/stateful-values-graph.ts
+++ b/libs/sdk-react/src/tests/fixtures/stateful-values-graph.ts
@@ -1,0 +1,35 @@
+import { AIMessage } from "@langchain/core/messages";
+import {
+  Annotation,
+  MessagesAnnotation,
+  START,
+  StateGraph,
+} from "@langchain/langgraph";
+
+/**
+ * State with a non-message channel (`status`) alongside `messages`.
+ * Used to exercise optimistic handling of non-message input keys:
+ * they merge into `values` immediately and converge to server truth.
+ */
+const StatefulState = Annotation.Root({
+  ...MessagesAnnotation.spec,
+  status: Annotation<string>({
+    reducer: (_prev, next) => next,
+    default: () => "idle",
+  }),
+});
+
+/**
+ * Sleeps before emitting so a test can observe the optimistic
+ * `status` value while the run is in flight, then overwrites it with
+ * the server-authoritative `"final"`.
+ */
+const statefulValuesGraph = new StateGraph(StatefulState)
+  .addNode("agent", async () => {
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    return { messages: [new AIMessage("Done.")], status: "final" };
+  })
+  .addEdge(START, "agent")
+  .compile();
+
+export { statefulValuesGraph };

--- a/libs/sdk-react/src/tests/mock-server.ts
+++ b/libs/sdk-react/src/tests/mock-server.ts
@@ -28,6 +28,7 @@ import { graph as customChannelGraph } from "./fixtures/custom-channel-graph.js"
 import { graph as slowGraph } from "./fixtures/slow-graph.js";
 import { graph as headlessToolGraph } from "./fixtures/headless-tool-graph.js";
 import { graph as removeMessageGraph } from "./fixtures/remove-message-graph.js";
+import { statefulValuesGraph } from "./fixtures/stateful-values-graph.js";
 
 declare module "vitest" {
   export interface ProvidedContext {
@@ -82,6 +83,7 @@ const graphs: Record<string, AnyPregel> = {
   slow_graph: slowGraph as unknown as AnyPregel,
   headless_tool_graph: headlessToolGraph as unknown as AnyPregel,
   remove_message_graph: removeMessageGraph as unknown as AnyPregel,
+  stateful_values_graph: statefulValuesGraph as unknown as AnyPregel,
 };
 
 let httpServer: Server | null = null;

--- a/libs/sdk-react/src/tests/stream.optimistic.test.tsx
+++ b/libs/sdk-react/src/tests/stream.optimistic.test.tsx
@@ -1,0 +1,226 @@
+import { expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { OptimisticStream } from "./components/OptimisticStream.js";
+import { OptimisticValuesStream } from "./components/OptimisticValuesStream.js";
+import { apiUrl, cleanupRender } from "./test-utils.js";
+
+it("echoes the submitted message immediately as pending, then marks it sent", async () => {
+  // `slow_graph` sleeps before emitting, giving us a stable window to
+  // observe the optimistic (pending) message while the run is in flight.
+  const screen = await render(
+    <OptimisticStream apiUrl={apiUrl} assistantId="slow_graph" />,
+  );
+
+  try {
+    await screen.getByTestId("submit").click();
+
+    // The human message paints before the server responds.
+    await expect
+      .element(screen.getByTestId("message-0-content"))
+      .toHaveTextContent("Hello");
+    await expect
+      .element(screen.getByTestId("message-0-status"))
+      .toHaveTextContent("pending");
+    await expect
+      .element(screen.getByTestId("loading"))
+      .toHaveTextContent("Loading...");
+
+    // Once the run settles, the optimistic message reconciles to sent
+    // and the assistant reply lands.
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 5_000 })
+      .toHaveTextContent("Not loading");
+    await expect
+      .element(screen.getByTestId("message-0-status"))
+      .toHaveTextContent("sent");
+    await expect
+      .element(screen.getByTestId("message-1-content"))
+      .toHaveTextContent("Done.");
+  } finally {
+    await cleanupRender(screen);
+  }
+});
+
+it("reconciles the server echo by id without duplicating the message", async () => {
+  const screen = await render(<OptimisticStream apiUrl={apiUrl} />);
+
+  try {
+    await screen.getByTestId("submit").click();
+
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 5_000 })
+      .toHaveTextContent("Not loading");
+
+    // Exactly one human message (reconciled by minted id) plus one
+    // assistant reply — no duplicate human turn from the server echo.
+    await expect
+      .element(screen.getByTestId("message-count"))
+      .toHaveTextContent("2");
+    await expect
+      .element(screen.getByTestId("message-0-content"))
+      .toHaveTextContent("Hello");
+    await expect
+      .element(screen.getByTestId("message-0-status"))
+      .toHaveTextContent("sent");
+    await expect
+      .element(screen.getByTestId("message-1-content"))
+      .toHaveTextContent("Plan accepted.");
+  } finally {
+    await cleanupRender(screen);
+  }
+});
+
+it("keeps the optimistic message and marks it failed when the run errors", async () => {
+  const screen = await render(
+    <OptimisticStream apiUrl={apiUrl} assistantId="error_graph" />,
+  );
+
+  try {
+    await screen.getByTestId("submit").click();
+
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 5_000 })
+      .toHaveTextContent("Not loading");
+
+    await expect.element(screen.getByTestId("error")).toBeInTheDocument();
+
+    // The human turn is retained (so the UI can offer a retry) and
+    // flagged as failed; no assistant message was produced.
+    await expect
+      .element(screen.getByTestId("message-count"))
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("message-0-content"))
+      .toHaveTextContent("Hello");
+    await expect
+      .element(screen.getByTestId("message-0-status"))
+      .toHaveTextContent("failed");
+  } finally {
+    await cleanupRender(screen);
+  }
+});
+
+it("does not echo optimistically when optimistic is disabled", async () => {
+  const screen = await render(
+    <OptimisticStream
+      apiUrl={apiUrl}
+      assistantId="slow_graph"
+      optimistic={false}
+    />,
+  );
+
+  try {
+    await screen.getByTestId("submit").click();
+
+    // No synchronous echo: while the slow run is in flight nothing has
+    // been projected yet.
+    await expect
+      .element(screen.getByTestId("loading"))
+      .toHaveTextContent("Loading...");
+    await expect
+      .element(screen.getByTestId("message-count"))
+      .toHaveTextContent("0");
+
+    // Server-authoritative state arrives once the run completes, and
+    // carries no optimistic status.
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 5_000 })
+      .toHaveTextContent("Not loading");
+    await expect
+      .element(screen.getByTestId("message-count"))
+      .toHaveTextContent("2");
+    await expect
+      .element(screen.getByTestId("message-0-content"))
+      .toHaveTextContent("Hello");
+    await expect
+      .element(screen.getByTestId("message-0-status"))
+      .toHaveTextContent("none");
+  } finally {
+    await cleanupRender(screen);
+  }
+});
+
+it("merges non-message state optimistically and converges to server truth", async () => {
+  const screen = await render(<OptimisticValuesStream apiUrl={apiUrl} />);
+
+  try {
+    await screen.getByTestId("submit").click();
+
+    // The submitted non-message key paints immediately while the slow
+    // run is still in flight.
+    await expect
+      .element(screen.getByTestId("status"))
+      .toHaveTextContent("draft");
+    await expect
+      .element(screen.getByTestId("loading"))
+      .toHaveTextContent("Loading...");
+
+    // Once the server's `values` snapshot lands, the key converges to
+    // the authoritative value.
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 5_000 })
+      .toHaveTextContent("Not loading");
+    await expect
+      .element(screen.getByTestId("status"))
+      .toHaveTextContent("final");
+    await expect
+      .element(screen.getByTestId("message-1"))
+      .toHaveTextContent("Done.");
+  } finally {
+    await cleanupRender(screen);
+  }
+});
+
+it("rolls back an optimistic non-message key when the run never starts", async () => {
+  // An unknown assistant id makes dispatch reject before any `values`
+  // snapshot streams back — the one case where the optimistic
+  // non-message key is reverted rather than converged to server truth.
+  const screen = await render(
+    <OptimisticValuesStream apiUrl={apiUrl} assistantId="missing_graph" />,
+  );
+
+  try {
+    await screen.getByTestId("submit").click();
+
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 5_000 })
+      .toHaveTextContent("Not loading");
+    await expect.element(screen.getByTestId("error")).toBeInTheDocument();
+
+    // No server `values` ever landed, so the optimistic `status` is
+    // reverted to its pre-submit state (absent).
+    await expect
+      .element(screen.getByTestId("status"))
+      .toHaveTextContent("none");
+  } finally {
+    await cleanupRender(screen);
+  }
+});
+
+it("does not merge non-message state when optimistic is disabled", async () => {
+  const screen = await render(
+    <OptimisticValuesStream apiUrl={apiUrl} optimistic={false} />,
+  );
+
+  try {
+    await screen.getByTestId("submit").click();
+
+    // No synchronous merge: the key is absent until the server replies.
+    await expect
+      .element(screen.getByTestId("loading"))
+      .toHaveTextContent("Loading...");
+    await expect
+      .element(screen.getByTestId("status"))
+      .toHaveTextContent("none");
+
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 5_000 })
+      .toHaveTextContent("Not loading");
+    await expect
+      .element(screen.getByTestId("status"))
+      .toHaveTextContent("final");
+  } finally {
+    await cleanupRender(screen);
+  }
+});

--- a/libs/sdk-react/src/use-stream.ts
+++ b/libs/sdk-react/src/use-stream.ts
@@ -450,6 +450,7 @@ export function useStream<
     onCompleted?: (info: RunCompletedInfo) => void;
     initialValues?: StateType;
     messagesKey?: string;
+    optimistic?: boolean;
   }
   const asBag = options as OptionsBag;
   // Narrow once: a non-string `transport` is a custom adapter; anything
@@ -507,6 +508,7 @@ export function useStream<
         onCompleted: options.onCompleted,
         initialValues: options.initialValues,
         messagesKey: options.messagesKey,
+        optimistic: asBag.optimistic,
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [client, assistantId, transport]

--- a/libs/sdk-svelte/src/tests/components/OptimisticMessageRow.svelte
+++ b/libs/sdk-svelte/src/tests/components/OptimisticMessageRow.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import type { BaseMessage } from "@langchain/core/messages";
+  import { useMessageMetadata, type AnyStream } from "../../index.js";
+
+  interface Props {
+    stream: AnyStream;
+    index: number;
+    message: BaseMessage;
+  }
+
+  const { stream, index, message }: Props = $props();
+
+  // svelte-ignore state_referenced_locally
+  const metadata = useMessageMetadata(stream, () => message.id);
+
+  function content(): string {
+    return typeof message.content === "string"
+      ? message.content
+      : JSON.stringify(message.content);
+  }
+</script>
+
+<div data-testid={`message-${index}`}>
+  <span data-testid={`message-${index}-content`}>{content()}</span>
+  <span data-testid={`message-${index}-status`}>
+    {metadata.current?.optimisticStatus ?? "none"}
+  </span>
+</div>

--- a/libs/sdk-svelte/src/tests/components/OptimisticStream.svelte
+++ b/libs/sdk-svelte/src/tests/components/OptimisticStream.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import type { BaseMessage } from "@langchain/core/messages";
+  import { useStream } from "../../index.js";
+  import OptimisticMessageRow from "./OptimisticMessageRow.svelte";
+
+  interface StreamState {
+    messages: BaseMessage[];
+  }
+
+  interface Props {
+    apiUrl: string;
+    assistantId?: string;
+    optimistic?: boolean;
+    submitText?: string;
+  }
+
+  const {
+    apiUrl,
+    assistantId = "stategraph_text",
+    optimistic,
+    submitText = "Hello",
+  }: Props = $props();
+
+  // svelte-ignore state_referenced_locally
+  const stream = useStream<StreamState>({ assistantId, apiUrl, optimistic });
+</script>
+
+<div>
+  <div data-testid="message-count">{stream.messages.length}</div>
+  <div data-testid="messages">
+    {#each stream.messages as msg, i (msg.id ?? i)}
+      <OptimisticMessageRow {stream} index={i} message={msg} />
+    {/each}
+  </div>
+  <div data-testid="loading">
+    {stream.isLoading ? "Loading..." : "Not loading"}
+  </div>
+  {#if stream.error}
+    <div data-testid="error">{String(stream.error)}</div>
+  {/if}
+  <button
+    data-testid="submit"
+    onclick={() =>
+      void stream.submit({
+        messages: [{ type: "human", content: submitText }],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)}
+  >
+    Send
+  </button>
+</div>

--- a/libs/sdk-svelte/src/tests/components/OptimisticValuesStream.svelte
+++ b/libs/sdk-svelte/src/tests/components/OptimisticValuesStream.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import type { BaseMessage } from "@langchain/core/messages";
+  import { useStream } from "../../index.js";
+
+  interface StreamState {
+    messages: BaseMessage[];
+    status?: string;
+  }
+
+  interface Props {
+    apiUrl: string;
+    assistantId?: string;
+    optimistic?: boolean;
+    submitStatus?: string;
+  }
+
+  const {
+    apiUrl,
+    assistantId = "stateful_values_graph",
+    optimistic,
+    submitStatus = "draft",
+  }: Props = $props();
+
+  // svelte-ignore state_referenced_locally
+  const stream = useStream<StreamState>({ assistantId, apiUrl, optimistic });
+
+  function content(msg: BaseMessage): string {
+    return typeof msg.content === "string"
+      ? msg.content
+      : JSON.stringify(msg.content);
+  }
+</script>
+
+<div>
+  <div data-testid="message-count">{stream.messages.length}</div>
+  <div data-testid="messages">
+    {#each stream.messages as msg, i (msg.id ?? i)}
+      <div data-testid={`message-${i}`}>{content(msg)}</div>
+    {/each}
+  </div>
+  <div data-testid="status">{stream.values.status ?? "none"}</div>
+  <div data-testid="loading">
+    {stream.isLoading ? "Loading..." : "Not loading"}
+  </div>
+  {#if stream.error}
+    <div data-testid="error">{String(stream.error)}</div>
+  {/if}
+  <button
+    data-testid="submit"
+    onclick={() =>
+      void stream.submit({
+        messages: [{ type: "human", content: "Hello" }],
+        status: submitStatus,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)}
+  >
+    Send
+  </button>
+</div>

--- a/libs/sdk-svelte/src/tests/fixtures/mock-server.ts
+++ b/libs/sdk-svelte/src/tests/fixtures/mock-server.ts
@@ -25,6 +25,7 @@ import {
 import {
   StateGraph,
   MessagesAnnotation,
+  Annotation,
   Command,
   interrupt,
   pushMessage,
@@ -201,6 +202,25 @@ const slowGraph = new StateGraph(MessagesAnnotation)
   .addNode("agent", async () => {
     await new Promise((resolve) => setTimeout(resolve, 400));
     return { messages: [new AIMessage("Done.")] };
+  })
+  .addEdge(START, "agent")
+  .compile();
+
+// State with a non-message channel alongside `messages`, used to
+// exercise optimistic handling of non-message input keys. Sleeps
+// before overwriting `status` with the server-authoritative value.
+const StatefulState = Annotation.Root({
+  ...MessagesAnnotation.spec,
+  status: Annotation<string>({
+    reducer: (_prev, next) => next,
+    default: () => "idle",
+  }),
+});
+
+const statefulValuesGraph = new StateGraph(StatefulState)
+  .addNode("agent", async () => {
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    return { messages: [new AIMessage("Done.")], status: "final" };
   })
   .addEdge(START, "agent")
   .compile();
@@ -539,6 +559,7 @@ const graphs: Record<string, AnyPregel> = {
   removeMessageAgent,
   errorAgent,
   slow_graph: slowGraph,
+  stateful_values_graph: statefulValuesGraph,
   customChannelAgent,
   headlessToolAgent,
   deepAgent: deepAgentGraph as unknown as AnyPregel,

--- a/libs/sdk-svelte/src/tests/stream.optimistic.test.ts
+++ b/libs/sdk-svelte/src/tests/stream.optimistic.test.ts
@@ -1,0 +1,175 @@
+import { expect, it, inject } from "vitest";
+import { render } from "vitest-browser-svelte";
+
+import OptimisticStream from "./components/OptimisticStream.svelte";
+import OptimisticValuesStream from "./components/OptimisticValuesStream.svelte";
+
+const serverUrl = inject("serverUrl");
+
+it("echoes the submitted message immediately as pending, then marks it sent", async () => {
+  // `slow_graph` sleeps before emitting, giving us a stable window to
+  // observe the optimistic (pending) message while the run is in flight.
+  const screen = render(OptimisticStream, {
+    apiUrl: serverUrl,
+    assistantId: "slow_graph",
+  });
+
+  await screen.getByTestId("submit").click();
+
+  await expect
+    .element(screen.getByTestId("message-0-content"))
+    .toHaveTextContent("Hello");
+  await expect
+    .element(screen.getByTestId("message-0-status"))
+    .toHaveTextContent("pending");
+  await expect
+    .element(screen.getByTestId("loading"))
+    .toHaveTextContent("Loading...");
+
+  await expect
+    .element(screen.getByTestId("loading"), { timeout: 5_000 })
+    .toHaveTextContent("Not loading");
+  await expect
+    .element(screen.getByTestId("message-0-status"))
+    .toHaveTextContent("sent");
+  await expect
+    .element(screen.getByTestId("message-1-content"))
+    .toHaveTextContent("Done.");
+});
+
+it("reconciles the server echo by id without duplicating the message", async () => {
+  const screen = render(OptimisticStream, { apiUrl: serverUrl });
+
+  await screen.getByTestId("submit").click();
+
+  await expect
+    .element(screen.getByTestId("loading"), { timeout: 5_000 })
+    .toHaveTextContent("Not loading");
+
+  await expect
+    .element(screen.getByTestId("message-count"))
+    .toHaveTextContent("2");
+  await expect
+    .element(screen.getByTestId("message-0-content"))
+    .toHaveTextContent("Hello");
+  await expect
+    .element(screen.getByTestId("message-0-status"))
+    .toHaveTextContent("sent");
+  await expect
+    .element(screen.getByTestId("message-1-content"))
+    .toHaveTextContent("Plan accepted.");
+});
+
+it("keeps the optimistic message and marks it failed when the run errors", async () => {
+  const screen = render(OptimisticStream, {
+    apiUrl: serverUrl,
+    assistantId: "errorAgent",
+  });
+
+  await screen.getByTestId("submit").click();
+
+  await expect
+    .element(screen.getByTestId("loading"), { timeout: 5_000 })
+    .toHaveTextContent("Not loading");
+
+  await expect.element(screen.getByTestId("error")).toBeInTheDocument();
+
+  await expect
+    .element(screen.getByTestId("message-count"))
+    .toHaveTextContent("1");
+  await expect
+    .element(screen.getByTestId("message-0-content"))
+    .toHaveTextContent("Hello");
+  await expect
+    .element(screen.getByTestId("message-0-status"))
+    .toHaveTextContent("failed");
+});
+
+it("does not echo optimistically when optimistic is disabled", async () => {
+  const screen = render(OptimisticStream, {
+    apiUrl: serverUrl,
+    assistantId: "slow_graph",
+    optimistic: false,
+  });
+
+  await screen.getByTestId("submit").click();
+
+  await expect
+    .element(screen.getByTestId("loading"))
+    .toHaveTextContent("Loading...");
+  await expect
+    .element(screen.getByTestId("message-count"))
+    .toHaveTextContent("0");
+
+  await expect
+    .element(screen.getByTestId("loading"), { timeout: 5_000 })
+    .toHaveTextContent("Not loading");
+  await expect
+    .element(screen.getByTestId("message-count"))
+    .toHaveTextContent("2");
+  await expect
+    .element(screen.getByTestId("message-0-content"))
+    .toHaveTextContent("Hello");
+  await expect
+    .element(screen.getByTestId("message-0-status"))
+    .toHaveTextContent("none");
+});
+
+it("merges non-message state optimistically and converges to server truth", async () => {
+  const screen = render(OptimisticValuesStream, { apiUrl: serverUrl });
+
+  await screen.getByTestId("submit").click();
+
+  await expect.element(screen.getByTestId("status")).toHaveTextContent("draft");
+  await expect
+    .element(screen.getByTestId("loading"))
+    .toHaveTextContent("Loading...");
+
+  await expect
+    .element(screen.getByTestId("loading"), { timeout: 5_000 })
+    .toHaveTextContent("Not loading");
+  await expect.element(screen.getByTestId("status")).toHaveTextContent("final");
+  await expect
+    .element(screen.getByTestId("message-1"))
+    .toHaveTextContent("Done.");
+});
+
+it("rolls back an optimistic non-message key when the run never starts", async () => {
+  // An unknown assistant id makes dispatch reject before any `values`
+  // snapshot streams back — the one case where the optimistic
+  // non-message key is reverted rather than converged to server truth.
+  const screen = render(OptimisticValuesStream, {
+    apiUrl: serverUrl,
+    assistantId: "missing_graph",
+  });
+
+  await screen.getByTestId("submit").click();
+
+  await expect
+    .element(screen.getByTestId("loading"), { timeout: 5_000 })
+    .toHaveTextContent("Not loading");
+  await expect.element(screen.getByTestId("error")).toBeInTheDocument();
+
+  // No server `values` ever landed, so the optimistic `status` is
+  // reverted to its pre-submit state (absent).
+  await expect.element(screen.getByTestId("status")).toHaveTextContent("none");
+});
+
+it("does not merge non-message state when optimistic is disabled", async () => {
+  const screen = render(OptimisticValuesStream, {
+    apiUrl: serverUrl,
+    optimistic: false,
+  });
+
+  await screen.getByTestId("submit").click();
+
+  await expect
+    .element(screen.getByTestId("loading"))
+    .toHaveTextContent("Loading...");
+  await expect.element(screen.getByTestId("status")).toHaveTextContent("none");
+
+  await expect
+    .element(screen.getByTestId("loading"), { timeout: 5_000 })
+    .toHaveTextContent("Not loading");
+  await expect.element(screen.getByTestId("status")).toHaveTextContent("final");
+});

--- a/libs/sdk-svelte/src/tests/stream.test.ts
+++ b/libs/sdk-svelte/src/tests/stream.test.ts
@@ -321,8 +321,17 @@ it("useStream forwards submissions to a custom AgentServerAdapter", async () => 
     expect.objectContaining({
       method: "run.start",
       params: expect.objectContaining({
+        // Optimistic echo mints a stable id for the id-less message and
+        // normalizes it to a message dict before dispatch, so the server
+        // can reconcile its echo by id.
         input: {
-          messages: [{ type: "human", content: "Hi" }],
+          messages: [
+            expect.objectContaining({
+              type: "human",
+              content: "Hi",
+              id: expect.any(String),
+            }),
+          ],
         },
         config: expect.objectContaining({
           configurable: expect.objectContaining({

--- a/libs/sdk-svelte/src/use-stream.svelte.ts
+++ b/libs/sdk-svelte/src/use-stream.svelte.ts
@@ -418,6 +418,7 @@ export function useStream<
     messagesKey?: string;
     tools?: AnyHeadlessToolImplementation[];
     onTool?: OnToolCallback;
+    optimistic?: boolean;
   }
   const asBag = options as OptionsBag;
 
@@ -465,6 +466,7 @@ export function useStream<
     onCompleted: options.onCompleted,
     initialValues: options.initialValues,
     messagesKey: options.messagesKey,
+    optimistic: asBag.optimistic,
   });
 
   // Deferred dispose: mirrors React's activate/dispose pattern so HMR

--- a/libs/sdk-vue/src/tests/components/OptimisticStream.tsx
+++ b/libs/sdk-vue/src/tests/components/OptimisticStream.tsx
@@ -1,0 +1,84 @@
+import { defineComponent, type PropType } from "vue";
+import { HumanMessage, type BaseMessage } from "@langchain/core/messages";
+
+import { useStream, useMessageMetadata } from "../../index.js";
+import type { UseStreamReturn } from "../../index.js";
+import { formatMessage } from "./format.js";
+
+interface StreamState {
+  messages: BaseMessage[];
+}
+
+const MessageRow = defineComponent({
+  name: "MessageRow",
+  props: {
+    stream: {
+      type: Object as PropType<UseStreamReturn<StreamState>>,
+      required: true,
+    },
+    index: { type: Number, required: true },
+    message: { type: Object as PropType<BaseMessage>, required: true },
+  },
+  setup(props) {
+    const metadata = useMessageMetadata(props.stream, () => props.message.id);
+    return () => (
+      <div data-testid={`message-${props.index}`}>
+        <span data-testid={`message-${props.index}-content`}>
+          {formatMessage(props.message)}
+        </span>
+        <span data-testid={`message-${props.index}-status`}>
+          {metadata.value?.optimisticStatus ?? "none"}
+        </span>
+      </div>
+    );
+  },
+});
+
+export const OptimisticStream = defineComponent({
+  name: "OptimisticStream",
+  props: {
+    apiUrl: { type: String, default: undefined },
+    assistantId: { type: String, default: "agent" },
+    optimistic: { type: Boolean as PropType<boolean>, default: undefined },
+    submitText: { type: String, default: "Hello" },
+  },
+  setup(props) {
+    const stream = useStream<StreamState>({
+      assistantId: props.assistantId,
+      apiUrl: props.apiUrl,
+      optimistic: props.optimistic,
+    });
+
+    return () => (
+      <div>
+        <div data-testid="message-count">{stream.messages.value.length}</div>
+        <div data-testid="messages">
+          {stream.messages.value.map((msg, i) => (
+            <MessageRow
+              key={msg.id ?? i}
+              stream={stream}
+              index={i}
+              message={msg}
+            />
+          ))}
+        </div>
+        <div data-testid="loading">
+          {stream.isLoading.value ? "Loading..." : "Not loading"}
+        </div>
+        {stream.error.value ? (
+          <div data-testid="error">{String(stream.error.value)}</div>
+        ) : null}
+        <button
+          data-testid="submit"
+          onClick={() =>
+            void stream.submit({
+              messages: [new HumanMessage(props.submitText)],
+            })
+          }
+        >
+          Send
+        </button>
+      </div>
+    );
+  },
+});

--- a/libs/sdk-vue/src/tests/components/OptimisticValuesStream.tsx
+++ b/libs/sdk-vue/src/tests/components/OptimisticValuesStream.tsx
@@ -1,0 +1,63 @@
+import { computed, defineComponent, type PropType } from "vue";
+import { HumanMessage, type BaseMessage } from "@langchain/core/messages";
+
+import { useStream } from "../../index.js";
+
+interface StreamState {
+  messages: BaseMessage[];
+  status?: string;
+}
+
+export const OptimisticValuesStream = defineComponent({
+  name: "OptimisticValuesStream",
+  props: {
+    apiUrl: { type: String, default: undefined },
+    assistantId: { type: String, default: "stateful_values_graph" },
+    optimistic: { type: Boolean as PropType<boolean>, default: undefined },
+    submitStatus: { type: String, default: "draft" },
+  },
+  setup(props) {
+    const stream = useStream<StreamState>({
+      assistantId: props.assistantId,
+      apiUrl: props.apiUrl,
+      optimistic: props.optimistic,
+    });
+
+    const status = computed(
+      () => (stream.values.value as StreamState).status ?? "none",
+    );
+
+    return () => (
+      <div>
+        <div data-testid="message-count">{stream.messages.value.length}</div>
+        <div data-testid="messages">
+          {stream.messages.value.map((msg, i) => (
+            <div key={msg.id ?? i} data-testid={`message-${i}`}>
+              {typeof msg.content === "string"
+                ? msg.content
+                : JSON.stringify(msg.content)}
+            </div>
+          ))}
+        </div>
+        <div data-testid="status">{status.value}</div>
+        <div data-testid="loading">
+          {stream.isLoading.value ? "Loading..." : "Not loading"}
+        </div>
+        {stream.error.value ? (
+          <div data-testid="error">{String(stream.error.value)}</div>
+        ) : null}
+        <button
+          data-testid="submit"
+          onClick={() =>
+            void stream.submit({
+              messages: [new HumanMessage("Hello")],
+              status: props.submitStatus,
+            })
+          }
+        >
+          Send
+        </button>
+      </div>
+    );
+  },
+});

--- a/libs/sdk-vue/src/tests/fixtures/mock-server.ts
+++ b/libs/sdk-vue/src/tests/fixtures/mock-server.ts
@@ -25,6 +25,7 @@ import {
 import {
   StateGraph,
   MessagesAnnotation,
+  Annotation,
   Command,
   interrupt,
   pushMessage,
@@ -202,6 +203,25 @@ const slowAgent = new StateGraph(MessagesAnnotation)
     return {
       messages: [new AIMessage("Done.")],
     };
+  })
+  .addEdge(START, "agent")
+  .compile();
+
+// State with a non-message channel alongside `messages`, used to
+// exercise optimistic handling of non-message input keys. Sleeps
+// before overwriting `status` with the server-authoritative value.
+const StatefulState = Annotation.Root({
+  ...MessagesAnnotation.spec,
+  status: Annotation<string>({
+    reducer: (_prev, next) => next,
+    default: () => "idle",
+  }),
+});
+
+const statefulValuesAgent = new StateGraph(StatefulState)
+  .addNode("agent", async () => {
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    return { messages: [new AIMessage("Done.")], status: "final" };
   })
   .addEdge(START, "agent")
   .compile();
@@ -523,6 +543,7 @@ const graphs: Record<string, AnyPregel> = {
   removeMessageAgent,
   errorAgent,
   slowAgent,
+  stateful_values_graph: statefulValuesAgent,
   headlessToolAgent,
   deepAgent: deepAgentGraph as unknown as AnyPregel,
   customChannelAgent,

--- a/libs/sdk-vue/src/tests/stream.optimistic.test.tsx
+++ b/libs/sdk-vue/src/tests/stream.optimistic.test.tsx
@@ -1,0 +1,206 @@
+import { expect, it } from "vitest";
+import { render } from "vitest-browser-vue";
+
+import { OptimisticStream } from "./components/OptimisticStream.js";
+import { OptimisticValuesStream } from "./components/OptimisticValuesStream.js";
+import { apiUrl } from "./test-utils.js";
+
+it("echoes the submitted message immediately as pending, then marks it sent", async () => {
+  // `slowAgent` sleeps before emitting, giving us a stable window to
+  // observe the optimistic (pending) message while the run is in flight.
+  const screen = await render(OptimisticStream, {
+    props: { apiUrl, assistantId: "slowAgent" },
+  });
+
+  try {
+    await screen.getByTestId("submit").click();
+
+    await expect
+      .element(screen.getByTestId("message-0-content"))
+      .toHaveTextContent("Hello");
+    await expect
+      .element(screen.getByTestId("message-0-status"))
+      .toHaveTextContent("pending");
+    await expect
+      .element(screen.getByTestId("loading"))
+      .toHaveTextContent("Loading...");
+
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 5_000 })
+      .toHaveTextContent("Not loading");
+    await expect
+      .element(screen.getByTestId("message-0-status"))
+      .toHaveTextContent("sent");
+    await expect
+      .element(screen.getByTestId("message-1-content"))
+      .toHaveTextContent("Done.");
+  } finally {
+    await screen.unmount();
+  }
+});
+
+it("reconciles the server echo by id without duplicating the message", async () => {
+  const screen = await render(OptimisticStream, { props: { apiUrl } });
+
+  try {
+    await screen.getByTestId("submit").click();
+
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 5_000 })
+      .toHaveTextContent("Not loading");
+
+    await expect
+      .element(screen.getByTestId("message-count"))
+      .toHaveTextContent("2");
+    await expect
+      .element(screen.getByTestId("message-0-content"))
+      .toHaveTextContent("Hello");
+    await expect
+      .element(screen.getByTestId("message-0-status"))
+      .toHaveTextContent("sent");
+    await expect
+      .element(screen.getByTestId("message-1-content"))
+      .toHaveTextContent("Hey");
+  } finally {
+    await screen.unmount();
+  }
+});
+
+it("keeps the optimistic message and marks it failed when the run errors", async () => {
+  const screen = await render(OptimisticStream, {
+    props: { apiUrl, assistantId: "errorAgent" },
+  });
+
+  try {
+    await screen.getByTestId("submit").click();
+
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 5_000 })
+      .toHaveTextContent("Not loading");
+
+    await expect.element(screen.getByTestId("error")).toBeInTheDocument();
+
+    await expect
+      .element(screen.getByTestId("message-count"))
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("message-0-content"))
+      .toHaveTextContent("Hello");
+    await expect
+      .element(screen.getByTestId("message-0-status"))
+      .toHaveTextContent("failed");
+  } finally {
+    await screen.unmount();
+  }
+});
+
+it("does not echo optimistically when optimistic is disabled", async () => {
+  const screen = await render(OptimisticStream, {
+    props: { apiUrl, assistantId: "slowAgent", optimistic: false },
+  });
+
+  try {
+    await screen.getByTestId("submit").click();
+
+    await expect
+      .element(screen.getByTestId("loading"))
+      .toHaveTextContent("Loading...");
+    await expect
+      .element(screen.getByTestId("message-count"))
+      .toHaveTextContent("0");
+
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 5_000 })
+      .toHaveTextContent("Not loading");
+    await expect
+      .element(screen.getByTestId("message-count"))
+      .toHaveTextContent("2");
+    await expect
+      .element(screen.getByTestId("message-0-content"))
+      .toHaveTextContent("Hello");
+    await expect
+      .element(screen.getByTestId("message-0-status"))
+      .toHaveTextContent("none");
+  } finally {
+    await screen.unmount();
+  }
+});
+
+it("merges non-message state optimistically and converges to server truth", async () => {
+  const screen = await render(OptimisticValuesStream, { props: { apiUrl } });
+
+  try {
+    await screen.getByTestId("submit").click();
+
+    await expect
+      .element(screen.getByTestId("status"))
+      .toHaveTextContent("draft");
+    await expect
+      .element(screen.getByTestId("loading"))
+      .toHaveTextContent("Loading...");
+
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 5_000 })
+      .toHaveTextContent("Not loading");
+    await expect
+      .element(screen.getByTestId("status"))
+      .toHaveTextContent("final");
+    await expect
+      .element(screen.getByTestId("message-1"))
+      .toHaveTextContent("Done.");
+  } finally {
+    await screen.unmount();
+  }
+});
+
+it("rolls back an optimistic non-message key when the run never starts", async () => {
+  // An unknown assistant id makes dispatch reject before any `values`
+  // snapshot streams back — the one case where the optimistic
+  // non-message key is reverted rather than converged to server truth.
+  const screen = await render(OptimisticValuesStream, {
+    props: { apiUrl, assistantId: "missing_graph" },
+  });
+
+  try {
+    await screen.getByTestId("submit").click();
+
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 5_000 })
+      .toHaveTextContent("Not loading");
+    await expect.element(screen.getByTestId("error")).toBeInTheDocument();
+
+    // No server `values` ever landed, so the optimistic `status` is
+    // reverted to its pre-submit state (absent).
+    await expect
+      .element(screen.getByTestId("status"))
+      .toHaveTextContent("none");
+  } finally {
+    await screen.unmount();
+  }
+});
+
+it("does not merge non-message state when optimistic is disabled", async () => {
+  const screen = await render(OptimisticValuesStream, {
+    props: { apiUrl, optimistic: false },
+  });
+
+  try {
+    await screen.getByTestId("submit").click();
+
+    await expect
+      .element(screen.getByTestId("loading"))
+      .toHaveTextContent("Loading...");
+    await expect
+      .element(screen.getByTestId("status"))
+      .toHaveTextContent("none");
+
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 5_000 })
+      .toHaveTextContent("Not loading");
+    await expect
+      .element(screen.getByTestId("status"))
+      .toHaveTextContent("final");
+  } finally {
+    await screen.unmount();
+  }
+});

--- a/libs/sdk-vue/src/use-stream.ts
+++ b/libs/sdk-vue/src/use-stream.ts
@@ -434,6 +434,7 @@ export function useStream<
     messagesKey?: string;
     tools?: AnyHeadlessToolImplementation[];
     onTool?: OnToolCallback;
+    optimistic?: boolean;
   }
   const asBag = options as OptionsBag;
 
@@ -502,6 +503,7 @@ export function useStream<
     onCompleted: options.onCompleted,
     initialValues: options.initialValues,
     messagesKey: options.messagesKey,
+    optimistic: asBag.optimistic,
   });
 
   // Deferred dispose: on the next microtask after the owning scope

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -20,6 +20,7 @@
  * one extra subscription per `(channels, namespace)` actually
  * rendered on screen.
  */
+import { v7 as uuidv7 } from "uuid";
 import { AIMessage, type BaseMessage } from "@langchain/core/messages";
 import type {
   Channel,
@@ -59,6 +60,10 @@ import {
 } from "./message-metadata-tracker.js";
 import { LifecycleLoadingTracker } from "./lifecycle-loading-tracker.js";
 import { RootMessageProjection } from "./root-message-projection.js";
+import {
+  prepareOptimisticInput,
+  type OptimisticHandle,
+} from "./optimistic-input.js";
 import {
   EMPTY_QUEUE,
   SubmitCoordinator,
@@ -207,6 +212,14 @@ export class StreamController<
   readonly #rootBus: RootEventBus;
   #activeRunId: string | undefined;
   #localRunDepth = 0;
+  /**
+   * `true` once a root `values` event has been applied for the current
+   * optimistic run. Reset to `false` in {@link #beginOptimistic} and
+   * read in {@link #settleOptimistic}: when a run terminates without
+   * the server ever echoing a `values` snapshot, optimistically-merged
+   * non-message keys are rolled back to their pre-submit values.
+   */
+  #sawValuesForRun = false;
 
   /**
    * Single-shot hydration promise. Exposed via `hydrationPromise`
@@ -307,6 +320,9 @@ export class StreamController<
       onRunCreated: (runId) => this.#notifyCreated(runId),
       onRunCompleted: (reason, runId) => this.#notifyCompleted(reason, runId),
       onRunEnd: () => this.#markLocalRunEnd(),
+      beginOptimistic: (input) => this.#beginOptimistic(input),
+      settleOptimistic: (handle, event) =>
+        this.#settleOptimistic(handle, event),
     });
     this.#hydrationPromise = this.#createHydrationPromise();
     /**
@@ -459,6 +475,18 @@ export class StreamController<
               }
             : undefined;
         this.#applyValues(state.values as unknown, syntheticCheckpoint);
+      }
+      /**
+       * Converge to server truth: drop any optimistic messages the
+       * server state does not contain (`pending` / `failed` that were
+       * never persisted — e.g. a failed run's user message). Echoed
+       * ids were flipped to `"sent"` by `#applyValues` above and so are
+       * excluded from `unpersistedOptimisticIds()`.
+       */
+      const unpersisted = this.#messageMetadata.unpersistedOptimisticIds();
+      if (unpersisted.size > 0) {
+        this.#rootMessages.dropOptimisticMessages(unpersisted);
+        this.#messageMetadata.forget(unpersisted);
       }
       /**
        * Sync the visible interrupt list to the server's authoritative
@@ -1482,11 +1510,98 @@ export class StreamController<
    * @param raw - Raw `values` channel payload.
    * @param checkpoint - Optional checkpoint envelope paired with the values event.
    */
+  /**
+   * Apply a submit input optimistically to the root projection before
+   * the server responds. Mints stable ids for id-less messages (so the
+   * server echo reconciles by id), appends them to the projection, and
+   * shallow-merges non-message input keys into `values`.
+   *
+   * Returns the dispatch payload (id-injected) for the coordinator to
+   * send, plus an {@link OptimisticHandle} for terminal reconciliation.
+   * Returns `undefined` when optimistic UI is disabled or there is
+   * nothing to echo, in which case the coordinator dispatches the raw
+   * input unchanged.
+   *
+   * @param input - Raw input passed to `submit()`.
+   */
+  #beginOptimistic(
+    input: unknown
+  ): { dispatchInput: unknown; handle: OptimisticHandle } | undefined {
+    if (this.#options.optimistic === false) return undefined;
+    if (input == null || typeof input !== "object" || Array.isArray(input)) {
+      return undefined;
+    }
+    const prepared = prepareOptimisticInput(
+      input as Record<string, unknown>,
+      this.#messagesKey,
+      () => uuidv7()
+    );
+    const extraKeys = Object.keys(prepared.extraValues);
+    if (prepared.echoedIds.length === 0 && extraKeys.length === 0) {
+      return undefined;
+    }
+
+    const currentValues = this.rootStore.getSnapshot().values as Record<
+      string,
+      unknown
+    >;
+    const restoreKeys = extraKeys.map((key) => ({
+      key,
+      hadKey: Object.prototype.hasOwnProperty.call(currentValues, key),
+      prevValue: currentValues[key],
+    }));
+
+    this.#sawValuesForRun = false;
+    this.#rootMessages.appendOptimistic(
+      prepared.optimisticMessages,
+      prepared.extraValues
+    );
+    if (prepared.echoedIds.length > 0) {
+      this.#messageMetadata.markPending(prepared.echoedIds);
+    }
+    return {
+      dispatchInput: prepared.dispatchInput,
+      handle: { echoedIds: prepared.echoedIds, restoreKeys },
+    };
+  }
+
+  /**
+   * Reconcile optimistic state when a run terminates.
+   *
+   *   - Messages: any echoed id still `"pending"` (never echoed by the
+   *     server) is flipped to `"sent"` on success/interrupt, or
+   *     `"failed"` on failure/abort. Ids the server already echoed were
+   *     flipped to `"sent"` in {@link #applyValues} and are untouched.
+   *   - Non-message keys: rolled back to their pre-submit values when no
+   *     server `values` event landed during the run (otherwise the
+   *     server snapshot already reconciled them). Skipped on abort,
+   *     where a superseding run (or `stop()`) owns subsequent state.
+   *
+   * @param handle - Handle returned by {@link #beginOptimistic}.
+   * @param event  - Terminal lifecycle event for the run.
+   */
+  #settleOptimistic(
+    handle: OptimisticHandle,
+    event: "completed" | "failed" | "interrupted" | "aborted"
+  ): void {
+    const failed = event === "failed" || event === "aborted";
+    this.#messageMetadata.resolvePending(
+      handle.echoedIds,
+      failed ? "failed" : "sent"
+    );
+    if (event !== "aborted" && !this.#sawValuesForRun) {
+      this.#rootMessages.restoreValueKeys(handle.restoreKeys);
+    }
+  }
+
   #applyValues(raw: unknown, checkpoint?: CheckpointEnvelope): void {
     if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
       return;
     }
     const state = raw as Record<string, unknown>;
+    // A root `values` snapshot landed: optimistic non-message keys are
+    // now reconciled against server truth (see #settleOptimistic).
+    this.#sawValuesForRun = true;
     /**
      * Surface parent_checkpoint per-message when the values event
      * carries the lightweight checkpoint envelope (populated by
@@ -1520,6 +1635,14 @@ export class StreamController<
     }
     this.#rootMessages.applyValues(nextValues, nextMessages);
     if (nextMessages.length > 0) {
+      // Any optimistic message the server just echoed is now
+      // server-authoritative: flip its status `pending` → `sent`.
+      this.#messageMetadata.resolvePending(
+        nextMessages
+          .map((m) => m.id)
+          .filter((id): id is string => typeof id === "string"),
+        "sent"
+      );
       this.rootStore.setState((s) => {
         const toolCalls = reconcileToolCallsFromMessages(
           s.toolCalls,

--- a/libs/sdk/src/stream/message-metadata-tracker.test.ts
+++ b/libs/sdk/src/stream/message-metadata-tracker.test.ts
@@ -222,4 +222,60 @@ describe("MessageMetadataTracker", () => {
       parentCheckpointId: "cp-0",
     });
   });
+
+  describe("optimistic status", () => {
+    it("marks ids pending", () => {
+      const tracker = new MessageMetadataTracker();
+      tracker.markPending(["a", "b"]);
+      expect(tracker.store.getSnapshot().get("a")?.optimisticStatus).toBe(
+        "pending"
+      );
+      expect(tracker.unpersistedOptimisticIds()).toEqual(new Set(["a", "b"]));
+    });
+
+    it("resolvePending only affects ids currently pending", () => {
+      const tracker = new MessageMetadataTracker();
+      tracker.markPending(["a"]);
+      // "server" message id "b" was never optimistic — must stay clean.
+      tracker.resolvePending(["a", "b"], "sent");
+      expect(tracker.store.getSnapshot().get("a")?.optimisticStatus).toBe(
+        "sent"
+      );
+      expect(tracker.store.getSnapshot().has("b")).toBe(false);
+      expect(tracker.unpersistedOptimisticIds().size).toBe(0);
+    });
+
+    it("treats failed ids as unpersisted", () => {
+      const tracker = new MessageMetadataTracker();
+      tracker.markPending(["a"]);
+      tracker.resolvePending(["a"], "failed");
+      expect(tracker.unpersistedOptimisticIds()).toEqual(new Set(["a"]));
+    });
+
+    it("forget removes status and metadata for ids", () => {
+      const tracker = new MessageMetadataTracker();
+      tracker.markPending(["a"]);
+      tracker.forget(["a"]);
+      expect(tracker.store.getSnapshot().has("a")).toBe(false);
+      expect(tracker.unpersistedOptimisticIds().size).toBe(0);
+    });
+
+    it("preserves parentCheckpointId when marking pending", () => {
+      const tracker = new MessageMetadataTracker();
+      tracker.recordMessages([{ id: "a" }], { parentCheckpointId: "cp-1" });
+      tracker.markPending(["a"]);
+      expect(tracker.store.getSnapshot().get("a")).toEqual({
+        parentCheckpointId: "cp-1",
+        optimisticStatus: "pending",
+      });
+    });
+
+    it("clears all optimistic state on reset", () => {
+      const tracker = new MessageMetadataTracker();
+      tracker.markPending(["a"]);
+      tracker.reset();
+      expect(tracker.unpersistedOptimisticIds().size).toBe(0);
+      expect(tracker.store.getSnapshot().size).toBe(0);
+    });
+  });
 });

--- a/libs/sdk/src/stream/message-metadata-tracker.ts
+++ b/libs/sdk/src/stream/message-metadata-tracker.ts
@@ -48,6 +48,24 @@ import { StreamStore } from "./store.js";
 import { namespaceKey } from "./namespace.js";
 
 /**
+ * Optimistic lifecycle status for a message that originated from a
+ * local {@link StreamController.submit} before the server echoed it.
+ *
+ *   - `"pending"` — applied optimistically; the run is in flight and
+ *     the server has not yet echoed this id in a `values` snapshot.
+ *   - `"sent"`    — the server echoed the id (run progressed); the
+ *     message is now server-authoritative.
+ *   - `"failed"`  — the run failed before the id was echoed. The
+ *     message is kept (so UIs can show it with a retry affordance) but
+ *     is dropped on the next {@link StreamController.hydrate} because
+ *     it was never persisted server-side.
+ *
+ * Server-originated messages (history, streamed assistant turns) never
+ * carry a status — `undefined` means "not optimistic".
+ */
+export type OptimisticStatus = "pending" | "sent" | "failed";
+
+/**
  * Metadata tracked per message id. Surfaced to applications via
  * `useMessageMetadata(stream, messageId)`.
  */
@@ -62,6 +80,13 @@ export interface MessageMetadata {
    * the caller stripped them upstream).
    */
   readonly parentCheckpointId: string | undefined;
+
+  /**
+   * Optimistic lifecycle status, present only for messages applied
+   * locally by an optimistic `submit()`. `undefined` for ordinary
+   * server-originated messages. See {@link OptimisticStatus}.
+   */
+  readonly optimisticStatus?: OptimisticStatus;
 }
 
 /**
@@ -127,12 +152,22 @@ export class MessageMetadataTracker {
   >();
 
   /**
+   * Ids of messages currently in the `"pending"` optimistic state.
+   * Maintained alongside the metadata map so the controller can cheaply
+   * (a) flip ids to `"sent"` when the server echoes them and (b) flip
+   * any leftover ids to `"sent"` / `"failed"` at run terminal, without
+   * scanning the whole metadata map.
+   */
+  readonly #pendingOptimisticIds = new Set<string>();
+
+  /**
    * Drop all buffered checkpoints and reset the metadata map to the
    * shared empty instance. Called on thread rebind / dispose so a new
    * thread's metadata can't bleed into the old one.
    */
   reset(): void {
     this.#pendingCheckpointByNamespace.clear();
+    this.#pendingOptimisticIds.clear();
     this.store.setState(() => EMPTY_METADATA_MAP);
   }
 
@@ -215,6 +250,94 @@ export class MessageMetadataTracker {
       }
       next.set(id, { ...prev, ...metadata });
       changed = true;
+    }
+    if (changed) this.store.setState(() => next);
+  }
+
+  /**
+   * Mark a set of message ids as optimistically `"pending"`.
+   *
+   * Called from {@link StreamController}'s optimistic submit path right
+   * after the messages are appended to the projection, so a UI can
+   * render a "sending…" affordance via
+   * `useMessageMetadata(stream, id).optimisticStatus`.
+   *
+   * @param ids - Message ids that were just applied optimistically.
+   */
+  markPending(ids: Iterable<string>): void {
+    let changed = false;
+    const next = new Map(this.store.getSnapshot());
+    for (const id of ids) {
+      if (typeof id !== "string" || id.length === 0) continue;
+      this.#pendingOptimisticIds.add(id);
+      const prev = next.get(id);
+      if (prev?.optimisticStatus === "pending") continue;
+      next.set(id, {
+        parentCheckpointId: prev?.parentCheckpointId,
+        ...prev,
+        optimisticStatus: "pending",
+      });
+      changed = true;
+    }
+    if (changed) this.store.setState(() => next);
+  }
+
+  /**
+   * Transition the given ids out of `"pending"`.
+   *
+   * Only ids currently tracked as pending are affected, so passing a
+   * full server `values.messages` id list (to flip echoed messages to
+   * `"sent"`) never stamps a status onto ordinary server messages.
+   *
+   * @param ids    - Candidate ids (e.g. all ids in a server snapshot,
+   *   or the ids echoed by a single submit).
+   * @param status - Terminal optimistic status (`"sent"` / `"failed"`).
+   */
+  resolvePending(ids: Iterable<string>, status: OptimisticStatus): void {
+    let changed = false;
+    const next = new Map(this.store.getSnapshot());
+    for (const id of ids) {
+      if (!this.#pendingOptimisticIds.has(id)) continue;
+      this.#pendingOptimisticIds.delete(id);
+      const prev = next.get(id);
+      next.set(id, {
+        parentCheckpointId: prev?.parentCheckpointId,
+        ...prev,
+        optimisticStatus: status,
+      });
+      changed = true;
+    }
+    if (changed) this.store.setState(() => next);
+  }
+
+  /**
+   * Snapshot of ids whose optimistic status is `"pending"` or
+   * `"failed"` — i.e. messages applied locally that the server has not
+   * echoed. Used by {@link StreamController.hydrate} to drop
+   * never-persisted optimistic messages so a reload converges to
+   * server truth.
+   */
+  unpersistedOptimisticIds(): Set<string> {
+    const ids = new Set<string>(this.#pendingOptimisticIds);
+    for (const [id, meta] of this.store.getSnapshot()) {
+      if (meta.optimisticStatus === "failed") ids.add(id);
+    }
+    return ids;
+  }
+
+  /**
+   * Drop all metadata for the given ids. Called after never-persisted
+   * optimistic messages are removed from the projection on
+   * {@link StreamController.hydrate}, so their status doesn't linger.
+   *
+   * @param ids - Message ids to forget.
+   */
+  forget(ids: Iterable<string>): void {
+    let changed = false;
+    const next = new Map(this.store.getSnapshot());
+    for (const id of ids) {
+      this.#pendingOptimisticIds.delete(id);
+      if (next.delete(id)) changed = true;
     }
     if (changed) this.store.setState(() => next);
   }

--- a/libs/sdk/src/stream/optimistic-input.test.ts
+++ b/libs/sdk/src/stream/optimistic-input.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { AIMessage, HumanMessage } from "@langchain/core/messages";
+
+import { prepareOptimisticInput } from "./optimistic-input.js";
+
+let counter = 0;
+const mint = () => `minted-${(counter += 1)}`;
+
+describe("prepareOptimisticInput", () => {
+  it("mints ids for id-less message objects and echoes them", () => {
+    counter = 0;
+    const result = prepareOptimisticInput(
+      { messages: [{ type: "human", content: "hi" }] },
+      "messages",
+      mint
+    );
+
+    expect(result.echoedIds).toEqual(["minted-1"]);
+    expect(result.optimisticMessages).toHaveLength(1);
+    expect(result.optimisticMessages[0].id).toBe("minted-1");
+    // Dispatch payload normalized to an array carrying the minted id.
+    const dispatched = result.dispatchInput.messages as Array<{ id: string }>;
+    expect(dispatched[0].id).toBe("minted-1");
+  });
+
+  it("preserves an existing message id (no mint)", () => {
+    const result = prepareOptimisticInput(
+      { messages: [{ type: "human", content: "hi", id: "keep-me" }] },
+      "messages",
+      mint
+    );
+    expect(result.echoedIds).toEqual(["keep-me"]);
+    expect(result.optimisticMessages[0].id).toBe("keep-me");
+  });
+
+  it("normalizes a bare string into a human message", () => {
+    counter = 0;
+    const result = prepareOptimisticInput(
+      { messages: "hello" },
+      "messages",
+      mint
+    );
+    expect(result.optimisticMessages).toHaveLength(1);
+    expect(result.optimisticMessages[0].getType()).toBe("human");
+    expect(result.optimisticMessages[0].content).toBe("hello");
+    expect(result.echoedIds).toEqual(["minted-1"]);
+  });
+
+  it("does not mutate the caller's BaseMessage instances", () => {
+    const original = new HumanMessage("hi");
+    expect(original.id).toBeUndefined();
+    const result = prepareOptimisticInput(
+      { messages: [original] },
+      "messages",
+      mint
+    );
+    // Caller's instance is untouched; a fresh instance carries the id.
+    expect(original.id).toBeUndefined();
+    expect(result.optimisticMessages[0].id).toBeTruthy();
+  });
+
+  it("separates non-message keys into extraValues", () => {
+    const result = prepareOptimisticInput(
+      { messages: [new AIMessage({ content: "x", id: "a" })], cursor: "c1" },
+      "messages",
+      mint
+    );
+    expect(result.extraValues).toEqual({ cursor: "c1" });
+    expect(result.dispatchInput.cursor).toBe("c1");
+  });
+
+  it("echoes nothing when input has no messages key", () => {
+    const result = prepareOptimisticInput(
+      { cursor: "c1" },
+      "messages",
+      mint
+    );
+    expect(result.echoedIds).toEqual([]);
+    expect(result.optimisticMessages).toEqual([]);
+    expect(result.extraValues).toEqual({ cursor: "c1" });
+  });
+
+  it("respects a custom messagesKey", () => {
+    counter = 0;
+    const result = prepareOptimisticInput(
+      { chat: [{ type: "human", content: "hi" }] },
+      "chat",
+      mint
+    );
+    expect(result.echoedIds).toEqual(["minted-1"]);
+    expect((result.dispatchInput.chat as unknown[]).length).toBe(1);
+  });
+});

--- a/libs/sdk/src/stream/optimistic-input.ts
+++ b/libs/sdk/src/stream/optimistic-input.ts
@@ -1,0 +1,151 @@
+/**
+ * Pure helpers for the optimistic `submit()` path.
+ *
+ * Splitting the input-shaping logic out of {@link StreamController}
+ * keeps it unit-testable in isolation: given a raw submit input it
+ * produces (a) the payload to dispatch to the server — with stable ids
+ * minted for any id-less message so the server echo reconciles by id —
+ * and (b) the coerced `BaseMessage` instances to append to the root
+ * projection immediately.
+ *
+ * No mutation of the caller's input is performed: message entries are
+ * rebuilt as fresh dicts before ids are injected, and the top-level
+ * object is shallow-cloned.
+ */
+import type { BaseMessage } from "@langchain/core/messages";
+import type { Message } from "../types.messages.js";
+import { ensureMessageInstances, toMessageDict } from "../ui/messages.js";
+
+/**
+ * Pre-submit snapshot of a single non-message `values` key, captured so
+ * it can be rolled back if the run fails before the server echoes any
+ * `values`.
+ */
+export interface OptimisticKeySnapshot {
+  readonly key: string;
+  /** Whether the key existed in `values` before the optimistic merge. */
+  readonly hadKey: boolean;
+  /** The pre-submit value (meaningful only when `hadKey` is true). */
+  readonly prevValue: unknown;
+}
+
+/**
+ * Opaque handle returned by the controller's optimistic apply step and
+ * threaded back through the submit coordinator to the terminal
+ * reconciliation step. Carries the echoed message ids (to transition
+ * `pending` → `sent` / `failed`) and the non-message key snapshot (to
+ * roll back on failure-before-echo).
+ */
+export interface OptimisticHandle {
+  readonly echoedIds: string[];
+  readonly restoreKeys: OptimisticKeySnapshot[];
+}
+
+/**
+ * Result of preparing a raw submit input for optimistic dispatch.
+ */
+export interface PreparedOptimisticInput {
+  /**
+   * Input to actually send to the server. The messages key (when
+   * present) is normalized to an array of message dicts, each carrying
+   * a stable id; all other keys are copied verbatim.
+   */
+  readonly dispatchInput: Record<string, unknown>;
+  /** Coerced message instances (with ids) to append to the projection. */
+  readonly optimisticMessages: BaseMessage[];
+  /** Ids of the messages echoed optimistically (minted or pre-existing). */
+  readonly echoedIds: string[];
+  /** Non-message input keys to shallow-merge into `values`. */
+  readonly extraValues: Record<string, unknown>;
+}
+
+function isBaseMessageInstance(value: unknown): value is BaseMessage {
+  return (
+    value != null &&
+    typeof (value as { getType?: unknown }).getType === "function"
+  );
+}
+
+function extractId(value: unknown): string | undefined {
+  const id = (value as { id?: unknown } | null)?.id;
+  return typeof id === "string" && id.length > 0 ? id : undefined;
+}
+
+/**
+ * Normalize a message-key value into an array of entries. Mirrors the
+ * server's `add_messages` coercion: a bare string or single message
+ * object is treated as a one-element list.
+ */
+function toEntryArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  return [value];
+}
+
+/**
+ * Build a message dict carrying `id` from an arbitrary input entry,
+ * without mutating the original.
+ */
+function toDispatchDict(entry: unknown, id: string): Message {
+  if (typeof entry === "string") {
+    return { type: "human", content: entry, id } as unknown as Message;
+  }
+  if (isBaseMessageInstance(entry)) {
+    return { ...toMessageDict(entry), id } as Message;
+  }
+  return { ...(entry as object), id } as Message;
+}
+
+/**
+ * Prepare a raw submit input for optimistic dispatch.
+ *
+ * @param raw         - Raw input passed to `submit()`. Must be a
+ *   non-null, non-array object (caller guards this).
+ * @param messagesKey - State key holding the message array.
+ * @param mintId      - Factory for stable client message ids.
+ * @returns The dispatch payload, optimistic messages, echoed ids, and
+ *   the non-message portion of the input.
+ */
+export function prepareOptimisticInput(
+  raw: Record<string, unknown>,
+  messagesKey: string,
+  mintId: () => string
+): PreparedOptimisticInput {
+  const dispatchInput: Record<string, unknown> = { ...raw };
+  const extraValues: Record<string, unknown> = {};
+  for (const key of Object.keys(raw)) {
+    if (key !== messagesKey) extraValues[key] = raw[key];
+  }
+
+  const echoedIds: string[] = [];
+  const messagesValue = raw[messagesKey];
+  if (messagesValue == null) {
+    return { dispatchInput, optimisticMessages: [], echoedIds, extraValues };
+  }
+
+  const entries = toEntryArray(messagesValue);
+  const dispatchEntries: unknown[] = [];
+  const optimisticDicts: Message[] = [];
+  for (const entry of entries) {
+    const echoable =
+      typeof entry === "string" ||
+      isBaseMessageInstance(entry) ||
+      (entry != null && typeof entry === "object" && !Array.isArray(entry));
+    if (!echoable) {
+      // Non-message-shaped entry (number/bool/null): forward as-is,
+      // nothing to echo.
+      dispatchEntries.push(entry);
+      continue;
+    }
+    const id = extractId(entry) ?? mintId();
+    const dict = toDispatchDict(entry, id);
+    dispatchEntries.push(dict);
+    optimisticDicts.push(dict);
+    echoedIds.push(id);
+  }
+
+  dispatchInput[messagesKey] = dispatchEntries;
+  const optimisticMessages = ensureMessageInstances(
+    optimisticDicts
+  ) as BaseMessage[];
+  return { dispatchInput, optimisticMessages, echoedIds, extraValues };
+}

--- a/libs/sdk/src/stream/root-message-projection.test.ts
+++ b/libs/sdk/src/stream/root-message-projection.test.ts
@@ -1020,4 +1020,89 @@ describe("RootMessageProjection", () => {
       expect(values.messages).toBeUndefined();
     });
   });
+
+  describe("appendOptimistic", () => {
+    it("appends an optimistic message after existing history", async () => {
+      const { store, projection } = makeProjection();
+
+      const existing = new AIMessage({ id: "a1", content: "prior" });
+      projection.applyValues({ messages: [existing] } as State, [existing]);
+      await drainFlush();
+
+      const optimistic = new HumanMessage({ id: "h1", content: "hi" });
+      projection.appendOptimistic([optimistic]);
+      await drainFlush();
+
+      const snap = store.getSnapshot();
+      expect(snap.messages.map((m) => m.id)).toEqual(["a1", "h1"]);
+    });
+
+    it("merges non-message extraValues into values", async () => {
+      const { store, projection } = makeProjection();
+
+      const optimistic = new HumanMessage({ id: "h1", content: "hi" });
+      projection.appendOptimistic([optimistic], { cursor: "pending" });
+      await drainFlush();
+
+      expect((store.getSnapshot().values as State).cursor).toBe("pending");
+    });
+
+    it("reconciles by id when the server echoes the message", async () => {
+      const { store, projection } = makeProjection();
+
+      const optimistic = new HumanMessage({ id: "h1", content: "hi" });
+      projection.appendOptimistic([optimistic]);
+      await drainFlush();
+
+      // Server echoes [h1, a1] — no duplicate h1, ai appended.
+      const echoed = new HumanMessage({ id: "h1", content: "hi" });
+      const ai = new AIMessage({ id: "a1", content: "reply" });
+      projection.applyValues({ messages: [echoed, ai] } as State, [echoed, ai]);
+      await drainFlush();
+
+      expect(store.getSnapshot().messages.map((m) => m.id)).toEqual([
+        "h1",
+        "a1",
+      ]);
+    });
+  });
+
+  describe("dropOptimisticMessages", () => {
+    it("removes the given ids and preserves the rest", async () => {
+      const { store, projection } = makeProjection();
+
+      const a = new AIMessage({ id: "a1", content: "keep" });
+      const h = new HumanMessage({ id: "h1", content: "drop" });
+      projection.applyValues({ messages: [a] } as State, [a]);
+      projection.appendOptimistic([h]);
+      await drainFlush();
+
+      projection.dropOptimisticMessages(new Set(["h1"]));
+      await drainFlush();
+
+      expect(store.getSnapshot().messages.map((m) => m.id)).toEqual(["a1"]);
+    });
+  });
+
+  describe("restoreValueKeys", () => {
+    it("restores a previously-existing key and deletes a new one", async () => {
+      const { store, projection } = makeProjection();
+
+      const h = new HumanMessage({ id: "h1", content: "hi" });
+      projection.appendOptimistic([h], { cursor: "optimistic", added: "x" });
+      await drainFlush();
+
+      projection.restoreValueKeys([
+        { key: "cursor", hadKey: true, prevValue: "prev" },
+        { key: "added", hadKey: false, prevValue: undefined },
+      ]);
+      await drainFlush();
+
+      const values = store.getSnapshot().values as Record<string, unknown>;
+      expect(values.cursor).toBe("prev");
+      expect("added" in values).toBe(false);
+      // Messages are left intact (kept on failure).
+      expect(store.getSnapshot().messages.map((m) => m.id)).toEqual(["h1"]);
+    });
+  });
 });

--- a/libs/sdk/src/stream/root-message-projection.ts
+++ b/libs/sdk/src/stream/root-message-projection.ts
@@ -373,6 +373,137 @@ export class RootMessageProjection<
   }
 
   /**
+   * Append messages applied optimistically by a local `submit()`,
+   * keyed by id so the eventual server echo reconciles cleanly.
+   *
+   * Unlike {@link applyValues}, the supplied messages are *not* treated
+   * as an authoritative ordered snapshot: they are appended to the end
+   * of the current projection (or replaced in place when the id already
+   * exists), preserving prior history ordering. When the server later
+   * emits a `values` snapshot containing the same ids,
+   * {@link applyValues} → {@link reconcileMessagesFromValues} takes over
+   * (server ordering wins, the echoed message replaces the optimistic
+   * one).
+   *
+   * Non-message input keys are shallow-merged into `values` via
+   * `extraValues`; they are dropped/overwritten automatically by the
+   * first server `values` event (which rebuilds `values` from the
+   * server snapshot), or rolled back via {@link restoreValueKeys} when
+   * the run fails before any echo.
+   *
+   * @param messages    - Optimistic messages (already coerced to
+   *   `BaseMessage` instances, each carrying a stable id).
+   * @param extraValues - Non-message input keys to shallow-merge into
+   *   `values`.
+   */
+  appendOptimistic(
+    messages: BaseMessage[],
+    extraValues?: Record<string, unknown>
+  ): void {
+    let working = this.#pendingMessages ?? this.#store.getSnapshot().messages;
+    let mutated = false;
+    for (const message of messages) {
+      const id = message.id;
+      if (id == null) continue;
+      const existingIdx = this.#indexById.get(id);
+      if (existingIdx == null) {
+        if (!mutated) {
+          working = working.slice();
+          mutated = true;
+        }
+        this.#indexById.set(id, working.length);
+        working.push(message);
+      } else if (!messagesEqual(working[existingIdx], message)) {
+        if (!mutated) {
+          working = working.slice();
+          mutated = true;
+        }
+        working[existingIdx] = message;
+      }
+    }
+
+    const baselineValues =
+      this.#pendingValues ?? this.#store.getSnapshot().values;
+    let values = baselineValues;
+    if (extraValues != null && Object.keys(extraValues).length > 0) {
+      values = { ...(baselineValues as object), ...extraValues } as StateType;
+    }
+    values = syncMessagesIntoValues(values, this.#messagesKey, working);
+    if (!mutated && values === baselineValues) return;
+    this.#pendingMessages = working;
+    if (values !== baselineValues) this.#pendingValues = values;
+    this.#scheduleFlush();
+  }
+
+  /**
+   * Drop optimistic messages by id without disturbing the rest of the
+   * projection. Used by {@link StreamController.hydrate} to remove
+   * never-persisted optimistic messages (`pending` / `failed`) so a
+   * reload converges to server truth.
+   *
+   * @param ids - Message ids to remove.
+   */
+  dropOptimisticMessages(ids: ReadonlySet<string>): void {
+    if (ids.size === 0) return;
+    const baselineMessages =
+      this.#pendingMessages ?? this.#store.getSnapshot().messages;
+    const next = baselineMessages.filter((m) => m.id == null || !ids.has(m.id));
+    if (next.length === baselineMessages.length) return;
+    this.#indexById.clear();
+    for (const [id, idx] of buildMessageIndex(next)) {
+      this.#indexById.set(id, idx);
+    }
+    const baselineValues =
+      this.#pendingValues ?? this.#store.getSnapshot().values;
+    this.#pendingMessages = next;
+    this.#pendingValues = syncMessagesIntoValues(
+      baselineValues,
+      this.#messagesKey,
+      next
+    );
+    this.#scheduleFlush();
+  }
+
+  /**
+   * Restore (or delete) `values` keys that were optimistically merged
+   * by {@link appendOptimistic} but never echoed by the server — i.e.
+   * roll back non-message optimistic state when the run fails before
+   * any `values` event lands. Messages are left untouched (kept on
+   * failure per the optimistic contract).
+   *
+   * @param restore - Per-key pre-submit snapshot: when `hadKey` is
+   *   false the key is deleted, otherwise it is reset to `prevValue`.
+   */
+  restoreValueKeys(
+    restore: ReadonlyArray<{
+      key: string;
+      hadKey: boolean;
+      prevValue: unknown;
+    }>
+  ): void {
+    if (restore.length === 0) return;
+    const baselineValues =
+      this.#pendingValues ?? this.#store.getSnapshot().values;
+    const next = { ...(baselineValues as Record<string, unknown>) };
+    let changed = false;
+    for (const { key, hadKey, prevValue } of restore) {
+      if (key === this.#messagesKey) continue;
+      if (hadKey) {
+        if (!Object.is(next[key], prevValue)) {
+          next[key] = prevValue;
+          changed = true;
+        }
+      } else if (Object.prototype.hasOwnProperty.call(next, key)) {
+        delete next[key];
+        changed = true;
+      }
+    }
+    if (!changed) return;
+    this.#pendingValues = next as StateType;
+    this.#scheduleFlush();
+  }
+
+  /**
    * Schedule a coalesced flush on the next macrotask. Idempotent
    * within a tick — multiple `handleMessage` / `applyValues` calls
    * before the flush fires collapse into one store write.

--- a/libs/sdk/src/stream/submit-coordinator.test.ts
+++ b/libs/sdk/src/stream/submit-coordinator.test.ts
@@ -12,6 +12,7 @@ import type {
   RunExecutionReason,
   StreamControllerOptions,
 } from "./types.js";
+import type { OptimisticHandle } from "./optimistic-input.js";
 
 interface State {
   count?: number;
@@ -86,7 +87,20 @@ function deferred<T = void>() {
   return { promise, resolve, reject };
 }
 
-function makeHarness(initial: { threadId?: string | null } = {}): Harness {
+interface OptimisticOverrides {
+  beginOptimistic?: (
+    input: unknown
+  ) => { dispatchInput: unknown; handle: OptimisticHandle } | undefined;
+  settleOptimistic?: (
+    handle: OptimisticHandle,
+    event: "completed" | "failed" | "interrupted" | "aborted"
+  ) => void;
+}
+
+function makeHarness(
+  initial: { threadId?: string | null } = {},
+  optimistic: OptimisticOverrides = {}
+): Harness {
   const rootStore = makeRootStore();
   const queueStore = new StreamStore<SubmissionQueueSnapshot<State>>(
     EMPTY_QUEUE as SubmissionQueueSnapshot<State>
@@ -184,6 +198,8 @@ function makeHarness(initial: { threadId?: string | null } = {}): Harness {
     onRunCreated,
     onRunCompleted,
     onRunEnd,
+    beginOptimistic: optimistic.beginOptimistic,
+    settleOptimistic: optimistic.settleOptimistic,
   });
 
   return {
@@ -247,6 +263,78 @@ describe("SubmitCoordinator", () => {
   });
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  describe("optimistic wiring", () => {
+    it("dispatches the optimistic dispatchInput instead of the raw input", async () => {
+      const handle = { echoedIds: ["m1"], restoreKeys: [] };
+      const beginOptimistic = vi.fn(() => ({
+        dispatchInput: { count: 1, messages: [{ id: "m1" }] },
+        handle,
+      }));
+      const settleOptimistic = vi.fn();
+      const h = makeHarness({}, { beginOptimistic, settleOptimistic });
+
+      const submitPromise = h.coordinator.submit({ count: 1 });
+      await h.terminalRegistered();
+      h.resolveSubmit({ run_id: "run-1" });
+      h.resolveTerminal({ event: "completed" });
+      await vi.runAllTimersAsync();
+      await submitPromise;
+
+      expect(beginOptimistic).toHaveBeenCalledWith({ count: 1 });
+      expect(h.submitRun.mock.calls[0][0].input).toEqual({
+        count: 1,
+        messages: [{ id: "m1" }],
+      });
+      expect(settleOptimistic).toHaveBeenCalledWith(handle, "completed");
+    });
+
+    it("settles with 'failed' when the run fails", async () => {
+      const handle = { echoedIds: ["m1"], restoreKeys: [] };
+      const settleOptimistic = vi.fn();
+      const h = makeHarness(
+        {},
+        {
+          beginOptimistic: () => ({ dispatchInput: { messages: [] }, handle }),
+          settleOptimistic,
+        }
+      );
+
+      const submitPromise = h.coordinator.submit({ messages: [] });
+      await h.terminalRegistered();
+      h.resolveSubmit({ run_id: "run-1" });
+      h.resolveTerminal({ event: "failed", error: "boom" });
+      await vi.runAllTimersAsync();
+      await submitPromise;
+
+      expect(settleOptimistic).toHaveBeenCalledWith(handle, "failed");
+    });
+
+    it("does not echo an enqueued submission until it drains", async () => {
+      const beginOptimistic = vi.fn(() => ({
+        dispatchInput: { messages: [] },
+        handle: { echoedIds: [], restoreKeys: [] },
+      }));
+      const h = makeHarness({}, { beginOptimistic });
+
+      // First run in flight.
+      const first = h.coordinator.submit({ count: 1 });
+      await h.terminalRegistered();
+      expect(beginOptimistic).toHaveBeenCalledTimes(1);
+
+      // Enqueue behind it — must NOT echo yet.
+      await h.coordinator.submit({ count: 2 }, { multitaskStrategy: "enqueue" });
+      expect(beginOptimistic).toHaveBeenCalledTimes(1);
+
+      // Finish the first run; the drained submission now echoes.
+      h.resolveSubmit({ run_id: "run-1" });
+      h.resolveTerminal({ event: "completed" });
+      await vi.runAllTimersAsync();
+      await first;
+
+      expect(beginOptimistic).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe("submit (happy path)", () => {

--- a/libs/sdk/src/stream/submit-coordinator.test.ts
+++ b/libs/sdk/src/stream/submit-coordinator.test.ts
@@ -311,6 +311,60 @@ describe("SubmitCoordinator", () => {
       expect(settleOptimistic).toHaveBeenCalledWith(handle, "failed");
     });
 
+    it("settles the submit lifecycle when optimistic preparation throws", async () => {
+      const err = new Error("malformed message entry");
+      const beginOptimistic = vi.fn(() => {
+        throw err;
+      });
+      const settleOptimistic = vi.fn();
+      const onError = vi.fn();
+      const h = makeHarness({}, { beginOptimistic, settleOptimistic });
+
+      const submitPromise = h.coordinator.submit({ count: 1 }, { onError });
+      await vi.runAllTimersAsync();
+      await submitPromise;
+
+      // A synchronous prep failure is surfaced like a dispatch failure…
+      expect(h.rootStore.getSnapshot().error).toBe(err);
+      expect(onError).toHaveBeenCalledWith(err);
+      // …and the lifecycle is fully settled: not stuck loading, no run
+      // dispatched, no optimistic state to reconcile.
+      expect(h.rootStore.getSnapshot().isLoading).toBe(false);
+      expect(h.submitRun).not.toHaveBeenCalled();
+      expect(h.onRunStart).not.toHaveBeenCalled();
+      expect(settleOptimistic).not.toHaveBeenCalled();
+      expect(h.onRunEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not strand later submits behind a phantom run when prep throws", async () => {
+      const beginOptimistic = vi
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error("malformed message entry");
+        })
+        .mockImplementation(() => undefined);
+      const h = makeHarness({}, { beginOptimistic });
+
+      // First submit: preparation throws before any dispatch.
+      await h.coordinator.submit({ count: 1 });
+      await vi.runAllTimersAsync();
+      expect(h.submitRun).not.toHaveBeenCalled();
+
+      // The abort slot must be clear, so a `reject` submit proceeds and
+      // dispatches instead of seeing a phantom in-flight run.
+      const second = h.coordinator.submit(
+        { count: 2 },
+        { multitaskStrategy: "reject" }
+      );
+      await h.terminalRegistered();
+      expect(h.submitRun).toHaveBeenCalledTimes(1);
+
+      h.resolveSubmit({ run_id: "run-1" });
+      h.resolveTerminal({ event: "completed" });
+      await vi.runAllTimersAsync();
+      await expect(second).resolves.toBeUndefined();
+    });
+
     it("does not echo an enqueued submission until it drains", async () => {
       const beginOptimistic = vi.fn(() => ({
         dispatchInput: { messages: [] },

--- a/libs/sdk/src/stream/submit-coordinator.ts
+++ b/libs/sdk/src/stream/submit-coordinator.ts
@@ -376,33 +376,11 @@ export class SubmitCoordinator<
       isLoading: true,
     }));
 
-    // Apply the input optimistically *before* the first await so the
-    // user's message (and any merged state) paints without waiting for
-    // the server round-trip. Runs only on the dispatched path — an
-    // `"enqueue"`d submission returns above and echoes when it drains,
-    // keeping one optimistic batch bound to exactly one run lifecycle.
-    // `dispatchInput` carries the minted ids the server must echo for
-    // reconciliation, so the run is dispatched with it (not raw input).
+    // Declared before the try so the catch/finally can settle the
+    // submit lifecycle (loading flag, abort slot, optimistic state)
+    // even if optimistic preparation or the pump wait throws.
     let optimisticHandle: OptimisticHandle | undefined;
     let dispatchInput: unknown = input;
-    const prepared = this.#beginOptimistic(input);
-    if (prepared != null) {
-      optimisticHandle = prepared.handle;
-      dispatchInput = prepared.dispatchInput;
-    }
-
-    // Wait for the root subscription to be live; otherwise the
-    // dispatch could resolve before we're listening for events and
-    // we'd miss the terminal that ends the run.
-    await this.#waitForRootPumpReady();
-
-    const boundConfig = bindThreadConfig(options?.config, currentThreadId);
-    // Subscribe to the next terminal *before* dispatching so a fast
-    // run's terminal can't race us.
-    const terminalPromise = this.#awaitNextTerminal(abort.signal);
-    this.#onRunStart();
-
-    let terminalSettled = false;
     let createdRunId: string | undefined;
     let pendingCompletionReason: RunExecutionReason | undefined;
     let completionNotified = false;
@@ -427,6 +405,37 @@ export class SubmitCoordinator<
     };
 
     try {
+      // Apply the input optimistically *before* the first await so the
+      // user's message (and any merged state) paints without waiting for
+      // the server round-trip. Kept as the first statement in the try so
+      // the synchronous paint still precedes the first `await`, while a
+      // synchronous coercion failure (e.g. a malformed message entry)
+      // settles the submit lifecycle through the catch/finally below —
+      // exactly like a dispatch failure — instead of wedging `isLoading`
+      // / `#runAbort` and stranding later enqueue/reject submits behind a
+      // phantom in-flight run. Runs only on the dispatched path — an
+      // `"enqueue"`d submission returns above and echoes when it drains,
+      // keeping one optimistic batch bound to exactly one run lifecycle.
+      // `dispatchInput` carries the minted ids the server must echo for
+      // reconciliation, so the run is dispatched with it (not raw input).
+      const prepared = this.#beginOptimistic(input);
+      if (prepared != null) {
+        optimisticHandle = prepared.handle;
+        dispatchInput = prepared.dispatchInput;
+      }
+
+      // Wait for the root subscription to be live; otherwise the
+      // dispatch could resolve before we're listening for events and
+      // we'd miss the terminal that ends the run.
+      await this.#waitForRootPumpReady();
+
+      const boundConfig = bindThreadConfig(options?.config, currentThreadId);
+      // Subscribe to the next terminal *before* dispatching so a fast
+      // run's terminal can't race us.
+      const terminalPromise = this.#awaitNextTerminal(abort.signal);
+      this.#onRunStart();
+
+      let terminalSettled = false;
       let terminal: TerminalResult | undefined;
 
       const commandPromise = thread.submitRun({

--- a/libs/sdk/src/stream/submit-coordinator.ts
+++ b/libs/sdk/src/stream/submit-coordinator.ts
@@ -56,6 +56,7 @@
 import { v7 as uuidv7 } from "uuid";
 import type { ThreadStream } from "../client/stream/index.js";
 import { StreamStore } from "./store.js";
+import type { OptimisticHandle } from "./optimistic-input.js";
 import type {
   RootSnapshot,
   RunExecutionReason,
@@ -190,6 +191,20 @@ export class SubmitCoordinator<
   ) => void;
   /** Marks the local run dispatch lifecycle as settled. */
   readonly #onRunEnd: () => void;
+  /**
+   * Apply a submit input optimistically before dispatch. Returns the
+   * id-injected payload to dispatch plus a handle for terminal
+   * reconciliation, or `undefined` when optimistic UI is disabled / no
+   * echo applies (dispatch the raw input).
+   */
+  readonly #beginOptimistic: (
+    input: unknown
+  ) => { dispatchInput: unknown; handle: OptimisticHandle } | undefined;
+  /** Reconcile optimistic state when a run terminates. */
+  readonly #settleOptimistic: (
+    handle: OptimisticHandle,
+    event: TerminalResult["event"]
+  ) => void;
 
   /**
    * Active submission's abort controller. `undefined` between submits.
@@ -221,6 +236,13 @@ export class SubmitCoordinator<
     onRunCreated?: (runId: string) => void;
     onRunCompleted?: (reason: RunExecutionReason, runId?: string) => void;
     onRunEnd?: () => void;
+    beginOptimistic?: (
+      input: unknown
+    ) => { dispatchInput: unknown; handle: OptimisticHandle } | undefined;
+    settleOptimistic?: (
+      handle: OptimisticHandle,
+      event: TerminalResult["event"]
+    ) => void;
   }) {
     this.#options = params.options;
     this.#rootStore = params.rootStore;
@@ -242,6 +264,8 @@ export class SubmitCoordinator<
     this.#onRunCreated = params.onRunCreated ?? (() => undefined);
     this.#onRunCompleted = params.onRunCompleted ?? (() => undefined);
     this.#onRunEnd = params.onRunEnd ?? (() => undefined);
+    this.#beginOptimistic = params.beginOptimistic ?? (() => undefined);
+    this.#settleOptimistic = params.settleOptimistic ?? (() => undefined);
   }
 
   /**
@@ -352,6 +376,21 @@ export class SubmitCoordinator<
       isLoading: true,
     }));
 
+    // Apply the input optimistically *before* the first await so the
+    // user's message (and any merged state) paints without waiting for
+    // the server round-trip. Runs only on the dispatched path — an
+    // `"enqueue"`d submission returns above and echoes when it drains,
+    // keeping one optimistic batch bound to exactly one run lifecycle.
+    // `dispatchInput` carries the minted ids the server must echo for
+    // reconciliation, so the run is dispatched with it (not raw input).
+    let optimisticHandle: OptimisticHandle | undefined;
+    let dispatchInput: unknown = input;
+    const prepared = this.#beginOptimistic(input);
+    if (prepared != null) {
+      optimisticHandle = prepared.handle;
+      dispatchInput = prepared.dispatchInput;
+    }
+
     // Wait for the root subscription to be live; otherwise the
     // dispatch could resolve before we're listening for events and
     // we'd miss the terminal that ends the run.
@@ -367,6 +406,7 @@ export class SubmitCoordinator<
     let createdRunId: string | undefined;
     let pendingCompletionReason: RunExecutionReason | undefined;
     let completionNotified = false;
+    let settleEvent: TerminalResult["event"] | undefined;
     const notifyCompletion = (reason: RunExecutionReason): void => {
       if (completionNotified) return;
       if (createdRunId == null) {
@@ -390,7 +430,7 @@ export class SubmitCoordinator<
       let terminal: TerminalResult | undefined;
 
       const commandPromise = thread.submitRun({
-        input: input ?? null,
+        input: dispatchInput ?? null,
         config: boundConfig,
         metadata: (options?.metadata ?? undefined) as Record<string, unknown>,
         forkFrom: options?.forkFrom,
@@ -463,6 +503,7 @@ export class SubmitCoordinator<
 
       terminal ??= await terminalPromise;
       terminalSettled = true;
+      settleEvent = terminal.event;
       if (terminal.event === "failed" && !abort.signal.aborted) {
         const runError = new Error(
           terminal.error ?? "Run failed with no error message"
@@ -476,6 +517,7 @@ export class SubmitCoordinator<
       }
       notifyCompletion(terminalReason(terminal.event));
     } catch (error) {
+      if (!abort.signal.aborted) settleEvent = "failed";
       reportError(error);
     } finally {
       // Always settle loading and clear our slot of the abort
@@ -483,6 +525,15 @@ export class SubmitCoordinator<
       // late state updates from this run finish flushing first.
       this.#rootStore.setState((s) => ({ ...s, isLoading: false }));
       if (this.#runAbort === abort) this.#runAbort = undefined;
+      // Reconcile optimistic state: flip pending messages to sent/failed
+      // and roll back un-echoed non-message keys. `aborted` covers a
+      // rollback-resubmit or `stop()` cancelling this run.
+      if (optimisticHandle != null) {
+        this.#settleOptimistic(
+          optimisticHandle,
+          abort.signal.aborted ? "aborted" : (settleEvent ?? "failed")
+        );
+      }
       this.#onRunEnd();
       setTimeout(() => this.#drainQueue(), 0);
     }

--- a/libs/sdk/src/stream/types.ts
+++ b/libs/sdk/src/stream/types.ts
@@ -138,6 +138,31 @@ export interface UseStreamCommonOptions<
   tools?: AnyHeadlessToolImplementation[];
   /** Observe lifecycle events for registered {@link tools}. */
   onTool?: OnToolCallback;
+  /**
+   * Optimistic UI for `submit()`. When enabled (the default), the input
+   * passed to `submit()` is reflected in `values` / `messages`
+   * immediately — before the server responds — then reconciled against
+   * the authoritative server state as it streams in:
+   *
+   *   - Messages in the input are appended right away. Any message
+   *     without an `id` is assigned a stable client id (sent to the
+   *     server, which `add_messages` preserves) so the server echo
+   *     reconciles by id instead of duplicating. Per-message progress
+   *     is exposed via `useMessageMetadata(stream, id).optimisticStatus`
+   *     (`"pending"` → `"sent"`, or `"failed"` if the run errors before
+   *     the message is echoed; failed optimistic messages are kept for
+   *     retry UIs and dropped on the next `hydrate()`).
+   *   - Other input keys are shallow-merged into `values` and converge
+   *     to server truth on the first `values` event (or are rolled back
+   *     if the run fails before any echo).
+   *
+   * Set to `false` to dispatch input verbatim with no client-side echo
+   * or id minting (server-authoritative only) — useful for non-chat
+   * state graphs or deterministic SSR/tests.
+   *
+   * @default true
+   */
+  optimistic?: boolean;
 }
 
 /**
@@ -296,6 +321,11 @@ export interface StreamControllerOptions<
   initialValues?: StateType;
   /** Key inside `values` that holds the message array. Defaults to `"messages"`. */
   messagesKey?: string;
+  /**
+   * Optimistic UI for `submit()`. Defaults to `true`. See
+   * {@link UseStreamCommonOptions.optimistic} for the full contract.
+   */
+  optimistic?: boolean;
 }
 
 export interface StreamSubmitOptions<


### PR DESCRIPTION
## Summary
- revive automatic optimistic updates to `@langchain/langgraph-sdk`: `submit()` input is echoed into `values` / `messages` immediately, messages without ids get client-minted ids for server reconciliation, and non-message keys are shallow-merged with rollback when no `values` snapshot arrives.
- Track per-message lifecycle via `useMessageMetadata(...).optimisticStatus` (`pending` → `sent` / `failed`); failed optimistic messages are kept for retry UX and dropped on `hydrate()`.
- Plumb `optimistic?: boolean` through React, Vue, Svelte, and Angular `useStream` hooks (defaults to enabled) and document the v1 migration path replacing legacy `optimisticValues`.
- Add browser e2e tests across all four framework SDKs covering message happy path, id reconciliation, failure handling, opt-out, and non-message state convergence/rollback.
