### PR TITLE
fix(sdk): hydrate custom transport without extra client config

### DIFF
--- a/.changeset/fix-custom-transport-hydration.md
+++ b/.changeset/fix-custom-transport-hydration.md
@@ -3,6 +3,7 @@
 "@langchain/react": patch
 "@langchain/vue": patch
 "@langchain/angular": patch
+"@langchain/svelte": patch
 ---
 
 fix(sdk): hydrate custom HttpAgentServerAdapter via transport getState

--- a/.changeset/fix-custom-transport-hydration.md
+++ b/.changeset/fix-custom-transport-hydration.md
@@ -1,0 +1,12 @@
+---
+"@langchain/langgraph-sdk": patch
+"@langchain/react": patch
+"@langchain/vue": patch
+"@langchain/angular": patch
+---
+
+fix(sdk): hydrate custom HttpAgentServerAdapter via transport getState
+
+StreamController now prefers adapter getState() before client.threads.getState,
+HttpAgentServerAdapter implements GET /threads/:id/state, and useStream inherits
+apiUrl from the transport so hydration no longer defaults to localhost:8123.

--- a/libs/sdk-angular/src/use-stream.ts
+++ b/libs/sdk-angular/src/use-stream.ts
@@ -20,6 +20,7 @@ import {
 } from "@langchain/langgraph-sdk";
 import {
   Client as ClientCtor,
+  resolveClientApiUrl,
   type ClientConfig,
   type ThreadStream,
 } from "@langchain/langgraph-sdk/client";
@@ -423,7 +424,10 @@ export function useStream<
   const client: Client =
     asBag.client ??
     (new ClientCtor({
-      apiUrl: asBag.apiUrl,
+      apiUrl: resolveClientApiUrl({
+        apiUrl: asBag.apiUrl,
+        transport: hasCustomAdapter ? transport : asBag.transport,
+      }),
       apiKey: asBag.apiKey,
       callerOptions: asBag.callerOptions,
       defaultHeaders: asBag.defaultHeaders,

--- a/libs/sdk-react/src/use-stream.ts
+++ b/libs/sdk-react/src/use-stream.ts
@@ -13,6 +13,7 @@ import {
 import {
   Client as ClientCtor,
   type ClientConfig,
+  resolveClientApiUrl,
   type ThreadStream,
 } from "@langchain/langgraph-sdk/client";
 import {
@@ -467,9 +468,13 @@ export function useStream<
   // fresh controller re-fires its constructor hydrate: a *duplicate*
   // `getState` + `getHistory`. A ref is never dropped, so the client
   // stays referentially stable until its config actually changes.
+  const resolvedApiUrl = resolveClientApiUrl({
+    apiUrl: asBag.apiUrl,
+    transport: hasCustomAdapter ? transport : asBag.transport,
+  });
   const clientDeps = [
     asBag.client,
-    asBag.apiUrl,
+    resolvedApiUrl,
     asBag.apiKey,
     asBag.callerOptions,
     asBag.defaultHeaders,
@@ -487,7 +492,7 @@ export function useStream<
       client:
         asBag.client ??
         (new ClientCtor({
-          apiUrl: asBag.apiUrl,
+          apiUrl: resolvedApiUrl,
           apiKey: asBag.apiKey,
           callerOptions: asBag.callerOptions,
           defaultHeaders: asBag.defaultHeaders,

--- a/libs/sdk-svelte/src/use-stream.svelte.ts
+++ b/libs/sdk-svelte/src/use-stream.svelte.ts
@@ -11,6 +11,7 @@ import {
 import {
   Client as ClientCtor,
   type ClientConfig,
+  resolveClientApiUrl,
   type ThreadStream,
 } from "@langchain/langgraph-sdk/client";
 import {
@@ -431,7 +432,10 @@ export function useStream<
   const client: Client =
     asBag.client ??
     (new ClientCtor({
-      apiUrl: asBag.apiUrl,
+      apiUrl: resolveClientApiUrl({
+        apiUrl: asBag.apiUrl,
+        transport: hasCustomAdapter ? transport : asBag.transport,
+      }),
       apiKey: asBag.apiKey,
       callerOptions: asBag.callerOptions,
       defaultHeaders: asBag.defaultHeaders,

--- a/libs/sdk-vue/src/use-stream.ts
+++ b/libs/sdk-vue/src/use-stream.ts
@@ -21,6 +21,7 @@ import {
 } from "@langchain/langgraph-sdk";
 import {
   Client as ClientCtor,
+  resolveClientApiUrl,
   type ClientConfig,
   type ThreadStream,
 } from "@langchain/langgraph-sdk/client";
@@ -455,7 +456,11 @@ export function useStream<
   // that flip a backend at runtime get a fresh client without a full
   // remount — the controller is swapped in lock-step below.
   const resolveApiUrl = () =>
-    toValue(asBag.apiUrl) ?? (pluginOptions as { apiUrl?: string }).apiUrl;
+    resolveClientApiUrl({
+      apiUrl:
+        toValue(asBag.apiUrl) ?? (pluginOptions as { apiUrl?: string }).apiUrl,
+      transport: hasCustomAdapter ? transport : asBag.transport,
+    });
   const resolveApiKey = () =>
     toValue(asBag.apiKey) ?? (pluginOptions as { apiKey?: string }).apiKey;
   const explicitClient =

--- a/libs/sdk/src/client.ts
+++ b/libs/sdk/src/client.ts
@@ -19,6 +19,7 @@ export {
   ProtocolSseTransportAdapter,
   ProtocolWebSocketTransportAdapter,
   HttpAgentServerAdapter,
+  resolveClientApiUrl,
 } from "./client/index.js";
 
 export type { HttpAgentServerAdapterOptions } from "./client/index.js";

--- a/libs/sdk/src/client/index.ts
+++ b/libs/sdk/src/client/index.ts
@@ -155,6 +155,7 @@ export {
 } from "./stream/transport/index.js";
 
 export type { HttpAgentServerAdapterOptions } from "./stream/transport/index.js";
+export { resolveClientApiUrl } from "./stream/resolve-client-api-url.js";
 
 export type {
   ProtocolRequestHook,

--- a/libs/sdk/src/client/stream/resolve-client-api-url.test.ts
+++ b/libs/sdk/src/client/stream/resolve-client-api-url.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { HttpAgentServerAdapter } from "./transport/agent-server.js";
+import { resolveClientApiUrl } from "./resolve-client-api-url.js";
+
+describe("resolveClientApiUrl", () => {
+  it("prefers an explicit apiUrl", () => {
+    const transport = new HttpAgentServerAdapter({
+      apiUrl: "http://adapter:9000/api",
+      threadId: "t1",
+    });
+    expect(
+      resolveClientApiUrl({
+        apiUrl: "http://explicit:8080/api",
+        transport,
+      })
+    ).toBe("http://explicit:8080/api");
+  });
+
+  it("inherits apiUrl from HttpAgentServerAdapter", () => {
+    const transport = new HttpAgentServerAdapter({
+      apiUrl: "http://adapter:9000/api",
+      threadId: "t1",
+    });
+    expect(resolveClientApiUrl({ transport })).toBe("http://adapter:9000/api");
+  });
+
+  it("returns undefined when no apiUrl is available", () => {
+    expect(resolveClientApiUrl({ transport: "sse" })).toBeUndefined();
+  });
+});

--- a/libs/sdk/src/client/stream/resolve-client-api-url.ts
+++ b/libs/sdk/src/client/stream/resolve-client-api-url.ts
@@ -1,0 +1,23 @@
+import type { AgentServerAdapter } from "./transport.js";
+
+/**
+ * Resolve the LangGraph SDK `Client` base URL for hydration and history
+ * reads when the caller uses a custom {@link AgentServerAdapter}.
+ *
+ * Explicit `apiUrl` wins; otherwise inherit from adapters that expose
+ * `apiUrl` (e.g. {@link HttpAgentServerAdapter}).
+ */
+export function resolveClientApiUrl(options: {
+  apiUrl?: string;
+  transport?: "sse" | "websocket" | AgentServerAdapter;
+}): string | undefined {
+  if (options.apiUrl != null) return options.apiUrl;
+
+  const { transport } = options;
+  if (transport != null && typeof transport === "object") {
+    const candidate = (transport as { apiUrl?: unknown }).apiUrl;
+    if (typeof candidate === "string") return candidate;
+  }
+
+  return undefined;
+}

--- a/libs/sdk/src/client/stream/transport.ts
+++ b/libs/sdk/src/client/stream/transport.ts
@@ -93,14 +93,18 @@ export interface TransportAdapter {
  */
 export interface AgentServerAdapter extends TransportAdapter {
   /**
-   * Fetch the latest checkpointed state for the bound thread. When
-   * the adapter doesn't expose state (e.g. a purely event-replay
-   * backend), leave this undefined — the framework will skip
-   * hydration.
+   * Fetch the latest checkpointed state for the bound thread via
+   * `GET /threads/:threadId/state` (or an adapter-specific override).
+   * When omitted, {@link StreamController.hydrate} falls back to
+   * `client.threads.getState()`.
    */
   getState?<StateType = unknown>(): Promise<{
     values: StateType;
+    next?: unknown;
+    tasks?: unknown;
+    metadata?: unknown;
     checkpoint?: { checkpoint_id?: string } | null;
+    parent_checkpoint?: { checkpoint_id?: string } | null;
   } | null>;
   /**
    * Fetch a slice of checkpoint history for the bound thread. Used

--- a/libs/sdk/src/client/stream/transport/agent-server.test.ts
+++ b/libs/sdk/src/client/stream/transport/agent-server.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { HttpAgentServerAdapter } from "./agent-server.js";
+import {
+  createFetchRecorder,
+  createWebSocketUrlRecorder,
+} from "./test-helpers.js";
+
+describe("HttpAgentServerAdapter hydration", () => {
+  it("exposes getState for the default SSE delegate", async () => {
+    const { fetch } = createFetchRecorder({
+      response: new Response(
+        JSON.stringify({ values: { messages: [] }, next: [], tasks: [] }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      ),
+    });
+    const adapter = new HttpAgentServerAdapter({
+      apiUrl: "http://localhost:4100/api",
+      threadId: "thread-1",
+      fetch,
+    });
+
+    expect(adapter.getState).toEqual(expect.any(Function));
+    await expect(adapter.getState?.()).resolves.toEqual({
+      values: { messages: [] },
+      next: [],
+      tasks: [],
+    });
+  });
+
+  it("omits getState for WebSocket delegates", () => {
+    const { webSocketFactory } = createWebSocketUrlRecorder();
+    const adapter = new HttpAgentServerAdapter({
+      apiUrl: "http://localhost:4100/api",
+      threadId: "thread-1",
+      webSocketFactory,
+    });
+
+    expect(adapter.getState).toBeUndefined();
+  });
+});

--- a/libs/sdk/src/client/stream/transport/agent-server.ts
+++ b/libs/sdk/src/client/stream/transport/agent-server.ts
@@ -60,10 +60,13 @@ export interface HttpAgentServerAdapterOptions {
 export class HttpAgentServerAdapter implements AgentServerAdapter {
   readonly threadId: string;
 
+  readonly apiUrl: string;
+
   readonly #delegate: TransportAdapter;
 
   constructor(options: HttpAgentServerAdapterOptions) {
     this.threadId = options.threadId;
+    this.apiUrl = options.apiUrl;
     this.#delegate =
       options.webSocketFactory != null
         ? new ProtocolWebSocketTransportAdapter({
@@ -107,5 +110,29 @@ export class HttpAgentServerAdapter implements AgentServerAdapter {
 
   close(): Promise<void> {
     return this.#delegate.close();
+  }
+
+  getState<StateType = unknown>(): Promise<{
+    values: StateType;
+    next?: unknown;
+    tasks?: unknown;
+    metadata?: unknown;
+    checkpoint?: { checkpoint_id?: string } | null;
+    parent_checkpoint?: { checkpoint_id?: string } | null;
+  } | null> {
+    const delegate = this.#delegate as {
+      getState?: () => Promise<{
+        values: StateType;
+        next?: unknown;
+        tasks?: unknown;
+        metadata?: unknown;
+        checkpoint?: { checkpoint_id?: string } | null;
+        parent_checkpoint?: { checkpoint_id?: string } | null;
+      } | null>;
+    };
+    if (typeof delegate.getState !== "function") {
+      return Promise.resolve(null);
+    }
+    return delegate.getState();
   }
 }

--- a/libs/sdk/src/client/stream/transport/agent-server.ts
+++ b/libs/sdk/src/client/stream/transport/agent-server.ts
@@ -64,6 +64,12 @@ export class HttpAgentServerAdapter implements AgentServerAdapter {
 
   readonly #delegate: TransportAdapter;
 
+  /**
+   * Thread-state reads are SSE-only. WebSocket delegates omit this so
+   * {@link StreamController} falls back to `client.threads.getState()`.
+   */
+  getState?: AgentServerAdapter["getState"];
+
   constructor(options: HttpAgentServerAdapterOptions) {
     this.threadId = options.threadId;
     this.apiUrl = options.apiUrl;
@@ -85,6 +91,11 @@ export class HttpAgentServerAdapter implements AgentServerAdapter {
             fetch: options.fetch,
             paths: options.paths,
           });
+
+    if (options.webSocketFactory == null) {
+      const sse = this.#delegate as ProtocolSseTransportAdapter;
+      this.getState = sse.getState.bind(sse);
+    }
   }
 
   open(): Promise<void> {
@@ -110,29 +121,5 @@ export class HttpAgentServerAdapter implements AgentServerAdapter {
 
   close(): Promise<void> {
     return this.#delegate.close();
-  }
-
-  getState<StateType = unknown>(): Promise<{
-    values: StateType;
-    next?: unknown;
-    tasks?: unknown;
-    metadata?: unknown;
-    checkpoint?: { checkpoint_id?: string } | null;
-    parent_checkpoint?: { checkpoint_id?: string } | null;
-  } | null> {
-    const delegate = this.#delegate as {
-      getState?: () => Promise<{
-        values: StateType;
-        next?: unknown;
-        tasks?: unknown;
-        metadata?: unknown;
-        checkpoint?: { checkpoint_id?: string } | null;
-        parent_checkpoint?: { checkpoint_id?: string } | null;
-      } | null>;
-    };
-    if (typeof delegate.getState !== "function") {
-      return Promise.resolve(null);
-    }
-    return delegate.getState();
   }
 }

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -71,4 +71,56 @@ describe("ProtocolSseTransportAdapter URL resolution", () => {
       `${LANGGRAPH_PROXY_API_URL}/threads/${THREAD_ID}/commands`
     );
   });
+
+  it("fetches thread state with GET for hydration", async () => {
+    const calls: Array<{ href: string; method?: string }> = [];
+    const fetch: typeof globalThis.fetch = (input, init) => {
+      const href =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      calls.push({ href, method: init?.method });
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            values: { messages: [] },
+            next: [],
+            tasks: [],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+      );
+    };
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: PROXIED_API_URL,
+      threadId: THREAD_ID,
+      fetch,
+      paths: {
+        state: `/threads/${THREAD_ID}/state`,
+      },
+    });
+
+    const state = await transport.getState();
+    expect(state?.values).toEqual({ messages: [] });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("GET");
+    expect(calls[0]?.href).toBe(
+      `${PROXIED_API_URL}/threads/${THREAD_ID}/state`
+    );
+  });
+
+  it("returns null when thread state is missing", async () => {
+    const { fetch } = createFetchRecorder({
+      response: new Response("not found", { status: 404 }),
+    });
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: PROXIED_API_URL,
+      threadId: THREAD_ID,
+      fetch,
+    });
+
+    await expect(transport.getState()).resolves.toBeNull();
+  });
 });

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -32,11 +32,11 @@ import { IterableReadableStream } from "../../../utils/stream.js";
 export class ProtocolSseTransportAdapter implements TransportAdapter {
   readonly threadId: string;
 
+  readonly apiUrl: string;
+
   private readonly queue = new AsyncQueue<Message>();
 
   private readonly fetchImpl: typeof fetch;
-
-  private readonly apiUrl: string;
 
   private readonly defaultHeaders: Record<string, HeaderValue>;
 
@@ -47,6 +47,8 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
   private readonly commandsUrl: string;
 
   private readonly streamUrl: string;
+
+  private readonly stateUrl: string;
 
   private readonly sessionAbortController = new AbortController();
 
@@ -65,6 +67,55 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
       options.paths?.commands ?? `/threads/${this.threadId}/commands`;
     this.streamUrl =
       options.paths?.stream ?? `/threads/${this.threadId}/stream/events`;
+    this.stateUrl = options.paths?.state ?? `/threads/${this.threadId}/state`;
+  }
+
+  /**
+   * Fetch checkpointed thread state for hydration.
+   *
+   * Uses `GET`, matching `client.threads.getState()` and both LangGraph
+   * Platform and Agent Protocol custom backends (`POST` is reserved for
+   * `updateState`).
+   */
+  async getState<StateType = unknown>(): Promise<{
+    values: StateType;
+    next?: unknown;
+    tasks?: unknown;
+    metadata?: unknown;
+    checkpoint?: { checkpoint_id?: string } | null;
+    parent_checkpoint?: { checkpoint_id?: string } | null;
+  } | null> {
+    const url = toAbsoluteUrl(this.apiUrl, this.stateUrl);
+    let requestInit: RequestInit = {
+      method: "GET",
+      headers: mergeHeaders(this.defaultHeaders, {}),
+    };
+
+    if (this.onRequest) {
+      requestInit = await this.onRequest(url, requestInit);
+    }
+
+    const fetchImpl = await this.resolveFetch();
+    const response = await fetchImpl(url.toString(), requestInit);
+    if (response.status === 404) return null;
+    if (!response.ok) {
+      const error = toError(
+        new Error(
+          `Thread state request failed: ${response.status} ${response.statusText}`
+        )
+      ) as Error & { status?: number };
+      error.status = response.status;
+      throw error;
+    }
+
+    return (await response.json()) as {
+      values: StateType;
+      next?: unknown;
+      tasks?: unknown;
+      metadata?: unknown;
+      checkpoint?: { checkpoint_id?: string } | null;
+      parent_checkpoint?: { checkpoint_id?: string } | null;
+    };
   }
 
   private async resolveFetch(): Promise<typeof fetch> {

--- a/libs/sdk/src/client/stream/transport/types.ts
+++ b/libs/sdk/src/client/stream/transport/types.ts
@@ -8,6 +8,8 @@ export type ProtocolRequestHook = (
 export interface ProtocolTransportPaths {
   commands?: string;
   stream?: string;
+  /** `GET` path for thread-state hydration. Defaults to `/threads/:threadId/state`. */
+  state?: string;
 }
 
 export interface ProtocolSseTransportOptions {

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -522,6 +522,43 @@ describe("StreamController", () => {
     await controller.dispose();
   });
 
+  it("prefers transport.getState over client.threads.getState", async () => {
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const transportGetState = vi.fn(async () => ({
+      values: { messages: [{ type: "human", content: "from transport" }] },
+      next: [],
+      tasks: [],
+    }));
+    const clientGetState = vi.fn(async () => {
+      throw new Error("client getState should not run");
+    });
+    const client = {
+      threads: {
+        getState: clientGetState,
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, unknown>({
+      assistantId: "custom-backend",
+      client: client as never,
+      threadId: "thread-transport",
+      transport: { getState: transportGetState } as never,
+    });
+    await controller.hydrationPromise;
+
+    expect(transportGetState).toHaveBeenCalledTimes(1);
+    expect(clientGetState).not.toHaveBeenCalled();
+
+    await controller.dispose();
+  });
+
   it("hydrate seeds rootStore.interrupts from getState tasks", async () => {
     let onEvent: ((event: Event) => void) | undefined;
     const thread = {

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -30,7 +30,7 @@ import type {
   ToolsEvent,
   ValuesEvent,
 } from "@langchain/protocol";
-import type { Interrupt } from "../schema.js";
+import type { Interrupt, ThreadState } from "../schema.js";
 import type { ThreadStream } from "../client/stream/index.js";
 import type { SubscriptionHandle } from "../client/stream/index.js";
 import { ToolCallAssembler } from "../client/stream/handles/tools.js";
@@ -469,6 +469,26 @@ export class StreamController<
   // ---------- public imperatives ----------
 
   /**
+   * Load thread state for hydration, preferring the active custom
+   * adapter's `getState()` when present.
+   */
+  async #fetchHydrationState(): Promise<ThreadState<StateType> | null> {
+    const threadId = this.#currentThreadId;
+    if (threadId == null) return null;
+
+    const transport = this.#options.transport;
+    if (
+      transport != null &&
+      typeof transport === "object" &&
+      typeof transport.getState === "function"
+    ) {
+      return (await transport.getState<StateType>()) as ThreadState<StateType> | null;
+    }
+
+    return this.#options.client.threads.getState<StateType>(threadId);
+  }
+
+  /**
    * Fetch the checkpointed thread state and seed the root snapshot.
    * Re-calling with a different `threadId` swaps the underlying
    * {@link ThreadStream}, rewires the registry to the new thread, and
@@ -540,9 +560,7 @@ export class StreamController<
     // Flipped to the real signal once we have the state in hand.
     let threadActive = true;
     try {
-      const state = await this.#options.client.threads.getState<StateType>(
-        this.#currentThreadId
-      );
+      const state = await this.#fetchHydrationState();
       threadExists = state != null;
       threadActive = isThreadStateActive(state);
       if (state?.values != null) {


### PR DESCRIPTION
## Summary
- `StreamController.hydrate()` calls `transport.getState()` when the adapter implements it, then falls back to `client.threads.getState()`.
- `HttpAgentServerAdapter` / `ProtocolSseTransportAdapter` add `getState()` via `GET /threads/:threadId/state` (optional `paths.state` override).
- `resolveClientApiUrl()` lets `useStream` build the hydration `Client` from the transport’s `apiUrl` when none is passed explicitly.
- React, Vue, and Angular `useStream` hooks use the resolver so custom-backend apps only need `transport={adapter}`.
