### PR TITLE
fix(langgraph-checkpoint-validation): align node engine with vitest

### DIFF
--- a/.changeset/tough-banks-itch.md
+++ b/.changeset/tough-banks-itch.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint-validation": minor
+---
+
+fix(langgraph-checkpoint-validation): align node engine with vitest

--- a/.gitignore
+++ b/.gitignore
@@ -24,11 +24,17 @@ coverage/
 **/.eslintcache
 
 .env
+.env.*
+*.pem
+*.key
+*.crt
+credentials.json
 .ipynb_checkpoints
 dist-cjs
 **/dist-cjs
 tmp/
 __pycache__
+.venv
 .DS_Store
 tsconfig.vitest-temp.json
 .pnpm-store

--- a/libs/checkpoint-validation/README.md
+++ b/libs/checkpoint-validation/README.md
@@ -2,6 +2,8 @@
 
 The checkpointer validation tool is used to validate that custom checkpointer implementations conform to LangGraph's requirements. LangGraph uses [checkpointers](https://langchain-ai.github.io/langgraphjs/concepts/persistence/#checkpointer-libraries) for persisting workflow state, providing the ability to "rewind" your workflow to some earlier point in time, and continue execution from there.
 
+The tool requires Node.js 20, 22, or 24 and later.
+
 The overall process for using this tool is as follows:
 
 1. Write your custom checkpointer implementation.
@@ -94,4 +96,3 @@ import { validate } from "@langchain/langgraph-validation";
 
 validate(MyCheckpointerInitializer);
 ```
-

--- a/libs/checkpoint-validation/package.json
+++ b/libs/checkpoint-validation/package.json
@@ -4,7 +4,7 @@
   "description": "Library for validating LangGraph checkpoint saver implementations.",
   "type": "module",
   "engines": {
-    "node": ">=18"
+    "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
   },
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- align checkpoint validation package Node engine with Vitest 4 runtime requirements
- document the CLI Node requirement
- add missing secret file patterns to .gitignore per commit safety preflight

## Testing
- Not run per request