### PR TITLE
fix: make AnyStream a true supertype so selector hooks need no cast

### DIFF
--- a/.changeset/fix-anystream-selector-cast.md
+++ b/.changeset/fix-anystream-selector-cast.md
@@ -1,0 +1,17 @@
+---
+"@langchain/react": patch
+"@langchain/vue": patch
+"@langchain/svelte": patch
+"@langchain/angular": patch
+---
+
+fix: make AnyStream a true supertype so selector hooks need no cast
+
+A concrete `useStream<typeof agent>()` handle was not assignable to
+`AnyStream` because generic-computed covariant members (`toolCalls`,
+`values`) don't widen under `any` — `InferToolCalls<any>[]` resolves to
+`AssembledToolCall<…, never>[]`, narrower than a concrete handle. Override
+those members with their widest forms (preserving each framework's
+reactivity wrapper — plain arrays for React/Svelte, `ShallowRef` for Vue,
+`Signal` for Angular) so the message/tool/value selector hooks accept a
+fully-typed stream without an `as AnyStream` cast.

--- a/libs/sdk-angular/src/tests/selector-cast.test-d.ts
+++ b/libs/sdk-angular/src/tests/selector-cast.test-d.ts
@@ -1,0 +1,44 @@
+/**
+ * Reproduction: a fully-typed `UseStreamReturn<typeof agent>` handle
+ * should flow into the selector primitives (`injectMessages`,
+ * `injectToolCalls`, `injectValues`) and into the public `AnyStream`
+ * escape-hatch type WITHOUT an `as AnyStream` cast.
+ */
+import { describe, test } from "vitest";
+import { createDeepAgent } from "deepagents";
+
+import {
+  useStream,
+  injectMessages,
+  injectToolCalls,
+  injectValues,
+  type AnyStream,
+  type UseStreamReturn,
+} from "../index.js";
+
+const agent = createDeepAgent({
+  tools: [],
+  subagents: [{ name: "researcher", description: "r", systemPrompt: "r" }],
+});
+
+describe("selector primitives accept concrete stream without cast", () => {
+  test("injectMessages / injectToolCalls / injectValues at root", () => {
+    const stream = useStream<typeof agent>({ assistantId: "deep-agent" });
+
+    injectMessages(stream);
+    injectToolCalls(stream);
+    injectValues(stream);
+  });
+
+  test("concrete handle is assignable to AnyStream", () => {
+    const stream = useStream<typeof agent>({ assistantId: "deep-agent" });
+    const erased: AnyStream = stream;
+    injectMessages(erased);
+  });
+
+  test("wrapper typed against UseStreamReturn flows in too", () => {
+    const stream = useStream<typeof agent>({ assistantId: "deep-agent" });
+    const handle: UseStreamReturn<typeof agent> = stream;
+    injectToolCalls(handle);
+  });
+});

--- a/libs/sdk-angular/src/use-stream.ts
+++ b/libs/sdk-angular/src/use-stream.ts
@@ -28,6 +28,7 @@ import {
   StreamController,
   type AgentServerAdapter,
   type AgentServerOptions as StreamAgentServerOptions,
+  type AssembledToolCall,
   type ChannelRegistry,
   type CustomAdapterOptions as StreamCustomAdapterOptions,
   type InferStateType,
@@ -351,9 +352,26 @@ export interface UseStreamReturn<
  * Erased handle useful as a parameter type for helper components that
  * pass a `stream` through to selector primitives without reading
  * `values` directly. Mirrors the React/Vue `AnyStream` alias.
+ *
+ * Widening the generic slots to `any` is **not** enough on its own:
+ * members computed from `T` in covariant positions don't collapse to a
+ * top type under `any`. `toolCalls` resolves to
+ * `Signal<AssembledToolCall<…, never>[]>` — the `never` output slot is
+ * narrower than a concrete handle's `…, unknown`, so a fully-typed
+ * `useStream<typeof agent>()` handle would fail to assign and every
+ * `injectToolCalls(stream)` call would need an `as AnyStream` cast.
+ * Override `toolCalls` / `values` (keeping the `Signal` wrapper) with
+ * their widest forms so the erased handle is a true supertype of every
+ * concrete `UseStreamReturn`.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyStream = UseStreamReturn<any, any, any>;
+export type AnyStream = Omit<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  UseStreamReturn<any, any, any>,
+  "toolCalls" | "values"
+> & {
+  readonly toolCalls: Signal<AssembledToolCall[]>;
+  readonly values: Signal<unknown>;
+};
 
 /**
  * Convenience alias — the fully-resolved return type of
@@ -647,10 +665,7 @@ export function useStream<
  *
  * @internal
  */
-export function getRegistry(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  stream: UseStreamReturn<any, any, any>
-): ChannelRegistry {
+export function getRegistry(stream: AnyStream): ChannelRegistry {
   return stream[STREAM_CONTROLLER].registry;
 }
 

--- a/libs/sdk-react/src/selectors.ts
+++ b/libs/sdk-react/src/selectors.ts
@@ -37,6 +37,7 @@ import {
 import {
   getRegistry,
   STREAM_CONTROLLER,
+  type AnyStream,
   type UseStreamReturn,
 } from "./use-stream.js";
 import { useProjection } from "./use-projection.js";
@@ -129,21 +130,17 @@ function namespaceKey(namespace: readonly string[]): string {
   return namespace.join(NAMESPACE_SEPARATOR);
 }
 
-// The stream type we accept for selectors — purposely loose so
-// selector hooks remain callable from components that don't carry
-// the exact State/Interrupt/Configurable generics. We use `any` for
-// all three generics because `UseStreamReturn` is
-// invariant in `State` and `Configurable` (they flow through both
-// reader and writer positions), so a concrete
-// `useStream<typeof agent>()` handle wouldn't flow into
-// a `<object, unknown, object>` slot otherwise.
+// The stream type we accept for selectors — the public {@link AnyStream}
+// erased handle. It overrides the generic-computed covariant members
+// (`toolCalls`, `values`, `~stateType`) with their widest forms so a
+// concrete `useStream<typeof agent>()` handle flows in without an
+// `as AnyStream` cast (a bare `UseStreamReturn<any, any, any>` does not
+// — see the `AnyStream` definition in `use-stream.ts`).
 //
-// Typed selectors (`useValues<S>` etc.) use {@link StreamHandle}
-// above so the concrete `StateType` flows into the return; hooks
-// that don't depend on state (`useMessages`, `useAudio`, …) stay on
-// `AnyStream` for maximum flexibility.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyStream = UseStreamReturn<any, any, any>;
+// Typed selectors (`useValues<S>` etc.) use {@link StreamHandle} above
+// so the concrete `StateType` flows into the return; hooks that don't
+// depend on state (`useMessages`, `useAudio`, …) stay on `AnyStream`
+// for maximum flexibility.
 
 /**
  * Subscribe to a scoped `messages` stream. Pass `stream` and

--- a/libs/sdk-react/src/tests/selector-cast.test-d.ts
+++ b/libs/sdk-react/src/tests/selector-cast.test-d.ts
@@ -1,0 +1,50 @@
+/**
+ * Reproduction: a fully-typed `UseStreamReturn<typeof agent>` handle
+ * should flow into the selector hooks (`useMessages`, `useToolCalls`,
+ * `useValues`) and into the public `AnyStream` escape-hatch type
+ * WITHOUT an `as AnyStream` cast.
+ */
+import { describe, test } from "vitest";
+import { createDeepAgent } from "deepagents";
+
+import {
+  useStream,
+  useMessages,
+  useToolCalls,
+  useValues,
+  type AnyStream,
+  type UseStreamReturn,
+} from "../index.js";
+
+const agent = createDeepAgent({
+  tools: [],
+  subagents: [
+    { name: "researcher", description: "r", systemPrompt: "r" },
+  ],
+});
+
+describe("selector hooks accept concrete stream without cast", () => {
+  test("useMessages / useToolCalls / useValues", () => {
+    const stream = useStream<typeof agent>({ assistantId: "deep-agent" });
+
+    useMessages(stream);
+    useToolCalls(stream);
+    useValues(stream);
+
+    const snapshot = [...stream.subagents.values()][0];
+    useMessages(stream, snapshot);
+    useToolCalls(stream, snapshot);
+  });
+
+  test("concrete handle is assignable to AnyStream", () => {
+    const stream = useStream<typeof agent>({ assistantId: "deep-agent" });
+    const erased: AnyStream = stream;
+    useMessages(erased);
+  });
+
+  test("wrapper typed against UseStreamReturn flows in too", () => {
+    const stream = useStream<typeof agent>({ assistantId: "deep-agent" });
+    const handle: UseStreamReturn<typeof agent> = stream;
+    useToolCalls(handle);
+  });
+});

--- a/libs/sdk-react/src/use-stream.ts
+++ b/libs/sdk-react/src/use-stream.ts
@@ -20,6 +20,7 @@ import {
   StreamController,
   type AgentServerAdapter,
   type AgentServerOptions as StreamAgentServerOptions,
+  type AssembledToolCall,
   type ChannelRegistry,
   type CustomAdapterOptions as StreamCustomAdapterOptions,
   type InferStateType,
@@ -370,11 +371,19 @@ export interface UseStreamReturn<
  * Erased stream handle useful as a parameter type for helpers and
  * wrapper components that pass a `stream` through to selector hooks
  * (`useMessages`, `useChannel`, …) without reading `values` directly.
- * Any fully-typed `UseStreamReturn<S, I, C>` is
- * assignable to `AnyStream` because the generic slots are `any`
- * (bivariant), which avoids the `CompiledStateGraph` → `Record<string,
- * unknown>` assignment friction you hit when using the bare
- * `UseStreamReturn` default.
+ *
+ * Any fully-typed `UseStreamReturn<T, I, C>` is assignable to
+ * `AnyStream`. Widening the three generic slots to `any` is **not**
+ * enough on its own: members whose types are computed from `T` in
+ * covariant positions don't collapse to a top type under `any`. In
+ * particular `toolCalls: InferToolCalls<any>[]` resolves to
+ * `AssembledToolCall<string, …, never>[]` — the `never` output slot is
+ * *narrower* than a concrete handle's `AssembledToolCall<…, unknown>[]`,
+ * so the concrete handle fails to assign and every `useToolCalls(stream)`
+ * call would need an `as AnyStream` cast. `values` / `~stateType`
+ * (computed via `InferStateType<any>`) have the same hazard. We override
+ * those members with their widest forms so the erased handle is a true
+ * supertype of every concrete `UseStreamReturn`.
  *
  * @example
  * ```tsx
@@ -387,8 +396,15 @@ export interface UseStreamReturn<
  * }
  * ```
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyStream = UseStreamReturn<any, any, any>;
+export type AnyStream = Omit<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  UseStreamReturn<any, any, any>,
+  "toolCalls" | "values" | "~stateType"
+> & {
+  readonly toolCalls: AssembledToolCall[];
+  readonly values: unknown;
+  readonly "~stateType"?: unknown;
+};
 
 /**
  * React binding for the v2-native stream runtime.
@@ -736,10 +752,7 @@ export type UseStreamResult<
  *
  * @internal
  */
-export function getRegistry(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  stream: UseStreamReturn<any, any, any>
-): ChannelRegistry {
+export function getRegistry(stream: AnyStream): ChannelRegistry {
   return stream[STREAM_CONTROLLER].registry;
 }
 

--- a/libs/sdk-svelte/src/tests/selector-cast.test-d.ts
+++ b/libs/sdk-svelte/src/tests/selector-cast.test-d.ts
@@ -1,0 +1,44 @@
+/**
+ * Reproduction: a fully-typed `UseStreamReturn<typeof agent>` handle
+ * should flow into the selector composables (`useMessages`,
+ * `useToolCalls`, `useValues`) and into the public `AnyStream`
+ * escape-hatch type WITHOUT an `as AnyStream` cast.
+ */
+import { describe, test } from "vitest";
+import { createDeepAgent } from "deepagents";
+
+import {
+  useStream,
+  useMessages,
+  useToolCalls,
+  useValues,
+  type AnyStream,
+  type UseStreamReturn,
+} from "../index.js";
+
+const agent = createDeepAgent({
+  tools: [],
+  subagents: [{ name: "researcher", description: "r", systemPrompt: "r" }],
+});
+
+describe("selector composables accept concrete stream without cast", () => {
+  test("useMessages / useToolCalls / useValues at root", () => {
+    const stream = useStream<typeof agent>({ assistantId: "deep-agent" });
+
+    useMessages(stream);
+    useToolCalls(stream);
+    useValues(stream);
+  });
+
+  test("concrete handle is assignable to AnyStream", () => {
+    const stream = useStream<typeof agent>({ assistantId: "deep-agent" });
+    const erased: AnyStream = stream;
+    useMessages(erased);
+  });
+
+  test("wrapper typed against UseStreamReturn flows in too", () => {
+    const stream = useStream<typeof agent>({ assistantId: "deep-agent" });
+    const handle: UseStreamReturn<typeof agent> = stream;
+    useToolCalls(handle);
+  });
+});

--- a/libs/sdk-svelte/src/use-stream.svelte.ts
+++ b/libs/sdk-svelte/src/use-stream.svelte.ts
@@ -18,6 +18,7 @@ import {
   StreamController,
   type AgentServerAdapter,
   type AgentServerOptions as StreamAgentServerOptions,
+  type AssembledToolCall,
   type ChannelRegistry,
   type CustomAdapterOptions as StreamCustomAdapterOptions,
   type InferStateType,
@@ -355,9 +356,25 @@ export interface UseStreamReturn<
  * components that pass a `stream` through to selector composables
  * without reading `values` directly. Mirrors the React
  * `AnyStream` alias.
+ *
+ * Widening the generic slots to `any` is **not** enough on its own:
+ * members computed from `T` in covariant positions don't collapse to a
+ * top type under `any`. `toolCalls: InferToolCalls<any>[]` resolves to
+ * `AssembledToolCall<…, never>[]` — the `never` output slot is narrower
+ * than a concrete handle's `AssembledToolCall<…, unknown>[]`, so a
+ * fully-typed `useStream<typeof agent>()` handle would fail to assign
+ * and every `useToolCalls(stream)` call would need an `as AnyStream`
+ * cast. Override `toolCalls` / `values` with their widest forms so the
+ * erased handle is a true supertype of every concrete `UseStreamReturn`.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyStream = UseStreamReturn<any, any, any>;
+export type AnyStream = Omit<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  UseStreamReturn<any, any, any>,
+  "toolCalls" | "values"
+> & {
+  readonly toolCalls: AssembledToolCall[];
+  readonly values: unknown;
+};
 
 /**
  * Svelte 5 binding for the v2-native stream runtime.
@@ -661,10 +678,7 @@ export type UseStreamResult<
  *
  * @internal
  */
-export function getRegistry(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  stream: UseStreamReturn<any, any, any>
-): ChannelRegistry {
+export function getRegistry(stream: AnyStream): ChannelRegistry {
   return stream[STREAM_CONTROLLER].registry;
 }
 

--- a/libs/sdk-vue/src/tests/selector-cast.test-d.ts
+++ b/libs/sdk-vue/src/tests/selector-cast.test-d.ts
@@ -1,0 +1,44 @@
+/**
+ * Reproduction: a fully-typed `UseStreamReturn<typeof agent>` handle
+ * should flow into the selector composables (`useMessages`,
+ * `useToolCalls`, `useValues`) and into the public `AnyStream`
+ * escape-hatch type WITHOUT an `as AnyStream` cast.
+ */
+import { describe, test } from "vitest";
+import { createDeepAgent } from "deepagents";
+
+import {
+  useStream,
+  useMessages,
+  useToolCalls,
+  useValues,
+  type AnyStream,
+  type UseStreamReturn,
+} from "../index.js";
+
+const agent = createDeepAgent({
+  tools: [],
+  subagents: [{ name: "researcher", description: "r", systemPrompt: "r" }],
+});
+
+describe("selector composables accept concrete stream without cast", () => {
+  test("useMessages / useToolCalls / useValues at root", () => {
+    const stream = useStream<typeof agent>({ assistantId: "deep-agent" });
+
+    useMessages(stream);
+    useToolCalls(stream);
+    useValues(stream);
+  });
+
+  test("concrete handle is assignable to AnyStream", () => {
+    const stream = useStream<typeof agent>({ assistantId: "deep-agent" });
+    const erased: AnyStream = stream;
+    useMessages(erased);
+  });
+
+  test("wrapper typed against UseStreamReturn flows in too", () => {
+    const stream = useStream<typeof agent>({ assistantId: "deep-agent" });
+    const handle: UseStreamReturn<typeof agent> = stream;
+    useToolCalls(handle);
+  });
+});

--- a/libs/sdk-vue/src/use-stream.ts
+++ b/libs/sdk-vue/src/use-stream.ts
@@ -29,6 +29,7 @@ import {
   StreamController,
   type AgentServerAdapter,
   type AgentServerOptions as StreamAgentServerOptions,
+  type AssembledToolCall,
   type ChannelRegistry,
   type CustomAdapterOptions as StreamCustomAdapterOptions,
   type InferStateType,
@@ -360,9 +361,26 @@ export interface UseStreamReturn<
  * components that pass a `stream` through to selector composables
  * without reading `values` directly. Mirrors the React
  * `AnyStream` alias.
+ *
+ * Widening the generic slots to `any` is **not** enough on its own:
+ * members computed from `T` in covariant positions don't collapse to a
+ * top type under `any`. `toolCalls` resolves to
+ * `Readonly<ShallowRef<AssembledToolCall<…, never>[]>>` — the `never`
+ * output slot is narrower than a concrete handle's `…, unknown`, so a
+ * fully-typed `useStream<typeof agent>()` handle would fail to assign
+ * and every `useToolCalls(stream)` call would need an `as AnyStream`
+ * cast. Override `toolCalls` / `values` (keeping the `ShallowRef`
+ * wrapper) with their widest forms so the erased handle is a true
+ * supertype of every concrete `UseStreamReturn`.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyStream = UseStreamReturn<any, any, any>;
+export type AnyStream = Omit<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  UseStreamReturn<any, any, any>,
+  "toolCalls" | "values"
+> & {
+  readonly toolCalls: Readonly<ShallowRef<AssembledToolCall[]>>;
+  readonly values: Readonly<ShallowRef<unknown>>;
+};
 
 /** Convenience alias for the fully-resolved stream handle type. */
 export type UseStreamResult<
@@ -687,10 +705,7 @@ export function useStream<
  *
  * @internal
  */
-export function getRegistry(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  stream: UseStreamReturn<any, any, any>
-): ChannelRegistry {
+export function getRegistry(stream: AnyStream): ChannelRegistry {
   return stream[STREAM_CONTROLLER].registry;
 }
 


### PR DESCRIPTION
## Summary
- `AnyStream` (`UseStreamReturn<any, any, any>`) was not actually a supertype of concrete stream handles: members computed from the generics in covariant positions don't collapse under `any`. `toolCalls` resolves via `InferToolCalls<any>` to `AssembledToolCall<string, …, never>[]`, whose `never` output slot is narrower than a concrete handle's `unknown`, so `UseStreamReturn<typeof agent>` failed to assign and every `useMessages`/`useToolCalls`/`useValues` (`inject*` on Angular) call required an `as AnyStream` cast.
- Redefined `AnyStream` in all four framework packages to `Omit` the generic-computed members and re-add them at their widest forms, preserving each framework's reactivity wrapper: plain arrays for React/Svelte, `Readonly<ShallowRef<…>>` for Vue, `Signal<…>` for Angular. React also drops `~stateType` (the only package that has that member).
- Retyped each package's internal `getRegistry` to accept `AnyStream`, removed React's duplicate local `AnyStream` in `selectors.ts` in favor of the public type, and corrected the misleading doc comments.
- Downstream (`langchainplus` agent-chat-v2) can drop its `stream as AnyStream` casts once these ship.
