### PR TITLE
fix(langgraph-checkpoint-postgres): reject SQL LIKE wildcards in PostgresStore namespace labels

### DIFF
--- a/.changeset/fix-postgres-store-namespace-like-wildcard.md
+++ b/.changeset/fix-postgres-store-namespace-like-wildcard.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint-postgres": patch
+---
+
+fix: reject SQL `LIKE` wildcards (`%`, `_`) and the backslash escape character in `PostgresStore` namespace labels. `BaseStore.search()` matches namespaces via `namespace_path LIKE ${prefix}%`, and these characters in caller-supplied namespace labels are interpreted as wildcards by Postgres even through a bound parameter — letting a namespace prefix of `["%"]` match every namespace in the store across tenants. `validateNamespace` now throws for these characters at all `search` / `get` / `put` entrypoints, keeping store-wide consistency. CWE-1336.

--- a/libs/checkpoint-postgres/src/store/modules/utils.test.ts
+++ b/libs/checkpoint-postgres/src/store/modules/utils.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { validateNamespace } from "./utils.js";
+
+describe("validateNamespace", () => {
+  it("accepts a simple, well-formed namespace", () => {
+    expect(() => validateNamespace(["tenants", "acme", "users"])).not.toThrow();
+  });
+
+  it("rejects empty namespace arrays", () => {
+    expect(() => validateNamespace([])).toThrow(/cannot be empty/);
+  });
+
+  it("rejects empty string labels", () => {
+    expect(() => validateNamespace(["tenants", ""])).toThrow(
+      /cannot be empty strings/
+    );
+  });
+
+  it("rejects labels containing periods", () => {
+    expect(() => validateNamespace(["a.b"])).toThrow(/cannot contain periods/);
+  });
+
+  it("rejects the reserved 'langgraph' root label", () => {
+    expect(() => validateNamespace(["langgraph", "users"])).toThrow(
+      /Root label.*cannot be "langgraph"/
+    );
+  });
+
+  // The block below covers the LIKE-wildcard cross-namespace leak. Search
+  // operations match via `namespace_path LIKE ${prefix}%` (bound parameter),
+  // and `%` / `_` / `\` in caller-supplied labels are still interpreted as
+  // LIKE wildcards / escapes by Postgres regardless of binding. A namespace
+  // prefix of `["%"]` would otherwise match every namespace in the store.
+  describe("LIKE wildcard / escape character rejection", () => {
+    it.each([
+      ["%"],
+      ["_"],
+      ["\\"],
+      ["acme%"],
+      ["acme_users"],
+      ["acme\\users"],
+      ["users", "%"],
+    ])("rejects namespace with LIKE-special label %j", (...labels) => {
+      expect(() => validateNamespace(labels)).toThrow(
+        /SQL LIKE wildcards.*backslash/
+      );
+    });
+
+    it("does not reject benign characters that look similar", () => {
+      // colon is the namespace path separator, hyphen / digit / unicode are fine
+      expect(() =>
+        validateNamespace(["tenant-1", "user:42", "プロジェクト"])
+      ).not.toThrow();
+    });
+  });
+});

--- a/libs/checkpoint-postgres/src/store/modules/utils.ts
+++ b/libs/checkpoint-postgres/src/store/modules/utils.ts
@@ -1,4 +1,18 @@
 /**
+ * Characters interpreted as wildcards (or escape) by Postgres `LIKE` patterns.
+ * Search operations match namespaces via `namespace_path LIKE ${prefix}%`, so
+ * any of these in a caller-supplied label silently changes the prefix match
+ * into a glob. A namespace prefix of `["%"]` would match every namespace in
+ * the store, exposing data across tenants. CWE-1336 / CWE-943.
+ *
+ * Equality-path operations (get / put / delete) use `namespace_path = $1` and
+ * are safe on their own, but we reject these characters everywhere to keep the
+ * Store API consistent (data written under such a namespace would never be
+ * reachable via search anyway).
+ */
+const LIKE_RESERVED_PATTERN = /[%_\\]/;
+
+/**
  * Validates the provided namespace.
  * @param namespace The namespace to validate.
  * @throws {Error} If the namespace is invalid.
@@ -22,6 +36,14 @@ export function validateNamespace(namespace: string[]): void {
     if (label === "") {
       throw new Error(
         `Namespace labels cannot be empty strings. Got ${label} in ${namespace}`
+      );
+    }
+    if (LIKE_RESERVED_PATTERN.test(label)) {
+      throw new Error(
+        `Invalid namespace label '${label}' found in ${namespace}. Namespace ` +
+          `labels cannot contain SQL LIKE wildcards ('%', '_') or the ` +
+          `backslash escape character ('\\\\'); these would cause search() to ` +
+          `match namespaces outside the requested prefix.`
       );
     }
   }


### PR DESCRIPTION
## Summary

`BaseStore.search()` on `PostgresStore` matches namespaces via `namespace_path LIKE \${prefix}%` (bound parameter). The bind protects against SQL injection but **does not** keep Postgres from interpreting `%`, `_`, or `\` inside the label itself as `LIKE` wildcards / escape characters. So a caller-supplied namespace prefix containing `%` silently widens the prefix into a glob — data leaks across namespaces in any multi-tenant deployment that pipes configurable values into a `BaseStore` namespace.

`InMemoryStore` is unaffected — it compares prefixes via literal `String.startsWith()`.

### Repro (conceptually, against the old `validateNamespace`)

```ts
const store = PostgresStore.fromConnString(url);

// tenant A writes private data
await store.put(["acme", "users", "alice"], "preferences", { theme: "dark" });

// tenant B searches under their own namespace — fine
await store.search(["other-tenant"]);

// but B can also do this, and the search returns A's row:
await store.search(["%"]);            // matches every namespace
await store.search(["a%", "users"]);  // matches "acme:users", "any:users", ...
```

After this PR `validateNamespace` rejects `%` / `_` / `\` at all `search` / `get` / `put` / `delete` entrypoints, matching the existing handling of `.` and empty labels.

### Tests

New `src/store/modules/utils.test.ts` exercises `validateNamespace` directly (it's a pure function, so no live Postgres needed). 8 new cases cover each wildcard char in isolation, in combination with other letters, and at non-first positions; benign characters that *look* similar (`-`, `:`, digits, unicode) are explicitly allowed.

**Reverse-verified**: with this PR's `utils.ts` reverted, 7 of the 7 new LIKE-wildcard tests fail (`expected [Function] to throw an error / Received undefined`).

### Consistency

| Store | Namespace prefix match | Wildcard handling |
|-------|------------------------|--------------------|
| `InMemoryStore` | `String.startsWith()` (literal) | n/a — already safe |
| `PostgresStore` | `namespace_path LIKE \${prefix}%` | wildcards rejected at validation (this PR) |
| `RedisStore` (precedent) | `KEYS namespace:*:...` | already rejects `*`/`?`/`[`/`]`/`\` via `assertSafeKeyComponent` |

CWE-1336 (Improper Neutralization of Special Elements Used in a Template Engine).

## AI Disclosure

This issue was identified via cross-store consistency review with AI assistance, and the fix was validated against a focused unit-test suite plus reverse-verification (test suite fails without the fix).