### PR TITLE
fix(langgraph-checkpoint-redis): honor WRITES_IDX_MAP for special channels in putWrites

### DIFF
--- a/.changeset/fix-redis-checkpoint-put-writes-special-channel-idx.md
+++ b/.changeset/fix-redis-checkpoint-put-writes-special-channel-idx.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint-redis": patch
+---
+
+fix: `RedisSaver.putWrites` now honors `WRITES_IDX_MAP`, pinning special channels (`__error__`, `__scheduled__`, `__interrupt__`, `__resume__`) to fixed negative indices in their Redis key (`checkpoint_write:…:<idx>`) instead of the call-local ordinal. Previously a mixed `putWrites([[…regular…], [INTERRUPT, …]], taskId)` placed the INTERRUPT key at the positive idx of its position in the batch, where a peer task's regular write at the same idx would overwrite it via the unconditional `JSON.SET`. The conflict-resolution clause now matches Postgres / SQLite / MongoDB: unguarded `JSON.SET` when every write is a special channel, `JSON.SET … NX` (insert-or-ignore) otherwise.

--- a/libs/checkpoint-redis/src/index.ts
+++ b/libs/checkpoint-redis/src/index.ts
@@ -8,6 +8,7 @@ import {
   PendingWrite,
   uuid6,
   TASKS,
+  WRITES_IDX_MAP,
   maxChannelVersion,
   copyCheckpoint,
 } from "@langchain/langgraph-checkpoint";
@@ -667,10 +668,25 @@ export class RedisSaver extends BaseCheckpointSaver {
     // Use high-resolution timestamp to ensure unique ordering across putWrites calls
     const baseTimestamp = performance.now() * 1000; // Microsecond precision
 
+    // Conflict resolution matches the Python checkpointer contract and the
+    // sibling TS implementations (Memory, Postgres, SQLite #2516, MongoDB):
+    //   - When every write targets a special channel (ERROR / SCHEDULED /
+    //     INTERRUPT / RESUME, each pinned to a negative `idx` by
+    //     WRITES_IDX_MAP), the write OVERWRITES any existing row so e.g.
+    //     INTERRUPT can be overwritten on RESUME.
+    //   - Otherwise it's an insert-or-ignore so a regular write from one
+    //     task can never silently clobber a regular write that another
+    //     concurrent task already stored at the same (task_id, idx).
+    const allSpecial = writes.every(([channel]) => channel in WRITES_IDX_MAP);
+
     // Store each write as a separate indexed JSON document
     for (let idx = 0; idx < writes.length; idx++) {
       const [channel, value] = writes[idx];
-      const writeKey = `checkpoint_write:${threadId}:${checkpointNs}:${checkpointId}:${taskId}:${idx}`;
+      // Special channels are stored at fixed negative indices so they
+      // never collide with regular per-step writes (whose `idx` is the
+      // ordinal within `writes`).
+      const writeIdx = WRITES_IDX_MAP[channel] ?? idx;
+      const writeKey = `checkpoint_write:${threadId}:${checkpointNs}:${checkpointId}:${taskId}:${writeIdx}`;
       writeKeys.push(writeKey);
 
       const writeDoc = {
@@ -678,7 +694,7 @@ export class RedisSaver extends BaseCheckpointSaver {
         checkpoint_ns: checkpointNs,
         checkpoint_id: checkpointId,
         task_id: taskId,
-        idx: idx,
+        idx: writeIdx,
         channel: channel,
         type: typeof value === "object" ? "json" : "string",
         value: value,
@@ -686,7 +702,17 @@ export class RedisSaver extends BaseCheckpointSaver {
         global_idx: baseTimestamp + idx, // Add microseconds for sub-millisecond ordering
       };
 
-      await this.client.json.set(writeKey, "$", writeDoc as any);
+      if (allSpecial) {
+        await this.client.json.set(writeKey, "$", writeDoc as never);
+      } else {
+        // Equivalent of SQL `INSERT OR IGNORE`: only set when the key is
+        // absent. `node-redis` exposes this as the `NX` modifier on
+        // `JSON.SET`. The return value is the string "OK" on insert and
+        // `null` on no-op, both of which are fine to discard here.
+        await this.client.json.set(writeKey, "$", writeDoc as never, {
+          NX: true,
+        });
+      }
     }
 
     // Register write keys in sorted set for efficient retrieval

--- a/libs/checkpoint-redis/src/tests/putWrites.test.ts
+++ b/libs/checkpoint-redis/src/tests/putWrites.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { RedisSaver } from "../index.js";
+
+// `RedisSaver.putWrites` stores one JSON document per write under a key shaped
+// `checkpoint_write:<thread>:<ns>:<ckpt>:<task>:<idx>`. The two things this
+// suite needs to assert are:
+//   1. special channels (ERROR / SCHEDULED / INTERRUPT / RESUME) are written
+//      to fixed negative `idx`es from WRITES_IDX_MAP, not the ordinal in the
+//      call — otherwise they collide with regular per-step writes.
+//   2. the conflict-resolution clause matches the contract: `$set`-style
+//      overwrite when every write is a special channel, NX (insert-or-ignore)
+//      otherwise.
+// Both are observable from the `json.set` call sites without standing up
+// real Redis.
+const makeMockClient = () => {
+  const jsonSetCalls: Array<{
+    key: string;
+    path: string;
+    value: unknown;
+    options?: { NX?: boolean; XX?: boolean };
+  }> = [];
+  const client = {
+    exists: async () => 0,
+    keys: async () => [],
+    json: {
+      set: async (
+        key: string,
+        path: string,
+        value: unknown,
+        options?: { NX?: boolean; XX?: boolean }
+      ) => {
+        jsonSetCalls.push({ key, path, value, options });
+        return "OK";
+      },
+      get: async () => null,
+    },
+    zAdd: async () => 0,
+    ft: { info: async () => ({}) },
+  } as never;
+  return { client, jsonSetCalls };
+};
+
+describe("RedisSaver.putWrites — WRITES_IDX_MAP", () => {
+  const config = {
+    configurable: {
+      thread_id: "t",
+      checkpoint_ns: "",
+      checkpoint_id: "c",
+    },
+  };
+
+  it("uses fixed negative indices for special channels mixed with regular writes, and NX-guards the inserts", async () => {
+    const { client, jsonSetCalls } = makeMockClient();
+    const saver = new RedisSaver(client);
+
+    await saver.putWrites(
+      config,
+      [
+        ["foo", "v_foo"],
+        ["bar", "v_bar"],
+        ["__interrupt__", "paused"],
+      ],
+      "task_A"
+    );
+
+    // Only the write-doc json.set calls — drop the trailing checkpoint
+    // has_writes marker by filtering on the key prefix.
+    const writeSets = jsonSetCalls.filter((c) =>
+      c.key.startsWith("checkpoint_write:")
+    );
+
+    const tails = writeSets.map((c) => c.key.split(":").pop());
+    // foo (idx 0), bar (idx 1), __interrupt__ (idx -3 via WRITES_IDX_MAP)
+    expect(tails.sort()).toEqual(["-3", "0", "1"].sort());
+
+    // Mixed batch → every JSON.SET must carry NX so a peer task's existing
+    // row at the same (task_id, idx) doesn't get clobbered.
+    for (const c of writeSets) {
+      expect(c.options).toMatchObject({ NX: true });
+    }
+  });
+
+  it("uses unguarded JSON.SET when every write is a special channel (INTERRUPT → RESUME state transitions must overwrite)", async () => {
+    const { client, jsonSetCalls } = makeMockClient();
+    const saver = new RedisSaver(client);
+
+    await saver.putWrites(config, [["__resume__", "carry_on"]], "task_A");
+
+    const writeSets = jsonSetCalls.filter((c) =>
+      c.key.startsWith("checkpoint_write:")
+    );
+    expect(writeSets).toHaveLength(1);
+    expect(writeSets[0].key.endsWith(":-4")).toBe(true); // RESUME → idx -4
+    // No NX option, so it overwrites whatever was there before.
+    expect(writeSets[0].options ?? {}).not.toHaveProperty("NX");
+  });
+});


### PR DESCRIPTION
## Summary

Third in the series following #2516 (SQLite) and #2517 (MongoDB). `RedisSaver.putWrites` stored each write at the call-local ordinal `idx` — the key suffix in `checkpoint_write:<thread>:<ns>:<ckpt>:<task>:<idx>` was just the loop index — and always used unguarded `JSON.SET`, ignoring `WRITES_IDX_MAP`.

- A follow-up `putWrites([[INTERRUPT, value]], taskId)` for the same checkpoint computed `idx=0` and collided with the task's first regular write key; the unconditional `JSON.SET` silently overwrote whichever row landed there first.
- A mixed call like `[[foo, …], [bar, …], [INTERRUPT, …]]` shifted the INTERRUPT to idx=2, where a peer task storing a regular write at the same idx for the same task_id would clobber it.

### Cross-impl parity after this PR

| Checkpointer | `WRITES_IDX_MAP` | Conflict clause |
|---|---|---|
| Memory (TS) | ✅ | gated by `idx >= 0` |
| Postgres (TS) | ✅ | `OR REPLACE` vs `INSERT` based on `all special` |
| SQLite (TS, #2516) | ✅ | `OR REPLACE` vs `OR IGNORE` based on `all special` |
| MongoDB (TS, #2517) | ✅ | `$set` vs `$setOnInsert` based on `all special` |
| **Redis (TS, this PR)** | ✅ | `JSON.SET` vs `JSON.SET … NX` based on `all special` |

### Fix

1. Key suffix now resolves to `WRITES_IDX_MAP[channel] ?? idx`, so ERROR / SCHEDULED / INTERRUPT / RESUME land at fixed negative indices that can't collide with per-step regular writes.
2. The `JSON.SET` call switches between unguarded and the `NX` modifier depending on whether every write targets a special channel. State transitions like INTERRUPT → RESUME still overwrite (both special); a regular write from one task can never silently overwrite another concurrent task's regular write at the same idx.

### Tests

Mock-based unit test in a new `putWrites.test.ts` (no Redis needed) captures every `client.json.set` call site and asserts:

- Mixed regular + INTERRUPT batch → key tails `[-3, 0, 1]` (vs the pre-fix `[0, 1, 2]`) and every JSON.SET carries `{ NX: true }`.
- Special-only batch (RESUME) → key tail `-4` and no NX (so state transitions can overwrite).

**Reverse-verified**: with the fix reverted both new tests fail.

## AI Disclosure

Identified via cross-implementation review against #2516 and #2517 — same root cause class, different storage layer.