### PR TITLE
fix(langgraph-checkpoint-redis): handle undefined pending writes

### DIFF
--- a/.changeset/fix-redis-undefined-pending-write-values.md
+++ b/.changeset/fix-redis-undefined-pending-write-values.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint-redis": patch
+---
+
+Fix Redis checkpoint pending write deserialization when a write document has no `value` field. RedisJSON omits `undefined` values, so `loadPendingWrites` now restores a missing `value` as `undefined` instead of passing it through JSON parsing.

--- a/libs/checkpoint-redis/src/index.ts
+++ b/libs/checkpoint-redis/src/index.ts
@@ -826,10 +826,9 @@ export class RedisSaver extends BaseCheckpointSaver {
     const pendingWrites: Array<[string, string, any]> = [];
     for (const writeDoc of writeDocuments) {
       // Deserialize write value using serde to restore LangChain objects
-      const deserializedValue = await this.serde.loadsTyped(
-        "json",
-        JSON.stringify(writeDoc.value)
-      );
+      const deserializedValue = Object.hasOwn(writeDoc, "value")
+        ? await this.serde.loadsTyped("json", JSON.stringify(writeDoc.value))
+        : undefined;
       pendingWrites.push([
         writeDoc.task_id,
         writeDoc.channel,

--- a/libs/checkpoint-redis/src/shallow.ts
+++ b/libs/checkpoint-redis/src/shallow.ts
@@ -632,10 +632,9 @@ export class ShallowRedisSaver extends BaseCheckpointSaver {
       const writeDoc = await this.client.json.get(writeKey);
       if (writeDoc) {
         // Deserialize write value using serde to restore LangChain objects
-        const deserializedValue = await this.serde.loadsTyped(
-          "json",
-          JSON.stringify(writeDoc.value)
-        );
+        const deserializedValue = Object.hasOwn(writeDoc, "value")
+          ? await this.serde.loadsTyped("json", JSON.stringify(writeDoc.value))
+          : undefined;
         pendingWrites.push([
           writeDoc.task_id,
           writeDoc.channel,

--- a/libs/checkpoint-redis/src/tests/putWrites.test.ts
+++ b/libs/checkpoint-redis/src/tests/putWrites.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { RedisSaver } from "../index.js";
+import { ShallowRedisSaver } from "../shallow.js";
 
 // `RedisSaver.putWrites` stores one JSON document per write under a key shaped
 // `checkpoint_write:<thread>:<ns>:<ckpt>:<task>:<idx>`. The two things this
@@ -93,5 +94,109 @@ describe("RedisSaver.putWrites — WRITES_IDX_MAP", () => {
     expect(writeSets[0].key.endsWith(":-4")).toBe(true); // RESUME → idx -4
     // No NX option, so it overwrites whatever was there before.
     expect(writeSets[0].options ?? {}).not.toHaveProperty("NX");
+  });
+});
+
+const makeCheckpointDocWithUndefinedPendingWrite = () => ({
+  thread_id: "t",
+  checkpoint_ns: "",
+  checkpoint_id: "c",
+  parent_checkpoint_id: null,
+  checkpoint: {
+    v: 4,
+    id: "c",
+    ts: "2026-01-01T00:00:00.000Z",
+    channel_values: {},
+    channel_versions: {},
+    versions_seen: {},
+  },
+  metadata: {},
+  checkpoint_ts: 1,
+  has_writes: "true",
+});
+
+const writeDocWithoutValue = {
+  thread_id: "t",
+  checkpoint_ns: "",
+  checkpoint_id: "c",
+  task_id: "task_A",
+  idx: 0,
+  channel: "regular",
+  type: "json",
+  timestamp: 1,
+  global_idx: 1,
+};
+
+describe("RedisSaver.loadPendingWrites — undefined values", () => {
+  it("restores a missing write value as undefined instead of parsing it as JSON", async () => {
+    const checkpointDoc = makeCheckpointDocWithUndefinedPendingWrite();
+    const client = {
+      keys: async (pattern: string) => {
+        if (pattern === "checkpoint_write:t::c:*") {
+          return ["checkpoint_write:t::c:task_A:0"];
+        }
+        return [];
+      },
+      json: {
+        get: async (key: string) => {
+          if (key === "checkpoint:t::c") {
+            return checkpointDoc;
+          }
+          if (key === "checkpoint_write:t::c:task_A:0") {
+            return writeDocWithoutValue;
+          }
+          return null;
+        },
+      },
+      ft: { info: async () => ({}) },
+    } as never;
+
+    const saver = new RedisSaver(client);
+    const tuple = await saver.getTuple({
+      configurable: {
+        thread_id: "t",
+        checkpoint_ns: "",
+        checkpoint_id: "c",
+      },
+    });
+
+    expect(tuple?.pendingWrites).toEqual([["task_A", "regular", undefined]]);
+  });
+});
+
+describe("ShallowRedisSaver.loadPendingWrites — undefined values", () => {
+  it("restores a missing write value as undefined instead of parsing it as JSON", async () => {
+    const checkpointDoc = makeCheckpointDocWithUndefinedPendingWrite();
+    const client = {
+      zRange: async (key: string) => {
+        if (key === "write_keys_zset:t::c") {
+          return ["checkpoint_write:t::c:task_A:0"];
+        }
+        return [];
+      },
+      json: {
+        get: async (key: string) => {
+          if (key === "checkpoint:t::shallow") {
+            return checkpointDoc;
+          }
+          if (key === "checkpoint_write:t::c:task_A:0") {
+            return writeDocWithoutValue;
+          }
+          return null;
+        },
+      },
+      ft: { info: async () => ({}) },
+    } as never;
+
+    const saver = new ShallowRedisSaver(client);
+    const tuple = await saver.getTuple({
+      configurable: {
+        thread_id: "t",
+        checkpoint_ns: "",
+        checkpoint_id: "c",
+      },
+    });
+
+    expect(tuple?.pendingWrites).toEqual([["task_A", "regular", undefined]]);
   });
 });


### PR DESCRIPTION
## Summary

Fix Redis checkpoint restore when a pending write document has no `value` field.

RedisJSON omits `undefined` values, but `loadPendingWrites` always tried to deserialize:

```ts
JSON.stringify(writeDoc.value)

When value is missing, this produces undefined and can fail with:

JSON Parse error: Unexpected EOF

This breaks interrupt/resume checkpoint loading.

## Changes

- Treat missing pending write value as undefined.
- Apply the fix to both RedisSaver and ShallowRedisSaver.
- Add unit tests for both.