### PR TITLE
chore(deps): remove uuid dependency in favor of embedded uuid in core

### DIFF
--- a/.changeset/remove-uuid-dep-use-core-utils.md
+++ b/.changeset/remove-uuid-dep-use-core-utils.md
@@ -1,0 +1,16 @@
+---
+"@langchain/langgraph-checkpoint": patch
+"@langchain/langgraph-checkpoint-redis": patch
+"@langchain/langgraph-api": patch
+"@langchain/langgraph-cli": patch
+"@langchain/langgraph-ui": patch
+"@langchain/langgraph": patch
+"@langchain/langgraph-supervisor": patch
+"@langchain/langgraph-sdk": patch
+---
+
+chore(deps): remove uuid dependency in favor of embedded uuid in core
+
+Replace direct `uuid` package imports with `@langchain/core/utils/uuid` across
+langgraph packages to deduplicate dependencies and align with @langchain/core's
+embedded UUID utilities.

--- a/internal/bench/src/react_agent.ts
+++ b/internal/bench/src/react_agent.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-promise-executor-return, import/order, import/first */
-import { v4 as uuid } from "uuid";
+import { v4 as uuid } from "@langchain/core/utils/uuid";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import { tool } from "@langchain/core/tools";
 import { z } from "zod/v3";

--- a/libs/checkpoint-mongodb/package.json
+++ b/libs/checkpoint-mongodb/package.json
@@ -38,7 +38,6 @@
     "@langchain/scripts": ">=0.1.3 <0.2.0",
     "@tsconfig/recommended": "^1.0.3",
     "@types/better-sqlite3": "^7.6.12",
-    "@types/uuid": "^10",
     "dotenv": "^16.3.1",
     "dpdm": "^3.12.0",
     "rollup": "^4.37.0",

--- a/libs/checkpoint-postgres/package.json
+++ b/libs/checkpoint-postgres/package.json
@@ -38,7 +38,6 @@
     "@langchain/scripts": ">=0.1.2 <0.2.0",
     "@tsconfig/recommended": "^1.0.3",
     "@types/pg": "^8.11.8",
-    "@types/uuid": "^10",
     "dotenv": "^16.3.1",
     "dpdm": "^3.12.0",
     "rollup": "^4.37.0",

--- a/libs/checkpoint-redis/package.json
+++ b/libs/checkpoint-redis/package.json
@@ -30,7 +30,7 @@
     "redis": "^4.7.0"
   },
   "peerDependencies": {
-    "@langchain/core": "^1.1.44",
+    "@langchain/core": "^1.1.48",
     "@langchain/langgraph-checkpoint": "^1.0.0"
   },
   "devDependencies": {

--- a/libs/checkpoint-redis/package.json
+++ b/libs/checkpoint-redis/package.json
@@ -27,8 +27,7 @@
   "author": "Brian Sam-Bodden <bsb@redis.com>",
   "license": "MIT",
   "dependencies": {
-    "redis": "^4.7.0",
-    "uuid": "^14.0.0"
+    "redis": "^4.7.0"
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.44",

--- a/libs/checkpoint-redis/src/store.ts
+++ b/libs/checkpoint-redis/src/store.ts
@@ -709,8 +709,8 @@ export class RedisStore {
 
             const score = (doc.value as any)?.__embedding_score
               ? this.calculateSimilarityScore(
-                parseFloat((doc.value as any).__embedding_score as string)
-              )
+                  parseFloat((doc.value as any).__embedding_score as string)
+                )
               : 0;
 
             // Apply similarity threshold if specified

--- a/libs/checkpoint-redis/src/store.ts
+++ b/libs/checkpoint-redis/src/store.ts
@@ -8,7 +8,7 @@ export type RedisClusterConnection = ReturnType<typeof createCluster>;
 
 /** A Redis connection, clustered or conventional. */
 export type RedisConnection = RedisClientConnection | RedisClusterConnection;
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4 } from "@langchain/core/utils/uuid";
 import {
   type GetOperation,
   InvalidNamespaceError,
@@ -709,8 +709,8 @@ export class RedisStore {
 
             const score = (doc.value as any)?.__embedding_score
               ? this.calculateSimilarityScore(
-                  parseFloat((doc.value as any).__embedding_score as string)
-                )
+                parseFloat((doc.value as any).__embedding_score as string)
+              )
               : 0;
 
             // Apply similarity threshold if specified

--- a/libs/checkpoint-sqlite/package.json
+++ b/libs/checkpoint-sqlite/package.json
@@ -38,7 +38,6 @@
     "@langchain/scripts": ">=0.1.3 <0.2.0",
     "@tsconfig/recommended": "^1.0.3",
     "@types/better-sqlite3": "^7.6.12",
-    "@types/uuid": "^10",
     "better-sqlite3": "^12.10.0",
     "dotenv": "^16.3.1",
     "dpdm": "^3.12.0",

--- a/libs/checkpoint-validation/package.json
+++ b/libs/checkpoint-validation/package.json
@@ -47,7 +47,6 @@
     "@testcontainers/mongodb": "^11.0.3",
     "@testcontainers/postgresql": "^11.0.3",
     "@tsconfig/recommended": "^1.0.3",
-    "@types/uuid": "^10",
     "@types/yargs": "^17.0.33",
     "better-sqlite3": "^12.10.0",
     "dotenv": "^16.3.1",

--- a/libs/checkpoint/package.json
+++ b/libs/checkpoint/package.json
@@ -27,7 +27,7 @@
   "author": "LangChain",
   "license": "MIT",
   "peerDependencies": {
-    "@langchain/core": "^1.1.44"
+    "@langchain/core": "^1.1.48"
   },
   "devDependencies": {
     "@langchain/scripts": ">=0.1.3 <0.2.0",

--- a/libs/checkpoint/package.json
+++ b/libs/checkpoint/package.json
@@ -26,16 +26,12 @@
   },
   "author": "LangChain",
   "license": "MIT",
-  "dependencies": {
-    "uuid": "^14.0.0"
-  },
   "peerDependencies": {
     "@langchain/core": "^1.1.44"
   },
   "devDependencies": {
     "@langchain/scripts": ">=0.1.3 <0.2.0",
     "@tsconfig/recommended": "^1.0.3",
-    "@types/uuid": "^10",
     "dotenv": "^16.3.1",
     "dpdm": "^3.12.0",
     "rollup": "^4.37.0",

--- a/libs/checkpoint/src/id.ts
+++ b/libs/checkpoint/src/id.ts
@@ -1,4 +1,4 @@
-import { v5, v6 } from "uuid";
+import { v5, v6 } from "@langchain/core/utils/uuid";
 
 // Monotonic timestamp state, mirroring uuid@10's internal v1 clock handling.
 // uuid@11+ dropped the sub-millisecond `nsecs` counter when an explicit

--- a/libs/langgraph-api/package.json
+++ b/libs/langgraph-api/package.json
@@ -79,7 +79,6 @@
     "stacktrace-parser": "^0.1.10",
     "superjson": "^2.2.2",
     "tsx": "^4.19.3",
-    "uuid": "^14.0.0",
     "winston": "^3.17.0",
     "winston-console-format": "^1.0.8",
     "zod": "^3.25.76 || ^4"
@@ -106,7 +105,6 @@
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.0.3",
     "@types/semver": "^7.7.0",
-    "@types/uuid": "^10.0.0",
     "deepagents": "^1.9.0",
     "jose": "^6.0.10",
     "langchain": "^1.4.4",

--- a/libs/langgraph-api/src/api/assistants.mts
+++ b/libs/langgraph-api/src/api/assistants.mts
@@ -236,7 +236,7 @@ api.get(
       "getSubgraphsAsync" in graph
         ? graph.getSubgraphsAsync.bind(graph)
         : // @ts-expect-error older versions of langgraph don't have getSubgraphsAsync
-        graph.getSubgraphs.bind(graph);
+          graph.getSubgraphs.bind(graph);
 
     let graphSchemaPromise:
       | ReturnType<typeof getCachedStaticGraphSchema>

--- a/libs/langgraph-api/src/api/assistants.mts
+++ b/libs/langgraph-api/src/api/assistants.mts
@@ -1,7 +1,7 @@
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 
-import { v7 as uuid } from "uuid";
+import { v7 as uuid } from "@langchain/core/utils/uuid";
 import { z } from "zod/v3";
 
 import {
@@ -236,7 +236,7 @@ api.get(
       "getSubgraphsAsync" in graph
         ? graph.getSubgraphsAsync.bind(graph)
         : // @ts-expect-error older versions of langgraph don't have getSubgraphsAsync
-          graph.getSubgraphs.bind(graph);
+        graph.getSubgraphs.bind(graph);
 
     let graphSchemaPromise:
       | ReturnType<typeof getCachedStaticGraphSchema>

--- a/libs/langgraph-api/src/api/protocol.mts
+++ b/libs/langgraph-api/src/api/protocol.mts
@@ -2,7 +2,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import type { UpgradeWebSocket } from "hono/ws";
-import { v7 as uuid7 } from "uuid";
+import { v7 as uuid7 } from "@langchain/core/utils/uuid";
 import { z } from "zod/v3";
 
 import { ProtocolService } from "../protocol/service.mjs";

--- a/libs/langgraph-api/src/api/runs.mts
+++ b/libs/langgraph-api/src/api/runs.mts
@@ -2,7 +2,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { streamSSE } from "hono/streaming";
-import { v7 as uuid7 } from "uuid";
+import { v7 as uuid7 } from "@langchain/core/utils/uuid";
 import { z } from "zod/v3";
 import type { AuthContext } from "../auth/index.mjs";
 import { getAssistantId } from "../graph/load.mjs";

--- a/libs/langgraph-api/src/api/threads.mts
+++ b/libs/langgraph-api/src/api/threads.mts
@@ -1,7 +1,7 @@
 import { zValidator } from "@hono/zod-validator";
 
 import { Hono } from "hono";
-import { v7 as uuid7 } from "uuid";
+import { v7 as uuid7 } from "@langchain/core/utils/uuid";
 
 import { z } from "zod/v3";
 import * as schemas from "../schemas.mjs";

--- a/libs/langgraph-api/src/experimental/embed/protocol.mts
+++ b/libs/langgraph-api/src/experimental/embed/protocol.mts
@@ -2,7 +2,7 @@ import type { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { streamSSE } from "hono/streaming";
 import type { UpgradeWebSocket } from "hono/ws";
-import { v7 as uuidv7 } from "uuid";
+import { v7 as uuidv7 } from "@langchain/core/utils/uuid";
 import { z } from "zod/v3";
 
 import * as schemas from "../../schemas.mjs";

--- a/libs/langgraph-api/src/experimental/embed/runs.mts
+++ b/libs/langgraph-api/src/experimental/embed/runs.mts
@@ -1,7 +1,7 @@
 import type { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { streamSSE } from "hono/streaming";
-import { v7 as uuidv7 } from "uuid";
+import { v7 as uuidv7 } from "@langchain/core/utils/uuid";
 import { z } from "zod/v3";
 
 import type { Run } from "../../storage/types.mjs";

--- a/libs/langgraph-api/src/experimental/embed/threads.mts
+++ b/libs/langgraph-api/src/experimental/embed/threads.mts
@@ -1,6 +1,6 @@
 import type { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
-import { v7 as uuidv7 } from "uuid";
+import { v7 as uuidv7 } from "@langchain/core/utils/uuid";
 import { z } from "zod/v3";
 import { RunnableConfig } from "@langchain/core/runnables";
 

--- a/libs/langgraph-api/src/experimental/embed/utils.mts
+++ b/libs/langgraph-api/src/experimental/embed/utils.mts
@@ -46,9 +46,9 @@ export function createStubRun(
         ...payload.checkpoint,
         ...(payload.langsmith_tracer
           ? {
-            langsmith_project: payload.langsmith_tracer.project_name,
-            langsmith_example_id: payload.langsmith_tracer.example_id,
-          }
+              langsmith_project: payload.langsmith_tracer.project_name,
+              langsmith_example_id: payload.langsmith_tracer.example_id,
+            }
           : null),
       },
     },

--- a/libs/langgraph-api/src/experimental/embed/utils.mts
+++ b/libs/langgraph-api/src/experimental/embed/utils.mts
@@ -1,4 +1,4 @@
-import { v7 as uuidv7 } from "uuid";
+import { v7 as uuidv7 } from "@langchain/core/utils/uuid";
 import { z } from "zod/v3";
 
 import type { MultitaskStrategy, Run } from "../../storage/types.mjs";
@@ -46,9 +46,9 @@ export function createStubRun(
         ...payload.checkpoint,
         ...(payload.langsmith_tracer
           ? {
-              langsmith_project: payload.langsmith_tracer.project_name,
-              langsmith_example_id: payload.langsmith_tracer.example_id,
-            }
+            langsmith_project: payload.langsmith_tracer.project_name,
+            langsmith_example_id: payload.langsmith_tracer.example_id,
+          }
           : null),
       },
     },

--- a/libs/langgraph-api/src/graph/load.mts
+++ b/libs/langgraph-api/src/graph/load.mts
@@ -1,6 +1,6 @@
 import { z } from "zod/v3";
 
-import * as uuid from "uuid";
+import * as uuid from "@langchain/core/utils/uuid";
 import type { AssistantsRepo } from "../storage/types.mjs";
 import type {
   BaseCheckpointSaver,

--- a/libs/langgraph-api/src/graph/load.utils.mts
+++ b/libs/langgraph-api/src/graph/load.utils.mts
@@ -1,5 +1,5 @@
 import type { CompiledGraph, Graph } from "@langchain/langgraph";
-import * as uuid from "uuid";
+import * as uuid from "@langchain/core/utils/uuid";
 import * as path from "node:path";
 import * as fs from "node:fs/promises";
 import { pathToFileURL } from "node:url";
@@ -46,8 +46,8 @@ export async function resolveGraph(
     | GraphLike
     | Promise<GraphLike>
     | ((config: {
-        configurable?: Record<string, unknown>;
-      }) => GraphLike | Promise<GraphLike>)
+      configurable?: Record<string, unknown>;
+    }) => GraphLike | Promise<GraphLike>)
     | undefined;
 
   const isGraph = (graph: GraphLike): graph is Graph<string> => {

--- a/libs/langgraph-api/src/graph/load.utils.mts
+++ b/libs/langgraph-api/src/graph/load.utils.mts
@@ -46,8 +46,8 @@ export async function resolveGraph(
     | GraphLike
     | Promise<GraphLike>
     | ((config: {
-      configurable?: Record<string, unknown>;
-    }) => GraphLike | Promise<GraphLike>)
+        configurable?: Record<string, unknown>;
+      }) => GraphLike | Promise<GraphLike>)
     | undefined;
 
   const isGraph = (graph: GraphLike): graph is Graph<string> => {

--- a/libs/langgraph-api/src/protocol/service.mts
+++ b/libs/langgraph-api/src/protocol/service.mts
@@ -367,10 +367,10 @@ export class ProtocolService {
     const currentRun =
       record.currentRunId != null
         ? await this.bindings.runs.get(
-          record.currentRunId,
-          record.threadId,
-          record.auth
-        )
+            record.currentRunId,
+            record.threadId,
+            record.auth
+          )
         : null;
     const hasPendingInterrupts = await this.hasPendingInterrupts(record);
     if (currentRun == null && !hasPendingInterrupts) {
@@ -421,10 +421,10 @@ export class ProtocolService {
     const currentRun =
       record.currentRunId != null
         ? await this.bindings.runs.get(
-          record.currentRunId,
-          record.threadId,
-          record.auth
-        )
+            record.currentRunId,
+            record.threadId,
+            record.auth
+          )
         : null;
     const currentStatus = currentRun?.status;
     const hasPendingInterrupts =
@@ -565,8 +565,8 @@ export class ProtocolService {
   ): Promise<ProtocolSuccess | ProtocolError> {
     const params = isRecord(command.params)
       ? (command.params as Partial<
-        ProtocolCommandByMethod<"state.get">["params"]
-      >)
+          ProtocolCommandByMethod<"state.get">["params"]
+        >)
       : {};
     const values = await this.bindings.threads.state.get(
       { configurable: { thread_id: record.threadId } },
@@ -578,23 +578,23 @@ export class ProtocolService {
       : undefined;
     const checkpoint: StateGetResult["checkpoint"] =
       checkpointConfig != null &&
-        typeof checkpointConfig.checkpoint_id === "string"
+      typeof checkpointConfig.checkpoint_id === "string"
         ? {
-          id: checkpointConfig.checkpoint_id,
-          ...(typeof checkpointConfig.checkpoint_ns === "string"
-            ? { ns: checkpointConfig.checkpoint_ns }
-            : {}),
-        }
+            id: checkpointConfig.checkpoint_id,
+            ...(typeof checkpointConfig.checkpoint_ns === "string"
+              ? { ns: checkpointConfig.checkpoint_ns }
+              : {}),
+          }
         : undefined;
     const requestedKeys = normalizeKeys(params.keys);
     const filteredValues =
       requestedKeys == null
         ? values.values
         : Object.fromEntries(
-          Object.entries(values.values).filter(([key]) =>
-            requestedKeys.includes(key)
-          )
-        );
+            Object.entries(values.values).filter(([key]) =>
+              requestedKeys.includes(key)
+            )
+          );
     return {
       type: "success",
       id: command.id,

--- a/libs/langgraph-api/src/protocol/service.mts
+++ b/libs/langgraph-api/src/protocol/service.mts
@@ -1,5 +1,5 @@
 import { inferChannel, isPrefixMatch } from "@langchain/langgraph/stream";
-import { v7 as uuid7 } from "uuid";
+import { v7 as uuid7 } from "@langchain/core/utils/uuid";
 import { getAssistantId } from "../graph/load.mjs";
 import type {
   Run,
@@ -367,10 +367,10 @@ export class ProtocolService {
     const currentRun =
       record.currentRunId != null
         ? await this.bindings.runs.get(
-            record.currentRunId,
-            record.threadId,
-            record.auth
-          )
+          record.currentRunId,
+          record.threadId,
+          record.auth
+        )
         : null;
     const hasPendingInterrupts = await this.hasPendingInterrupts(record);
     if (currentRun == null && !hasPendingInterrupts) {
@@ -421,10 +421,10 @@ export class ProtocolService {
     const currentRun =
       record.currentRunId != null
         ? await this.bindings.runs.get(
-            record.currentRunId,
-            record.threadId,
-            record.auth
-          )
+          record.currentRunId,
+          record.threadId,
+          record.auth
+        )
         : null;
     const currentStatus = currentRun?.status;
     const hasPendingInterrupts =
@@ -565,8 +565,8 @@ export class ProtocolService {
   ): Promise<ProtocolSuccess | ProtocolError> {
     const params = isRecord(command.params)
       ? (command.params as Partial<
-          ProtocolCommandByMethod<"state.get">["params"]
-        >)
+        ProtocolCommandByMethod<"state.get">["params"]
+      >)
       : {};
     const values = await this.bindings.threads.state.get(
       { configurable: { thread_id: record.threadId } },
@@ -578,23 +578,23 @@ export class ProtocolService {
       : undefined;
     const checkpoint: StateGetResult["checkpoint"] =
       checkpointConfig != null &&
-      typeof checkpointConfig.checkpoint_id === "string"
+        typeof checkpointConfig.checkpoint_id === "string"
         ? {
-            id: checkpointConfig.checkpoint_id,
-            ...(typeof checkpointConfig.checkpoint_ns === "string"
-              ? { ns: checkpointConfig.checkpoint_ns }
-              : {}),
-          }
+          id: checkpointConfig.checkpoint_id,
+          ...(typeof checkpointConfig.checkpoint_ns === "string"
+            ? { ns: checkpointConfig.checkpoint_ns }
+            : {}),
+        }
         : undefined;
     const requestedKeys = normalizeKeys(params.keys);
     const filteredValues =
       requestedKeys == null
         ? values.values
         : Object.fromEntries(
-            Object.entries(values.values).filter(([key]) =>
-              requestedKeys.includes(key)
-            )
-          );
+          Object.entries(values.values).filter(([key]) =>
+            requestedKeys.includes(key)
+          )
+        );
     return {
       type: "success",
       id: command.id,

--- a/libs/langgraph-api/src/protocol/session/index.mts
+++ b/libs/langgraph-api/src/protocol/session/index.mts
@@ -1,5 +1,5 @@
 import { inferChannel, isSupportedChannel } from "@langchain/langgraph/stream";
-import { v7 as uuid7 }  from "@langchain/core/utils/uuid";
+import { v7 as uuid7 } from "@langchain/core/utils/uuid";
 
 import type { AuthContext } from "../../auth/index.mjs";
 import type { Run } from "../../storage/types.mjs";

--- a/libs/langgraph-api/src/protocol/session/index.mts
+++ b/libs/langgraph-api/src/protocol/session/index.mts
@@ -1,5 +1,5 @@
 import { inferChannel, isSupportedChannel } from "@langchain/langgraph/stream";
-import { v7 as uuid7 } from "uuid";
+import { v7 as uuid7 }  from "@langchain/core/utils/uuid";
 
 import type { AuthContext } from "../../auth/index.mjs";
 import type { Run } from "../../storage/types.mjs";

--- a/libs/langgraph-api/src/storage/ops.mts
+++ b/libs/langgraph-api/src/storage/ops.mts
@@ -1,6 +1,6 @@
 import type { StateSnapshot as LangGraphStateSnapshot } from "@langchain/langgraph";
 import { HTTPException } from "hono/http-exception";
-import { v7 as uuid7, v5 as uuid5 } from "uuid";
+import { v7 as uuid7, v5 as uuid5 } from "@langchain/core/utils/uuid";
 import { handleAuthEvent, isAuthMatching } from "../auth/index.mjs";
 import type { AuthContext } from "../auth/index.mjs";
 import { getLangGraphCommand, type RunCommand } from "../command.mjs";
@@ -73,8 +73,8 @@ export class FileSystemOps implements Ops {
   }
 }
 
-class TimeoutError extends Error {}
-class AbortError extends Error {}
+class TimeoutError extends Error { }
+class AbortError extends Error { }
 
 class Queue {
   private log: Message[] = [];
@@ -436,9 +436,9 @@ export class FileSystemAssistants implements AssistantsRepo {
       const metadata =
         mutable.metadata != null
           ? {
-              ...assistant["metadata"],
-              ...mutable.metadata,
-            }
+            ...assistant["metadata"],
+            ...mutable.metadata,
+          }
           : null;
 
       if (options?.graph_id != null) {
@@ -893,12 +893,12 @@ export class FileSystemThreads implements ThreadsRepo {
       thread.interrupts =
         options.checkpoint != null
           ? options.checkpoint.tasks.reduce<Record<string, unknown>>(
-              (acc, task) => {
-                if (task.interrupts) acc[task.id] = task.interrupts;
-                return acc;
-              },
-              {}
-            )
+            (acc, task) => {
+              if (task.interrupts) acc[task.id] = task.interrupts;
+              return acc;
+            },
+            {}
+          )
           : undefined;
     });
   }
@@ -1160,11 +1160,11 @@ export class FileSystemThreads implements ThreadsRepo {
       supersteps: Array<{
         updates: Array<{
           values?:
-            | Record<string, unknown>[]
-            | Record<string, unknown>
-            | unknown
-            | null
-            | undefined;
+          | Record<string, unknown>[]
+          | Record<string, unknown>
+          | unknown
+          | null
+          | undefined;
           command?: RunCommand | undefined | null;
           as_node?: string | undefined;
         }>;
@@ -1872,4 +1872,4 @@ export class FileSystemRuns implements RunsRepo {
   };
 }
 
-export class Crons {}
+export class Crons { }

--- a/libs/langgraph-api/src/storage/ops.mts
+++ b/libs/langgraph-api/src/storage/ops.mts
@@ -73,8 +73,8 @@ export class FileSystemOps implements Ops {
   }
 }
 
-class TimeoutError extends Error { }
-class AbortError extends Error { }
+class TimeoutError extends Error {}
+class AbortError extends Error {}
 
 class Queue {
   private log: Message[] = [];
@@ -436,9 +436,9 @@ export class FileSystemAssistants implements AssistantsRepo {
       const metadata =
         mutable.metadata != null
           ? {
-            ...assistant["metadata"],
-            ...mutable.metadata,
-          }
+              ...assistant["metadata"],
+              ...mutable.metadata,
+            }
           : null;
 
       if (options?.graph_id != null) {
@@ -893,12 +893,12 @@ export class FileSystemThreads implements ThreadsRepo {
       thread.interrupts =
         options.checkpoint != null
           ? options.checkpoint.tasks.reduce<Record<string, unknown>>(
-            (acc, task) => {
-              if (task.interrupts) acc[task.id] = task.interrupts;
-              return acc;
-            },
-            {}
-          )
+              (acc, task) => {
+                if (task.interrupts) acc[task.id] = task.interrupts;
+                return acc;
+              },
+              {}
+            )
           : undefined;
     });
   }
@@ -1160,11 +1160,11 @@ export class FileSystemThreads implements ThreadsRepo {
       supersteps: Array<{
         updates: Array<{
           values?:
-          | Record<string, unknown>[]
-          | Record<string, unknown>
-          | unknown
-          | null
-          | undefined;
+            | Record<string, unknown>[]
+            | Record<string, unknown>
+            | unknown
+            | null
+            | undefined;
           command?: RunCommand | undefined | null;
           as_node?: string | undefined;
         }>;
@@ -1872,4 +1872,4 @@ export class FileSystemRuns implements RunsRepo {
   };
 }
 
-export class Crons { }
+export class Crons {}

--- a/libs/langgraph-api/tests/graphs/agent.mts
+++ b/libs/langgraph-api/tests/graphs/agent.mts
@@ -10,7 +10,7 @@ import {
 } from "@langchain/langgraph";
 import { FakeListChatModel } from "@langchain/core/utils/testing";
 import { ChatGenerationChunk } from "@langchain/core/outputs";
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4 } from "@langchain/core/utils/uuid";
 import { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
 const GraphAnnotationOutput = Annotation.Root({
   messages: Annotation<BaseMessage[]>({

--- a/libs/langgraph-api/tests/protocol-v2/stream-sdk.test.mts
+++ b/libs/langgraph-api/tests/protocol-v2/stream-sdk.test.mts
@@ -4,7 +4,7 @@
  * end-to-end against the embed server over real HTTP/SSE.
  */
 import type { Server } from "node:http";
-import { v7 as uuidv7 } from "uuid";
+import { v7 as uuidv7 } from "@langchain/core/utils/uuid";
 import {
   afterAll,
   beforeAll,

--- a/libs/langgraph-core/package.json
+++ b/libs/langgraph-core/package.json
@@ -32,8 +32,7 @@
     "@langchain/langgraph-checkpoint": "workspace:^",
     "@langchain/langgraph-sdk": "workspace:~",
     "@langchain/protocol": "^0.0.16",
-    "@standard-schema/spec": "1.1.0",
-    "uuid": "^14.0.0"
+    "@standard-schema/spec": "1.1.0"
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.48",
@@ -57,7 +56,6 @@
     "@testing-library/dom": "^10.4.0",
     "@tsconfig/recommended": "^1.0.3",
     "@types/pg": "^8",
-    "@types/uuid": "^10",
     "@vitest/browser": "^4.1.8",
     "@vitest/browser-playwright": "^4.1.8",
     "@xenova/transformers": "^2.17.2",

--- a/libs/langgraph-core/src/graph/graph.ts
+++ b/libs/langgraph-core/src/graph/graph.ts
@@ -13,7 +13,7 @@ import {
 } from "@langchain/core/runnables/graph";
 import { All, BaseCheckpointSaver } from "@langchain/langgraph-checkpoint";
 import { z } from "zod/v4";
-import { validate as isUuid } from "uuid";
+import { validate as isUuid } from "@langchain/core/utils/uuid";
 import type {
   RunnableLike,
   LangGraphRunnableConfig,
@@ -79,16 +79,16 @@ type CompiledGraphTypeStreamTransformers<Spec> = Spec extends {
   streamTransformers: infer Transformers;
 }
   ? Transformers extends ReadonlyArray<
-      () => StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
-    >
-    ? Transformers
-    : Transformers extends ReadonlyArray<
-          StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
-        >
-      ? { readonly [K in keyof Transformers]: () => Transformers[K] }
-      : Transformers extends StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
-        ? readonly [() => Transformers]
-        : []
+    () => StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
+  >
+  ? Transformers
+  : Transformers extends ReadonlyArray<
+    StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
+  >
+  ? { readonly [K in keyof Transformers]: () => Transformers[K] }
+  : Transformers extends StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
+  ? readonly [() => Transformers]
+  : []
   : [];
 
 /**
@@ -144,12 +144,12 @@ export class Branch<
     }
     this.ends = Array.isArray(options.pathMap)
       ? options.pathMap.reduce(
-          (acc, n) => {
-            acc[n] = n;
-            return acc;
-          },
-          {} as Record<string, N | typeof END>
-        )
+        (acc, n) => {
+          acc[n] = n;
+          return acc;
+        },
+        {} as Record<string, N | typeof END>
+      )
       : options.pathMap;
   }
 
@@ -173,7 +173,7 @@ export class Branch<
             if (e.name === NodeInterrupt.unminifiable_name) {
               console.warn(
                 "[WARN]: 'NodeInterrupt' thrown in conditional edge. This is likely a bug in your graph implementation.\n" +
-                  "NodeInterrupt should only be thrown inside a node, not in edge conditions."
+                "NodeInterrupt should only be thrown inside a node, not in edge conditions."
               );
             }
             throw e;
@@ -313,10 +313,10 @@ export class Graph<
     nodes:
       | Record<K, NodeAction<NodeInput, NodeOutput, C>>
       | [
-          key: K,
-          action: NodeAction<NodeInput, NodeOutput, C>,
-          options?: AddNodeOptions,
-        ][]
+        key: K,
+        action: NodeAction<NodeInput, NodeOutput, C>,
+        options?: AddNodeOptions,
+      ][]
   ): Graph<N | K, RunInput, RunOutput>;
 
   addNode<K extends string, NodeInput = RunInput, NodeOutput = RunOutput>(
@@ -328,30 +328,30 @@ export class Graph<
   addNode<K extends string, NodeInput = RunInput, NodeOutput = RunOutput>(
     ...args:
       | [
+        key: K,
+        action: NodeAction<NodeInput, NodeOutput, C>,
+        options?: AddNodeOptions,
+      ]
+      | [
+        nodes:
+        | Record<K, NodeAction<NodeInput, NodeOutput, C>>
+        | [
           key: K,
           action: NodeAction<NodeInput, NodeOutput, C>,
           options?: AddNodeOptions,
-        ]
-      | [
-          nodes:
-            | Record<K, NodeAction<NodeInput, NodeOutput, C>>
-            | [
-                key: K,
-                action: NodeAction<NodeInput, NodeOutput, C>,
-                options?: AddNodeOptions,
-              ][],
-        ]
+        ][],
+      ]
   ): Graph<N | K, RunInput, RunOutput> {
     function isMutlipleNodes(
       args: unknown[]
     ): args is [
       nodes:
-        | Record<K, NodeAction<NodeInput, RunOutput, C>>
-        | [
-            key: K,
-            action: NodeAction<NodeInput, RunOutput, C>,
-            options?: AddNodeOptions,
-          ][],
+      | Record<K, NodeAction<NodeInput, RunOutput, C>>
+      | [
+        key: K,
+        action: NodeAction<NodeInput, RunOutput, C>,
+        options?: AddNodeOptions,
+      ][],
       options?: AddNodeOptions,
     ] {
       return args.length >= 1 && typeof args[0] !== "string";
@@ -521,7 +521,7 @@ export class Graph<
   compile<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const TTransformers extends ReadonlyArray<() => StreamTransformer<any>> =
-      [],
+    [],
   >({
     checkpointer,
     interruptBefore,
@@ -733,7 +733,7 @@ export class CompiledGraph<
 
   override withConfig<
     const TTransformers extends ReadonlyArray<() => StreamTransformer<any>> =
-      [],
+    [],
   >(
     config: Omit<LangGraphRunnableConfig, "store" | "writer" | "interrupt"> & {
       streamTransformers: TTransformers;
@@ -921,9 +921,9 @@ export class CompiledGraph<
         const drawableSubgraph =
           subgraphs[key] !== undefined
             ? await subgraphs[key].getGraphAsync({
-                ...config,
-                xray: newXrayValue,
-              })
+              ...config,
+              xray: newXrayValue,
+            })
             : node.getGraph(config);
 
         drawableSubgraph.trimFirstNode();
@@ -1129,9 +1129,9 @@ export class CompiledGraph<
         const drawableSubgraph =
           subgraphs[key] !== undefined
             ? subgraphs[key].getGraph({
-                ...config,
-                xray: newXrayValue,
-              })
+              ...config,
+              xray: newXrayValue,
+            })
             : node.getGraph(config);
         drawableSubgraph.trimFirstNode();
         drawableSubgraph.trimLastNode();

--- a/libs/langgraph-core/src/graph/graph.ts
+++ b/libs/langgraph-core/src/graph/graph.ts
@@ -79,16 +79,16 @@ type CompiledGraphTypeStreamTransformers<Spec> = Spec extends {
   streamTransformers: infer Transformers;
 }
   ? Transformers extends ReadonlyArray<
-    () => StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
-  >
-  ? Transformers
-  : Transformers extends ReadonlyArray<
-    StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
-  >
-  ? { readonly [K in keyof Transformers]: () => Transformers[K] }
-  : Transformers extends StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
-  ? readonly [() => Transformers]
-  : []
+      () => StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
+    >
+    ? Transformers
+    : Transformers extends ReadonlyArray<
+          StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        >
+      ? { readonly [K in keyof Transformers]: () => Transformers[K] }
+      : Transformers extends StreamTransformer<any> // eslint-disable-line @typescript-eslint/no-explicit-any
+        ? readonly [() => Transformers]
+        : []
   : [];
 
 /**
@@ -144,12 +144,12 @@ export class Branch<
     }
     this.ends = Array.isArray(options.pathMap)
       ? options.pathMap.reduce(
-        (acc, n) => {
-          acc[n] = n;
-          return acc;
-        },
-        {} as Record<string, N | typeof END>
-      )
+          (acc, n) => {
+            acc[n] = n;
+            return acc;
+          },
+          {} as Record<string, N | typeof END>
+        )
       : options.pathMap;
   }
 
@@ -173,7 +173,7 @@ export class Branch<
             if (e.name === NodeInterrupt.unminifiable_name) {
               console.warn(
                 "[WARN]: 'NodeInterrupt' thrown in conditional edge. This is likely a bug in your graph implementation.\n" +
-                "NodeInterrupt should only be thrown inside a node, not in edge conditions."
+                  "NodeInterrupt should only be thrown inside a node, not in edge conditions."
               );
             }
             throw e;
@@ -313,10 +313,10 @@ export class Graph<
     nodes:
       | Record<K, NodeAction<NodeInput, NodeOutput, C>>
       | [
-        key: K,
-        action: NodeAction<NodeInput, NodeOutput, C>,
-        options?: AddNodeOptions,
-      ][]
+          key: K,
+          action: NodeAction<NodeInput, NodeOutput, C>,
+          options?: AddNodeOptions,
+        ][]
   ): Graph<N | K, RunInput, RunOutput>;
 
   addNode<K extends string, NodeInput = RunInput, NodeOutput = RunOutput>(
@@ -328,30 +328,30 @@ export class Graph<
   addNode<K extends string, NodeInput = RunInput, NodeOutput = RunOutput>(
     ...args:
       | [
-        key: K,
-        action: NodeAction<NodeInput, NodeOutput, C>,
-        options?: AddNodeOptions,
-      ]
-      | [
-        nodes:
-        | Record<K, NodeAction<NodeInput, NodeOutput, C>>
-        | [
           key: K,
           action: NodeAction<NodeInput, NodeOutput, C>,
           options?: AddNodeOptions,
-        ][],
-      ]
+        ]
+      | [
+          nodes:
+            | Record<K, NodeAction<NodeInput, NodeOutput, C>>
+            | [
+                key: K,
+                action: NodeAction<NodeInput, NodeOutput, C>,
+                options?: AddNodeOptions,
+              ][],
+        ]
   ): Graph<N | K, RunInput, RunOutput> {
     function isMutlipleNodes(
       args: unknown[]
     ): args is [
       nodes:
-      | Record<K, NodeAction<NodeInput, RunOutput, C>>
-      | [
-        key: K,
-        action: NodeAction<NodeInput, RunOutput, C>,
-        options?: AddNodeOptions,
-      ][],
+        | Record<K, NodeAction<NodeInput, RunOutput, C>>
+        | [
+            key: K,
+            action: NodeAction<NodeInput, RunOutput, C>,
+            options?: AddNodeOptions,
+          ][],
       options?: AddNodeOptions,
     ] {
       return args.length >= 1 && typeof args[0] !== "string";
@@ -521,7 +521,7 @@ export class Graph<
   compile<
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const TTransformers extends ReadonlyArray<() => StreamTransformer<any>> =
-    [],
+      [],
   >({
     checkpointer,
     interruptBefore,
@@ -733,7 +733,7 @@ export class CompiledGraph<
 
   override withConfig<
     const TTransformers extends ReadonlyArray<() => StreamTransformer<any>> =
-    [],
+      [],
   >(
     config: Omit<LangGraphRunnableConfig, "store" | "writer" | "interrupt"> & {
       streamTransformers: TTransformers;
@@ -921,9 +921,9 @@ export class CompiledGraph<
         const drawableSubgraph =
           subgraphs[key] !== undefined
             ? await subgraphs[key].getGraphAsync({
-              ...config,
-              xray: newXrayValue,
-            })
+                ...config,
+                xray: newXrayValue,
+              })
             : node.getGraph(config);
 
         drawableSubgraph.trimFirstNode();
@@ -1129,9 +1129,9 @@ export class CompiledGraph<
         const drawableSubgraph =
           subgraphs[key] !== undefined
             ? subgraphs[key].getGraph({
-              ...config,
-              xray: newXrayValue,
-            })
+                ...config,
+                xray: newXrayValue,
+              })
             : node.getGraph(config);
         drawableSubgraph.trimFirstNode();
         drawableSubgraph.trimLastNode();

--- a/libs/langgraph-core/src/graph/messages_reducer.ts
+++ b/libs/langgraph-core/src/graph/messages_reducer.ts
@@ -4,7 +4,7 @@ import {
   coerceMessageLikeToMessage,
   RemoveMessage,
 } from "@langchain/core/messages";
-import { v4 } from "uuid";
+import { v4 } from "@langchain/core/utils/uuid";
 
 /**
  * Special value that signifies the intent to remove all previous messages in the state reducer.

--- a/libs/langgraph-core/src/pregel/loop.ts
+++ b/libs/langgraph-core/src/pregel/loop.ts
@@ -442,7 +442,7 @@ export class PregelLoop {
       this.config.metadata?.run_id !== undefined &&
       (this.checkpointMetadata as { run_id?: unknown })?.run_id !== undefined &&
       this.config.metadata.run_id ===
-      (this.checkpointMetadata as { run_id?: unknown })?.run_id;
+        (this.checkpointMetadata as { run_id?: unknown })?.run_id;
 
     return (
       hasChannelVersions &&
@@ -560,13 +560,13 @@ export class PregelLoop {
       config.configurable?.checkpoint_id === undefined &&
       config.configurable?.[CONFIG_KEY_CHECKPOINT_MAP] !== undefined &&
       config.configurable?.[CONFIG_KEY_CHECKPOINT_MAP]?.[
-      config.configurable?.checkpoint_ns
+        config.configurable?.checkpoint_ns
       ]
     ) {
       checkpointConfig = patchConfigurable(config, {
         checkpoint_id:
           config.configurable[CONFIG_KEY_CHECKPOINT_MAP][
-          config.configurable?.checkpoint_ns
+            config.configurable?.checkpoint_ns
           ],
       });
     }
@@ -1420,7 +1420,7 @@ export class PregelLoop {
         configurable?.[CONFIG_KEY_CHECKPOINT_NS] !== "" &&
         configurable?.[CONFIG_KEY_CHECKPOINT_MAP] !== undefined &&
         configurable[CONFIG_KEY_CHECKPOINT_NS] in
-        configurable[CONFIG_KEY_CHECKPOINT_MAP]) ||
+          configurable[CONFIG_KEY_CHECKPOINT_MAP]) ||
         !(
           (inputIsCommand && (this.input as Command).resume != null) ||
           configurable?.[CONFIG_KEY_RESUMING] === true ||
@@ -1559,7 +1559,7 @@ export class PregelLoop {
         ) {
           replayCheckpointId =
             this.prevCheckpointConfig.configurable?.[
-            CONFIG_KEY_CHECKPOINT_ID
+              CONFIG_KEY_CHECKPOINT_ID
             ] ?? replayCheckpointId;
         }
         replayState = new ReplayState(replayCheckpointId);
@@ -1583,8 +1583,8 @@ export class PregelLoop {
     }
     const deepest = deepestCheckpointMapNamespace(
       this.config.configurable?.[CONFIG_KEY_CHECKPOINT_MAP] as
-      | Record<string, string>
-      | undefined
+        | Record<string, string>
+        | undefined
     );
     return deepest.length > 0 ? deepest : ns;
   }
@@ -1768,7 +1768,7 @@ export class PregelLoop {
         updatedChannels: this.updatedChannels,
         getNextVersion: doCheckpoint
           ? (current) =>
-            this.checkpointerGetNextVersion(current as number | undefined)
+              this.checkpointerGetNextVersion(current as number | undefined)
           : undefined,
       }
     );

--- a/libs/langgraph-core/src/pregel/loop.ts
+++ b/libs/langgraph-core/src/pregel/loop.ts
@@ -1,7 +1,7 @@
 import type { RunnableConfig } from "@langchain/core/runnables";
 import type { CallbackManagerForChainRun } from "@langchain/core/callbacks/manager";
 import { BaseMessage } from "@langchain/core/messages";
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4 } from "@langchain/core/utils/uuid";
 import {
   BaseCheckpointSaver,
   Checkpoint,
@@ -442,7 +442,7 @@ export class PregelLoop {
       this.config.metadata?.run_id !== undefined &&
       (this.checkpointMetadata as { run_id?: unknown })?.run_id !== undefined &&
       this.config.metadata.run_id ===
-        (this.checkpointMetadata as { run_id?: unknown })?.run_id;
+      (this.checkpointMetadata as { run_id?: unknown })?.run_id;
 
     return (
       hasChannelVersions &&
@@ -560,13 +560,13 @@ export class PregelLoop {
       config.configurable?.checkpoint_id === undefined &&
       config.configurable?.[CONFIG_KEY_CHECKPOINT_MAP] !== undefined &&
       config.configurable?.[CONFIG_KEY_CHECKPOINT_MAP]?.[
-        config.configurable?.checkpoint_ns
+      config.configurable?.checkpoint_ns
       ]
     ) {
       checkpointConfig = patchConfigurable(config, {
         checkpoint_id:
           config.configurable[CONFIG_KEY_CHECKPOINT_MAP][
-            config.configurable?.checkpoint_ns
+          config.configurable?.checkpoint_ns
           ],
       });
     }
@@ -1420,7 +1420,7 @@ export class PregelLoop {
         configurable?.[CONFIG_KEY_CHECKPOINT_NS] !== "" &&
         configurable?.[CONFIG_KEY_CHECKPOINT_MAP] !== undefined &&
         configurable[CONFIG_KEY_CHECKPOINT_NS] in
-          configurable[CONFIG_KEY_CHECKPOINT_MAP]) ||
+        configurable[CONFIG_KEY_CHECKPOINT_MAP]) ||
         !(
           (inputIsCommand && (this.input as Command).resume != null) ||
           configurable?.[CONFIG_KEY_RESUMING] === true ||
@@ -1559,7 +1559,7 @@ export class PregelLoop {
         ) {
           replayCheckpointId =
             this.prevCheckpointConfig.configurable?.[
-              CONFIG_KEY_CHECKPOINT_ID
+            CONFIG_KEY_CHECKPOINT_ID
             ] ?? replayCheckpointId;
         }
         replayState = new ReplayState(replayCheckpointId);
@@ -1583,8 +1583,8 @@ export class PregelLoop {
     }
     const deepest = deepestCheckpointMapNamespace(
       this.config.configurable?.[CONFIG_KEY_CHECKPOINT_MAP] as
-        | Record<string, string>
-        | undefined
+      | Record<string, string>
+      | undefined
     );
     return deepest.length > 0 ? deepest : ns;
   }
@@ -1768,7 +1768,7 @@ export class PregelLoop {
         updatedChannels: this.updatedChannels,
         getNextVersion: doCheckpoint
           ? (current) =>
-              this.checkpointerGetNextVersion(current as number | undefined)
+            this.checkpointerGetNextVersion(current as number | undefined)
           : undefined,
       }
     );

--- a/libs/langgraph-core/src/tests/pregel/pregel.cancellation.test.ts
+++ b/libs/langgraph-core/src/tests/pregel/pregel.cancellation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4 } from "@langchain/core/utils/uuid";
 import {
   Annotation,
   Command,

--- a/libs/langgraph-core/src/tests/python_port/checkpoint.test.ts
+++ b/libs/langgraph-core/src/tests/python_port/checkpoint.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4 } from "@langchain/core/utils/uuid";
 import { RunnableConfig } from "@langchain/core/runnables";
 import {
   AIMessage,

--- a/libs/langgraph-core/src/tests/utils.models.ts
+++ b/libs/langgraph-core/src/tests/utils.models.ts
@@ -19,7 +19,7 @@ import {
 } from "@langchain/core/messages";
 import { ChatResult, ChatGenerationChunk } from "@langchain/core/outputs";
 import { RunnableLambda } from "@langchain/core/runnables";
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4 } from "@langchain/core/utils/uuid";
 
 export interface FakeChatModelArgs extends BaseChatModelParams {
   responses: BaseMessage[];

--- a/libs/langgraph-supervisor/package.json
+++ b/libs/langgraph-supervisor/package.json
@@ -27,7 +27,6 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "uuid": "^14.0.0",
     "zod": "^3.25.76 || ^4"
   },
   "peerDependencies": {

--- a/libs/langgraph-supervisor/package.json
+++ b/libs/langgraph-supervisor/package.json
@@ -30,7 +30,7 @@
     "zod": "^3.25.76 || ^4"
   },
   "peerDependencies": {
-    "@langchain/core": "^1.1.44",
+    "@langchain/core": "^1.1.48",
     "@langchain/langgraph": "^1.3.1-rc.0"
   },
   "devDependencies": {

--- a/libs/langgraph-supervisor/src/handoff.ts
+++ b/libs/langgraph-supervisor/src/handoff.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4 } from "@langchain/core/utils/uuid";
 import { z } from "zod";
 import { AIMessage, ToolMessage } from "@langchain/core/messages";
 import { tool } from "@langchain/core/tools";

--- a/libs/langgraph-supervisor/src/supervisor.ts
+++ b/libs/langgraph-supervisor/src/supervisor.ts
@@ -128,12 +128,12 @@ export type CreateSupervisorParams<
    */
   agents: (
     | CompiledStateGraph<
-      AnnotationRootT["State"],
-      AnnotationRootT["Update"],
-      string,
-      AnnotationRootT["spec"],
-      AnnotationRootT["spec"]
-    >
+        AnnotationRootT["State"],
+        AnnotationRootT["Update"],
+        string,
+        AnnotationRootT["spec"],
+        AnnotationRootT["spec"]
+      >
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     | CompiledStateGraph<any, any, string, any, any>
     | RemoteGraph
@@ -177,14 +177,14 @@ export type CreateSupervisorParams<
    * This is not the only strategy to get structured responses, see more options in [this guide](https://langchain-ai.github.io/langgraph/how-tos/react-agent-structured-output/).
    */
   responseFormat?:
-  | InteropZodType<StructuredResponseFormat>
-  | {
-    prompt: string;
-    schema:
     | InteropZodType<StructuredResponseFormat>
+    | {
+        prompt: string;
+        schema:
+          | InteropZodType<StructuredResponseFormat>
+          | Record<string, unknown>;
+      }
     | Record<string, unknown>;
-  }
-  | Record<string, unknown>;
 
   /**
    * State schema to use for the supervisor graph
@@ -316,7 +316,7 @@ const createSupervisor = <
     if (!agent.name || agent.name === "LangGraph") {
       throw new Error(
         "Please specify a name when you create your agent, either via `createReactAgent({ ..., name: agentName })` " +
-        "or via `graph.compile({ name: agentName })`."
+          "or via `graph.compile({ name: agentName })`."
       );
     }
 

--- a/libs/langgraph-supervisor/src/supervisor.ts
+++ b/libs/langgraph-supervisor/src/supervisor.ts
@@ -24,7 +24,7 @@ import {
   BindToolsInput,
 } from "@langchain/core/language_models/chat_models";
 import type { RemoteGraph } from "@langchain/langgraph/remote";
-import { v5 as uuidv5 } from "uuid";
+import { v5 as uuidv5 } from "@langchain/core/utils/uuid";
 import { createHandoffTool, createHandoffBackMessages } from "./handoff.js";
 
 export type { AgentNameMode };
@@ -128,12 +128,12 @@ export type CreateSupervisorParams<
    */
   agents: (
     | CompiledStateGraph<
-        AnnotationRootT["State"],
-        AnnotationRootT["Update"],
-        string,
-        AnnotationRootT["spec"],
-        AnnotationRootT["spec"]
-      >
+      AnnotationRootT["State"],
+      AnnotationRootT["Update"],
+      string,
+      AnnotationRootT["spec"],
+      AnnotationRootT["spec"]
+    >
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     | CompiledStateGraph<any, any, string, any, any>
     | RemoteGraph
@@ -177,14 +177,14 @@ export type CreateSupervisorParams<
    * This is not the only strategy to get structured responses, see more options in [this guide](https://langchain-ai.github.io/langgraph/how-tos/react-agent-structured-output/).
    */
   responseFormat?:
+  | InteropZodType<StructuredResponseFormat>
+  | {
+    prompt: string;
+    schema:
     | InteropZodType<StructuredResponseFormat>
-    | {
-        prompt: string;
-        schema:
-          | InteropZodType<StructuredResponseFormat>
-          | Record<string, unknown>;
-      }
     | Record<string, unknown>;
+  }
+  | Record<string, unknown>;
 
   /**
    * State schema to use for the supervisor graph
@@ -316,7 +316,7 @@ const createSupervisor = <
     if (!agent.name || agent.name === "LangGraph") {
       throw new Error(
         "Please specify a name when you create your agent, either via `createReactAgent({ ..., name: agentName })` " +
-          "or via `graph.compile({ name: agentName })`."
+        "or via `graph.compile({ name: agentName })`."
       );
     }
 

--- a/libs/langgraph-supervisor/src/tests/supervisorRemote.test.ts
+++ b/libs/langgraph-supervisor/src/tests/supervisorRemote.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { HumanMessage, AIMessage } from "@langchain/core/messages";
-import { v5 as uuidv5 } from "uuid";
+import { v5 as uuidv5 } from "@langchain/core/utils/uuid";
 import { RemoteGraph } from "@langchain/langgraph/remote";
 import { createReactAgent, ToolNode } from "@langchain/langgraph/prebuilt";
 import { createSupervisor } from "../supervisor.js";

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -22,8 +22,7 @@
     "@langchain/protocol": "^0.0.16",
     "@types/json-schema": "^7.0.15",
     "p-queue": "^9.0.1",
-    "p-retry": "^7.1.1",
-    "uuid": "^14.0.0"
+    "p-retry": "^7.1.1"
   },
   "devDependencies": {
     "@langchain/core": "^1.1.48",
@@ -32,7 +31,6 @@
     "@types/node": "^18.15.11",
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
-    "@types/uuid": "^9.0.1",
     "@types/ws": "^8.18.1",
     "deepagents": "^1.8.3",
     "langchain": "^1.4.4",

--- a/libs/sdk/src/client/threads/index.ts
+++ b/libs/sdk/src/client/threads/index.ts
@@ -1,4 +1,4 @@
-import { v7 as uuidv7 } from "uuid";
+import { v7 as uuidv7 } from "@langchain/core/utils/uuid";
 
 import {
   Checkpoint,
@@ -474,9 +474,9 @@ export class ThreadsClient<
     const { threadId, options } =
       typeof threadIdOrOptions === "string"
         ? {
-            threadId: threadIdOrOptions,
-            options: maybeOptions as ThreadStreamOptions,
-          }
+          threadId: threadIdOrOptions,
+          options: maybeOptions as ThreadStreamOptions,
+        }
         : { threadId: uuidv7(), options: threadIdOrOptions };
 
     // `transport` accepts either a preset string (`"sse"` / `"websocket"`)
@@ -515,14 +515,14 @@ export class ThreadsClient<
       transport =
         transportKind === "websocket"
           ? new ProtocolWebSocketTransportAdapter({
-              ...commonOpts,
-              webSocketFactory: options.webSocketFactory,
-            })
+            ...commonOpts,
+            webSocketFactory: options.webSocketFactory,
+          })
           : new ProtocolSseTransportAdapter({
-              ...commonOpts,
-              fetch: userFetch,
-              asyncCaller: userFetch ? undefined : this.asyncCaller,
-            });
+            ...commonOpts,
+            fetch: userFetch,
+            asyncCaller: userFetch ? undefined : this.asyncCaller,
+          });
     }
 
     return new ThreadStream<TExtensions>(transport, {

--- a/libs/sdk/src/client/threads/index.ts
+++ b/libs/sdk/src/client/threads/index.ts
@@ -474,9 +474,9 @@ export class ThreadsClient<
     const { threadId, options } =
       typeof threadIdOrOptions === "string"
         ? {
-          threadId: threadIdOrOptions,
-          options: maybeOptions as ThreadStreamOptions,
-        }
+            threadId: threadIdOrOptions,
+            options: maybeOptions as ThreadStreamOptions,
+          }
         : { threadId: uuidv7(), options: threadIdOrOptions };
 
     // `transport` accepts either a preset string (`"sse"` / `"websocket"`)
@@ -515,14 +515,14 @@ export class ThreadsClient<
       transport =
         transportKind === "websocket"
           ? new ProtocolWebSocketTransportAdapter({
-            ...commonOpts,
-            webSocketFactory: options.webSocketFactory,
-          })
+              ...commonOpts,
+              webSocketFactory: options.webSocketFactory,
+            })
           : new ProtocolSseTransportAdapter({
-            ...commonOpts,
-            fetch: userFetch,
-            asyncCaller: userFetch ? undefined : this.asyncCaller,
-          });
+              ...commonOpts,
+              fetch: userFetch,
+              asyncCaller: userFetch ? undefined : this.asyncCaller,
+            });
     }
 
     return new ThreadStream<TExtensions>(transport, {

--- a/libs/sdk/src/react-ui/server/server.ts
+++ b/libs/sdk/src/react-ui/server/server.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuidv4 } from "@langchain/core/utils/uuid";
 import type { ComponentPropsWithoutRef, ElementType } from "react";
 import type { RemoveUIMessage, UIMessage } from "../types.js";
 

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -20,7 +20,7 @@
  * one extra subscription per `(channels, namespace)` actually
  * rendered on screen.
  */
-import { v7 as uuidv7 } from "uuid";
+import { v7 as uuidv7 } from "@langchain/core/utils/uuid";
 import { AIMessage, type BaseMessage } from "@langchain/core/messages";
 import type {
   Channel,
@@ -588,12 +588,12 @@ export class StreamController<
         const syntheticCheckpoint =
           typeof checkpointId === "string"
             ? {
-                id: checkpointId,
-                ...(parentCheckpointId != null
-                  ? { parent_id: parentCheckpointId }
-                  : {}),
-                ...(typeof seedStep === "number" ? { step: seedStep } : {}),
-              }
+              id: checkpointId,
+              ...(parentCheckpointId != null
+                ? { parent_id: parentCheckpointId }
+                : {}),
+              ...(typeof seedStep === "number" ? { step: seedStep } : {}),
+            }
             : undefined;
         this.#applyValues(state.values as unknown, syntheticCheckpoint);
 
@@ -1269,9 +1269,9 @@ export class StreamController<
     const resolved =
       options?.interruptId != null
         ? {
-            interruptId: options.interruptId,
-            namespace: options.namespace ?? [...ROOT_NAMESPACE],
-          }
+          interruptId: options.interruptId,
+          namespace: options.namespace ?? [...ROOT_NAMESPACE],
+        }
         : this.#resolveInterruptForResume();
     if (resolved == null) {
       throw new Error("No pending interrupt to respond to.");

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -588,12 +588,12 @@ export class StreamController<
         const syntheticCheckpoint =
           typeof checkpointId === "string"
             ? {
-              id: checkpointId,
-              ...(parentCheckpointId != null
-                ? { parent_id: parentCheckpointId }
-                : {}),
-              ...(typeof seedStep === "number" ? { step: seedStep } : {}),
-            }
+                id: checkpointId,
+                ...(parentCheckpointId != null
+                  ? { parent_id: parentCheckpointId }
+                  : {}),
+                ...(typeof seedStep === "number" ? { step: seedStep } : {}),
+              }
             : undefined;
         this.#applyValues(state.values as unknown, syntheticCheckpoint);
 
@@ -1269,9 +1269,9 @@ export class StreamController<
     const resolved =
       options?.interruptId != null
         ? {
-          interruptId: options.interruptId,
-          namespace: options.namespace ?? [...ROOT_NAMESPACE],
-        }
+            interruptId: options.interruptId,
+            namespace: options.namespace ?? [...ROOT_NAMESPACE],
+          }
         : this.#resolveInterruptForResume();
     if (resolved == null) {
       throw new Error("No pending interrupt to respond to.");

--- a/libs/sdk/src/stream/submit-coordinator.ts
+++ b/libs/sdk/src/stream/submit-coordinator.ts
@@ -53,7 +53,7 @@
  *
  * @see StreamController - The owner; injects every collaborator dep.
  */
-import { v7 as uuidv7 } from "uuid";
+import { v7 as uuidv7 } from "@langchain/core/utils/uuid";
 import type { ThreadStream } from "../client/stream/index.js";
 import { StreamStore } from "./store.js";
 import type { OptimisticHandle } from "./optimistic-input.js";

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "pnpm": {
     "overrides": {
-      "@langchain/core": "^1.1.44",
+      "@langchain/core": "^1.1.48",
       "langchain": "1.4.0-dev-1777615538778",
       "@examples/streaming>langchain": "1.4.0-dev-1777615538778",
       "@examples/ui-react>langchain": "1.4.0-dev-1777615538778",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@langchain/core': ^1.1.44
+  '@langchain/core': ^1.1.48
   langchain: 1.4.0-dev-1777615538778
   '@examples/streaming>langchain': 1.4.0-dev-1777615538778
   '@examples/ui-react>langchain': 1.4.0-dev-1777615538778
@@ -114,7 +114,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:*
@@ -138,7 +138,7 @@ importers:
   examples/ai-elements:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:*
@@ -277,7 +277,7 @@ importers:
         specifier: ^0.12.5
         version: 0.12.5(@assistant-ui/react@0.12.17(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)))(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:*
@@ -347,7 +347,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:*
@@ -374,7 +374,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/groq':
         specifier: ^1.2.1
@@ -440,7 +440,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/groq':
         specifier: ^1.2.1
@@ -506,7 +506,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/groq':
         specifier: ^1.2.1
@@ -572,7 +572,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/groq':
         specifier: ^1.2.1
@@ -638,7 +638,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/groq':
         specifier: ^1.2.1
@@ -704,7 +704,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/groq':
         specifier: ^1.2.1
@@ -770,7 +770,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/groq':
         specifier: ^1.2.1
@@ -836,7 +836,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/groq':
         specifier: ^1.2.1
@@ -902,7 +902,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/groq':
         specifier: ^1.2.1
@@ -968,7 +968,7 @@ importers:
         specifier: ^1.0.34
         version: 1.0.34(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(cheerio@1.2.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(typeorm@0.3.28(better-sqlite3@12.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1))(ws@8.21.0)
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:*
@@ -1007,7 +1007,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:*
@@ -1058,7 +1058,7 @@ importers:
         specifier: workspace:*
         version: link:../../libs/sdk-angular
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:*
@@ -1101,7 +1101,7 @@ importers:
   examples/ui-multimodal:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:*
@@ -1180,7 +1180,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:*
@@ -1247,7 +1247,7 @@ importers:
         specifier: ^1.19.13
         version: 1.19.13(hono@4.12.23)
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:*
@@ -1296,7 +1296,7 @@ importers:
   examples/ui-svelte:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:*
@@ -1336,7 +1336,7 @@ importers:
   examples/ui-vue:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:*
@@ -1382,7 +1382,7 @@ importers:
   internal/bench:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:*
@@ -1473,7 +1473,7 @@ importers:
   libs/checkpoint:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
     devDependencies:
       '@langchain/scripts':
@@ -1504,7 +1504,7 @@ importers:
   libs/checkpoint-mongodb:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       mongodb:
         specifier: ^6.21.0
@@ -1544,7 +1544,7 @@ importers:
   libs/checkpoint-postgres:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       pg:
         specifier: ^8.12.0
@@ -1584,7 +1584,7 @@ importers:
   libs/checkpoint-redis:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       redis:
         specifier: ^4.7.0
@@ -1627,7 +1627,7 @@ importers:
   libs/checkpoint-sqlite:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       better-sqlite3:
         specifier: ^12.10.0
@@ -1667,7 +1667,7 @@ importers:
   libs/checkpoint-validation:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       vitest:
         specifier: ^4.1.0
@@ -1774,7 +1774,7 @@ importers:
   libs/langgraph:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:*
@@ -1866,7 +1866,7 @@ importers:
         version: 4.3.6
     devDependencies:
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:*
@@ -2015,7 +2015,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       '@langchain/langgraph-checkpoint-postgres':
         specifier: workspace:*
@@ -2093,7 +2093,7 @@ importers:
   libs/langgraph-cua:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       scrapybara:
         specifier: ^2.4.4
@@ -2139,7 +2139,7 @@ importers:
   libs/langgraph-supervisor:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       zod:
         specifier: ^4.3.5
@@ -2179,7 +2179,7 @@ importers:
   libs/langgraph-swarm:
     dependencies:
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       zod:
         specifier: ^4.3.5
@@ -2266,7 +2266,7 @@ importers:
         version: 7.1.1
     devDependencies:
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)
       '@langchain/scripts':
         specifier: ^0.1.4
@@ -2351,7 +2351,7 @@ importers:
         specifier: ^1.3.0
         version: 1.3.1(@hono/node-server@2.0.1(hono@4.12.23))(hono@4.12.23)
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:^
@@ -2418,7 +2418,7 @@ importers:
         specifier: ^1.3.0
         version: 1.3.1(@hono/node-server@1.19.13(hono@4.12.23))(hono@4.12.23)
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:^
@@ -2485,7 +2485,7 @@ importers:
         specifier: ^1.3.0
         version: 1.3.1(@hono/node-server@1.19.13(hono@4.12.23))(hono@4.12.23)
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:^
@@ -2549,7 +2549,7 @@ importers:
         specifier: ^1.3.0
         version: 1.3.1(@hono/node-server@1.19.13(hono@4.12.23))(hono@4.12.23)
       '@langchain/core':
-        specifier: ^1.1.44
+        specifier: ^1.1.48
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph':
         specifier: workspace:*
@@ -4049,13 +4049,13 @@ packages:
     resolution: {integrity: sha512-rs1yVydrHjyiD31uChdCnKZpmDuKa0Bpz8Raiy9GvqnqmfXPMe0oOrap/2paE+NRSinDbtax8mMpP/yv8EbO1A==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.1.44
+      '@langchain/core': ^1.1.48
 
   '@langchain/classic@1.0.34':
     resolution: {integrity: sha512-4VG+3QRFBDwYWW4UdVDsbUoeaeTo0XED7wYkeZDc4wa3ZlP4r6GJ/KZlQfHq2AS+CxjW8OQZw2ha6tESesjawQ==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.1.44
+      '@langchain/core': ^1.1.48
       cheerio: ^1.0.0-rc.12
       peggy: ^5.1.0
       typeorm: '*'
@@ -4075,13 +4075,13 @@ packages:
     resolution: {integrity: sha512-K3QK3lVTUqxheA9u8upwN0cu04cySyaoKRmnN3vp5fEWQjzm08TYEv6FypyVEcEx0ZzBrHaYKsZIZKZSINN3RQ==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.1.44
+      '@langchain/core': ^1.1.48
 
   '@langchain/langgraph@1.2.1':
     resolution: {integrity: sha512-OeLMejye1DZeZBPnurus2bqvjRi+pyrqfAXX77hYdUqKeQ3hAG7pLG04xdrvMs0pl/F57ZtwywqoE2oVqcI6JA==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': ^1.1.44
+      '@langchain/core': ^1.1.48
       zod: ^4.3.5
       zod-to-json-schema: ^3.x
     peerDependenciesMeta:
@@ -4092,7 +4092,7 @@ packages:
     resolution: {integrity: sha512-3c7BtGycHC2v9p6w/Hv8L7kEl1YnZYOQTDJtmAp3knk6JOedO7d2bYP3y0SRyhv5orUEGf/KGvx8ZsB/ideP7g==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': ^1.1.44
+      '@langchain/core': ^1.1.48
       zod: ^4.3.5
       zod-to-json-schema: ^3.x
     peerDependenciesMeta:
@@ -4104,7 +4104,7 @@ packages:
     version: 1.2.9
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': ^1.1.44
+      '@langchain/core': ^1.1.48
       zod: ^4.3.5
       zod-to-json-schema: ^3.x
     peerDependenciesMeta:
@@ -4115,19 +4115,19 @@ packages:
     resolution: {integrity: sha512-MUGLKgJbfH81UIvvKLRHmMZxWnyg6qPTeiXnIu3zbzjJR456W5eWOWjr4LLuXIRTy1hRxX+mZZHyqHu4Bkq+0Q==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.1.44
+      '@langchain/core': ^1.1.48
 
   '@langchain/ollama@1.2.7':
     resolution: {integrity: sha512-7Gu17q1dn4nKGB3ZYJyaaL8H/2k7LHvcL6V25S8cVDniTTSvd0fWzI5MzPJvbf9WPxBhvmf+rDDLAhOWljHEtQ==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.1.44
+      '@langchain/core': ^1.1.48
 
   '@langchain/openai@1.4.7':
     resolution: {integrity: sha512-i1YLV4pWbGC6W8m0ZNpLObJuf1nyU4o8aWyX4AF9fHn7eM67HfIJWQ5n5XzcCpuSa41otrxA9jvH5XRKwI1qDA==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.1.44
+      '@langchain/core': ^1.1.48
 
   '@langchain/protocol@0.0.15':
     resolution: {integrity: sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==}
@@ -4150,13 +4150,13 @@ packages:
     resolution: {integrity: sha512-aPLPgtw8+b/Rnr3H+X8H8z98T/Y7JuCE4B5eqRDHoEWgZvMDUFF7divqwQqCTMq2deQttlVrm5bN5JbKaAR7/w==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.1.44
+      '@langchain/core': ^1.1.48
 
   '@langchain/textsplitters@1.0.1':
     resolution: {integrity: sha512-rheJlB01iVtrOUzttscutRgLybPH9qR79EyzBEbf1u97ljWyuxQfCwIWK+SjoQTM9O8M7GGLLRBSYE26Jmcoww==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.1.44
+      '@langchain/core': ^1.1.48
 
   '@listr2/prompt-adapter-inquirer@4.2.3':
     resolution: {integrity: sha512-Co9U3AJ3LW0J8XBHjVoNKA79dMAyFt8EZH3OaKTMcDTj8r+6kG3vSUPq/eGLHT7P0iK3uLaFfhdFYd3033P24g==}
@@ -9665,7 +9665,7 @@ packages:
     resolution: {integrity: sha512-QUuTkv3A7sws6Jxj68E907RlzSFmMtFWhHp1/kdK7n8l69GELXXzPW246EHbnNK2jIL9L6XXfOPbQ8QgonL/jQ==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.1.44
+      '@langchain/core': ^1.1.48
 
   langsmith@0.6.0:
     resolution: {integrity: sha512-GGaj5IMRfLv2HXXFzGk9diISMYLTpSTh6fzCZGKxWYW/NqEztIFtnXLq6G/RVhzFRmCykLap1fuC67LVKoQLcg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1475,9 +1475,6 @@ importers:
       '@langchain/core':
         specifier: ^1.1.44
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
-      uuid:
-        specifier: ^14.0.0
-        version: 14.0.0
     devDependencies:
       '@langchain/scripts':
         specifier: '>=0.1.3 <0.2.0'
@@ -1485,9 +1482,6 @@ importers:
       '@tsconfig/recommended':
         specifier: ^1.0.3
         version: 1.0.13
-      '@types/uuid':
-        specifier: ^10
-        version: 10.0.0
       dotenv:
         specifier: ^16.3.1
         version: 16.6.1
@@ -1528,9 +1522,6 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.12
         version: 7.6.13
-      '@types/uuid':
-        specifier: ^10
-        version: 10.0.0
       dotenv:
         specifier: ^16.3.1
         version: 16.6.1
@@ -1571,9 +1562,6 @@ importers:
       '@types/pg':
         specifier: ^8.11.8
         version: 8.18.0
-      '@types/uuid':
-        specifier: ^10
-        version: 10.0.0
       dotenv:
         specifier: ^16.3.1
         version: 16.6.1
@@ -1601,9 +1589,6 @@ importers:
       redis:
         specifier: ^4.7.0
         version: 4.7.1
-      uuid:
-        specifier: ^14.0.0
-        version: 14.0.0
     devDependencies:
       '@langchain/langgraph-checkpoint':
         specifier: workspace:*
@@ -1660,9 +1645,6 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.12
         version: 7.6.13
-      '@types/uuid':
-        specifier: ^10
-        version: 10.0.0
       dotenv:
         specifier: ^16.3.1
         version: 16.6.1
@@ -1724,9 +1706,6 @@ importers:
       '@tsconfig/recommended':
         specifier: ^1.0.3
         version: 1.0.13
-      '@types/uuid':
-        specifier: ^10
-        version: 10.0.0
       '@types/yargs':
         specifier: ^17.0.33
         version: 17.0.35
@@ -1876,9 +1855,6 @@ importers:
       tsx:
         specifier: ^4.19.3
         version: 4.21.0
-      uuid:
-        specifier: ^14.0.0
-        version: 14.0.0
       winston:
         specifier: ^3.17.0
         version: 3.19.0
@@ -1916,9 +1892,6 @@ importers:
       '@types/semver':
         specifier: ^7.7.0
         version: 7.7.1
-      '@types/uuid':
-        specifier: ^10.0.0
-        version: 10.0.0
       deepagents:
         specifier: ^1.9.0
         version: 1.9.1(@opentelemetry/api@1.9.0)(langsmith@0.7.4(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
@@ -2034,9 +2007,6 @@ importers:
       '@standard-schema/spec':
         specifier: 1.1.0
         version: 1.1.0
-      uuid:
-        specifier: ^14.0.0
-        version: 14.0.0
       zod:
         specifier: ^4.3.5
         version: 4.4.3
@@ -2074,9 +2044,6 @@ importers:
       '@types/pg':
         specifier: ^8
         version: 8.18.0
-      '@types/uuid':
-        specifier: ^10
-        version: 10.0.0
       '@vitest/browser':
         specifier: ^4.1.8
         version: 4.1.8(msw@2.12.10(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.99.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.8)
@@ -2174,9 +2141,6 @@ importers:
       '@langchain/core':
         specifier: ^1.1.44
         version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
-      uuid:
-        specifier: ^14.0.0
-        version: 14.0.0
       zod:
         specifier: ^4.3.5
         version: 4.3.6
@@ -2300,13 +2264,10 @@ importers:
       p-retry:
         specifier: ^7.1.1
         version: 7.1.1
-      uuid:
-        specifier: ^14.0.0
-        version: 14.0.0
     devDependencies:
       '@langchain/core':
         specifier: ^1.1.44
-        version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
+        version: 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)
       '@langchain/scripts':
         specifier: ^0.1.4
         version: 0.1.4
@@ -2322,18 +2283,15 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.16)
-      '@types/uuid':
-        specifier: ^9.0.1
-        version: 9.0.8
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
       deepagents:
         specifier: ^1.8.3
-        version: 1.8.3(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
+        version: 1.8.3(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)(zod-to-json-schema@3.25.2(zod@4.3.6))
       langchain:
         specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
+        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)(zod-to-json-schema@3.25.2(zod@4.3.6))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -7123,12 +7081,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/uuid@10.0.0':
-    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
-
-  '@types/uuid@9.0.8':
-    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
   '@types/webidl-conversions@7.0.3':
     resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
@@ -14500,6 +14452,22 @@ snapshots:
       - openai
       - ws
 
+  '@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      '@standard-schema/spec': 1.1.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.7.4(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+
   '@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
@@ -14553,6 +14521,17 @@ snapshots:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       groq-sdk: 1.2.1
 
+  '@langchain/langgraph@1.2.1(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.4.2)':
+    dependencies:
+      '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)
+      '@langchain/langgraph-checkpoint': link:libs/checkpoint
+      '@langchain/langgraph-sdk': link:libs/sdk
+      '@standard-schema/spec': 1.1.0
+      uuid: 10.0.0
+      zod: 4.4.2
+    optionalDependencies:
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+
   '@langchain/langgraph@1.2.1(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.4.2)':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
@@ -14586,6 +14565,18 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       zod-to-json-schema: 3.25.1(zod@4.3.6)
+
+  '@langchain/langgraph@https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)':
+    dependencies:
+      '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)
+      '@langchain/langgraph-checkpoint': link:libs/checkpoint
+      '@langchain/langgraph-sdk': link:libs/sdk
+      '@langchain/protocol': 0.0.15
+      '@standard-schema/spec': 1.1.0
+      uuid: 10.0.0
+      zod: 4.3.6
+    optionalDependencies:
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
 
   '@langchain/langgraph@https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)':
     dependencies:
@@ -17317,10 +17308,6 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@types/uuid@10.0.0': {}
-
-  '@types/uuid@9.0.8': {}
-
   '@types/webidl-conversions@7.0.3': {}
 
   '@types/whatwg-url@11.0.5':
@@ -19230,6 +19217,23 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deepagents@1.8.3(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)(zod-to-json-schema@3.25.2(zod@4.3.6)):
+    dependencies:
+      '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)
+      '@langchain/langgraph': 1.2.1(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.4.2)
+      fast-glob: 3.3.3
+      langchain: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)(zod-to-json-schema@3.25.2(zod@4.3.6))
+      micromatch: 4.0.8
+      yaml: 2.8.3
+      zod: 4.4.2
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+      - zod-to-json-schema
+
   deepagents@1.8.3(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6)):
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
@@ -20736,6 +20740,21 @@ snapshots:
       - ws
       - zod-to-json-schema
 
+  langchain@1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)(zod-to-json-schema@3.25.2(zod@4.3.6)):
+    dependencies:
+      '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)
+      '@langchain/langgraph': https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
+      '@langchain/langgraph-checkpoint': link:libs/checkpoint
+      langsmith: 0.7.4(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1)
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+      - zod-to-json-schema
+
   langchain@1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6)):
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
@@ -20812,6 +20831,14 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       openai: 4.104.0(ws@8.21.0)(zod@4.3.6)
       ws: 8.21.0
+
+  langsmith@0.7.4(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.20.1)(zod@4.3.6))(ws@8.20.1):
+    dependencies:
+      p-queue: 6.6.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      openai: 6.42.0(ws@8.20.1)(zod@4.3.6)
+      ws: 8.20.1
 
   langsmith@0.7.4(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0):
     dependencies:
@@ -22074,6 +22101,12 @@ snapshots:
       zod: 4.3.6
     transitivePeerDependencies:
       - encoding
+
+  openai@6.42.0(ws@8.20.1)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.20.1
+      zod: 4.3.6
+    optional: true
 
   openai@6.42.0(ws@8.21.0)(zod@4.3.6):
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Remove the direct `uuid` npm dependency from `@langchain/langgraph`, `@langchain/langgraph-checkpoint`, `@langchain/langgraph-checkpoint-redis`, `@langchain/langgraph-api`, `@langchain/langgraph-supervisor`, and `@langchain/langgraph-sdk`.
- Switch all UUID generation and validation to `@langchain/core/utils/uuid` (v4, v5, v6, v7, and `validate`).
- Drop unused `@types/uuid` devDependencies from checkpoint backend packages that no longer reference `uuid` directly.

fixes #2481