### PR TITLE
fix(langgraph-checkpoint-sqlite): allow filter on arbitrary metadata keys in list()

### DIFF
--- a/.changeset/fix-sqlite-checkpoint-filter-arbitrary-keys.md
+++ b/.changeset/fix-sqlite-checkpoint-filter-arbitrary-keys.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint-sqlite": patch
+---
+
+fix: `SqliteSaver.list({}, { filter })` now honors arbitrary metadata keys (e.g. `tenant_id`, `env`), matching the behavior of the MongoDB, Postgres, and Redis checkpointers. Previously only `source`, `step`, and `parents` were honored — any other key was silently dropped, returning unfiltered results.

--- a/libs/checkpoint-sqlite/src/index.ts
+++ b/libs/checkpoint-sqlite/src/index.ts
@@ -36,33 +36,6 @@ interface PendingSendColumn {
   value: string;
 }
 
-// In the `SqliteSaver.list` method, we need to sanitize the `options.filter` argument to ensure it only contains keys
-// that are part of the `CheckpointMetadata` type. The lines below ensure that we get compile-time errors if the list
-// of keys that we use is out of sync with the `CheckpointMetadata` type.
-const checkpointMetadataKeys = ["source", "step", "parents"] as const;
-
-type CheckKeys<T, K extends readonly (keyof T)[]> = [K[number]] extends [
-  keyof T,
-]
-  ? [keyof T] extends [K[number]]
-    ? K
-    : never
-  : never;
-
-function validateKeys<T, K extends readonly (keyof T)[]>(
-  keys: CheckKeys<T, K>
-): K {
-  return keys;
-}
-
-// If this line fails to compile, the list of keys that we use in the `SqliteSaver.list` method is out of sync with the
-// `CheckpointMetadata` type. In that case, just update `checkpointMetadataKeys` to contain all the keys in
-// `CheckpointMetadata`
-const validCheckpointMetadataKeys = validateKeys<
-  CheckpointMetadata,
-  typeof checkpointMetadataKeys
->(checkpointMetadataKeys);
-
 function prepareSql(db: DatabaseType, checkpointId: boolean) {
   const sql = `
   SELECT
@@ -314,16 +287,12 @@ CREATE TABLE IF NOT EXISTS writes (
     }
 
     const sanitizedFilter = Object.fromEntries(
-      Object.entries(filter ?? {}).filter(
-        ([key, value]) =>
-          value !== undefined &&
-          validCheckpointMetadataKeys.includes(key as keyof CheckpointMetadata)
-      )
+      Object.entries(filter ?? {}).filter(([, value]) => value !== undefined)
     );
 
     whereClause.push(
-      ...Object.entries(sanitizedFilter).map(
-        ([key]) => `jsonb(CAST(metadata AS TEXT))->'$.${key}' = ?`
+      ...Object.keys(sanitizedFilter).map(
+        () => `jsonb(CAST(metadata AS TEXT))->? = ?`
       )
     );
 
@@ -342,7 +311,10 @@ CREATE TABLE IF NOT EXISTS writes (
       thread_id,
       checkpoint_ns,
       before?.configurable?.checkpoint_id,
-      ...Object.values(sanitizedFilter).map((value) => JSON.stringify(value)),
+      ...Object.entries(sanitizedFilter).flatMap(([key, value]) => [
+        `$.${key}`,
+        JSON.stringify(value),
+      ]),
     ].filter((value) => value !== undefined && value !== null);
 
     const rows: CheckpointRow[] = this.db

--- a/libs/checkpoint-sqlite/src/tests/checkpoints.test.ts
+++ b/libs/checkpoint-sqlite/src/tests/checkpoints.test.ts
@@ -183,7 +183,8 @@ describe("SqliteSaver", () => {
       return tuples;
     };
 
-    expect((await collect({ tenant_id: "acme" })).length).toBe(2);
+    const ids = (tuples) => tuples.map(t => t.config.configurable?.thread_id).sort();
+    expect(ids(await collect({ tenant_id: "acme" }))).toEqual(["1", "2"]);
     expect((await collect({ env: "prod" })).length).toBe(2);
     expect((await collect({ tenant_id: "acme", env: "prod" })).length).toBe(1);
     expect((await collect({ tenant_id: "missing" })).length).toBe(0);

--- a/libs/checkpoint-sqlite/src/tests/checkpoints.test.ts
+++ b/libs/checkpoint-sqlite/src/tests/checkpoints.test.ts
@@ -147,6 +147,48 @@ describe("SqliteSaver", () => {
     expect(checkpointTuple1.checkpoint.ts).toBe("2024-04-20T17:19:07.952Z");
   });
 
+  it("should filter on arbitrary metadata keys, not just CheckpointMetadata keys", async () => {
+    const sqliteSaver = SqliteSaver.fromConnString(":memory:");
+
+    const put = (id: string, tenant: string, env: string) =>
+      sqliteSaver.put(
+        { configurable: { thread_id: id } },
+        {
+          ...emptyCheckpoint(),
+          id: uuid6(parseInt(id, 10)),
+          ts: `2024-06-08T0${id}:00:00.000Z`,
+        },
+        {
+          source: "update",
+          step: 0,
+          parents: {},
+          // arbitrary user-defined keys that other checkpointers
+          // (MongoDB / Postgres / Redis) all support
+          tenant_id: tenant,
+          env,
+        } as Parameters<typeof sqliteSaver.put>[2]
+      );
+
+    await put("1", "acme", "prod");
+    await put("2", "acme", "dev");
+    await put("3", "globex", "prod");
+
+    const collect = async (
+      filter: Record<string, unknown>
+    ): Promise<CheckpointTuple[]> => {
+      const tuples: CheckpointTuple[] = [];
+      for await (const t of sqliteSaver.list({} as RunnableConfig, { filter })) {
+        tuples.push(t);
+      }
+      return tuples;
+    };
+
+    expect((await collect({ tenant_id: "acme" })).length).toBe(2);
+    expect((await collect({ env: "prod" })).length).toBe(2);
+    expect((await collect({ tenant_id: "acme", env: "prod" })).length).toBe(1);
+    expect((await collect({ tenant_id: "missing" })).length).toBe(0);
+  });
+
   it("should delete thread", async () => {
     const saver = SqliteSaver.fromConnString(":memory:");
     await saver.put({ configurable: { thread_id: "1" } }, emptyCheckpoint(), {


### PR DESCRIPTION
## Summary

`SqliteSaver.list({}, { filter })` was silently dropping any filter key that wasn't `source`, `step`, or `parents` — returning the full unfiltered result set instead. The other checkpointers (MongoDB, Postgres, Redis) all accept arbitrary metadata keys, so SQLite was the only odd one out.

### Repro (failing on `main`)

```ts
await saver.put({ configurable: { thread_id: "1" } }, cp, { source: "update", step: 0, parents: {}, tenant_id: "acme" });
await saver.put({ configurable: { thread_id: "2" } }, cp, { source: "update", step: 0, parents: {}, tenant_id: "globex" });

// expected: 1 result (only thread 1)
// actual on main: 2 results (filter silently ignored)
for await (const t of saver.list({}, { filter: { tenant_id: "acme" } })) { ... }
```

### Fix

- Drop the `validCheckpointMetadataKeys` allow-list (`["source", "step", "parents"]`).
- Pass the JSON path as a bound parameter (`jsonb(...)->? = ?`) so arbitrary user keys flow through safely without SQL-injection risk. Validated `better-sqlite3` supports parameterized JSON path on the `->` operator.

### Tests

New test `should filter on arbitrary metadata keys, not just CheckpointMetadata keys` exercises three custom keys (`tenant_id`, `env`, missing) plus combined filters. **Reverse-verified**: with the fix reverted the new test fails with `expected 2, actual 3` (filter silently no-ops).

### Consistency parity

| Checkpointer | Arbitrary metadata filter | Before this PR |
|--------------|---------------------------|----------------|
| MongoDB | ✅ via `metadata_search.{key}` (#2186) | ✅ |
| Postgres | ✅ via `metadata @> $1` | ✅ |
| Redis | ✅ via RediSearch tags | ✅ |
| **SQLite** | ✅ via `jsonb(metadata)->? = ?` (this PR) | ❌ |

## AI Disclosure
This bug was identified through cross-checkpointer code review with AI assistance, and the fix was validated against the existing test suite plus a new regression test.