### PR TITLE
fix(core): expose StateSchema JSON schemas for Studio introspection

### DIFF
--- a/.changeset/fix-stateschema-studio-schema.md
+++ b/.changeset/fix-stateschema-studio-schema.md
@@ -1,0 +1,11 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(schema): expose StateSchema JSON schemas for Studio introspection
+
+Route StateSchema runtime definitions through getJsonSchema() and
+getInputJsonSchema() so LangGraph Studio receives state, input, and
+context schemas when graphs use the StateSchema primitive.
+
+Fixes #2466

--- a/libs/langgraph-core/src/graph/zod/schema.ts
+++ b/libs/langgraph-core/src/graph/zod/schema.ts
@@ -8,15 +8,20 @@ import {
   SchemaMetaRegistry,
   schemaMetaRegistry,
 } from "./meta.js";
+import { StateSchema, type AnyStateSchema } from "../../state/schema.js";
 
 const PartialStateSchema = Symbol.for("langgraph.state.partial");
 type PartialStateSchema = typeof PartialStateSchema;
 
 interface GraphWithZodLike {
   builder: {
-    _schemaRuntimeDefinition: InteropZodObject | undefined;
-    _inputRuntimeDefinition: InteropZodObject | PartialStateSchema | undefined;
-    _outputRuntimeDefinition: InteropZodObject | undefined;
+    _schemaRuntimeDefinition: InteropZodObject | AnyStateSchema | undefined;
+    _inputRuntimeDefinition:
+      | InteropZodObject
+      | AnyStateSchema
+      | PartialStateSchema
+      | undefined;
+    _outputRuntimeDefinition: InteropZodObject | AnyStateSchema | undefined;
     _configRuntimeSchema: InteropZodObject | undefined;
   };
 }
@@ -80,6 +85,7 @@ export function getStateTypeSchema(
   if (!isGraphWithZodLike(graph)) return undefined;
   const schemaDef = graph.builder._schemaRuntimeDefinition;
   if (!schemaDef) return undefined;
+  if (StateSchema.isInstance(schemaDef)) return schemaDef.getJsonSchema();
 
   return toJsonSchema(
     registry.getExtendedChannelSchemas(schemaDef, {
@@ -100,6 +106,7 @@ export function getUpdateTypeSchema(
   if (!isGraphWithZodLike(graph)) return undefined;
   const schemaDef = graph.builder._schemaRuntimeDefinition;
   if (!schemaDef) return undefined;
+  if (StateSchema.isInstance(schemaDef)) return schemaDef.getInputJsonSchema();
 
   return toJsonSchema(
     registry.getExtendedChannelSchemas(schemaDef, {
@@ -126,6 +133,7 @@ export function getInputTypeSchema(
     schemaDef = graph.builder._schemaRuntimeDefinition;
   }
   if (!schemaDef) return undefined;
+  if (StateSchema.isInstance(schemaDef)) return schemaDef.getInputJsonSchema();
 
   return toJsonSchema(
     registry.getExtendedChannelSchemas(schemaDef, {
@@ -148,6 +156,7 @@ export function getOutputTypeSchema(
   if (!isGraphWithZodLike(graph)) return undefined;
   const schemaDef = graph.builder._outputRuntimeDefinition;
   if (!schemaDef) return undefined;
+  if (StateSchema.isInstance(schemaDef)) return schemaDef.getJsonSchema();
 
   return toJsonSchema(
     registry.getExtendedChannelSchemas(schemaDef, {

--- a/libs/langgraph-core/src/tests/pregel.test.ts
+++ b/libs/langgraph-core/src/tests/pregel.test.ts
@@ -112,6 +112,7 @@ import {
   TASKS,
 } from "../constants.js";
 import { MessagesAnnotation } from "../graph/messages_annotation.js";
+import { StateSchema, MessagesValue } from "../state/index.js";
 import { LangGraphRunnableConfig } from "../pregel/runnable_types.js";
 import { interrupt } from "../interrupt.js";
 import {
@@ -11454,6 +11455,79 @@ graph TD;
           )
         ).rejects.toBeDefined();
 
+        expect(getConfigTypeSchema(graph)).toStrictEqual(expectedConfigSchema);
+      });
+
+      it("with StateSchema and zod context", async () => {
+        const state = new StateSchema({
+          messages: MessagesValue,
+          agentId: z4.string().describe("Agent ID from the dashboard"),
+        });
+        const config = z4.object({
+          prompt: withLangGraph(z4.string().min(1), {
+            jsonSchemaExtra: {
+              langgraph_nodes: ["agent"],
+              langgraph_type: "prompt",
+            },
+          }),
+        });
+
+        const graph = new StateGraph(state, config)
+          .addNode("agent", () => ({
+            messages: [{ role: "assistant", content: "Hi" }],
+          }))
+          .addEdge("__start__", "agent")
+          .compile();
+
+        expect(
+          await graph.invoke(
+            { agentId: "agent-1" },
+            { configurable: { thread_id: "1", prompt: "user input" } }
+          )
+        ).toMatchObject({ agentId: "agent-1" });
+
+        expect(getStateTypeSchema(graph)).toMatchObject({
+          type: "object",
+          properties: {
+            messages: { langgraph_type: "messages" },
+            agentId: {
+              type: "string",
+              description: "Agent ID from the dashboard",
+            },
+          },
+          required: ["agentId"],
+        });
+        expect(getInputTypeSchema(graph)).toMatchObject({
+          type: "object",
+          properties: {
+            messages: { langgraph_type: "messages" },
+            agentId: {
+              type: "string",
+              description: "Agent ID from the dashboard",
+            },
+          },
+        });
+        expect(getUpdateTypeSchema(graph)).toMatchObject({
+          type: "object",
+          properties: {
+            messages: { langgraph_type: "messages" },
+            agentId: {
+              type: "string",
+              description: "Agent ID from the dashboard",
+            },
+          },
+        });
+        expect(getOutputTypeSchema(graph)).toMatchObject({
+          type: "object",
+          properties: {
+            messages: { langgraph_type: "messages" },
+            agentId: {
+              type: "string",
+              description: "Agent ID from the dashboard",
+            },
+          },
+          required: ["agentId"],
+        });
         expect(getConfigTypeSchema(graph)).toStrictEqual(expectedConfigSchema);
       });
     });


### PR DESCRIPTION
## Summary
- Fix schema introspection for graphs built with `StateSchema` so LangGraph Studio receives correct state, input, update, and output JSON schemas.
- Add regression coverage for `new StateGraph(StateSchema, z.object(...))`, including context/config schema exposure.
- Closes #2466.