### PR TITLE
fix(sdk): reconnect SSE streams when heartbeat idle is detected

### DIFF
--- a/.changeset/fix-sse-heartbeat-idle-reconnect.md
+++ b/.changeset/fix-sse-heartbeat-idle-reconnect.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): reconnect SSE streams when heartbeat idle is detected
+
+Detect half-open SSE connections by watching for server keep-alive heartbeats (`: heartbeat`) and reconnecting with Last-Event-ID or `since` when they stop. `"auto"` mode arms only after heartbeats are observed, so long tool calls and HITL pauses do not false-fire on heartbeat-emitting servers.

--- a/libs/sdk/src/client/base.ts
+++ b/libs/sdk/src/client/base.ts
@@ -2,7 +2,12 @@ import { AsyncCaller, AsyncCallerParams } from "../utils/async_caller.js";
 import { getEnvironmentVariable } from "../utils/env.js";
 import { mergeSignals } from "../utils/signals.js";
 import { BytesLineDecoder, SSEDecoder } from "../utils/sse.js";
-import { streamWithRetry, StreamRequestParams } from "../utils/stream.js";
+import {
+  streamWithRetry,
+  idleReconnectStream,
+  type IdleReconnectMode,
+  StreamRequestParams,
+} from "../utils/stream.js";
 import type { StreamProtocol } from "../types.js";
 
 export type HeaderValue = string | undefined | null;
@@ -400,6 +405,7 @@ export class BaseClient {
     params?: Record<string, unknown>;
     json?: unknown;
     maxRetries?: number;
+    idleReconnect?: IdleReconnectMode;
     onReconnect?: (options: {
       attempt: number;
       lastEventId?: string;
@@ -441,9 +447,20 @@ export class BaseClient {
         await config.onInitialResponse(response);
       }
 
-      const stream: ReadableStream<T> = response.body
-        .pipeThrough(BytesLineDecoder())
-        .pipeThrough(SSEDecoder()) as ReadableStream<T>;
+      // Insert the idle watchdog on the line stream (between the byte-line
+      // decoder and the SSE decoder) so it can both reset on any line and
+      // recognise `:` keep-alive heartbeats to drive `"auto"` mode. The SSE
+      // decoder downstream discards those comment lines.
+      const idleMode = config.idleReconnect ?? "auto";
+      const enableIdle = idleMode === "auto" || idleMode > 0;
+
+      const lines = response.body.pipeThrough(BytesLineDecoder());
+      const watched = enableIdle
+        ? lines.pipeThrough(idleReconnectStream({ mode: idleMode }))
+        : lines;
+      const stream: ReadableStream<T> = watched.pipeThrough(
+        SSEDecoder()
+      ) as ReadableStream<T>;
 
       return { response, stream };
     };

--- a/libs/sdk/src/client/runs/index.ts
+++ b/libs/sdk/src/client/runs/index.ts
@@ -13,6 +13,7 @@ import type {
   StreamEvent,
 } from "../../types.js";
 import type { StreamMode, TypedAsyncGenerator } from "../../types.stream.js";
+import type { IdleReconnectMode } from "../../utils/stream.js";
 
 import { BaseClient, getRunMetadataFromResponse } from "../base.js";
 
@@ -105,6 +106,7 @@ export class RunsClient<
       method: "POST",
       json,
       signal: payload?.signal,
+      idleReconnect: payload?.streamIdleReconnect,
       onInitialResponse: (response) => {
         const runMetadata = getRunMetadataFromResponse(response);
         if (runMetadata) payload?.onRunCreated?.(runMetadata);
@@ -408,6 +410,20 @@ export class RunsClient<
           cancelOnDisconnect?: boolean;
           lastEventId?: string;
           streamMode?: StreamMode | StreamMode[];
+          /**
+           * Idle-reconnect policy.
+           *
+           * Guards against half-open sockets that hang with no
+           * error or close; on idle the read re-joins with the last seen
+           * `Last-Event-ID`.
+           *
+           * - `"auto"` (default): arms only once the
+           * server's keep-alive heartbeats are observed and sizes the window
+           * from their cadence;
+           * - a `number`: a fixed idle window in ms;
+           * - `0`: disables it.
+           */
+          streamIdleReconnect?: IdleReconnectMode;
         }
       | AbortSignal
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -427,6 +443,7 @@ export class RunsClient<
           : `/runs/${runId}/stream`,
       method: "GET",
       signal: opts?.signal,
+      idleReconnect: opts?.streamIdleReconnect,
       headers: opts?.lastEventId
         ? { "Last-Event-ID": opts.lastEventId }
         : undefined,

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -22,7 +22,11 @@ import {
   isProtocolResponse,
 } from "./utils.js";
 import { BytesLineDecoder, SSEDecoder } from "../../../utils/sse.js";
-import { IterableReadableStream } from "../../../utils/stream.js";
+import {
+  IterableReadableStream,
+  idleReconnectStream,
+  type IdleReconnectMode,
+} from "../../../utils/stream.js";
 import { webSocketReconnectDelayMs } from "./websocket.js";
 
 /**
@@ -50,6 +54,8 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
 
   private readonly maxReconnectAttempts: number;
 
+  private readonly idleReconnect: IdleReconnectMode | null;
+
   private readonly onReconnect?: ProtocolSseTransportOptions["onReconnect"];
 
   private readonly reconnectDelayMs: (attempt: number) => number;
@@ -76,6 +82,13 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
     // Custom fetch (tests/mocks) must not auto-reconnect — same policy as skipping AsyncCaller.
     this.maxReconnectAttempts =
       options.fetch != null ? 0 : (options.maxReconnectAttempts ?? 5);
+    // Custom fetch (tests/mocks) also disables the idle watchdog, matching the
+    // no-auto-reconnect policy above — a tripped watchdog would have nothing to
+    // reconnect to and would surface spurious errors in those harnesses.
+    // Otherwise default to heartbeat-adaptive `"auto"`, which stays dormant
+    // unless the server actually emits keep-alive heartbeats.
+    this.idleReconnect =
+      options.fetch != null ? null : (options.idleReconnect ?? "auto");
     this.onReconnect = options.onReconnect;
     this.reconnectDelayMs =
       options.reconnectDelayMs ?? webSocketReconnectDelayMs;
@@ -251,9 +264,21 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
               },
             });
 
-          const stream = readable
-            .pipeThrough(BytesLineDecoder())
-            .pipeThrough(SSEDecoder());
+          // Idle watchdog on the line stream (between byte-line and SSE
+          // decoding) so it can reset on any line and recognise `:` keep-alive
+          // heartbeats to drive `"auto"` mode. On idle it errors the stream,
+          // which the catch below treats like any other disconnect and
+          // reconnects with `since` from the last seen sequence.
+          const enableIdle =
+            this.idleReconnect === "auto" ||
+            (typeof this.idleReconnect === "number" && this.idleReconnect > 0);
+          const lines = readable.pipeThrough(BytesLineDecoder());
+          const watched = enableIdle
+            ? lines.pipeThrough(
+                idleReconnectStream({ mode: this.idleReconnect! })
+              )
+            : lines;
+          const stream = watched.pipeThrough(SSEDecoder());
           const iterable = IterableReadableStream.fromReadableStream(stream);
 
           for await (const event of iterable) {

--- a/libs/sdk/src/client/stream/transport/types.ts
+++ b/libs/sdk/src/client/stream/transport/types.ts
@@ -1,5 +1,6 @@
 import type { CommandResponse, ErrorResponse } from "@langchain/protocol";
 import type { AsyncCaller } from "../../../utils/async_caller.js";
+import type { IdleReconnectMode } from "../../../utils/stream.js";
 
 export type ProtocolRequestHook = (
   url: URL,
@@ -32,6 +33,23 @@ export interface ProtocolSseTransportOptions {
    * Defaults to 5. Set to 0 to disable automatic reconnection.
    */
   maxReconnectAttempts?: number;
+  /**
+   * Idle-reconnect policy guarding against half-open sockets that hang
+   * indefinitely with no error or close (e.g. a platform revision rollover
+   * that hard-kills the serving pod). On idle the underlying read is aborted,
+   * which the reconnect loop treats like any other disconnect, re-subscribing
+   * with `since` from the last seen sequence.
+   *
+   * - `"auto"`: arm only once the server's SSE keep-alive heartbeats
+   *   (LangGraph Platform: `: heartbeat` every ~5s) are observed, sizing the
+   *   window from their cadence. Independent of agent activity; stays dormant
+   *   on heartbeat-less servers.
+   * - a `number`: a fixed idle window in milliseconds.
+   * - `0`: disables it.
+   *
+   * @see {@link IdleReconnectMode}
+   */
+  idleReconnect?: IdleReconnectMode;
   /** Called before each SSE reconnect attempt (after backoff delay). */
   onReconnect?: (options: { attempt: number; cause: unknown }) => void;
   /**

--- a/libs/sdk/src/client/stream/types.ts
+++ b/libs/sdk/src/client/stream/types.ts
@@ -41,10 +41,10 @@ export type EventMethodByChannel = {
 
 export type EventForChannel<TChannel extends Channel> =
   TChannel extends keyof EventMethodByChannel
-  ? Extract<Event, { method: EventMethodByChannel[TChannel] }>
-  : TChannel extends `custom:${string}`
-  ? Extract<Event, { method: "custom" }>
-  : never;
+    ? Extract<Event, { method: EventMethodByChannel[TChannel] }>
+    : TChannel extends `custom:${string}`
+      ? Extract<Event, { method: "custom" }>
+      : never;
 
 export type EventForChannels<TChannels extends readonly Channel[]> =
   EventForChannel<TChannels[number]>;
@@ -246,7 +246,7 @@ export interface InterruptPayload<TPayload = unknown> {
  * opened on first property access and cached.
  */
 export interface ThreadExtension<T = unknown>
-  extends AsyncIterable<T>, PromiseLike<T> { }
+  extends AsyncIterable<T>, PromiseLike<T> {}
 
 /**
  * Unwrap a single in-process projection value to its observable payload

--- a/libs/sdk/src/client/stream/types.ts
+++ b/libs/sdk/src/client/stream/types.ts
@@ -15,6 +15,7 @@ import type {
   SubscribeParams,
 } from "@langchain/protocol";
 
+import type { IdleReconnectMode } from "../../utils/stream.js";
 import type { AssembledMessage } from "./messages.js";
 import type { AgentServerAdapter } from "./transport.js";
 
@@ -40,10 +41,10 @@ export type EventMethodByChannel = {
 
 export type EventForChannel<TChannel extends Channel> =
   TChannel extends keyof EventMethodByChannel
-    ? Extract<Event, { method: EventMethodByChannel[TChannel] }>
-    : TChannel extends `custom:${string}`
-      ? Extract<Event, { method: "custom" }>
-      : never;
+  ? Extract<Event, { method: EventMethodByChannel[TChannel] }>
+  : TChannel extends `custom:${string}`
+  ? Extract<Event, { method: "custom" }>
+  : never;
 
 export type EventForChannels<TChannels extends readonly Channel[]> =
   EventForChannel<TChannels[number]>;
@@ -131,6 +132,19 @@ export interface ThreadStreamOptions {
    * attempts after an unexpected disconnect. Defaults to 5.
    */
   maxReconnectAttempts?: number;
+  /**
+   * Built-in `"sse"` transport only: idle-reconnect policy guarding against
+   * half-open sockets that hang with no error or close (e.g. a platform
+   * revision rollover).
+   *
+   * - `"auto"` (default): arm only once the server's SSE keep-alive
+   *   heartbeats are observed (LangGraph Platform emits `: heartbeat` every
+   *   ~5s), sizing the window from their cadence. Independent of agent
+   *   activity; stays dormant on heartbeat-less servers.
+   * - a `number`: a fixed idle window in milliseconds.
+   * - `0`: disables it.
+   */
+  streamIdleReconnect?: IdleReconnectMode;
   /**
    * Built-in transports only: delay before each reconnect attempt.
    * Defaults to exponential backoff with jitter.
@@ -232,7 +246,7 @@ export interface InterruptPayload<TPayload = unknown> {
  * opened on first property access and cached.
  */
 export interface ThreadExtension<T = unknown>
-  extends AsyncIterable<T>, PromiseLike<T> {}
+  extends AsyncIterable<T>, PromiseLike<T> { }
 
 /**
  * Unwrap a single in-process projection value to its observable payload

--- a/libs/sdk/src/client/threads/index.ts
+++ b/libs/sdk/src/client/threads/index.ts
@@ -520,6 +520,7 @@ export class ThreadsClient<
             })
           : new ProtocolSseTransportAdapter({
               ...commonOpts,
+              idleReconnect: options.streamIdleReconnect,
               fetch: userFetch,
               asyncCaller: userFetch ? undefined : this.asyncCaller,
             });

--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -1,6 +1,7 @@
 import type { LangChainTracer } from "@langchain/core/tracers/tracer_langchain";
 import { Checkpoint, Config, Metadata } from "./schema.js";
 import { StreamMode } from "./types.stream.js";
+import type { IdleReconnectMode } from "./utils/stream.js";
 
 export type MultitaskStrategy = "reject" | "interrupt" | "rollback" | "enqueue";
 export type OnConflictBehavior = "raise" | "do_nothing";
@@ -186,6 +187,26 @@ export interface RunsStreamPayload<
    * If true, the stream can be resumed and replayed in its entirety even after disconnection.
    */
   streamResumable?: boolean;
+
+  /**
+   * Idle-reconnect policy guarding against half-open sockets that hang
+   * indefinitely with no error or close (e.g. a platform revision rollover
+   * that hard-kills the serving pod). On idle the read is aborted and
+   * re-issued with `Last-Event-ID`, resuming from the persisted buffer
+   * (requires `streamResumable: true`).
+   *
+   * - `"auto"` (default): the client watches for the server's SSE keep-alive
+   *   heartbeats (LangGraph Platform sends `: heartbeat` every ~5s) and only
+   *   arms idle detection once it has observed them, sizing the window from
+   *   the observed cadence. Because heartbeats keep flowing while the agent
+   *   is merely quiet (long tool calls, HITL pauses), this is independent of
+   *   agent activity and won't false-fire. On a server that never sends
+   *   heartbeats it stays dormant.
+   * - a `number`: a fixed idle window in milliseconds (arms from the first
+   *   byte; does not depend on heartbeats).
+   * - `0`: disables it.
+   */
+  streamIdleReconnect?: IdleReconnectMode;
 
   /**
    * Pass one or more feedbackKeys if you want to request short-lived signed URLs

--- a/libs/sdk/src/utils/idle-reconnect.test.ts
+++ b/libs/sdk/src/utils/idle-reconnect.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { idleReconnectStream, StreamIdleTimeoutError } from "./stream.js";
+
+const enc = new TextEncoder();
+/** BytesLineDecoder emits lines without their trailing newline. */
+const line = (s: string) => enc.encode(s);
+const HEARTBEAT = line(": heartbeat");
+const DATA = line('data: {"x":1}');
+
+/**
+ * Drain the readable in the background, resolving when the stream ends
+ * (`done`) or rejects (idle-timeout error).
+ */
+function drain(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<{
+  errored: boolean;
+  error?: unknown;
+}> {
+  return (async () => {
+    try {
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const { done } = await reader.read();
+        if (done) return { errored: false };
+      }
+    } catch (error) {
+      return { errored: true, error };
+    }
+  })();
+}
+
+describe("idleReconnectStream", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("auto: arms after two heartbeats and fires after ~3x the cadence of silence", async () => {
+    vi.useFakeTimers();
+    const ts = idleReconnectStream({ mode: "auto" });
+    const writer = ts.writable.getWriter();
+    const result = drain(ts.readable.getReader());
+
+    await writer.write(HEARTBEAT); // t=0, first heartbeat (no cadence yet)
+    await vi.advanceTimersByTimeAsync(5_000);
+    await writer.write(HEARTBEAT); // t=5s → interval 5s → window 15s
+
+    // 14s of silence: still alive.
+    await vi.advanceTimersByTimeAsync(14_000);
+    // Cross the 15s window.
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    const res = await result;
+    expect(res.errored).toBe(true);
+    expect(res.error).toBeInstanceOf(StreamIdleTimeoutError);
+    expect((res.error as StreamIdleTimeoutError).idleTimeoutMs).toBe(15_000);
+  });
+
+  it("auto: stays dormant on a heartbeat-less stream even through long silence", async () => {
+    vi.useFakeTimers();
+    const ts = idleReconnectStream({ mode: "auto" });
+    const writer = ts.writable.getWriter();
+    const result = drain(ts.readable.getReader());
+
+    await writer.write(DATA);
+    // Long silence with no heartbeats ever observed → never arms.
+    await vi.advanceTimersByTimeAsync(120_000);
+    await writer.close();
+
+    const res = await result;
+    expect(res.errored).toBe(false);
+  });
+
+  it("auto: heartbeats every 5s keep a quiet stream alive indefinitely", async () => {
+    vi.useFakeTimers();
+    const ts = idleReconnectStream({ mode: "auto" });
+    const writer = ts.writable.getWriter();
+    const result = drain(ts.readable.getReader());
+
+    for (let i = 0; i < 20; i += 1) {
+      await writer.write(HEARTBEAT);
+      await vi.advanceTimersByTimeAsync(5_000);
+    }
+    await writer.close();
+
+    const res = await result;
+    expect(res.errored).toBe(false);
+  });
+
+  it("fixed: arms from the first byte and fires after the configured window", async () => {
+    vi.useFakeTimers();
+    const ts = idleReconnectStream({ mode: 10_000 });
+    const result = drain(ts.readable.getReader());
+
+    // No writes at all → fires at 10s.
+    await vi.advanceTimersByTimeAsync(11_000);
+
+    const res = await result;
+    expect(res.errored).toBe(true);
+    expect(res.error).toBeInstanceOf(StreamIdleTimeoutError);
+    expect((res.error as StreamIdleTimeoutError).idleTimeoutMs).toBe(10_000);
+  });
+
+  it("fixed: activity resets the window", async () => {
+    vi.useFakeTimers();
+    const ts = idleReconnectStream({ mode: 10_000 });
+    const writer = ts.writable.getWriter();
+    const result = drain(ts.readable.getReader());
+
+    // A line every 8s keeps resetting the 10s window.
+    for (let i = 0; i < 5; i += 1) {
+      await vi.advanceTimersByTimeAsync(8_000);
+      await writer.write(DATA);
+    }
+    await writer.close();
+
+    const res = await result;
+    expect(res.errored).toBe(false);
+  });
+});

--- a/libs/sdk/src/utils/stream.ts
+++ b/libs/sdk/src/utils/stream.ts
@@ -54,6 +54,160 @@ export class MaxReconnectAttemptsError extends Error {
 }
 
 /**
+ * Error injected into the stream by {@link idleReconnectStream} when no lines
+ * arrive within the active idle window. Surfacing this during the read is what
+ * lets the reconnect loops in `streamWithRetry` and the protocol SSE transport
+ * recover from a half-open socket — one that was silently dropped (e.g. a hard
+ * pod kill on a platform revision rollover) without a TCP FIN/RST, so neither
+ * a `done` nor a thrown network error ever arrives.
+ */
+export class StreamIdleTimeoutError extends Error {
+  readonly idleTimeoutMs: number;
+
+  constructor(idleTimeoutMs: number) {
+    super(
+      `No SSE bytes received for ${idleTimeoutMs}ms; assuming the connection is half-open and reconnecting.`
+    );
+    this.name = "StreamIdleTimeoutError";
+    this.idleTimeoutMs = idleTimeoutMs;
+  }
+}
+
+/** `":"` — first byte of an SSE comment / keep-alive line. */
+const SSE_COMMENT_BYTE = 0x3a;
+
+/**
+ * How {@link idleReconnectStream} decides when the connection is idle.
+ *
+ * - A `number` is a fixed idle window in milliseconds: the watchdog arms
+ *   immediately (even before the first byte) and trips after that long with no
+ *   activity. Use when you know your server's behaviour and want guaranteed
+ *   coverage from t=0; it does not depend on heartbeats.
+ * - `"auto"` is heartbeat-adaptive: the watchdog stays dormant until it has
+ *   observed the server's SSE keep-alive comments (e.g. LangGraph Platform's
+ *   `: heartbeat` every ~5s), then arms with a window derived from the
+ *   observed cadence. On a server that never sends heartbeats it never arms,
+ *   so it can't false-fire during a legitimately quiet period.
+ */
+export type IdleReconnectMode = number | "auto";
+
+export interface IdleReconnectStreamOptions {
+  /** Fixed timeout (ms) or `"auto"` heartbeat-adaptive. */
+  mode: IdleReconnectMode;
+  /** `"auto"`: multiplier applied to the observed heartbeat interval. Default 3. */
+  timeoutFactor?: number;
+  /** `"auto"`: lower clamp for the derived timeout (ms). Default 6000. */
+  minTimeoutMs?: number;
+  /** `"auto"`: upper clamp for the derived timeout (ms). Default 30000. */
+  maxTimeoutMs?: number;
+  /** Fired immediately before the stream is errored, for logging/metrics. */
+  onIdle?: (info: { timeoutMs: number; source: "fixed" | "heartbeat" }) => void;
+}
+
+/**
+ * A pass-through {@link TransformStream} that errors the stream when it goes
+ * idle, so the surrounding reconnect logic can recover a half-open socket.
+ *
+ * MUST sit on the *line* stream — i.e. after
+ * {@link import("./sse.js").BytesLineDecoder} but before
+ * {@link import("./sse.js").SSEDecoder} (which discards `:` comment lines).
+ * Operating at the line level lets the watchdog both (a) reset on any line
+ * (data *or* heartbeat = liveness) and (b) recognise heartbeat comment lines
+ * to drive `"auto"` mode.
+ *
+ * In `"auto"` mode the watchdog is intentionally dormant until it has seen at
+ * least two heartbeats (so it can measure the cadence). This means a socket
+ * that dies inside the first heartbeat interval won't be caught until a
+ * heartbeat would have been due — an acceptable trade for never false-firing
+ * on heartbeat-less servers. Pass a fixed `number` if you need coverage from
+ * the very first byte.
+ */
+export function idleReconnectStream(
+  options: IdleReconnectStreamOptions
+): TransformStream<Uint8Array, Uint8Array> {
+  const factor = options.timeoutFactor ?? 3;
+  const minTimeoutMs = options.minTimeoutMs ?? 6_000;
+  const maxTimeoutMs = options.maxTimeoutMs ?? 30_000;
+  const fixedTimeoutMs = typeof options.mode === "number" ? options.mode : null;
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let controllerRef: TransformStreamDefaultController<Uint8Array> | undefined;
+
+  // `"auto"` cadence inference.
+  let lastHeartbeatAt: number | undefined;
+  // The active idle window: the fixed value, or (auto) the heartbeat-derived
+  // value once known. `null` means "not armed yet".
+  let derivedTimeoutMs: number | null = fixedTimeoutMs;
+
+  const clear = () => {
+    if (timer != null) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+
+  const arm = () => {
+    clear();
+    const timeoutMs = derivedTimeoutMs;
+    if (timeoutMs == null || timeoutMs <= 0) return;
+    timer = setTimeout(() => {
+      options.onIdle?.({
+        timeoutMs,
+        source: fixedTimeoutMs != null ? "fixed" : "heartbeat",
+      });
+      try {
+        controllerRef?.error(new StreamIdleTimeoutError(timeoutMs));
+      } catch {
+        // Stream already closed/errored/cancelled — nothing to abort.
+      }
+    }, timeoutMs);
+    // Don't let the watchdog by itself keep a Node process alive.
+    (timer as unknown as { unref?: () => void }).unref?.();
+  };
+
+  const noteHeartbeat = () => {
+    if (fixedTimeoutMs != null) return; // cadence irrelevant in fixed mode
+    const now = Date.now();
+    if (lastHeartbeatAt != null) {
+      const interval = now - lastHeartbeatAt;
+      if (interval > 0) {
+        const candidate = Math.min(
+          Math.max(interval * factor, minTimeoutMs),
+          maxTimeoutMs
+        );
+        // Keep the most conservative (largest) window observed so far.
+        derivedTimeoutMs =
+          derivedTimeoutMs == null
+            ? candidate
+            : Math.max(derivedTimeoutMs, candidate);
+      }
+    }
+    lastHeartbeatAt = now;
+  };
+
+  return new TransformStream<Uint8Array, Uint8Array>({
+    start(controller) {
+      controllerRef = controller;
+      // Fixed mode arms eagerly (also catches pre-first-byte silence). Auto
+      // mode waits until a cadence is established in `transform`.
+      arm();
+    },
+    transform(line, controller) {
+      // A line beginning with ":" is an SSE comment / keep-alive heartbeat.
+      if (line.length > 0 && line[0] === SSE_COMMENT_BYTE) {
+        noteHeartbeat();
+      }
+      // Any line is liveness — (re)arm the idle timer.
+      arm();
+      controller.enqueue(line);
+    },
+    flush() {
+      clear();
+    },
+  });
+}
+
+/**
  * Stream with automatic retry logic for SSE connections.
  * Implements reconnection behavior similar to the Python SDK.
  *


### PR DESCRIPTION
## Summary
- Add heartbeat-adaptive idle reconnect for SSE streams (`idleReconnectStream`) so half-open connections (e.g. platform revision rollover) are detected when `: heartbeat` comments stop arriving and the existing reconnect path resumes with `Last-Event-ID` or `since`.
- `"auto"` mode (default on built-in SSE transports) stays dormant until heartbeats are observed, sizes the idle window from their cadence (~15s on the platform's 5s heartbeat), and does not false-fire during long tool calls or HITL pauses.
- Expose `streamIdleReconnect?: IdleReconnectMode` on `runs.stream`, `runs.joinStream`, and `threads.stream`; reuse `IdleReconnectMode` across public option types.
