### PR TITLE
fix(sdk): stop re-streaming seeded messages on idle-thread submit

### DIFF
--- a/.changeset/fix-idle-thread-message-replay.md
+++ b/.changeset/fix-idle-thread-message-replay.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): stop re-streaming seeded messages on idle-thread submit
+
+An idle (finished) thread defers its root SSE pump, so the first `submit()` brings it up and the transport replays the finished run from `seq=0`. The replayed `messages` channel carries no step (unlike `values`, guarded by `maxStep`), so it rebuilt each already-complete message from an empty `message-start` and re-streamed the whole turn token-by-token — a visible "messages replay" of the existing conversation. Seal the message ids seeded from the idle `getState()` snapshot so replayed deltas can't downgrade the complete tail; the seal lifts once a newer checkpoint advances the timeline or on thread rebind, and ids from the next run are never sealed.

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -956,6 +956,83 @@ describe("StreamController", () => {
     await controller.dispose();
   });
 
+  it("does not re-stream seeded messages on idle submit when getState omits metadata.step", async () => {
+    // Same as above, but the idle thread's getState carries no
+    // metadata.step (server/custom transport). The seal boundary is then
+    // unknown, so the deferred pump's replayed `values` checkpoints —
+    // which carry their own increasing steps — must NOT advance the
+    // timeline past the seed and lift the seal mid-replay (the bug).
+    const rootSubscription = makePushableSubscription();
+    const submitRun = vi.fn(async () => ({ run_id: "run-1" }));
+    const thread = {
+      subscribe: vi.fn(async () => rootSubscription),
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      submitRun,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const seededMessages = [
+      { type: "human", content: "ship it", id: "human-1" },
+      { type: "ai", id: "ai-1", content: "All done." },
+    ];
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({
+          values: { messages: seededMessages },
+          next: [],
+          tasks: [],
+          checkpoint: { checkpoint_id: "cp-latest" },
+          // No metadata.step — the seal boundary is unknown.
+          metadata: {},
+        })),
+        getHistory: vi.fn(async () => []),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State>({
+      assistantId: "deep-agent",
+      client: client as never,
+      threadId: "thread-idle-no-step",
+    });
+    await controller.hydrationPromise;
+    await waitForExpectation(() => {
+      expect(controller.rootStore.getSnapshot().messages).toHaveLength(2);
+    });
+
+    void controller.submit({ messages: [] });
+    await waitForExpectation(() => {
+      expect(thread.submitRun).toHaveBeenCalled();
+      expect(thread.subscribe).toHaveBeenCalled();
+    });
+    await rootSubscription.started;
+
+    // seq=0 replay of the finished run: its checkpoints carry increasing
+    // steps that initialize and then advance the projection's high-water
+    // mark. With an unknown seal boundary these must not lift the seal.
+    rootSubscription.push(checkpointsEvent(1, 1));
+    rootSubscription.push(valuesEvent(seededMessages, 2));
+    rootSubscription.push(checkpointsEvent(2, 3));
+    rootSubscription.push(valuesEvent(seededMessages, 4));
+
+    // ...and the replayed `messages` channel re-streams ai-1 from empty.
+    rootSubscription.push(messageStartEvent("ai-1", 5));
+    rootSubscription.push(messageDeltaEvent(6, "A"));
+    rootSubscription.push(messageDeltaEvent(7, "All do"));
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const messages = controller.rootStore.getSnapshot().messages;
+    expect(messages.map((m) => (m as { id?: string }).id)).toEqual([
+      "human-1",
+      "ai-1",
+    ]);
+    expect((messages[1] as { text?: string }).text).toBe("All done.");
+
+    await controller.dispose();
+  });
+
   it("opens SSE pumps eagerly when getState omits `next` (unknown shape)", async () => {
     const startLifecycleWatcher = vi.fn(() => undefined);
     const subscribe = vi.fn(async () => makeNeverEndingSubscription());

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -153,6 +153,38 @@ function lifecycleEvent(event: string, seq: number): Event {
   } as Event;
 }
 
+function messageStartEvent(id: string, seq: number, role = "ai"): Event {
+  return {
+    type: "event",
+    event_id: `msg-start-${id}-${seq}`,
+    seq,
+    method: "messages",
+    params: {
+      namespace: [],
+      timestamp: 0,
+      data: { event: "message-start", id, role },
+    },
+  } as unknown as Event;
+}
+
+function messageDeltaEvent(seq: number, text: string): Event {
+  return {
+    type: "event",
+    event_id: `msg-delta-${seq}`,
+    seq,
+    method: "messages",
+    params: {
+      namespace: [],
+      timestamp: 0,
+      data: {
+        event: "content-block-delta",
+        index: 0,
+        content: { type: "text", text },
+      },
+    },
+  } as unknown as Event;
+}
+
 function namespacedLifecycleEvent(
   namespace: readonly string[],
   event: "started" | "completed",
@@ -852,6 +884,75 @@ describe("StreamController", () => {
       expect(thread.submitRun).toHaveBeenCalled();
       expect(subscribe).toHaveBeenCalled();
     });
+    await controller.dispose();
+  });
+
+  it("does not re-stream seeded messages when the first submit replays an idle thread", async () => {
+    // Open a finished thread (idle), seeded from getState with a complete
+    // tail. On the first submit the deferred pump comes up and the
+    // transport replays the finished run from seq=0 — including the
+    // `messages` channel. That replay must NOT clobber the seeded tail by
+    // re-streaming it from an empty start (the visible "messages replay").
+    const rootSubscription = makePushableSubscription();
+    const submitRun = vi.fn(async () => ({ run_id: "run-1" }));
+    const thread = {
+      subscribe: vi.fn(async () => rootSubscription),
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      submitRun,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const seededMessages = [
+      { type: "human", content: "ship it", id: "human-1" },
+      { type: "ai", id: "ai-1", content: "All done." },
+    ];
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({
+          values: { messages: seededMessages },
+          next: [],
+          tasks: [],
+          checkpoint: { checkpoint_id: "cp-latest" },
+          metadata: { step: 5 },
+        })),
+        getHistory: vi.fn(async () => []),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State>({
+      assistantId: "deep-agent",
+      client: client as never,
+      threadId: "thread-idle",
+    });
+    await controller.hydrationPromise;
+    await waitForExpectation(() => {
+      expect(controller.rootStore.getSnapshot().messages).toHaveLength(2);
+    });
+
+    void controller.submit({ messages: [] });
+    await waitForExpectation(() => {
+      expect(thread.submitRun).toHaveBeenCalled();
+      expect(thread.subscribe).toHaveBeenCalled();
+    });
+    await rootSubscription.started;
+
+    // seq=0 replay of the finished run re-streams ai-1 from an empty start.
+    rootSubscription.push(messageStartEvent("ai-1", 1));
+    rootSubscription.push(messageDeltaEvent(2, "A"));
+    rootSubscription.push(messageDeltaEvent(3, "All do"));
+
+    // Give the projection's macrotask flush time to (incorrectly) clobber.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const messages = controller.rootStore.getSnapshot().messages;
+    expect(messages.map((m) => (m as { id?: string }).id)).toEqual([
+      "human-1",
+      "ai-1",
+    ]);
+    expect((messages[1] as { text?: string }).text).toBe("All done.");
+
     await controller.dispose();
   });
 

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -610,6 +610,27 @@ export class StreamController<
         ];
         if (Array.isArray(seedMessages)) {
           this.#subagents.seedFromCheckpointMessages(seedMessages);
+
+          /**
+           * An idle (finished) thread defers its root SSE pump; the first
+           * `submit()` brings it up and the transport replays the finished
+           * run from `seq=0`. Seal the seeded message ids so that replay's
+           * `messages` channel deltas can't downgrade the already-complete
+           * tail to empty partials (a visible "messages replay"). Only safe
+           * for idle threads, where every seeded message is final — an
+           * active thread's tail may still be streaming and must keep
+           * receiving deltas. New ids from the next run are never sealed,
+           * and the seal lifts once a newer checkpoint advances the
+           * timeline.
+           */
+          if (!threadActive) {
+            const sealedIds = (seedMessages as Array<{ id?: unknown }>)
+              .map((message) => message?.id)
+              .filter((id): id is string => typeof id === "string");
+            if (sealedIds.length > 0) {
+              this.#rootMessages.sealMessageIds(sealedIds);
+            }
+          }
         }
       }
       /**

--- a/libs/sdk/src/stream/root-message-projection.test.ts
+++ b/libs/sdk/src/stream/root-message-projection.test.ts
@@ -898,6 +898,77 @@ describe("RootMessageProjection", () => {
       await drainFlush();
       expect(store.getSnapshot().messages[0].text).toBe("edited");
     });
+
+    it("does not lift on replayed checkpoints at or below the seed step", async () => {
+      const { store, projection } = makeProjection();
+
+      const seeded = new AIMessage({ id: "a1", content: "All done." });
+      projection.applyValues({ messages: [seeded] } as State, [seeded], {
+        step: 5,
+      });
+      projection.sealMessageIds(["a1"]);
+      await drainFlush();
+
+      // The deferred pump replays the finished run: its checkpoints are
+      // at or below the seed step (5). They advance nothing past the
+      // seal boundary, so the seal must hold.
+      const replay = new AIMessage({ id: "a1", content: "All done." });
+      projection.applyValues({ messages: [replay] } as State, [replay], {
+        step: 4,
+      });
+      const replayAtSeed = new AIMessage({ id: "a1", content: "All done." });
+      projection.applyValues(
+        { messages: [replayAtSeed] } as State,
+        [replayAtSeed],
+        { step: 5 }
+      );
+
+      // Replayed messages deltas for a1 must still be dropped.
+      projection.handleMessage(startEvent({ id: "a1", role: "ai" }));
+      projection.handleMessage(blockStartEvent(0, { type: "text", text: "" }));
+      projection.handleMessage(blockDeltaEvent(0, { type: "text", text: "A" }));
+
+      await drainFlush();
+      const snap = store.getSnapshot();
+      expect(snap.messages).toHaveLength(1);
+      expect(snap.messages[0].text).toBe("All done.");
+    });
+
+    it("holds the seal when the seed step is unknown and replay advances maxStep", async () => {
+      const { store, projection } = makeProjection();
+
+      // Idle thread whose getState() carried no metadata.step: the seed
+      // applyValues has no step, so the projection starts with no
+      // high-water mark and the seal boundary is unknown.
+      const seeded = new AIMessage({ id: "a1", content: "All done." });
+      projection.applyValues({ messages: [seeded] } as State, [seeded]);
+      projection.sealMessageIds(["a1"]);
+      await drainFlush();
+      expect(store.getSnapshot().messages[0].text).toBe("All done.");
+
+      // The deferred pump replays the finished run from seq=0: its values
+      // checkpoints carry increasing steps that initialize and then
+      // advance maxStep. These are replay, not a new run, so an unknown
+      // seal boundary must NOT lift the seal (the bug this guards).
+      const replay1 = new AIMessage({ id: "a1", content: "All done." });
+      projection.applyValues({ messages: [replay1] } as State, [replay1], {
+        step: 1,
+      });
+      const replay2 = new AIMessage({ id: "a1", content: "All done." });
+      projection.applyValues({ messages: [replay2] } as State, [replay2], {
+        step: 2,
+      });
+
+      // Replayed messages deltas for a1 must still be dropped.
+      projection.handleMessage(startEvent({ id: "a1", role: "ai" }));
+      projection.handleMessage(blockStartEvent(0, { type: "text", text: "" }));
+      projection.handleMessage(blockDeltaEvent(0, { type: "text", text: "A" }));
+
+      await drainFlush();
+      const snap = store.getSnapshot();
+      expect(snap.messages).toHaveLength(1);
+      expect(snap.messages[0].text).toBe("All done.");
+    });
   });
 
   describe("reset", () => {

--- a/libs/sdk/src/stream/root-message-projection.test.ts
+++ b/libs/sdk/src/stream/root-message-projection.test.ts
@@ -821,6 +821,85 @@ describe("RootMessageProjection", () => {
     });
   });
 
+  describe("sealMessageIds", () => {
+    it("drops replayed streamed deltas for a sealed (idle-seeded) message", async () => {
+      const { store, projection } = makeProjection();
+
+      // Seed an idle thread's complete tail from getState, then seal it.
+      const seeded = new AIMessage({ id: "a1", content: "All done." });
+      projection.applyValues({ messages: [seeded] } as State, [seeded], {
+        step: 5,
+      });
+      projection.sealMessageIds(["a1"]);
+      await drainFlush();
+      expect(store.getSnapshot().messages[0].text).toBe("All done.");
+
+      // The deferred pump's seq=0 replay re-streams a1 from an empty
+      // start. Without the seal this would clobber the seeded content
+      // and re-stream the whole turn.
+      projection.handleMessage(startEvent({ id: "a1", role: "ai" }));
+      projection.handleMessage(blockStartEvent(0, { type: "text", text: "" }));
+      projection.handleMessage(blockDeltaEvent(0, { type: "text", text: "A" }));
+
+      await drainFlush();
+      const snap = store.getSnapshot();
+      expect(snap.messages).toHaveLength(1);
+      expect(snap.messages[0].id).toBe("a1");
+      expect(snap.messages[0].text).toBe("All done.");
+    });
+
+    it("still streams a non-sealed message id from the next run", async () => {
+      const { store, projection } = makeProjection();
+
+      const seeded = new AIMessage({ id: "a1", content: "All done." });
+      projection.applyValues({ messages: [seeded] } as State, [seeded], {
+        step: 5,
+      });
+      projection.sealMessageIds(["a1"]);
+      await drainFlush();
+
+      // The next run appends a brand-new id, which must stream normally.
+      projection.handleMessage(startEvent({ id: "a2", role: "ai" }));
+      projection.handleMessage(blockStartEvent(0, { type: "text", text: "" }));
+      projection.handleMessage(
+        blockDeltaEvent(0, { type: "text", text: "fresh" })
+      );
+
+      await drainFlush();
+      const snap = store.getSnapshot();
+      expect(snap.messages).toHaveLength(2);
+      expect(snap.messages[0].text).toBe("All done.");
+      expect(snap.messages[1].id).toBe("a2");
+      expect(snap.messages[1].text).toBe("fresh");
+    });
+
+    it("lifts the seal once a newer checkpoint advances the timeline", async () => {
+      const { store, projection } = makeProjection();
+
+      const seeded = new AIMessage({ id: "a1", content: "All done." });
+      projection.applyValues({ messages: [seeded] } as State, [seeded], {
+        step: 5,
+      });
+      projection.sealMessageIds(["a1"]);
+
+      // A genuinely newer checkpoint (step 6 > seed 5) means the live
+      // timeline advanced past the replayed history, so the seal lifts.
+      const advanced = new AIMessage({ id: "a1", content: "All done." });
+      projection.applyValues({ messages: [advanced] } as State, [advanced], {
+        step: 6,
+      });
+
+      // A later delta for a1 now streams again (seal lifted).
+      projection.handleMessage(startEvent({ id: "a1", role: "ai" }));
+      projection.handleMessage(
+        blockStartEvent(0, { type: "text", text: "edited" })
+      );
+
+      await drainFlush();
+      expect(store.getSnapshot().messages[0].text).toBe("edited");
+    });
+  });
+
   describe("reset", () => {
     it("clears all per-thread state", async () => {
       const { store, projection } = makeProjection();

--- a/libs/sdk/src/stream/root-message-projection.ts
+++ b/libs/sdk/src/stream/root-message-projection.ts
@@ -180,6 +180,23 @@ export class RootMessageProjection<
   #maxStep: number | undefined = undefined;
 
   /**
+   * Message ids seeded as complete-and-final from an idle thread's
+   * `getState()` snapshot. An idle thread defers its root SSE pump, and
+   * the first `submit()` brings it up — at which point the transport
+   * replays the finished run from `seq=0`. Unlike the `values` channel
+   * (guarded by {@link #maxStep}), `messages`-channel deltas carry no
+   * step, so that replay would otherwise rebuild each already-complete
+   * message from an empty `message-start` and re-stream the whole turn
+   * token-by-token, clobbering the seeded tail (a visible "messages
+   * replay" on the first submit). Deltas for a sealed id are dropped in
+   * {@link handleMessage}. The seal is lifted once a newer checkpoint
+   * advances the timeline past the seed (see {@link applyValues}) or on
+   * thread rebind ({@link reset}). New ids from the next run are never
+   * sealed, so they stream normally.
+   */
+  readonly #sealedMessageIds = new Set<string>();
+
+  /**
    * @param params.messagesKey - Key inside `values` that holds the
    *   message array.
    * @param params.store       - Root snapshot store to mutate.
@@ -209,6 +226,21 @@ export class RootMessageProjection<
     this.#pendingValues = null;
     this.#flushScheduled = false;
     this.#maxStep = undefined;
+    this.#sealedMessageIds.clear();
+  }
+
+  /**
+   * Seal message ids so the streamed `messages` channel cannot downgrade
+   * them to partial re-streams. Called by {@link StreamController.hydrate}
+   * after seeding an idle thread, whose deferred pump replays the finished
+   * run from `seq=0` on the first submit. The seal is lifted once a newer
+   * checkpoint advances the timeline past the seed (see {@link applyValues})
+   * or on thread rebind ({@link reset}).
+   *
+   * @param ids - Complete message ids from the idle `getState()` seed.
+   */
+  sealMessageIds(ids: Iterable<string>): void {
+    for (const id of ids) this.#sealedMessageIds.add(id);
   }
 
   /**
@@ -274,6 +306,12 @@ export class RootMessageProjection<
     if (update == null) return;
     const id = update.message.id;
     if (id == null) return;
+    // A sealed id belongs to a message seeded complete from an idle
+    // thread's `getState()`; the deferred pump's `seq=0` replay would
+    // otherwise rebuild it from an empty start and re-stream the whole
+    // turn. Drop the replayed delta — the authoritative seed already
+    // holds the final content (see {@link #sealedMessageIds}).
+    if (this.#sealedMessageIds.has(id)) return;
     const captured = this.#roles.get(id) ?? { role: "ai" as const };
     const base = assembledMessageToBaseMessage(update.message, captured.role, {
       toolCallId: captured.toolCallId,
@@ -349,6 +387,14 @@ export class RootMessageProjection<
     const addOnly =
       step != null && this.#maxStep != null && step < this.#maxStep;
     if (step != null && (this.#maxStep == null || step > this.#maxStep)) {
+      // A checkpoint strictly newer than the current high-water step
+      // means the live timeline has advanced past the replayed (idle)
+      // history, so seeded ids may now receive genuine updates — lift
+      // the replay seal. The `== null` case is the seed itself (or the
+      // first live snapshot) and must not lift it.
+      if (this.#maxStep != null && this.#sealedMessageIds.size > 0) {
+        this.#sealedMessageIds.clear();
+      }
       this.#maxStep = step;
     }
 

--- a/libs/sdk/src/stream/root-message-projection.ts
+++ b/libs/sdk/src/stream/root-message-projection.ts
@@ -189,12 +189,28 @@ export class RootMessageProjection<
    * message from an empty `message-start` and re-stream the whole turn
    * token-by-token, clobbering the seeded tail (a visible "messages
    * replay" on the first submit). Deltas for a sealed id are dropped in
-   * {@link handleMessage}. The seal is lifted once a newer checkpoint
-   * advances the timeline past the seed (see {@link applyValues}) or on
+   * {@link handleMessage}. The seal is lifted once a checkpoint advances
+   * strictly past {@link #sealStep} (see {@link applyValues}) or on
    * thread rebind ({@link reset}). New ids from the next run are never
    * sealed, so they stream normally.
    */
   readonly #sealedMessageIds = new Set<string>();
+
+  /**
+   * High-water {@link #maxStep} captured when {@link sealMessageIds} ran,
+   * i.e. the seed checkpoint's step (or `undefined` when `getState()`
+   * carried no `metadata.step`). It is the boundary between the replayed
+   * idle history (steps `<= #sealStep`, emitted by the deferred pump's
+   * `seq=0` replay) and the new run (steps `> #sealStep`); only a
+   * checkpoint strictly past it lifts the seal. Without this boundary the
+   * replayed old-run checkpoints — which themselves carry increasing
+   * steps — would advance {@link #maxStep} and lift the seal mid-replay,
+   * reopening the clobber. When the seed step is unknown the boundary
+   * stays `undefined` and the seal holds until {@link reset}; the
+   * `values` channel (which ignores the seal) still reconciles any
+   * genuine change to a sealed id, only its streamed deltas are dropped.
+   */
+  #sealStep: number | undefined = undefined;
 
   /**
    * @param params.messagesKey - Key inside `values` that holds the
@@ -227,20 +243,28 @@ export class RootMessageProjection<
     this.#flushScheduled = false;
     this.#maxStep = undefined;
     this.#sealedMessageIds.clear();
+    this.#sealStep = undefined;
   }
 
   /**
    * Seal message ids so the streamed `messages` channel cannot downgrade
    * them to partial re-streams. Called by {@link StreamController.hydrate}
    * after seeding an idle thread, whose deferred pump replays the finished
-   * run from `seq=0` on the first submit. The seal is lifted once a newer
-   * checkpoint advances the timeline past the seed (see {@link applyValues})
-   * or on thread rebind ({@link reset}).
+   * run from `seq=0` on the first submit.
+   *
+   * Captures the current {@link #maxStep} as the lift boundary
+   * ({@link #sealStep}). The seal is applied immediately after the seed's
+   * `getState()` snapshot is reconciled, so `#maxStep` here is the seed
+   * step (or `undefined` when `getState()` carried no `metadata.step`).
+   * The seal is lifted once a checkpoint advances strictly past that
+   * boundary (see {@link applyValues}) or on thread rebind
+   * ({@link reset}).
    *
    * @param ids - Complete message ids from the idle `getState()` seed.
    */
   sealMessageIds(ids: Iterable<string>): void {
     for (const id of ids) this.#sealedMessageIds.add(id);
+    if (this.#sealStep == null) this.#sealStep = this.#maxStep;
   }
 
   /**
@@ -387,15 +411,25 @@ export class RootMessageProjection<
     const addOnly =
       step != null && this.#maxStep != null && step < this.#maxStep;
     if (step != null && (this.#maxStep == null || step > this.#maxStep)) {
-      // A checkpoint strictly newer than the current high-water step
-      // means the live timeline has advanced past the replayed (idle)
-      // history, so seeded ids may now receive genuine updates — lift
-      // the replay seal. The `== null` case is the seed itself (or the
-      // first live snapshot) and must not lift it.
-      if (this.#maxStep != null && this.#sealedMessageIds.size > 0) {
-        this.#sealedMessageIds.clear();
-      }
       this.#maxStep = step;
+    }
+    // Lift the replay seal only when a checkpoint advances strictly past
+    // the step captured when the ids were sealed (the seed step). That
+    // boundary separates the replayed idle history (steps <= #sealStep,
+    // emitted by the deferred pump's seq=0 replay) from the new run
+    // (steps > #sealStep), so crossing it means seeded ids may now take
+    // genuine streamed updates. Replayed old-run checkpoints advance
+    // #maxStep but never reach past #sealStep, so they can't lift it. A
+    // `null` boundary (the seed step was unknown) keeps the seal until
+    // reset() — we can't tell replay from live, and the values channel
+    // still reconciles a sealed id even while its streamed deltas drop.
+    if (
+      this.#sealedMessageIds.size > 0 &&
+      step != null &&
+      this.#sealStep != null &&
+      step > this.#sealStep
+    ) {
+      this.#sealedMessageIds.clear();
     }
 
     if (nextMessages.length === 0) {


### PR DESCRIPTION
## Summary
- Fixes a visible "messages replay" where opening a finished thread and submitting re-streamed every existing message token-by-token.
- Root cause: an idle thread defers its root SSE pump, so the first `submit()` replays the finished run from `seq=0`. The `messages` channel carries no step (unlike `values`, guarded by `#maxStep`), so it rebuilt each already-complete message from an empty `message-start`, clobbering the tail seeded from `getState()`.
- Adds a message-id seal in `RootMessageProjection`: ids seeded from an idle thread's `getState()` snapshot drop replayed `messages` deltas in `handleMessage()`. The seal is cleared on thread rebind (`reset()`) and lifts in `applyValues()` once a strictly-newer checkpoint `step` advances the timeline past the seed. `controller.hydrate()` only seals for idle threads (`!threadActive`) — active threads keep streaming their live tail, and ids from the next run are never sealed.
