### PR TITLE
fix(langgraph-checkpoint-sqlite): honor WRITES_IDX_MAP for special channels in putWrites

### DIFF
--- a/.changeset/fix-sqlite-checkpoint-put-writes-special-channel-idx.md
+++ b/.changeset/fix-sqlite-checkpoint-put-writes-special-channel-idx.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint-sqlite": patch
+---
+
+fix: `SqliteSaver.putWrites` now honors `WRITES_IDX_MAP`, pinning special channels (`__error__`, `__scheduled__`, `__interrupt__`, `__resume__`) to fixed negative indices instead of the call-local ordinal. Previously a follow-up `putWrites([[INTERRUPT, …]], taskId)` for the same checkpoint silently `REPLACE`d the regular write previously stored at `idx=0` for that task, losing data. The conflict-resolution clause also now matches the Python checkpointer contract: `OR REPLACE` only when every channel is a special one (so e.g. INTERRUPT→RESUME state transitions overwrite), `OR IGNORE` otherwise.

--- a/libs/checkpoint-sqlite/src/index.ts
+++ b/libs/checkpoint-sqlite/src/index.ts
@@ -9,6 +9,7 @@ import {
   type PendingWrite,
   type CheckpointMetadata,
   TASKS,
+  WRITES_IDX_MAP,
   copyCheckpoint,
   maxChannelVersion,
 } from "@langchain/langgraph-checkpoint";
@@ -457,9 +458,19 @@ CREATE TABLE IF NOT EXISTS writes (
       throw new Error("Missing checkpoint_id field in config.configurable.");
     }
 
+    // Conflict resolution matches the Python SQLite checkpointer and the
+    // langgraph-checkpoint contract (BaseCheckpointSaver.put_writes):
+    //   - When every write targets a special channel (ERROR / SCHEDULED /
+    //     INTERRUPT / RESUME, each pinned to a negative `idx` by
+    //     WRITES_IDX_MAP), we REPLACE so e.g. INTERRUPT can be overwritten on
+    //     RESUME.
+    //   - Otherwise we IGNORE so a regular write from one task can never
+    //     clobber a regular write that another concurrent task already stored
+    //     at the same (task_id, idx).
+    const allSpecial = writes.every(([channel]) => channel in WRITES_IDX_MAP);
     const stmt = this.db.prepare(`
-      INSERT OR REPLACE INTO writes 
-      (thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, value) 
+      INSERT ${allSpecial ? "OR REPLACE" : "OR IGNORE"} INTO writes
+      (thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel, type, value)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
@@ -477,7 +488,10 @@ CREATE TABLE IF NOT EXISTS writes (
           config.configurable?.checkpoint_ns,
           config.configurable?.checkpoint_id,
           taskId,
-          idx,
+          // Special channels are stored at fixed negative indices so they
+          // never collide with regular per-step writes (whose `idx` is the
+          // ordinal within `writes`).
+          WRITES_IDX_MAP[write[0]] ?? idx,
           write[0],
           type,
           serializedWrite,

--- a/libs/checkpoint-sqlite/src/tests/checkpoints.test.ts
+++ b/libs/checkpoint-sqlite/src/tests/checkpoints.test.ts
@@ -3,6 +3,8 @@ import {
   Checkpoint,
   CheckpointTuple,
   emptyCheckpoint,
+  INTERRUPT,
+  RESUME,
   TASKS,
   uuid6,
 } from "@langchain/langgraph-checkpoint";
@@ -145,6 +147,79 @@ describe("SqliteSaver", () => {
 
     const checkpointTuple1 = checkpointTuples[0];
     expect(checkpointTuple1.checkpoint.ts).toBe("2024-04-20T17:19:07.952Z");
+  });
+
+  it("should preserve INTERRUPT/RESUME writes at fixed negative indices and not clobber prior regular writes", async () => {
+    const sqliteSaver = SqliteSaver.fromConnString(":memory:");
+    // Persist a checkpoint first so that getTuple can resolve and dump back
+    // the writes we attached to it via putWrites.
+    const checkpoint: Checkpoint = {
+      ...emptyCheckpoint(),
+      id: uuid6(1),
+      ts: "2024-04-19T17:19:07.952Z",
+    };
+    const savedConfig = await sqliteSaver.put(
+      { configurable: { thread_id: "t1" } },
+      checkpoint,
+      {
+        source: "input",
+        step: -1,
+        parents: {},
+      } as Parameters<typeof sqliteSaver.put>[2]
+    );
+    const config: RunnableConfig = {
+      configurable: {
+        thread_id: "t1",
+        checkpoint_ns: savedConfig.configurable!.checkpoint_ns,
+        checkpoint_id: checkpoint.id,
+      },
+    };
+
+    // 1. Task A stores two regular writes (idx 0 and 1).
+    await sqliteSaver.putWrites(
+      config,
+      [
+        ["foo", "val_foo"],
+        ["bar", "val_bar"],
+      ],
+      "task_A"
+    );
+
+    // 2. Task A then signals an INTERRUPT for the same checkpoint.
+    //    Previously this would have been stored at idx=0 (it's the first write
+    //    in the new putWrites call) and silently REPLACEd the row above, since
+    //    the table is keyed by (thread_id, checkpoint_ns, checkpoint_id,
+    //    task_id, idx). With WRITES_IDX_MAP it lands at idx=-3 instead.
+    await sqliteSaver.putWrites(config, [[INTERRUPT, "paused"]], "task_A");
+
+    // 3. Task A is later resumed; RESUME also has a fixed idx (-4) and is
+    //    allowed to overwrite the prior RESUME for the same task — but it
+    //    must not collide with anything else.
+    await sqliteSaver.putWrites(config, [[RESUME, "carry_on"]], "task_A");
+
+    // 4. A concurrent Task B stores a regular write of its own. Its idx=0
+    //    must not overwrite Task A's INTERRUPT/RESUME, and conversely it
+    //    must not be ignored just because some other task happened to use
+    //    idx=0.
+    await sqliteSaver.putWrites(config, [["baz", "val_baz"]], "task_B");
+
+    // Round-trip through getTuple so we exercise the same row layout consumers
+    // see; pendingWrites is [taskId, channel, value][] in put order.
+    const tuple = await sqliteSaver.getTuple(config);
+    const writes = tuple?.pendingWrites?.map(
+      ([taskId, channel]) => `${taskId}:${channel}`
+    );
+
+    // All four logical writes from Task A plus Task B's write must survive.
+    expect(new Set(writes)).toEqual(
+      new Set([
+        "task_A:foo",
+        "task_A:bar",
+        "task_A:__interrupt__",
+        "task_A:__resume__",
+        "task_B:baz",
+      ])
+    );
   });
 
   it("should filter on arbitrary metadata keys, not just CheckpointMetadata keys", async () => {


### PR DESCRIPTION
## Summary

`SqliteSaver.putWrites` stored every write at the call-local ordinal `idx`, ignoring `WRITES_IDX_MAP`. So when an `INTERRUPT` (or `ERROR` / `SCHEDULED` / `RESUME`) followed a regular write for the same task, both landed at `idx=0` and the table PK `(thread_id, checkpoint_ns, checkpoint_id, task_id, idx)` collided — `INSERT OR REPLACE` silently dropped the regular write.

Other checkpointer implementations (Memory in `libs/checkpoint`, Postgres) and the **Python** SQLite checkpointer (`langgraph/checkpoint/sqlite/__init__.py`) all pin special channels to fixed negative indices via `WRITES_IDX_MAP` so they can't collide with per-step regular writes.

### Cross-impl parity before this PR

| Checkpointer | `WRITES_IDX_MAP` | Conflict clause |
|---|---|---|
| Memory (TS) | ✅ | gated by `idx >= 0` |
| Postgres (TS) | ✅ | `OR REPLACE` vs `INSERT` based on `all special` |
| Python SQLite | ✅ | `OR REPLACE` vs `OR IGNORE` based on `all special` |
| **TS SQLite** | ❌ | always `OR REPLACE` |

### Fix

1. `idx` resolves to `WRITES_IDX_MAP[channel] ?? idx`.
2. Statement switches between `INSERT OR REPLACE` and `INSERT OR IGNORE` depending on whether every write targets a special channel, matching `langgraph/checkpoint/sqlite/__init__.py`. INTERRUPT→RESUME state transitions overwrite (both special); concurrent tasks can't clobber each other's regular writes at the same idx.

### Tests

New regression test interleaves regular and special-channel writes across two tasks (`task_A` does regular writes → INTERRUPT → RESUME, `task_B` does a regular write). All five logical writes survive `getTuple().pendingWrites`.

**Reverse-verified**: without the fix, `task_A:foo` and `task_A:__interrupt__` both disappear from the round-trip — the test fails with `Set { task_A:__resume__, task_A:bar, task_B:baz }`.

## AI Disclosure

This bug was identified via cross-implementation review against the Python SQLite checkpointer and TS `MemorySaver` / `PostgresSaver`, with AI assistance. The fix mirrors the Python reference implementation.