### PR TITLE
fix(sdk): resume useChannel subscriptions across serial runs

### DIFF
--- a/.changeset/fix-usechannel-resume-across-runs.md
+++ b/.changeset/fix-usechannel-resume-across-runs.md
@@ -1,0 +1,14 @@
+---
+"@langchain/langgraph-sdk": patch
+"@langchain/react": patch
+"@langchain/vue": patch
+"@langchain/svelte": patch
+"@langchain/angular": patch
+---
+
+fix(sdk): resume useChannel subscriptions across serial runs
+
+Enable `resumeOnPause` on the channel projection so `useChannel` keeps
+accumulating events across prompts on the same thread. Clarify selector
+docs and JSDoc: `useChannel` for the full event stream, `useExtension`
+for the latest payload.

--- a/libs/sdk-angular/docs/selectors.md
+++ b/libs/sdk-angular/docs/selectors.md
@@ -13,8 +13,8 @@ subscription, and the last consumer's `DestroyRef` closes it.
 | `injectValues(stream, target?)` | State snapshot for the target. |
 | `injectMessageMetadata(stream, msgId)` | `{ parentCheckpointId }` for forking / editing. |
 | `injectSubmissionQueue(stream)` | `{ entries, size, cancel(id), clear() }` for the enqueue strategy. |
-| `injectExtension(stream, name, target?)` | Read a named protocol extension. |
-| `injectChannel(stream, channels, target?)` | Raw event buffer — escape hatch. |
+| `injectExtension(stream, name, target?)` | Latest payload of a `custom:<name>` extension. |
+| `injectChannel(stream, channels, target?)` | Raw event stream (bounded buffer, all runs) — escape hatch. |
 | `injectAudio` / `injectImages` / `injectVideo` / `injectFiles` | Multimodal media streams. |
 | `injectMediaUrl(media)` | Create + revoke an `objectURL` for a media handle. |
 
@@ -72,6 +72,17 @@ The first consumer of `injectMessages(stream, subagent)` opens a
 scoped subscription; when the last card unmounts, the subscription is
 released. Mounting / unmounting subagent cards mid-run is safe — no
 manual cleanup required.
+
+## `injectChannel` vs. `injectExtension`
+
+For a `custom:<name>` channel both injectors keep receiving events
+across serial runs on the same thread, but they expose different shapes:
+
+- **`injectExtension`** — the **latest** payload only. Use it for
+  "current state" panels (progress, score, status).
+- **`injectChannel`** — the **full history** of events as a bounded
+  buffer. Use it for an event log or to derive your own running totals,
+  e.g. `injectChannel(stream, ["custom:redaction-stats"])`.
 
 ## Media selectors
 

--- a/libs/sdk-angular/src/selectors.ts
+++ b/libs/sdk-angular/src/selectors.ts
@@ -281,6 +281,11 @@ export function injectValues(
 /**
  * Subscribe to a `custom:<name>` stream extension — the most recent
  * payload emitted by the transformer, scoped to the target namespace.
+ *
+ * Returns only the latest value and resumes across serial runs, so it is
+ * ideal for "current state" panels (progress, score, status). When you
+ * need the full history of events rather than just the latest payload,
+ * use {@link injectChannel} instead.
  */
 export function injectExtension<T = unknown>(
   stream: AnyStream,
@@ -302,8 +307,13 @@ export function injectExtension<T = unknown>(
 /**
  * Raw-events escape hatch. Subscribes to one or more channels at a
  * namespace and returns a bounded buffer of raw protocol events.
- * Prefer {@link injectMessages} / {@link injectToolCalls} /
- * {@link injectValues} for the common cases.
+ *
+ * The buffer keeps accumulating across serial runs for the lifetime of
+ * the thread, so this is the hook to use for an event log / stream of a
+ * custom channel (e.g. `["custom:redaction-stats"]`). When you only need
+ * the latest payload of a single `custom:<name>` channel, prefer
+ * {@link injectExtension}. For the common message/tool/value cases prefer
+ * {@link injectMessages} / {@link injectToolCalls} / {@link injectValues}.
  */
 export type InjectChannelOptions = ChannelProjectionOptions;
 

--- a/libs/sdk-react/docs/selectors.md
+++ b/libs/sdk-react/docs/selectors.md
@@ -134,15 +134,23 @@ Escape hatch to the raw protocol event stream. Subscribe to one or more channels
 const events = useChannel(stream, ["values", "updates"]);
 ```
 
+The buffer keeps accumulating across serial runs for the lifetime of the thread, so this is the hook for an **event log / stream** of a channel — e.g. every payload published on a custom channel:
+
+```tsx
+const statsEvents = useChannel(stream, ["custom:redaction-stats"]);
+```
+
 Pass `target` (subagent / subgraph / `{ namespace }`) to scope. Useful for bespoke reducers that can't be expressed through `useValues` / `useMessages`.
 
 ## `useExtension`
 
-Read a single custom extension (wire-level `custom:<name>` channel) as a reactive snapshot:
+Read a single custom extension (wire-level `custom:<name>` channel) as a reactive snapshot of the **latest** payload:
 
 ```tsx
 const telemetry = useExtension<Telemetry>(stream, "telemetry");
 ```
+
+`useExtension` and `useChannel` are complementary for custom channels: reach for `useExtension` when you only need the current value (progress, score, status), and `useChannel` when you need the full history of events. Both keep receiving events across serial runs on the same thread.
 
 ## `useSubmissionQueue`
 

--- a/libs/sdk-react/src/selectors.ts
+++ b/libs/sdk-react/src/selectors.ts
@@ -283,8 +283,13 @@ export function useValues(
 }
 
 /**
- * Subscribe to a `custom:<name>` stream extension — most-recent
+ * Subscribe to a `custom:<name>` stream extension — the most-recent
  * payload emitted by the transformer, scoped to the target namespace.
+ *
+ * Returns only the latest value and resumes across serial runs, so it is
+ * ideal for "current state" panels (progress, score, status). When you
+ * need the full history of events rather than just the latest payload,
+ * use {@link useChannel} instead.
  */
 export function useExtension<T = unknown>(
   stream: AnyStream,
@@ -301,12 +306,6 @@ export function useExtension<T = unknown>(
   );
 }
 
-/**
- * Raw-events escape hatch. Subscribes to one or more channels at a
- * namespace and returns a bounded buffer of raw protocol events.
- * Prefer {@link useMessages} / {@link useToolCalls} / {@link useValues}
- * for the common cases.
- */
 /**
  * Subscribe to a scoped audio-media stream. Returns an array of
  * {@link AudioMedia} handles, one per message containing at least one
@@ -398,6 +397,17 @@ const EMPTY_FILES: FileMedia[] = [];
 
 export type UseChannelOptions = ChannelProjectionOptions;
 
+/**
+ * Raw-events escape hatch. Subscribes to one or more channels at a
+ * namespace and returns a bounded buffer of raw protocol events.
+ *
+ * The buffer keeps accumulating across serial runs for the lifetime of
+ * the thread, so this is the hook to use for an event log / stream of a
+ * custom channel (e.g. `["custom:redaction-stats"]`). When you only need
+ * the latest payload of a single `custom:<name>` channel, prefer
+ * {@link useExtension}. For the common message/tool/value cases prefer
+ * {@link useMessages} / {@link useToolCalls} / {@link useValues}.
+ */
 export function useChannel(
   stream: AnyStream,
   channels: readonly Channel[],

--- a/libs/sdk-react/src/tests/stream.selectors.test.tsx
+++ b/libs/sdk-react/src/tests/stream.selectors.test.tsx
@@ -195,6 +195,32 @@ it("unwraps named custom event payloads through useExtension", async () => {
   }
 });
 
+it("continues useChannel subscriptions across serial submits", async () => {
+  const screen = await render(<ExtensionSelectorsStream apiUrl={apiUrl} />);
+
+  try {
+    await screen.getByTestId("submit").click();
+
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 10_000 })
+      .toHaveTextContent("Not loading");
+    await expect
+      .element(screen.getByTestId("custom-event-count"))
+      .toHaveTextContent("3");
+
+    await screen.getByTestId("submit").click();
+
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 10_000 })
+      .toHaveTextContent("Not loading");
+    await expect
+      .element(screen.getByTestId("custom-event-count"))
+      .toHaveTextContent("6");
+  } finally {
+    await cleanupRender(screen);
+  }
+});
+
 it("continues useExtension subscriptions across serial submits", async () => {
   const screen = await render(<ExtensionSelectorsStream apiUrl={apiUrl} />);
 

--- a/libs/sdk-svelte/docs/selector-composables.md
+++ b/libs/sdk-svelte/docs/selector-composables.md
@@ -11,8 +11,8 @@ Each selector opens a **ref-counted** subscription when the first component moun
 | `useMessages(stream, target?)`                    | `{ current: BaseMessage[] }`                                             | Scoped messages. At root delegates to `stream.messages`. |
 | `useToolCalls(stream, target?)`                   | `{ current: AssembledToolCall[] }`                                       | Scoped tool calls.                                       |
 | `useValues(stream, target?, options?)`            | `{ current: StateType }` (root) / `{ current: T \| undefined }` (scoped) | Scoped state values.                                     |
-| `useExtension(stream, name, target?)`             | `{ current: T \| undefined }`                                            | Read a `custom:<name>` stream extension.                 |
-| `useChannel(stream, channels, target?, options?)` | `{ current: Event[] }`                                                   | Raw-protocol events (bounded buffer).                    |
+| `useExtension(stream, name, target?)`             | `{ current: T \| undefined }`                                            | Latest payload of a `custom:<name>` stream extension.    |
+| `useChannel(stream, channels, target?, options?)` | `{ current: Event[] }`                                                   | Raw-protocol event stream (bounded buffer, all runs).    |
 | `useMessageMetadata(stream, messageId)`           | `{ current: MessageMetadata \| undefined }`                              | Per-message metadata (`parentCheckpointId`).             |
 | `useSubmissionQueue(stream)`                      | `{ entries, size, cancel, clear }`                                       | Server-side [submission queue](./submission-queue.md).   |
 | `useAudio(stream, target?)`                       | `{ current: AudioMedia[] }`                                              | Audio attachments in the namespace.                      |
@@ -71,3 +71,19 @@ Reach for `useChannel` when you need to observe the wire protocol directly — f
   <pre>{JSON.stringify(ev)}</pre>
 {/each}
 ```
+
+The buffer keeps accumulating across serial runs for the lifetime of the thread, so `useChannel` is also the composable to use for an **event log** of a custom channel (e.g. `["custom:redaction-stats"]`):
+
+```svelte
+<script lang="ts">
+  import { useChannel } from "@langchain/svelte";
+  const statsEvents = useChannel(stream, ["custom:redaction-stats"]);
+</script>
+```
+
+## `useChannel` vs. `useExtension`
+
+Both keep receiving events across serial runs on the same thread, but they expose different shapes for a `custom:<name>` channel:
+
+- **`useExtension`** — the **latest** payload only. Use it for "current state" panels (progress, score, status).
+- **`useChannel`** — the **full history** of events as a bounded buffer. Use it when you need an event log or want to derive your own running totals.

--- a/libs/sdk-svelte/src/selectors.svelte.ts
+++ b/libs/sdk-svelte/src/selectors.svelte.ts
@@ -306,8 +306,13 @@ export function useValues(
 }
 
 /**
- * Subscribe to a `custom:<name>` stream extension — most-recent
+ * Subscribe to a `custom:<name>` stream extension — the most-recent
  * payload emitted by the transformer, scoped to the target namespace.
+ *
+ * Returns only the latest value and resumes across serial runs, so it is
+ * ideal for "current state" panels (progress, score, status). When you
+ * need the full history of events rather than just the latest payload,
+ * use {@link useChannel} instead.
  *
  * `name` accepts either a plain string or a getter so component
  * state can drive the extension name at runtime.
@@ -340,8 +345,13 @@ export function useExtension<T = unknown>(
 /**
  * Raw-events escape hatch. Subscribes to one or more channels at a
  * namespace and returns a bounded buffer of raw protocol events.
- * Prefer {@link useMessages} / {@link useToolCalls} / {@link useValues}
- * for the common cases.
+ *
+ * The buffer keeps accumulating across serial runs for the lifetime of
+ * the thread, so this is the hook to use for an event log / stream of a
+ * custom channel (e.g. `["custom:redaction-stats"]`). When you only need
+ * the latest payload of a single `custom:<name>` channel, prefer
+ * {@link useExtension}. For the common message/tool/value cases prefer
+ * {@link useMessages} / {@link useToolCalls} / {@link useValues}.
  */
 export type UseChannelOptions = ChannelProjectionOptions;
 

--- a/libs/sdk-vue/docs/selectors.md
+++ b/libs/sdk-vue/docs/selectors.md
@@ -18,8 +18,8 @@ never render a subagent's content never pay for its wire traffic.
 | `useValues(stream, target?)` | State snapshot for the target. |
 | `useMessageMetadata(stream, msgId)` | `{ parentCheckpointId }` for forking / editing. `msgId` accepts a ref / getter. |
 | `useSubmissionQueue(stream)` | `{ entries, size, cancel(id), clear() }` for the enqueue strategy. |
-| `useExtension(stream, name, target?)` | Read a named protocol extension. |
-| `useChannel(stream, channels, target?)` | Raw event buffer — escape hatch. |
+| `useExtension(stream, name, target?)` | Latest payload of a `custom:<name>` extension. |
+| `useChannel(stream, channels, target?)` | Raw event stream (bounded buffer, all runs) — escape hatch. |
 | `useAudio` / `useImages` / `useVideo` / `useFiles` | Multimodal media streams. |
 | `useMediaURL(media)` | Create + revoke an `objectURL` for a media handle. |
 | `useAudioPlayer(audio, options?)` | PCM-to-`AudioContext` player with play / pause / seek controls. |
@@ -59,6 +59,31 @@ const hasValues = computed(() => rootValues.value != null);
 
 Scoped reads open a namespaced subscription on mount. See
 [Subagents & subgraphs](./subagents.md) for a full example.
+
+## `useChannel` vs. `useExtension`
+
+For a `custom:<name>` channel both composables keep receiving events
+across serial runs on the same thread, but they expose different shapes:
+
+- **`useExtension`** returns the **latest** payload only — ideal for
+  "current state" panels (progress, score, status):
+
+  ```vue
+  <script setup lang="ts">
+  import { useExtension } from "@langchain/vue";
+  const telemetry = useExtension<Telemetry>(stream, "telemetry");
+  </script>
+  ```
+
+- **`useChannel`** returns the **full history** of events as a bounded
+  buffer — use it for an event log or to derive your own running totals:
+
+  ```vue
+  <script setup lang="ts">
+  import { useChannel } from "@langchain/vue";
+  const statsEvents = useChannel(stream, ["custom:redaction-stats"]);
+  </script>
+  ```
 
 ## Lifecycle & cleanup
 

--- a/libs/sdk-vue/src/selectors.ts
+++ b/libs/sdk-vue/src/selectors.ts
@@ -233,8 +233,13 @@ export function useValues(
 }
 
 /**
- * Subscribe to a `custom:<name>` stream extension — most-recent
+ * Subscribe to a `custom:<name>` stream extension — the most-recent
  * payload emitted by the transformer, scoped to the target namespace.
+ *
+ * Returns only the latest value and resumes across serial runs, so it is
+ * ideal for "current state" panels (progress, score, status). When you
+ * need the full history of events rather than just the latest payload,
+ * use {@link useChannel} instead.
  */
 export function useExtension<T = unknown>(
   stream: AnyStream,
@@ -254,8 +259,13 @@ export function useExtension<T = unknown>(
 /**
  * Raw-events escape hatch. Subscribes to one or more channels at a
  * namespace and returns a bounded buffer of raw protocol events.
- * Prefer {@link useMessages} / {@link useToolCalls} / {@link useValues}
- * for the common cases.
+ *
+ * The buffer keeps accumulating across serial runs for the lifetime of
+ * the thread, so this is the hook to use for an event log / stream of a
+ * custom channel (e.g. `["custom:redaction-stats"]`). When you only need
+ * the latest payload of a single `custom:<name>` channel, prefer
+ * {@link useExtension}. For the common message/tool/value cases prefer
+ * {@link useMessages} / {@link useToolCalls} / {@link useValues}.
  */
 export type UseChannelOptions = ChannelProjectionOptions;
 

--- a/libs/sdk/src/stream/projections/channel.test.ts
+++ b/libs/sdk/src/stream/projections/channel.test.ts
@@ -58,6 +58,48 @@ describe("channelProjection", () => {
     });
   });
 
+  it("resumes the subscription across paused runs", async () => {
+    const firstRun = lifecycleEvent(["worker:run"], "started");
+    const secondRun = lifecycleEvent(["worker:run"], "started");
+    let resumeRun: (() => void) | undefined;
+    const resumed = new Promise<void>((resolve) => {
+      resumeRun = resolve;
+    });
+    let batch = 0;
+    const subscription = {
+      // First run pauses on its terminal event; flips to unpaused once the
+      // second (final) batch has been delivered so the resume loop exits.
+      isPaused: true,
+      async unsubscribe() {},
+      waitForResume: () => resumed,
+      async *[Symbol.asyncIterator]() {
+        batch += 1;
+        if (batch === 1) {
+          yield firstRun;
+          return;
+        }
+        yield secondRun;
+        this.isPaused = false;
+      },
+    };
+    const thread = {
+      subscribe: vi.fn(async () => subscription),
+    } as unknown as ThreadStream;
+    const rootBus = makeRootBus();
+    const projection = channelProjection(["lifecycle"], []);
+    const store = new StreamStore(projection.initial);
+
+    projection.open({ thread, store, rootBus });
+
+    await vi.waitFor(() => expect(store.getSnapshot()).toEqual([firstRun]));
+
+    resumeRun?.();
+
+    await vi.waitFor(() =>
+      expect(store.getSnapshot()).toEqual([firstRun, secondRun]),
+    );
+  });
+
   it("uses the root bus for covered root channels when replay is disabled", () => {
     const rootBus = makeRootBus();
     const projection = channelProjection(["lifecycle"], [], { replay: false });

--- a/libs/sdk/src/stream/projections/channel.ts
+++ b/libs/sdk/src/stream/projections/channel.ts
@@ -2,10 +2,13 @@
  * Raw channel escape hatch.
  *
  * Subscribes to an arbitrary list of channels at an arbitrary
- * namespace and retains a bounded buffer of events. Consumers that
- * need assembly semantics should use `messagesProjection`,
- * `toolCallsProjection`, etc. instead; this one is for inspection,
- * custom reducers, or niche use-cases.
+ * namespace and retains a bounded buffer of events. The subscription
+ * resumes across serial runs, so the buffer keeps accumulating events
+ * for the lifetime of the thread (use `extensionProjection` instead when
+ * you only need the most-recent payload of a single `custom:<name>`
+ * channel). Consumers that need assembly semantics should use
+ * `messagesProjection`, `toolCallsProjection`, etc. instead; this one is
+ * for inspection, custom reducers, or niche use-cases.
  */
 import type { Channel, Event } from "@langchain/protocol";
 import type { ProjectionSpec, ProjectionRuntime } from "../types.js";
@@ -101,6 +104,11 @@ export function channelProjection(
         thread,
         channels: chs as Channel[],
         namespace: ns,
+        // Keep the buffer alive across serial runs. Some transports pause a
+        // subscription on each run's terminal lifecycle event; without
+        // resuming, the channel would go silent after the first run and a
+        // second prompt on the same thread would emit no further events.
+        resumeOnPause: true,
         onEvent(event) {
           const current = store.getSnapshot();
           const next =


### PR DESCRIPTION
## Summary
- Fix `channelProjection` to pass `resumeOnPause: true`, matching `extensionProjection`, so `useChannel` continues receiving events after each run's terminal lifecycle event instead of going silent after the first prompt on a thread.
- Add a unit test that simulates a paused subscription resuming with a second event batch, and a React browser integration test asserting `useChannel` event count grows across two serial submits (3 → 6).
- Update selector JSDoc and `selectors.md` / `selector-composables.md` across React, Vue, Svelte, and Angular to document the complementary roles: `useChannel` = full bounded event history across runs; `useExtension` = latest payload only.
