### PR TITLE
fix(langgraph): validate Zod state updates from nodes

### DIFF
--- a/.changeset/fix-zod-state-update-validation.md
+++ b/.changeset/fix-zod-state-update-validation.md
@@ -1,0 +1,10 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(state): validate Zod state updates from nodes
+
+Validate node return values and Command updates against Zod state schema
+constraints before applying them to graph state.
+
+Fixes #2519

--- a/libs/langgraph-core/src/graph/state.test.ts
+++ b/libs/langgraph-core/src/graph/state.test.ts
@@ -1284,6 +1284,54 @@ describe("StateGraph", () => {
         const result = await graph.invoke({});
         expect(result.items).toEqual(["replaced"]);
       });
+
+      it("should preserve duplicate Command updates", async () => {
+        const AgentState = new StateSchema({
+          items: new ReducedValue(
+            z.array(z.string()).default(() => []),
+            {
+              inputSchema: z.string(),
+              reducer: (current: string[], next: string) => [...current, next],
+            }
+          ),
+        });
+
+        const graph = new StateGraph(AgentState)
+          .addNode("append", () => [
+            new Command({ update: { items: "a1" } }),
+            new Command({ update: { items: "a2" } }),
+          ])
+          .addEdge(START, "append")
+          .addEdge("append", END)
+          .compile();
+
+        await expect(graph.invoke({})).resolves.toEqual({
+          items: ["a1", "a2"],
+        });
+      });
+
+      it("should validate each duplicate Command update", async () => {
+        const AgentState = new StateSchema({
+          items: new ReducedValue(
+            z.array(z.string()).default(() => []),
+            {
+              inputSchema: z.string().min(2),
+              reducer: (current: string[], next: string) => [...current, next],
+            }
+          ),
+        });
+
+        const graph = new StateGraph(AgentState)
+          .addNode("append", () => [
+            new Command({ update: { items: "x" } }),
+            new Command({ update: { items: "ok" } }),
+          ])
+          .addEdge(START, "append")
+          .addEdge("append", END)
+          .compile();
+
+        await expect(graph.invoke({})).rejects.toThrow(/items/);
+      });
     });
   });
 });

--- a/libs/langgraph-core/src/graph/state.ts
+++ b/libs/langgraph-core/src/graph/state.ts
@@ -1801,17 +1801,17 @@ export class CompiledStateGraph<
       const schemaDef = this.builder._schemaRuntimeDefinition;
       if (StateSchema.isInstance(schemaDef)) {
         const schemaKeys = new Set(schemaDef.getChannelKeys());
-        const schemaUpdates = updates.filter(([k]) => schemaKeys.has(k));
-        if (schemaUpdates.length === 0) return updates;
+        return Promise.all(
+          updates.map(async ([k, v]) => {
+            if (!schemaKeys.has(k)) return [k, v];
 
-        const updateObj = Object.fromEntries(schemaUpdates);
-        const parsed = await schemaDef.validateInput(updateObj);
-        return updates.map(([k, v]) => [
-          k,
-          schemaKeys.has(k) && Object.prototype.hasOwnProperty.call(parsed, k)
-            ? parsed[k]
-            : v,
-        ]);
+            const parsed = await schemaDef.validateInput({ [k]: v });
+            return [
+              k,
+              Object.prototype.hasOwnProperty.call(parsed, k) ? parsed[k] : v,
+            ];
+          })
+        );
       }
 
       if (isInteropZodObject(schemaDef)) {
@@ -1827,43 +1827,26 @@ export class CompiledStateGraph<
           })
         );
         const valueSchema = interopZodObjectPartial(schemaDef);
-        const parsed = new Map<string, unknown>();
+        return updates.map(([k, v]) => {
+          if (!schemaKeys.has(k)) return [k, v];
 
-        const normalUpdates: [string, unknown][] = [];
-        const overwriteUpdates: [string, unknown][] = [];
-        for (const [k, v] of schemaUpdates) {
           const [isOverwrite, overwriteValue] = _getOverwriteValue(v);
           if (isOverwrite) {
-            overwriteUpdates.push([k, overwriteValue]);
-          } else {
-            normalUpdates.push([k, v]);
+            const parsed = interopParse(valueSchema, { [k]: overwriteValue });
+            return [
+              k,
+              Object.prototype.hasOwnProperty.call(parsed, k)
+                ? { [OVERWRITE]: parsed[k] }
+                : v,
+            ];
           }
-        }
 
-        if (normalUpdates.length > 0) {
-          const normalObj = Object.fromEntries(normalUpdates);
-          const normalParsed = interopParse(updateSchema, normalObj);
-          for (const k of Object.keys(normalObj)) {
-            if (Object.prototype.hasOwnProperty.call(normalParsed, k)) {
-              parsed.set(k, normalParsed[k]);
-            }
-          }
-        }
-
-        if (overwriteUpdates.length > 0) {
-          const overwriteObj = Object.fromEntries(overwriteUpdates);
-          const overwriteParsed = interopParse(valueSchema, overwriteObj);
-          for (const k of Object.keys(overwriteObj)) {
-            if (Object.prototype.hasOwnProperty.call(overwriteParsed, k)) {
-              parsed.set(k, { [OVERWRITE]: overwriteParsed[k] });
-            }
-          }
-        }
-
-        return updates.map(([k, v]) => [
-          k,
-          schemaKeys.has(k) && parsed.has(k) ? parsed.get(k) : v,
-        ]);
+          const parsed = interopParse(updateSchema, { [k]: v });
+          return [
+            k,
+            Object.prototype.hasOwnProperty.call(parsed, k) ? parsed[k] : v,
+          ];
+        });
       }
 
       return updates;

--- a/libs/langgraph-core/src/graph/state.ts
+++ b/libs/langgraph-core/src/graph/state.ts
@@ -7,6 +7,7 @@ import {
   BaseStore,
 } from "@langchain/langgraph-checkpoint";
 import {
+  getInteropZodObjectShape,
   type InteropZodObject,
   interopParse,
   interopZodObjectPartial,
@@ -55,6 +56,8 @@ import {
   Interrupt,
   INTERRUPT,
   CONFIG_KEY_NODE_ERROR,
+  _getOverwriteValue,
+  OVERWRITE,
 } from "../constants.js";
 import {
   InvalidUpdateError,
@@ -1788,14 +1791,95 @@ export class CompiledStateGraph<
     const nodeKey = key;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    function _getUpdates(input: U): [string, any][] | null {
+    const validateStateUpdates = async (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      updates: [string, any][] | null
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ): Promise<[string, any][] | null> => {
+      if (updates == null || updates.length === 0) return updates;
+
+      const schemaDef = this.builder._schemaRuntimeDefinition;
+      if (StateSchema.isInstance(schemaDef)) {
+        const schemaKeys = new Set(schemaDef.getChannelKeys());
+        const schemaUpdates = updates.filter(([k]) => schemaKeys.has(k));
+        if (schemaUpdates.length === 0) return updates;
+
+        const updateObj = Object.fromEntries(schemaUpdates);
+        const parsed = await schemaDef.validateInput(updateObj);
+        return updates.map(([k, v]) => [
+          k,
+          schemaKeys.has(k) && Object.prototype.hasOwnProperty.call(parsed, k)
+            ? parsed[k]
+            : v,
+        ]);
+      }
+
+      if (isInteropZodObject(schemaDef)) {
+        const schemaKeys = new Set(
+          Object.keys(getInteropZodObjectShape(schemaDef))
+        );
+        const schemaUpdates = updates.filter(([k]) => schemaKeys.has(k));
+        if (schemaUpdates.length === 0) return updates;
+
+        const updateSchema = interopZodObjectPartial(
+          this._metaRegistry.getExtendedChannelSchemas(schemaDef, {
+            withReducerSchema: true,
+          })
+        );
+        const valueSchema = interopZodObjectPartial(schemaDef);
+        const parsed = new Map<string, unknown>();
+
+        const normalUpdates: [string, unknown][] = [];
+        const overwriteUpdates: [string, unknown][] = [];
+        for (const [k, v] of schemaUpdates) {
+          const [isOverwrite, overwriteValue] = _getOverwriteValue(v);
+          if (isOverwrite) {
+            overwriteUpdates.push([k, overwriteValue]);
+          } else {
+            normalUpdates.push([k, v]);
+          }
+        }
+
+        if (normalUpdates.length > 0) {
+          const normalObj = Object.fromEntries(normalUpdates);
+          const normalParsed = interopParse(updateSchema, normalObj);
+          for (const k of Object.keys(normalObj)) {
+            if (Object.prototype.hasOwnProperty.call(normalParsed, k)) {
+              parsed.set(k, normalParsed[k]);
+            }
+          }
+        }
+
+        if (overwriteUpdates.length > 0) {
+          const overwriteObj = Object.fromEntries(overwriteUpdates);
+          const overwriteParsed = interopParse(valueSchema, overwriteObj);
+          for (const k of Object.keys(overwriteObj)) {
+            if (Object.prototype.hasOwnProperty.call(overwriteParsed, k)) {
+              parsed.set(k, { [OVERWRITE]: overwriteParsed[k] });
+            }
+          }
+        }
+
+        return updates.map(([k, v]) => [
+          k,
+          schemaKeys.has(k) && parsed.has(k) ? parsed.get(k) : v,
+        ]);
+      }
+
+      return updates;
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async function _getUpdates(input: U): Promise<[string, any][] | null> {
       if (!input) {
         return null;
       } else if (isCommand(input)) {
         if (input.graph === Command.PARENT) {
           return null;
         }
-        return input._updateAsTuples().filter(([k]) => outputKeys.includes(k));
+        return validateStateUpdates(
+          input._updateAsTuples().filter(([k]) => outputKeys.includes(k))
+        );
       } else if (
         Array.isArray(input) &&
         input.length > 0 &&
@@ -1811,15 +1895,17 @@ export class CompiledStateGraph<
               ...item._updateAsTuples().filter(([k]) => outputKeys.includes(k))
             );
           } else {
-            const itemUpdates = _getUpdates(item);
+            const itemUpdates = await _getUpdates(item);
             if (itemUpdates) {
               updates.push(...(itemUpdates ?? []));
             }
           }
         }
-        return updates;
+        return validateStateUpdates(updates);
       } else if (typeof input === "object" && !Array.isArray(input)) {
-        return Object.entries(input).filter(([k]) => outputKeys.includes(k));
+        return validateStateUpdates(
+          Object.entries(input).filter(([k]) => outputKeys.includes(k))
+        );
       } else {
         const typeofInput = Array.isArray(input) ? "array" : typeof input;
         throw new InvalidUpdateError(

--- a/libs/langgraph-core/src/state/schema.ts
+++ b/libs/langgraph-core/src/state/schema.ts
@@ -13,7 +13,11 @@ import { UntrackedValueChannel } from "../channels/untracked_value.js";
 import type { SerializableSchema } from "./types.js";
 import { isStandardSchema } from "./types.js";
 import { getJsonSchemaFromSchema, getSchemaDefaultGetter } from "./adapter.js";
-import type { OverwriteValue } from "../constants.js";
+import {
+  _getOverwriteValue,
+  OVERWRITE,
+  type OverwriteValue,
+} from "../constants.js";
 import { ReducedValue } from "./values/reduced.js";
 import { UntrackedValue } from "./values/untracked.js";
 
@@ -384,6 +388,22 @@ export class StateSchema<TFields extends StateSchemaFields> {
       let schema: StandardSchemaV1 | undefined;
 
       if (ReducedValue.isInstance(fieldDef)) {
+        const [isOverwrite, overwriteValue] = _getOverwriteValue(value);
+        if (isOverwrite) {
+          schema = fieldDef.valueSchema;
+          const validationResult =
+            await schema["~standard"].validate(overwriteValue);
+          if (validationResult.issues) {
+            throw new Error(
+              `Validation failed for field "${key}": ${JSON.stringify(
+                validationResult.issues
+              )}`
+            );
+          }
+          result[key] = { [OVERWRITE]: validationResult.value };
+          continue;
+        }
+
         schema = fieldDef.inputSchema;
       } else if (UntrackedValue.isInstance(fieldDef)) {
         schema = fieldDef.schema;

--- a/libs/langgraph-core/src/tests/zod_state.test.ts
+++ b/libs/langgraph-core/src/tests/zod_state.test.ts
@@ -89,6 +89,40 @@ describe("StateGraph with Zod schemas", () => {
     });
   });
 
+  it("should validate Zod node updates against state schema constraints", async () => {
+    const stateSchema = z4.object({
+      count: z4.number().min(0).max(10),
+    });
+
+    const graph = new StateGraph(stateSchema)
+      .addNode("increment", (state) => ({ count: state.count + 15 }))
+      .addEdge(START, "increment")
+      .addEdge("increment", END)
+      .compile();
+
+    await expect(graph.invoke({ count: 0 })).rejects.toThrow(/count/);
+  });
+
+  it("should validate Zod Command updates against state schema constraints", async () => {
+    const stateSchema = z4.object({
+      count: z4.number().min(0).max(10),
+    });
+
+    const graph = new StateGraph(stateSchema)
+      .addNode(
+        "increment",
+        (state) =>
+          new Command({
+            update: { count: state.count + 15 },
+          })
+      )
+      .addEdge(START, "increment")
+      .addEdge("increment", END)
+      .compile();
+
+    await expect(graph.invoke({ count: 0 })).rejects.toThrow(/count/);
+  });
+
   it("should accept Zod messages schema & return tagged JSON schema", async () => {
     const schema = MessagesZodState.extend({ count: z.number() });
 


### PR DESCRIPTION
## Summary
- Validates StateGraph node return values and Command updates against Zod state schema constraints before applying writes.
- Preserves Overwrite behavior by validating reducer overwrites against stored value schemas.
- Adds regression coverage for invalid Zod node returns and Command updates.

Fixes #2519