### PR TITLE
fix(sdk): late-bind threadId on custom AgentServerAdapter transports

### DIFF
--- a/.changeset/late-bound-transport-thread-id.md
+++ b/.changeset/late-bound-transport-thread-id.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+Allow custom `AgentServerAdapter`s to be late-bound and re-bound to a thread. Adapters can now implement an optional `setThreadId(threadId)`, which `client.threads.stream(threadId, { transport })` calls when binding the active thread — including the lazily-minted id from the first `submit()` on a `threadId: null` controller. The built-in `ProtocolSseTransportAdapter`, `ProtocolWebSocketTransportAdapter`, and `HttpAgentServerAdapter` implement it: `threadId` is now optional at construction, request URLs derive from the currently-bound thread, and `paths` entries may be functions of the thread id (`(threadId) => string`). This lets a single custom transport back a lazy thread-creation flow instead of being pinned to one thread at construction.

--- a/libs/sdk-angular/docs/README.md
+++ b/libs/sdk-angular/docs/README.md
@@ -38,6 +38,8 @@ interactive agent workflows.
 - [`transports.md`](./transports.md) compares the built-in LangGraph Platform
   transports and custom adapters.
 - [`custom-transport.md`](./custom-transport.md) is the detailed guide for
-  implementing custom transport layers.
+  pointing `injectStream` at a custom backend — `HttpAgentServerAdapter`,
+  server-side protocol handling, lazy thread binding, and implementing
+  `AgentServerAdapter` directly.
 - [`v1-migration.md`](./v1-migration.md) explains how to migrate from earlier
   Angular SDK APIs to v1.

--- a/libs/sdk-angular/docs/custom-transport.md
+++ b/libs/sdk-angular/docs/custom-transport.md
@@ -114,6 +114,64 @@ construction in a field initializer, provider, or other one-time
 setup. Recreating it in an `effect` without cleanup closes the old
 stream and opens a new one.
 
+## Binding To A Thread
+
+The examples above bake a fixed `threadId` into the adapter and its
+`paths`. That is fine for a single-thread local demo, but a real
+multi-thread backend should let the framework **bind the thread**
+instead.
+
+`HttpAgentServerAdapter` — and any `AgentServerAdapter` that implements
+the optional `setThreadId` — can be constructed **without** a `threadId`.
+When you pass it to `injectStream` / `provideStream`, the framework calls
+`transport.setThreadId(threadId)` before each run, including the id the
+SDK mints on the first `submit()` of a brand-new thread (`threadId:
+null`). To make a re-bound adapter target the right thread, write `paths`
+as **functions of the thread id** rather than fixed strings:
+
+```typescript
+import { Component, signal } from "@angular/core";
+import { HttpAgentServerAdapter, injectStream } from "@langchain/angular";
+
+@Component({
+  standalone: true,
+  selector: "app-chat",
+  template: `<!-- … -->`,
+})
+export class ChatComponent {
+  // Start at `null`; the SDK mints the id on the first submit and reports
+  // it via `onThreadId`, which you store so later runs stay bound.
+  readonly threadId = signal<string | null>(null);
+
+  readonly stream = injectStream<GraphType>({
+    transport: new HttpAgentServerAdapter({
+      apiUrl: window.location.origin,
+      // No `threadId` — the framework binds it via `setThreadId`.
+      paths: {
+        commands: (id) => `/api/threads/${id}/commands`,
+        stream: (id) => `/api/threads/${id}/stream`,
+      },
+    }),
+    threadId: this.threadId,
+    onThreadId: (id) => this.threadId.set(id),
+  });
+}
+```
+
+A fixed-string path (the form used in
+[Client Setup In Angular](#client-setup-in-angular)) is still honored
+verbatim and is independent of the bound thread — use it only when the
+adapter never moves off a single thread.
+
+### Switching Between Existing Threads
+
+Lazy binding covers the create-a-new-thread flow. Switching a single
+provider between **different existing** threads tears down the previous
+stream — which closes the transport — so one long-lived instance cannot
+be reused across an existing-thread switch; give the adapter a fresh
+identity per thread instead. Creating a thread and staying on it never
+tears down, so lazy creation is unaffected.
+
 ## Updated Example Architecture
 
 On the server, `CustomGraphServer` owns a `LocalThreadSession` per
@@ -350,14 +408,19 @@ custom browser adapter that knows how to reverse that transformation.
 
 ## `HttpAgentServerAdapter` Options
 
-Use `paths` when your backend routes do not live at the default
-`/threads/:threadId/...` paths:
+`threadId` is optional. Omit it to let the framework bind the thread via
+`setThreadId` (see [Binding To A Thread](#binding-to-a-thread)). Use
+`paths` when your backend routes do not live at the default
+`/threads/:threadId/...` paths. Each path is `string | (threadId =>
+string)` — pass a function when the adapter is bound lazily so the URL
+follows the bound thread:
 
 ```ts
 const transport = new HttpAgentServerAdapter({
   apiUrl: window.location.origin,
-  threadId: "local",
+  threadId: "local", // optional — omit for lazy binding
   paths: {
+    // string for a fixed thread, or (id) => string when bound lazily
     commands: "/api/threads/local/commands",
     stream: "/api/threads/local/stream",
   },
@@ -390,6 +453,11 @@ adapter cannot describe your transport.
 ```ts
 interface AgentServerAdapter {
   readonly threadId: string;
+  // Optional. The framework calls this to bind / re-bind the adapter to
+  // a thread before each run — including the id minted on the first
+  // submit of a `threadId: null` stream. Omit it to stay pinned to the
+  // thread the adapter was constructed with.
+  setThreadId?(threadId: string): void;
   open(): Promise<void>;
   close(): Promise<void>;
   send(command: Command): Promise<CommandResponse | ErrorResponse | void>;
@@ -401,6 +469,10 @@ interface AgentServerAdapter {
   } | null>;
 }
 ```
+
+Implement `setThreadId` if a single instance should follow lazy thread
+creation or re-binds, and derive your connection URLs from the
+currently-bound `threadId` rather than capturing it at construction.
 
 Direct adapters are useful for in-memory tests, browser-native
 transports, a shared socket that multiplexes many logical threads, or
@@ -424,6 +496,9 @@ If your backend can expose command and stream endpoints, prefer
   `custom:a2a`.
 - **Recreating the adapter during change detection.** Construct in a
   field initializer, provider, or explicitly cleaned-up effect.
+- **Baking a fixed `threadId` / fixed string `paths` into a lazily
+  bound adapter.** Omit `threadId` and use function `paths`
+  (`(id) => …`) so `setThreadId` can re-point the connection URLs.
 - **Treating the example session as production persistence.**
   `LocalThreadSession` is process-local and in-memory by design.
 

--- a/libs/sdk-angular/docs/transports.md
+++ b/libs/sdk-angular/docs/transports.md
@@ -104,6 +104,12 @@ guide walks through the current `examples/ui-react-transport` setup,
 where the UI uses `HttpAgentServerAdapter` and the Hono backend
 implements `/commands` and `/stream` with a `LocalThreadSession`.
 
+`threadId` is optional on `HttpAgentServerAdapter`. Omit it (and write
+`paths` as functions of the thread id) to let the framework bind the
+thread via the adapter's optional `setThreadId` — including the id the
+SDK mints on the first submit of a `threadId: null` stream. See
+[Binding to a thread](./custom-transport.md#binding-to-a-thread).
+
 ## Related
 
 - [`injectStream` options](./inject-stream.md#options)

--- a/libs/sdk-react/docs/README.md
+++ b/libs/sdk-react/docs/README.md
@@ -39,4 +39,6 @@ interrupts, media, and subagents.
 - [`transports.md`](./transports.md) compares built-in SSE, WebSocket,
   header-based auth, and custom adapters.
 - [`custom-transport.md`](./custom-transport.md) is the detailed guide for
-  implementing custom transport layers.
+  pointing `useStream` at a custom backend — `HttpAgentServerAdapter`,
+  server-side protocol handling, lazy thread binding, and implementing
+  `AgentServerAdapter` directly.

--- a/libs/sdk-react/docs/custom-transport.md
+++ b/libs/sdk-react/docs/custom-transport.md
@@ -67,6 +67,85 @@ function App() {
 Wrap the adapter in `useMemo`. Recreating it on every render closes
 the old stream and opens a new one.
 
+## Binding To A Thread
+
+The example above bakes a fixed `threadId` into the adapter and its
+`paths`. That is fine for a single-thread local demo, but a real
+multi-thread backend should let the framework **bind the thread**
+instead.
+
+`HttpAgentServerAdapter` — and any `AgentServerAdapter` that implements
+the optional `setThreadId` — can be constructed **without** a `threadId`.
+When you hand the adapter to `useStream`, the framework calls
+`transport.setThreadId(threadId)` before each run, including the id the
+SDK mints on the first `submit()` of a brand-new thread (`threadId:
+null`). To make a re-bound adapter target the right thread, write `paths`
+as **functions of the thread id** rather than fixed strings:
+
+```tsx
+// Your app owns the thread id. Start at `null` for a brand-new thread;
+// the SDK mints the real id on the first submit and reports it through
+// `onThreadId`, which you store here.
+const [threadId, setThreadId] = useState<string | null>(null);
+
+const transport = useMemo(
+  () =>
+    new HttpAgentServerAdapter({
+      apiUrl: window.location.origin,
+      // No `threadId` — the framework binds it via `setThreadId`.
+      paths: {
+        commands: (id) => `/api/threads/${id}/commands`,
+        stream: (id) => `/api/threads/${id}/stream`,
+      },
+    }),
+  []
+);
+
+// `threadId: null` starts a new thread on the first submit. The SDK
+// mints the id, reports it via `onThreadId`, and binds it to the adapter
+// — you don't mint one yourself, and the new thread skips the `getState`
+// hydrate (no 404 against a thread that does not exist yet).
+const stream = useStream<GraphType>({
+  transport,
+  threadId,
+  onThreadId: setThreadId,
+});
+```
+
+`threadId` / `setThreadId` here are plain React state (`useState`):
+`useStream` reads the current `threadId` and calls `setThreadId` (via
+`onThreadId`) once the SDK mints the new id, so a later render can stay
+bound to that thread. A fixed-string path (the form used in
+[Client Setup](#client-setup)) is still honored verbatim and is
+independent of the bound thread — use it only when the adapter never
+moves off a single thread.
+
+### Switching Between Existing Threads
+
+Lazy binding covers the create-a-new-thread flow. If a single provider
+instead switches between **different existing** threads, give the
+adapter a fresh identity per thread (memoize it on `threadId`) so
+`useStream` builds a new stream for the new thread:
+
+```tsx
+const transport = useMemo(
+  () =>
+    new HttpAgentServerAdapter({
+      apiUrl: window.location.origin,
+      paths: {
+        commands: (id) => `/api/threads/${id}/commands`,
+        stream: (id) => `/api/threads/${id}/stream`,
+      },
+    }),
+  [threadId]
+);
+```
+
+Switching threads tears down the previous stream — which closes the
+transport — so one long-lived instance cannot be reused across an
+existing-thread switch. Creating a thread and staying on it never tears
+down, so lazy creation is unaffected.
+
 ## Server Architecture
 
 On the server, `CustomGraphServer` owns a `LocalThreadSession` per
@@ -279,16 +358,21 @@ custom browser adapter that knows how to reverse that transformation.
 
 ## `HttpAgentServerAdapter` Options
 
+`threadId` is optional. Omit it to let the framework bind the thread via
+`setThreadId` (see [Binding To A Thread](#binding-to-a-thread)); supply it
+to pin the adapter to one thread.
+
 Use `paths` when your backend routes do not live at the default
-`/threads/:threadId/...` paths:
+`/threads/:threadId/...` paths. Each entry is either a fixed string or a
+function of the bound thread id — use the function form whenever the
+adapter is late-bound or re-bound:
 
 ```tsx
 const transport = new HttpAgentServerAdapter({
   apiUrl: window.location.origin,
-  threadId: "local",
   paths: {
-    commands: "/api/threads/local/commands",
-    stream: "/api/threads/local/stream",
+    commands: (threadId) => `/api/threads/${threadId}/commands`,
+    stream: (threadId) => `/api/threads/${threadId}/stream`,
   },
 });
 ```
@@ -324,12 +408,21 @@ interface AgentServerAdapter {
   send(command: Command): Promise<CommandResponse | ErrorResponse | void>;
   events(): AsyncIterable<Message>;
   openEventStream?(params: SubscribeParams): EventStreamHandle;
+  // Bind / re-bind the adapter to a thread. The framework calls this
+  // before each run — including the id minted on the first submit of a
+  // `threadId: null` stream. Omit it to keep the adapter pinned to the
+  // thread it was constructed with (the per-call id is then ignored).
+  setThreadId?(threadId: string): void;
   getState?<S = unknown>(): Promise<{
     values: S;
     checkpoint?: { checkpoint_id?: string } | null;
   } | null>;
 }
 ```
+
+Implement `setThreadId` if you want a single instance to follow lazy
+thread creation or re-binds; derive your connection URLs from the
+currently-bound `threadId` rather than capturing it at construction.
 
 Direct adapters are useful for in-memory tests, browser-native
 transports, a shared socket that multiplexes many logical threads, or
@@ -353,6 +446,10 @@ If your backend can expose command and stream endpoints, prefer
   `custom:a2a`.
 - **Recreating the adapter on every render.** Wrap
   `new HttpAgentServerAdapter(...)` in `useMemo`.
+- **Baking the thread id into fixed `paths` when you re-bind.** A
+  late-bound or re-bound adapter needs function `paths`
+  (`(threadId) => ...`); fixed strings stay pinned to one thread. See
+  [Binding To A Thread](#binding-to-a-thread).
 - **Treating the example session as production persistence.**
   `LocalThreadSession` is process-local and in-memory by design.
 

--- a/libs/sdk-react/docs/transports.md
+++ b/libs/sdk-react/docs/transports.md
@@ -89,6 +89,27 @@ app uses this shape: the React tree uses `HttpAgentServerAdapter`, while
 the Hono backend implements `/commands` and `/stream` with a
 `LocalThreadSession`.
 
+`threadId` is optional. Omit it (and write `paths` as functions of the
+thread id) to let the framework bind the thread — including the id
+minted on the first `submit()` of a `threadId: null` stream — so a
+custom backend gets the same lazy thread-creation flow as the built-in
+transports:
+
+```tsx
+const transport = new HttpAgentServerAdapter({
+  apiUrl: window.location.origin,
+  paths: {
+    commands: (threadId) => `/api/threads/${threadId}/commands`,
+    stream: (threadId) => `/api/threads/${threadId}/stream`,
+  },
+});
+
+const stream = useStream({ transport, threadId: null });
+```
+
+See [Binding to a thread](./custom-transport.md#binding-to-a-thread) for
+the full re-bind and thread-switching rules.
+
 On the custom-adapter branch, `assistantId` is optional (defaults to `"_"`) and server-only options (`apiUrl`, `apiKey`, `fetch`, `webSocketFactory`) are rejected at compile time.
 
 ## Custom `AgentServerAdapter`
@@ -107,7 +128,9 @@ interface AgentServerAdapter {
   openEventStream?(params: SubscribeParams): EventStreamHandle;
   close(): Promise<void>;
 
-  // Optional:
+  // Optional: bind / re-bind the adapter to a thread (lazy creation,
+  // thread switches). Omit to stay pinned to the constructed thread.
+  setThreadId?(threadId: string): void;
   getState?<S = unknown>(): Promise<{
     values: S;
     checkpoint?: { checkpoint_id?: string } | null;

--- a/libs/sdk-svelte/docs/README.md
+++ b/libs/sdk-svelte/docs/README.md
@@ -31,4 +31,6 @@ workflows.
 - [`headless-tools.md`](./headless-tools.md) covers tool implementations and
   lifecycle events for headless tools.
 - [`custom-transport.md`](./custom-transport.md) is the detailed guide for
-  implementing custom transport layers in Svelte apps.
+  pointing `useStream` at a custom backend in Svelte apps —
+  `HttpAgentServerAdapter`, server-side protocol handling, lazy thread
+  binding, and implementing `AgentServerAdapter` directly.

--- a/libs/sdk-svelte/docs/custom-transport.md
+++ b/libs/sdk-svelte/docs/custom-transport.md
@@ -87,6 +87,59 @@ For a single component, call `useStream` directly:
 Construct the adapter at component initialization time. Recreating it
 inside a hot `$effect` closes the old stream and opens a new one.
 
+## Binding To A Thread
+
+The examples above bake a fixed `threadId` into the adapter and its
+`paths`. That is fine for a single-thread local demo, but a real
+multi-thread backend should let the framework **bind the thread**
+instead.
+
+`HttpAgentServerAdapter` — and any `AgentServerAdapter` that implements
+the optional `setThreadId` — can be constructed **without** a `threadId`.
+When you pass it to `useStream` / `provideStream`, the framework calls
+`transport.setThreadId(threadId)` before each run, including the id the
+SDK mints on the first `submit()` of a brand-new thread (`threadId:
+null`). To make a re-bound adapter target the right thread, write `paths`
+as **functions of the thread id** rather than fixed strings:
+
+```svelte
+<script lang="ts">
+  import { HttpAgentServerAdapter, useStream } from "@langchain/svelte";
+
+  const transport = new HttpAgentServerAdapter({
+    apiUrl: window.location.origin,
+    // No `threadId` — the framework binds it via `setThreadId`.
+    paths: {
+      commands: (id) => `/api/threads/${id}/commands`,
+      stream: (id) => `/api/threads/${id}/stream`,
+    },
+  });
+
+  // Start at `null`; the SDK mints the id on the first submit and reports
+  // it via `onThreadId`, which you store so later renders stay bound.
+  let threadId = $state<string | null>(null);
+  const stream = useStream<GraphType>({
+    transport,
+    threadId: () => threadId,
+    onThreadId: (id) => (threadId = id),
+  });
+</script>
+```
+
+A fixed-string path (the form used in
+[Client Setup In Svelte](#client-setup-in-svelte)) is still honored
+verbatim and is independent of the bound thread — use it only when the
+adapter never moves off a single thread.
+
+### Switching Between Existing Threads
+
+Lazy binding covers the create-a-new-thread flow. Switching a single
+provider between **different existing** threads tears down the previous
+stream — which closes the transport — so one long-lived instance cannot
+be reused across an existing-thread switch; give the adapter a fresh
+identity per thread instead. Creating a thread and staying on it never
+tears down, so lazy creation is unaffected.
+
 ## Updated Example Architecture
 
 On the server, `CustomGraphServer` owns a `LocalThreadSession` per
@@ -308,14 +361,19 @@ custom browser adapter that knows how to reverse that transformation.
 
 ## `HttpAgentServerAdapter` Options
 
-Use `paths` when your backend routes do not live at the default
-`/threads/:threadId/...` paths:
+`threadId` is optional. Omit it to let the framework bind the thread via
+`setThreadId` (see [Binding To A Thread](#binding-to-a-thread)). Use
+`paths` when your backend routes do not live at the default
+`/threads/:threadId/...` paths. Each path is `string | (threadId =>
+string)` — pass a function when the adapter is bound lazily so the URL
+follows the bound thread:
 
 ```ts
 const transport = new HttpAgentServerAdapter({
   apiUrl: window.location.origin,
-  threadId: "local",
+  threadId: "local", // optional — omit for lazy binding
   paths: {
+    // string for a fixed thread, or (id) => string when bound lazily
     commands: "/api/threads/local/commands",
     stream: "/api/threads/local/stream",
   },
@@ -348,6 +406,11 @@ adapter cannot describe your transport.
 ```ts
 interface AgentServerAdapter {
   readonly threadId: string;
+  // Optional. The framework calls this to bind / re-bind the adapter to
+  // a thread before each run — including the id minted on the first
+  // submit of a `threadId: null` stream. Omit it to stay pinned to the
+  // thread the adapter was constructed with.
+  setThreadId?(threadId: string): void;
   open(): Promise<void>;
   close(): Promise<void>;
   send(command: Command): Promise<CommandResponse | ErrorResponse | void>;
@@ -359,6 +422,10 @@ interface AgentServerAdapter {
   } | null>;
 }
 ```
+
+Implement `setThreadId` if a single instance should follow lazy thread
+creation or re-binds, and derive your connection URLs from the
+currently-bound `threadId` rather than capturing it at construction.
 
 Direct adapters are useful for in-memory tests, browser-native
 transports, a shared socket that multiplexes many logical threads, or
@@ -382,6 +449,9 @@ If your backend can expose command and stream endpoints, prefer
   `custom:a2a`.
 - **Recreating the adapter in reactive code.** Construct at script
   initialization time or inside an explicitly keyed lifecycle path.
+- **Baking a fixed `threadId` / fixed string `paths` into a lazily
+  bound adapter.** Omit `threadId` and use function `paths`
+  (`(id) => …`) so `setThreadId` can re-point the connection URLs.
 - **Treating the example session as production persistence.**
   `LocalThreadSession` is process-local and in-memory by design.
 

--- a/libs/sdk-vue/docs/README.md
+++ b/libs/sdk-vue/docs/README.md
@@ -40,6 +40,8 @@ context sharing, selectors, transports, testing, and advanced agent workflows.
 - [`transports.md`](./transports.md) compares built-in SSE, WebSocket, and
   custom adapter options.
 - [`custom-transport.md`](./custom-transport.md) is the detailed guide for
-  implementing custom transport layers.
+  pointing `useStream` at a custom backend — `HttpAgentServerAdapter`,
+  server-side protocol handling, lazy thread binding, and implementing
+  `AgentServerAdapter` directly.
 - [`v1-migration.md`](./v1-migration.md) explains how to migrate to
   `@langchain/vue` v1.

--- a/libs/sdk-vue/docs/custom-transport.md
+++ b/libs/sdk-vue/docs/custom-transport.md
@@ -95,6 +95,62 @@ const stream = useStream({
 Keep the adapter identity stable. Recreating it during each render or
 reactive update closes the old stream and opens a new one.
 
+## Binding To A Thread
+
+The examples above bake a fixed `threadId` into the adapter and its
+`paths`. That is fine for a single-thread local demo, but a real
+multi-thread backend should let the framework **bind the thread**
+instead.
+
+`HttpAgentServerAdapter` — and any `AgentServerAdapter` that implements
+the optional `setThreadId` — can be constructed **without** a `threadId`.
+When you pass it to `useStream` / `provideStream`, the framework calls
+`transport.setThreadId(threadId)` before each run, including the id the
+SDK mints on the first `submit()` of a brand-new thread (`threadId:
+null`). To make a re-bound adapter target the right thread, write `paths`
+as **functions of the thread id** rather than fixed strings:
+
+```vue
+<script setup lang="ts">
+import { ref, shallowRef } from "vue";
+import { HttpAgentServerAdapter, useStream } from "@langchain/vue";
+
+const transport = shallowRef(
+  new HttpAgentServerAdapter({
+    apiUrl: window.location.origin,
+    // No `threadId` — the framework binds it via `setThreadId`.
+    paths: {
+      commands: (id) => `/api/threads/${id}/commands`,
+      stream: (id) => `/api/threads/${id}/stream`,
+    },
+  })
+);
+
+// Start at `null`; the SDK mints the id on the first submit and reports
+// it via `onThreadId`, which you store so later renders stay bound.
+const threadId = ref<string | null>(null);
+const stream = useStream<GraphType>({
+  transport: transport.value,
+  threadId,
+  onThreadId: (id) => (threadId.value = id),
+});
+</script>
+```
+
+A fixed-string path (the form used in
+[Client Setup In Vue](#client-setup-in-vue)) is still honored verbatim
+and is independent of the bound thread — use it only when the adapter
+never moves off a single thread.
+
+### Switching Between Existing Threads
+
+Lazy binding covers the create-a-new-thread flow. Switching a single
+provider between **different existing** threads tears down the previous
+stream — which closes the transport — so one long-lived instance cannot
+be reused across an existing-thread switch; give the adapter a fresh
+identity per thread instead. Creating a thread and staying on it never
+tears down, so lazy creation is unaffected.
+
 ## Updated Example Architecture
 
 On the server, `CustomGraphServer` owns a `LocalThreadSession` per
@@ -315,14 +371,19 @@ custom browser adapter that knows how to reverse that transformation.
 
 ## `HttpAgentServerAdapter` Options
 
-Use `paths` when your backend routes do not live at the default
-`/threads/:threadId/...` paths:
+`threadId` is optional. Omit it to let the framework bind the thread via
+`setThreadId` (see [Binding To A Thread](#binding-to-a-thread)). Use
+`paths` when your backend routes do not live at the default
+`/threads/:threadId/...` paths. Each path is `string | (threadId =>
+string)` — pass a function when the adapter is bound lazily so the URL
+follows the bound thread:
 
 ```ts
 const transport = new HttpAgentServerAdapter({
   apiUrl: window.location.origin,
-  threadId: "local",
+  threadId: "local", // optional — omit for lazy binding
   paths: {
+    // string for a fixed thread, or (id) => string when bound lazily
     commands: "/api/threads/local/commands",
     stream: "/api/threads/local/stream",
   },
@@ -355,6 +416,11 @@ adapter cannot describe your transport.
 ```ts
 interface AgentServerAdapter {
   readonly threadId: string;
+  // Optional. The framework calls this to bind / re-bind the adapter to
+  // a thread before each run — including the id minted on the first
+  // submit of a `threadId: null` stream. Omit it to stay pinned to the
+  // thread the adapter was constructed with.
+  setThreadId?(threadId: string): void;
   open(): Promise<void>;
   close(): Promise<void>;
   send(command: Command): Promise<CommandResponse | ErrorResponse | void>;
@@ -366,6 +432,10 @@ interface AgentServerAdapter {
   } | null>;
 }
 ```
+
+Implement `setThreadId` if a single instance should follow lazy thread
+creation or re-binds, and derive your connection URLs from the
+currently-bound `threadId` rather than capturing it at construction.
 
 Direct adapters are useful for in-memory tests, browser-native
 transports, a shared socket that multiplexes many logical threads, or
@@ -390,6 +460,9 @@ If your backend can expose command and stream endpoints, prefer
 - **Recreating the adapter during reactive updates.** Keep
   `new HttpAgentServerAdapter(...)` in a stable `shallowRef`, module
   singleton, or explicitly keyed setup.
+- **Baking a fixed `threadId` / fixed string `paths` into a lazily
+  bound adapter.** Omit `threadId` and use function `paths`
+  (`(id) => …`) so `setThreadId` can re-point the connection URLs.
 - **Treating the example session as production persistence.**
   `LocalThreadSession` is process-local and in-memory by design.
 

--- a/libs/sdk-vue/docs/transports.md
+++ b/libs/sdk-vue/docs/transports.md
@@ -107,6 +107,12 @@ Subclass `HttpAgentServerAdapter` for header injection / auth /
 observability, or implement `AgentServerAdapter` directly for transports
 that are not HTTP/SSE shaped.
 
+`threadId` is optional on `HttpAgentServerAdapter`. Omit it (and write
+`paths` as functions of the thread id) to let the framework bind the
+thread via `setThreadId` — including the id the SDK mints on the first
+submit of a `threadId: null` stream. See
+[Binding to a thread](./custom-transport.md#binding-to-a-thread).
+
 ## Implementing `AgentServerAdapter` from scratch
 
 The [**custom transports**](./custom-transport.md) guide walks through
@@ -123,6 +129,10 @@ interface AgentServerAdapter {
   close(): Promise<void>;
 
   // Optional:
+  // Bind / re-bind the adapter to a thread before each run, including the
+  // id minted on the first submit of a `threadId: null` stream. Omit to
+  // stay pinned to the constructed thread.
+  setThreadId?(threadId: string): void;
   getState?<S = unknown>(): Promise<{
     values: S;
     checkpoint?: { checkpoint_id?: string } | null;

--- a/libs/sdk/docs/transports.md
+++ b/libs/sdk/docs/transports.md
@@ -98,6 +98,11 @@ interface AgentServerAdapter extends TransportAdapter {
 
 interface TransportAdapter {
   readonly threadId: string;
+  // Optional. `client.threads.stream(threadId, …)` calls this to bind /
+  // re-bind the adapter to a thread (including the id minted on the first
+  // submit of a `threadId: null` stream). Omit to stay pinned to the
+  // thread the adapter was constructed with.
+  setThreadId?(threadId: string): void;
   open(): Promise<void>;
   send(command: Command): Promise<CommandResponse | ErrorResponse | void>;
   events(): AsyncIterable<Message>;
@@ -143,6 +148,27 @@ const thread = client.threads.stream({
 
 Supply `webSocketFactory` to flip it into WebSocket mode; otherwise
 it delegates to the SSE transport internally.
+
+`threadId` is optional. `client.threads.stream(threadId, { transport })`
+calls `transport.setThreadId(threadId)` before each run — including the
+id the SDK mints on the first `submit()` of a `threadId: null` controller
+— so a single adapter can follow **lazy thread creation** instead of
+being pinned at construction. Write `paths` as functions of the thread id
+when you rely on this (each entry is `string | (threadId) => string`):
+
+```ts
+const adapter = new HttpAgentServerAdapter({
+  apiUrl: "https://agent.example.com",
+  // No `threadId` — bound by the framework via `setThreadId`.
+  paths: {
+    commands: (threadId) => `/threads/${threadId}/commands`,
+    stream: (threadId) => `/threads/${threadId}/stream/events`,
+  },
+});
+
+// A brand-new thread: the SDK mints the id on the first run and binds it.
+const thread = client.threads.stream({ assistantId: "agent", transport: adapter });
+```
 
 ### When to implement `getState` / `getHistory`
 

--- a/libs/sdk/src/client/index.test.ts
+++ b/libs/sdk/src/client/index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { Client } from "./index.js";
 import { ThreadStream } from "./stream/index.js";
+import { HttpAgentServerAdapter } from "./stream/transport/agent-server.js";
 import { ProtocolSseTransportAdapter } from "./stream/transport/http.js";
 import {
   PROXIED_API_URL,
@@ -157,5 +158,45 @@ describe("Client", () => {
     expect(calls[0]).toBe(
       `ws://localhost:4100/api/chat-langchain/threads/${THREAD_ID}/stream/events`
     );
+  });
+
+  it("threads.stream binds a custom adapter to the requested thread via setThreadId", () => {
+    const client = new Client({
+      apiUrl: "http://localhost:9999",
+      apiKey: null,
+    });
+
+    // Constructed unbound — the framework binds it to the thread passed to
+    // threads.stream (the lazy-create seam).
+    const adapter = new HttpAgentServerAdapter({
+      apiUrl: "http://localhost:9999",
+    });
+    const thread = client.threads.stream("late-thread", {
+      assistantId: "my-agent",
+      transport: adapter,
+    });
+
+    expect(adapter.threadId).toBe("late-thread");
+    expect(thread.threadId).toBe("late-thread");
+  });
+
+  it("threads.stream binds a custom adapter to an auto-generated thread id", () => {
+    const client = new Client({
+      apiUrl: "http://localhost:9999",
+      apiKey: null,
+    });
+
+    const adapter = new HttpAgentServerAdapter({
+      apiUrl: "http://localhost:9999",
+    });
+    const thread = client.threads.stream({
+      assistantId: "my-agent",
+      transport: adapter,
+    });
+
+    expect(adapter.threadId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+    expect(thread.threadId).toBe(adapter.threadId);
   });
 });

--- a/libs/sdk/src/client/stream/transport.ts
+++ b/libs/sdk/src/client/stream/transport.ts
@@ -24,14 +24,31 @@ export interface EventStreamHandle {
  * Transport abstraction implemented by concrete client transports such as
  * WebSocket or SSE adapters.
  *
- * In the thread-centric protocol, transports are bound to a specific
- * thread at construction time — the thread ID is part of the connection URL.
+ * In the thread-centric protocol the thread ID is part of the request
+ * URLs. Transports may be bound at construction time, or left unbound and
+ * bound later via {@link setThreadId} (see that method) — which lets a
+ * single instance follow a lazily-created thread.
  */
 export interface TransportAdapter {
   /**
-   * Thread ID this transport is bound to.
+   * Thread ID this transport currently targets.
    */
   readonly threadId: string;
+  /**
+   * Rebind this transport to a different thread.
+   *
+   * `client.threads.stream(threadId, { transport })` calls this (when
+   * implemented) whenever the framework binds or re-binds the active
+   * thread — including the lazily-minted id from the first `submit()` on
+   * a `threadId: null` controller. Implementing it lets an adapter be
+   * constructed once (optionally with no `threadId`) and reused as the
+   * active thread becomes known, so the framework doesn't have to tear
+   * down and rebuild a custom transport when the thread id appears.
+   *
+   * Optional: adapters that bake `threadId` at construction can omit it,
+   * in which case the per-call `threadId` is ignored (prior behaviour).
+   */
+  setThreadId?(threadId: string): void;
   /**
    * Opens the underlying connection (e.g. WebSocket handshake).
    * For HTTP/SSE transports this is a no-op.

--- a/libs/sdk/src/client/stream/transport/agent-server.test.ts
+++ b/libs/sdk/src/client/stream/transport/agent-server.test.ts
@@ -39,3 +39,42 @@ describe("HttpAgentServerAdapter hydration", () => {
     expect(adapter.getState).toBeUndefined();
   });
 });
+
+describe("HttpAgentServerAdapter thread binding", () => {
+  it("binds the SSE delegate lazily via setThreadId", async () => {
+    const { calls, fetch } = createFetchRecorder({
+      response: new Response(
+        JSON.stringify({ values: { messages: [] }, next: [], tasks: [] }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      ),
+    });
+    const adapter = new HttpAgentServerAdapter({
+      apiUrl: "http://localhost:4100/api",
+      fetch,
+    });
+
+    adapter.setThreadId("thread-late");
+    expect(adapter.threadId).toBe("thread-late");
+
+    await adapter.getState?.();
+    expect(calls).toHaveLength(1);
+    expect(calls[0].href).toBe(
+      "http://localhost:4100/api/threads/thread-late/state"
+    );
+  });
+
+  it("forwards setThreadId to the WebSocket delegate", async () => {
+    const { calls, webSocketFactory, sentinel } = createWebSocketUrlRecorder();
+    const adapter = new HttpAgentServerAdapter({
+      apiUrl: "http://localhost:4100/api",
+      webSocketFactory,
+    });
+
+    adapter.setThreadId("thread-ws");
+    expect(adapter.threadId).toBe("thread-ws");
+
+    await expect(adapter.open()).rejects.toBe(sentinel);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("/threads/thread-ws/stream/events");
+  });
+});

--- a/libs/sdk/src/client/stream/transport/agent-server.ts
+++ b/libs/sdk/src/client/stream/transport/agent-server.ts
@@ -38,7 +38,13 @@ import type {
 
 export interface HttpAgentServerAdapterOptions {
   apiUrl: string;
-  threadId: string;
+  /**
+   * Thread this adapter targets. Optional: omit to construct an unbound
+   * adapter and let the framework bind it via {@link HttpAgentServerAdapter.setThreadId}
+   * (`client.threads.stream` does this) — e.g. lazy thread creation, where
+   * the id is only known after the first `submit()`.
+   */
+  threadId?: string;
   /** Auth / tenant / diagnostic headers applied to every request. */
   defaultHeaders?: Record<string, HeaderValue>;
   /** Per-request hook for last-mile header mutation. */
@@ -65,7 +71,7 @@ export interface HttpAgentServerAdapterOptions {
 }
 
 export class HttpAgentServerAdapter implements AgentServerAdapter {
-  readonly threadId: string;
+  threadId: string;
 
   readonly apiUrl: string;
 
@@ -78,7 +84,7 @@ export class HttpAgentServerAdapter implements AgentServerAdapter {
   getState?: AgentServerAdapter["getState"];
 
   constructor(options: HttpAgentServerAdapterOptions) {
-    this.threadId = options.threadId;
+    this.threadId = options.threadId ?? "";
     this.apiUrl = options.apiUrl;
     this.#delegate =
       options.webSocketFactory != null
@@ -104,6 +110,12 @@ export class HttpAgentServerAdapter implements AgentServerAdapter {
       const sse = this.#delegate as ProtocolSseTransportAdapter;
       this.getState = sse.getState.bind(sse);
     }
+  }
+
+  /** {@inheritDoc TransportAdapter.setThreadId} */
+  setThreadId(threadId: string): void {
+    this.threadId = threadId;
+    this.#delegate.setThreadId?.(threadId);
   }
 
   open(): Promise<void> {

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -127,6 +127,86 @@ describe("ProtocolSseTransportAdapter URL resolution", () => {
   });
 });
 
+describe("ProtocolSseTransportAdapter thread binding", () => {
+  it("binds lazily via setThreadId when constructed without a threadId", async () => {
+    const { calls, fetch } = createFetchRecorder();
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: PROXIED_API_URL,
+      fetch,
+    });
+
+    transport.setThreadId(THREAD_ID);
+    await transport.send({ id: 1, method: "state.get", params: { namespace: [] } });
+
+    expect(transport.threadId).toBe(THREAD_ID);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].href).toBe(
+      `${PROXIED_API_URL}/threads/${THREAD_ID}/commands`
+    );
+  });
+
+  it("follows setThreadId re-binds for commands and state", async () => {
+    const calls: Array<string> = [];
+    const fetch: typeof globalThis.fetch = (input) => {
+      const href = typeof input === "string" ? input : input.toString();
+      calls.push(href);
+      // `/commands` expects a protocol response; `/state` a state body.
+      if (href.endsWith("/state")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ values: { messages: [] }, next: [], tasks: [] }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          )
+        );
+      }
+      return Promise.resolve(protocolSuccessResponse());
+    };
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: PROXIED_API_URL,
+      threadId: "thread-a",
+      fetch,
+    });
+
+    await transport.send({ id: 1, method: "state.get", params: { namespace: [] } });
+    transport.setThreadId("thread-b");
+    await transport.send({ id: 2, method: "state.get", params: { namespace: [] } });
+    await transport.getState();
+
+    expect(calls).toEqual([
+      `${PROXIED_API_URL}/threads/thread-a/commands`,
+      `${PROXIED_API_URL}/threads/thread-b/commands`,
+      `${PROXIED_API_URL}/threads/thread-b/state`,
+    ]);
+  });
+
+  it("resolves function paths against the currently-bound thread", async () => {
+    const { calls, fetch } = createFetchRecorder();
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: PROXIED_API_URL,
+      fetch,
+      paths: { commands: (id) => `/sessions/${id}/cmd` },
+    });
+
+    transport.setThreadId("thread-z");
+    await transport.send({ id: 1, method: "state.get", params: { namespace: [] } });
+
+    expect(calls[0].href).toBe(`${PROXIED_API_URL}/sessions/thread-z/cmd`);
+  });
+
+  it("throws a helpful error when a command is sent before binding a thread", async () => {
+    const { calls, fetch } = createFetchRecorder();
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: PROXIED_API_URL,
+      fetch,
+    });
+
+    await expect(
+      transport.send({ id: 1, method: "state.get", params: { namespace: [] } })
+    ).rejects.toThrow(/no bound threadId/);
+    expect(calls).toHaveLength(0);
+  });
+});
+
 describe("ProtocolSseTransportAdapter AsyncCaller", () => {
   it("retries transient command failures when asyncCaller is provided", async () => {
     let attempts = 0;

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -12,6 +12,7 @@ import type {
   HeaderValue,
   ProtocolRequestHook,
   ProtocolSseTransportOptions,
+  ProtocolTransportPaths,
 } from "./types.js";
 import type { TransportAdapter, EventStreamHandle } from "../transport.js";
 import {
@@ -20,6 +21,7 @@ import {
   mergeHeaders,
   toError,
   isProtocolResponse,
+  resolveProtocolPath,
 } from "./utils.js";
 import { BytesLineDecoder, SSEDecoder } from "../../../utils/sse.js";
 import { IterableReadableStream } from "../../../utils/stream.js";
@@ -27,12 +29,14 @@ import { webSocketReconnectDelayMs } from "./websocket.js";
 
 /**
  * Transport adapter that speaks the thread-centric protocol over HTTP
- * commands plus SSE event streams. Bound to a specific `threadId`
- * at construction. Each {@link openEventStream} call opens an independent
- * filtered SSE connection via `POST /threads/:thread_id/stream/events`.
+ * commands plus SSE event streams. Bound to a `threadId` at construction
+ * or later via {@link setThreadId}; request URLs derive from the
+ * currently-bound thread. Each {@link openEventStream} call opens an
+ * independent filtered SSE connection via
+ * `POST /threads/:thread_id/stream/events`.
  */
 export class ProtocolSseTransportAdapter implements TransportAdapter {
-  readonly threadId: string;
+  threadId: string;
 
   readonly apiUrl: string;
 
@@ -54,11 +58,7 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
 
   private readonly reconnectDelayMs: (attempt: number) => number;
 
-  private readonly commandsUrl: string;
-
-  private readonly streamUrl: string;
-
-  private readonly stateUrl: string;
+  private readonly paths?: ProtocolTransportPaths;
 
   private readonly sessionAbortController = new AbortController();
 
@@ -79,12 +79,42 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
     this.onReconnect = options.onReconnect;
     this.reconnectDelayMs =
       options.reconnectDelayMs ?? webSocketReconnectDelayMs;
-    this.threadId = options.threadId;
-    this.commandsUrl =
-      options.paths?.commands ?? `/threads/${this.threadId}/commands`;
-    this.streamUrl =
-      options.paths?.stream ?? `/threads/${this.threadId}/stream/events`;
-    this.stateUrl = options.paths?.state ?? `/threads/${this.threadId}/state`;
+    this.threadId = options.threadId ?? "";
+    this.paths = options.paths;
+  }
+
+  /** {@inheritDoc TransportAdapter.setThreadId} */
+  setThreadId(threadId: string): void {
+    this.threadId = threadId;
+  }
+
+  /**
+   * Command/stream/state URLs derive from the currently-bound thread so a
+   * single adapter can follow {@link setThreadId} re-binds. A fixed
+   * `paths.*` string overrides the default and is used as-is.
+   */
+  private get commandsUrl(): string {
+    return resolveProtocolPath(
+      this.paths?.commands,
+      this.threadId,
+      (id) => `/threads/${id}/commands`
+    );
+  }
+
+  private get streamUrl(): string {
+    return resolveProtocolPath(
+      this.paths?.stream,
+      this.threadId,
+      (id) => `/threads/${id}/stream/events`
+    );
+  }
+
+  private get stateUrl(): string {
+    return resolveProtocolPath(
+      this.paths?.state,
+      this.threadId,
+      (id) => `/threads/${id}/state`
+    );
   }
 
   /**

--- a/libs/sdk/src/client/stream/transport/types.ts
+++ b/libs/sdk/src/client/stream/transport/types.ts
@@ -6,16 +6,31 @@ export type ProtocolRequestHook = (
   init: RequestInit
 ) => Promise<RequestInit> | RequestInit;
 
+/**
+ * A protocol request path. Either a fixed string (bound to a specific
+ * thread) or a function of the active threadId. Use the function form
+ * when a single adapter instance must follow {@link TransportAdapter.setThreadId}
+ * re-binds — e.g. lazy thread creation, where the id is only known after
+ * the first `submit()`.
+ */
+export type ProtocolPath = string | ((threadId: string) => string);
+
 export interface ProtocolTransportPaths {
-  commands?: string;
-  stream?: string;
+  commands?: ProtocolPath;
+  stream?: ProtocolPath;
   /** `GET` path for thread-state hydration. Defaults to `/threads/:threadId/state`. */
-  state?: string;
+  state?: ProtocolPath;
 }
 
 export interface ProtocolSseTransportOptions {
   apiUrl: string;
-  threadId: string;
+  /**
+   * Thread this transport targets. Optional: omit to construct an
+   * unbound transport and bind later via {@link TransportAdapter.setThreadId}
+   * (the framework does this from `client.threads.stream`). Requests throw
+   * until a thread is bound.
+   */
+  threadId?: string;
   defaultHeaders?: Record<string, HeaderValue>;
   onRequest?: ProtocolRequestHook;
   fetch?: typeof fetch;
@@ -43,7 +58,11 @@ export interface ProtocolSseTransportOptions {
 
 export interface ProtocolWebSocketTransportOptions {
   apiUrl: string;
-  threadId: string;
+  /**
+   * Thread this transport targets. Optional: omit to construct an
+   * unbound transport and bind later via {@link TransportAdapter.setThreadId}.
+   */
+  threadId?: string;
   defaultHeaders?: Record<string, HeaderValue>;
   onRequest?: ProtocolRequestHook;
   webSocketFactory?: (url: string) => WebSocket;

--- a/libs/sdk/src/client/stream/transport/utils.ts
+++ b/libs/sdk/src/client/stream/transport/utils.ts
@@ -1,8 +1,37 @@
-import type { HeaderValue } from "./types.js";
+import type { HeaderValue, ProtocolPath } from "./types.js";
 import type { CommandResponse, ErrorResponse } from "@langchain/protocol";
 
 export const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
+
+/**
+ * Resolve a {@link ProtocolPath} against the transport's currently-bound
+ * thread.
+ *
+ * - a fixed `string` is used verbatim (back-compat: a baked path is
+ *   independent of the bound thread);
+ * - a function path and the default fallback are evaluated against
+ *   `threadId`, so late-bound / re-bound adapters target the right thread.
+ *
+ * Throws when neither a fixed path nor a bound thread is available — i.e.
+ * a request was attempted before `client.threads.stream(threadId, …)` /
+ * {@link TransportAdapter.setThreadId} bound a thread.
+ */
+export function resolveProtocolPath(
+  path: ProtocolPath | undefined,
+  threadId: string,
+  fallback: (threadId: string) => string
+): string {
+  if (typeof path === "string") return path;
+  if (!threadId) {
+    throw new Error(
+      "Protocol transport has no bound threadId. Bind one — the framework " +
+        "calls client.threads.stream(threadId, { transport }) / " +
+        "transport.setThreadId(threadId) — before issuing requests."
+    );
+  }
+  return path ? path(threadId) : fallback(threadId);
+}
 
 /** Match {@link BaseClient.prepareFetchOptions}: preserve any apiUrl path prefix. */
 export const toAbsoluteUrl = (apiUrl: string, path: string) =>

--- a/libs/sdk/src/client/stream/transport/websocket.test.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.test.ts
@@ -133,6 +133,40 @@ describe("ProtocolWebSocketTransportAdapter URL resolution", () => {
   });
 });
 
+describe("ProtocolWebSocketTransportAdapter thread binding", () => {
+  it("rejects rebinding to another thread while the socket is open", async () => {
+    const urls: string[] = [];
+    const sockets: FakeWebSocket[] = [];
+    const transport = new ProtocolWebSocketTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: "thread-a",
+      webSocketFactory: (url) => {
+        urls.push(url);
+        const socket = new FakeWebSocket(url);
+        sockets.push(socket);
+        return socket as unknown as WebSocket;
+      },
+    });
+
+    await transport.open();
+
+    expect(() => transport.setThreadId("thread-a")).not.toThrow();
+    expect(() => transport.setThreadId("thread-b")).toThrow(
+      /cannot be rebound/
+    );
+    expect(transport.threadId).toBe("thread-a");
+
+    await transport.open();
+
+    expect(urls).toEqual([
+      "ws://localhost:8123/threads/thread-a/stream/events",
+    ]);
+    expect(sockets[0].readyState).toBe(FakeWebSocket.OPEN);
+
+    await transport.close();
+  });
+});
+
 describe("webSocketReconnectDelayMs", () => {
   it("caps exponential backoff", () => {
     expect(webSocketReconnectDelayMs(1)).toBeLessThanOrEqual(6000);

--- a/libs/sdk/src/client/stream/transport/websocket.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.ts
@@ -12,11 +12,13 @@ import {
   isRecord,
   hasHeaders,
   toError,
+  resolveProtocolPath,
 } from "./utils.js";
 import type {
   HeaderValue,
   ProtocolRequestHook,
   PendingResponse,
+  ProtocolTransportPaths,
   ProtocolWebSocketTransportOptions,
 } from "./types.js";
 import type { TransportAdapter } from "../transport.js";
@@ -55,8 +57,9 @@ export function webSocketReconnectDelayMs(attempt: number): number {
 
 /**
  * Transport adapter that speaks the thread-centric protocol over a
- * bidirectional WebSocket. Bound to a specific `threadId` — the socket
- * connects to `ws://.../threads/:thread_id/stream/events`.
+ * bidirectional WebSocket. Bound to a `threadId` at construction or later
+ * via {@link setThreadId} — the socket connects to
+ * `ws://.../threads/:thread_id/stream/events`.
  *
  * On unexpected disconnect the adapter reconnects with exponential
  * backoff (see {@link ProtocolWebSocketTransportOptions.maxReconnectAttempts}).
@@ -66,7 +69,7 @@ export function webSocketReconnectDelayMs(attempt: number): number {
  * `subscription.subscribe` commands.
  */
 export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
-  readonly threadId: string;
+  threadId: string;
 
   private readonly queue = new AsyncQueue<Message>();
 
@@ -78,7 +81,7 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
 
   private readonly webSocketFactory: (url: string) => WebSocket;
 
-  private readonly streamUrl: string;
+  private readonly paths?: Pick<ProtocolTransportPaths, "stream">;
 
   private readonly maxReconnectAttempts: number;
 
@@ -100,18 +103,35 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
 
   constructor(options: ProtocolWebSocketTransportOptions) {
     this.apiUrl = options.apiUrl;
-    this.threadId = options.threadId;
+    this.threadId = options.threadId ?? "";
     this.defaultHeaders = options.defaultHeaders;
     this.onRequest = options.onRequest;
     this.webSocketFactory =
       options.webSocketFactory ?? ((url) => new WebSocket(url));
-    this.streamUrl =
-      options.paths?.stream ?? `/threads/${this.threadId}/stream/events`;
+    this.paths = options.paths;
     this.maxReconnectAttempts = options.maxReconnectAttempts ?? 5;
     this.onReconnect = options.onReconnect;
     this.onReconnected = options.onReconnected;
     this.reconnectDelayMs =
       options.reconnectDelayMs ?? webSocketReconnectDelayMs;
+  }
+
+  /** {@inheritDoc TransportAdapter.setThreadId} */
+  setThreadId(threadId: string): void {
+    this.threadId = threadId;
+  }
+
+  /**
+   * Socket URL derives from the currently-bound thread so a single adapter
+   * can follow {@link setThreadId} re-binds; the next {@link open} connects
+   * to the new thread. A fixed `paths.stream` string overrides the default.
+   */
+  private get streamUrl(): string {
+    return resolveProtocolPath(
+      this.paths?.stream,
+      this.threadId,
+      (id) => `/threads/${id}/stream/events`
+    );
   }
 
   /**

--- a/libs/sdk/src/client/stream/transport/websocket.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.ts
@@ -118,6 +118,17 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
 
   /** {@inheritDoc TransportAdapter.setThreadId} */
   setThreadId(threadId: string): void {
+    if (threadId === this.threadId) {
+      return;
+    }
+    if (
+      this.reconnectInFlight != null ||
+      (this.socket != null && this.socket.readyState !== WEB_SOCKET_CLOSED)
+    ) {
+      throw new Error(
+        "Protocol WebSocket transport cannot be rebound to a different thread while the socket is open. Close the current stream and create a new WebSocket transport for the new thread."
+      );
+    }
     this.threadId = threadId;
   }
 

--- a/libs/sdk/src/client/threads/index.ts
+++ b/libs/sdk/src/client/threads/index.ts
@@ -493,6 +493,11 @@ export class ThreadsClient<
     let transport: TransportAdapter;
     if (options.transport != null && typeof options.transport !== "string") {
       transport = options.transport;
+      // Bind (or re-bind) the caller-supplied adapter to this thread so a
+      // single instance can follow lazy creation (the first `submit()` on a
+      // `threadId: null` controller mints the id here) and thread switches.
+      // No-op for adapters that bake `threadId` at construction.
+      transport.setThreadId?.(threadId);
     } else {
       const transportKind: ThreadStreamTransportKind =
         options.transport ??


### PR DESCRIPTION
## Summary
- Add optional `setThreadId(threadId)` to `TransportAdapter` and call it from `client.threads.stream` when binding a custom adapter to the active thread (including the id minted on the first `submit()` of a `threadId: null` stream).
- Make `threadId` optional at construction on `ProtocolSseTransportAdapter`, `ProtocolWebSocketTransportAdapter`, and `HttpAgentServerAdapter`; derive command/stream/state URLs from the currently-bound thread and allow `paths` entries to be `(threadId) => string`.
- Add unit tests for lazy binding, re-binding, function paths, and `client.threads.stream` wiring.
- Document lazy thread binding for custom backends in core SDK and framework docs (React, Vue, Svelte, Angular).
