### PR TITLE
feat(langgraph): forward task metadata and name subagents via lc_agent_name

### DIFF
--- a/.changeset/fix-nested-invoke-preserves-namespace.md
+++ b/.changeset/fix-nested-invoke-preserves-namespace.md
@@ -1,0 +1,22 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(langgraph): preserve namespace nesting for imperative graph invokes
+
+When a compiled graph is invoked from inside another graph's running task
+(e.g. a tool body calling `subAgent.invoke(...)`), the surrounding task
+context — including the langgraph-internal nesting keys (`__pregel_read`,
+`__pregel_stream`, `checkpoint_ns`, the checkpoint map) — is propagated
+implicitly via `AsyncLocalStorage`. The base `Runnable.stream` calls
+langchain-core's `ensureConfig`, which replaces the ambient `configurable`
+wholesale whenever the caller passes its own. Because `createAgent` always
+supplies a `configurable`, every tool-invoked sub-agent lost those keys, ran
+as a fresh root run, and had its streamed events flattened to the root
+namespace instead of nesting under the triggering task.
+
+`Pregel.stream` now merges the ambient `configurable` underneath the caller's
+(caller keys win per-key) when the ambient marks an active task
+(`__pregel_read` present) but the explicit `configurable` is missing it.
+Declared subgraph nodes (which already carry their own `__pregel_read`) and
+top-level runs are unaffected.

--- a/.changeset/fix-task-metadata-lifecycle-subagents.md
+++ b/.changeset/fix-task-metadata-lifecycle-subagents.md
@@ -1,0 +1,11 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(langgraph): forward task metadata and name subagents via lc_agent_name
+
+`mapDebugTasks` now forwards filtered user-meaningful task config metadata
+(including `lc_agent_name`) onto `tasks` stream payloads. The lifecycle
+transformer uses that metadata to set subagent `graph_name` from
+`lc_agent_name` and recover `cause: { type: "toolCall", tool_call_id }`
+from parent tool-dispatch tasks. Ports langgraph#7928.

--- a/.changeset/fix-task-metadata-lifecycle-subagents.md
+++ b/.changeset/fix-task-metadata-lifecycle-subagents.md
@@ -1,5 +1,6 @@
 ---
 "@langchain/langgraph": patch
+"@langchain/langgraph-checkpoint": patch
 ---
 
 fix(langgraph): forward task metadata and name subagents via lc_agent_name
@@ -8,4 +9,5 @@ fix(langgraph): forward task metadata and name subagents via lc_agent_name
 (including `lc_agent_name`) onto `tasks` stream payloads. The lifecycle
 transformer uses that metadata to set subagent `graph_name` from
 `lc_agent_name` and recover `cause: { type: "toolCall", tool_call_id }`
-from parent tool-dispatch tasks. Ports langgraph#7928.
+from parent tool-dispatch tasks. Adds the shared `EXCLUDED_METADATA_KEYS`
+constant to `@langchain/langgraph-checkpoint`. Ports langgraph#7928.

--- a/libs/checkpoint/src/base.ts
+++ b/libs/checkpoint/src/base.ts
@@ -285,6 +285,27 @@ export const WRITES_IDX_MAP: Record<string, number> = {
   [RESUME]: -4,
 };
 
+/**
+ * Metadata keys that are LangGraph's internal framework bookkeeping and
+ * should not be surfaced as user-meaningful metadata.
+ *
+ * Consumed by stream handlers (e.g. the `tasks` debug stream) to drop
+ * framework keys — which are redundant with a task's own fields and
+ * namespace — while keeping keys like `lc_agent_name`, `ls_integration`,
+ * and user-supplied metadata.
+ */
+export const EXCLUDED_METADATA_KEYS: ReadonlySet<string> = new Set([
+  "thread_id",
+  "checkpoint_id",
+  "checkpoint_ns",
+  "checkpoint_map",
+  "langgraph_step",
+  "langgraph_node",
+  "langgraph_triggers",
+  "langgraph_path",
+  "langgraph_checkpoint_ns",
+]);
+
 export function getCheckpointId(config: RunnableConfig): string {
   return (
     config.configurable?.checkpoint_id || config.configurable?.thread_ts || ""

--- a/libs/langgraph-core/src/pregel/debug.test.ts
+++ b/libs/langgraph-core/src/pregel/debug.test.ts
@@ -1,9 +1,28 @@
 import { describe, expect, it, vi } from "vitest";
-import { wrap, tasksWithWrites, _readChannels } from "./debug.js";
+import { wrap, tasksWithWrites, _readChannels, mapDebugTasks } from "./debug.js";
 import { BaseChannel } from "../channels/base.js";
 import { LastValue } from "../channels/last_value.js";
 import { EmptyChannelError } from "../errors.js";
 import { ERROR, INTERRUPT, PULL } from "../constants.js";
+import type { PregelExecutableTask } from "./types.js";
+import type { LangGraphRunnableConfig } from "./runnable_types.js";
+
+function makeTask(overrides: {
+  id?: string;
+  name?: string;
+  input?: unknown;
+  triggers?: string[];
+  config?: LangGraphRunnableConfig;
+}): PregelExecutableTask<string, string> {
+  return {
+    id: overrides.id ?? "t1",
+    name: overrides.name ?? "tools",
+    input: overrides.input ?? [],
+    triggers: overrides.triggers ?? ["x"],
+    config: overrides.config,
+    writes: [],
+  } as unknown as PregelExecutableTask<string, string>;
+}
 
 describe("wrap", () => {
   it("should wrap text with color codes", () => {
@@ -291,5 +310,98 @@ describe("tasksWithWrites", () => {
         result: undefined,
       },
     ]);
+  });
+});
+
+describe("mapDebugTasks", () => {
+  it("forwards user-meaningful metadata when present", () => {
+    const task = makeTask({
+      config: { metadata: { lc_agent_name: "weather_agent" } },
+    });
+    const [payload] = Array.from(mapDebugTasks([task]));
+    expect(payload.id).toBe("t1");
+    expect(payload.name).toBe("tools");
+    expect(payload.metadata).toEqual({ lc_agent_name: "weather_agent" });
+  });
+
+  it("omits metadata when the config metadata dict is empty", () => {
+    const task = makeTask({ config: { metadata: {} } });
+    const [payload] = Array.from(mapDebugTasks([task]));
+    expect(payload).not.toHaveProperty("metadata");
+  });
+
+  it("omits metadata when config has no metadata key", () => {
+    const task = makeTask({ config: {} });
+    const [payload] = Array.from(mapDebugTasks([task]));
+    expect(payload).not.toHaveProperty("metadata");
+  });
+
+  it("handles an undefined config without crashing", () => {
+    const task = makeTask({ config: undefined });
+    const payloads = Array.from(mapDebugTasks([task]));
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).not.toHaveProperty("metadata");
+  });
+
+  it("drops internal framework metadata keys, keeping user-meaningful ones", () => {
+    const task = makeTask({
+      config: {
+        metadata: {
+          lc_agent_name: "weather_agent",
+          ls_integration: "langchain_create_agent",
+          my_user_key: "x",
+          thread_id: "thread-1",
+          langgraph_step: 1,
+          langgraph_node: "tools",
+          langgraph_path: ["__pregel_pull", "tools"],
+          langgraph_checkpoint_ns: "tools:abc",
+          checkpoint_ns: "",
+        },
+      },
+    });
+    const [payload] = Array.from(mapDebugTasks([task]));
+    expect(payload.metadata).toEqual({
+      lc_agent_name: "weather_agent",
+      ls_integration: "langchain_create_agent",
+      my_user_key: "x",
+    });
+  });
+
+  it("does not mutate the source config metadata", () => {
+    const metadata = { lc_agent_name: "a" };
+    const task = makeTask({ config: { metadata } });
+    const [payload] = Array.from(mapDebugTasks([task]));
+    (metadata as Record<string, unknown>).lc_agent_name = "MUTATED";
+    expect((payload.metadata as Record<string, unknown>).lc_agent_name).toBe(
+      "a"
+    );
+  });
+
+  it("folds filtered config tags into metadata under `tags`", () => {
+    const task = makeTask({
+      config: {
+        metadata: { lc_agent_name: "weather_agent" },
+        tags: ["seq:step:1", "user-tag", "session-123"],
+      },
+    });
+    const [payload] = Array.from(mapDebugTasks([task]));
+    expect(payload.metadata).toEqual({
+      lc_agent_name: "weather_agent",
+      tags: ["user-tag", "session-123"],
+    });
+  });
+
+  it("omits tags when the only tags are internal seq:step markers", () => {
+    const task = makeTask({
+      config: { metadata: { lc_agent_name: "a" }, tags: ["seq:step:1"] },
+    });
+    const [payload] = Array.from(mapDebugTasks([task]));
+    expect(payload.metadata).toEqual({ lc_agent_name: "a" });
+  });
+
+  it("surfaces filtered tags even without other metadata", () => {
+    const task = makeTask({ config: { tags: ["user-tag"] } });
+    const [payload] = Array.from(mapDebugTasks([task]));
+    expect(payload.metadata).toEqual({ tags: ["user-tag"] });
   });
 });

--- a/libs/langgraph-core/src/pregel/debug.ts
+++ b/libs/langgraph-core/src/pregel/debug.ts
@@ -20,6 +20,7 @@ import {
 } from "./types.js";
 import { readChannels } from "./io.js";
 import { findSubgraphPregel } from "./utils/subgraph.js";
+import { EXCLUDED_METADATA_KEYS, filterToUserTags } from "./utils/config.js";
 
 type ConsoleColors = {
   start: string;
@@ -87,6 +88,30 @@ export function* _readChannels<Value>(
   }
 }
 
+/**
+ * Build the user-meaningful metadata to forward on a task's stream payload.
+ *
+ * Drops langgraph's internal framework keys ({@link EXCLUDED_METADATA_KEYS}) —
+ * which are redundant with the task's own fields and namespace — while keeping
+ * keys like `lc_agent_name`, `ls_integration`, and any user-supplied metadata.
+ * Filtered config tags are folded in under `tags`, mirroring the messages
+ * stream handler. Returns `undefined` when there is nothing to forward.
+ */
+function buildTaskMetadata(
+  config: RunnableConfig | undefined
+): Record<string, unknown> | undefined {
+  if (config == null) return undefined;
+  const metadata: Record<string, unknown> = {};
+  if (config.metadata != null) {
+    for (const [key, value] of Object.entries(config.metadata)) {
+      if (!EXCLUDED_METADATA_KEYS.has(key)) metadata[key] = value;
+    }
+  }
+  const filteredTags = filterToUserTags(config.tags);
+  if (filteredTags != null) metadata.tags = filteredTags;
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
 export function* mapDebugTasks<N extends PropertyKey, C extends PropertyKey>(
   tasks: readonly PregelExecutableTask<N, C>[]
 ) {
@@ -100,7 +125,17 @@ export function* mapDebugTasks<N extends PropertyKey, C extends PropertyKey>(
       .map(([, v]) => {
         return v;
       });
-    yield { id, name, input, triggers, interrupts };
+    const payload: {
+      id: string;
+      name: N;
+      input: unknown;
+      triggers: string[];
+      interrupts: unknown[];
+      metadata?: Record<string, unknown>;
+    } = { id, name, input, triggers, interrupts };
+    const metadata = buildTaskMetadata(config);
+    if (metadata != null) payload.metadata = metadata;
+    yield payload;
   }
 }
 

--- a/libs/langgraph-core/src/pregel/debug.ts
+++ b/libs/langgraph-core/src/pregel/debug.ts
@@ -2,6 +2,7 @@ import { RunnableConfig } from "@langchain/core/runnables";
 import {
   CheckpointMetadata,
   CheckpointPendingWrite,
+  EXCLUDED_METADATA_KEYS,
   PendingWrite,
 } from "@langchain/langgraph-checkpoint";
 import { BaseChannel } from "../channels/base.js";
@@ -20,7 +21,7 @@ import {
 } from "./types.js";
 import { readChannels } from "./io.js";
 import { findSubgraphPregel } from "./utils/subgraph.js";
-import { EXCLUDED_METADATA_KEYS, filterToUserTags } from "./utils/config.js";
+import { filterToUserTags } from "./utils/config.js";
 
 type ConsoleColors = {
   start: string;

--- a/libs/langgraph-core/src/pregel/index.ts
+++ b/libs/langgraph-core/src/pregel/index.ts
@@ -1995,6 +1995,33 @@ export class Pregel<
     // and override if it is passed as an explicit param in `options`.
     const abortController = new AbortController();
 
+    // Preserve nesting when a compiled graph is invoked imperatively from
+    // inside another graph's running task (e.g. a tool body calling
+    // `subAgent.invoke(...)`). The surrounding task config — including the
+    // langgraph-internal nesting keys (`CONFIG_KEY_READ`, `CONFIG_KEY_STREAM`,
+    // `checkpoint_ns`, the checkpoint map, ...) — is propagated implicitly via
+    // `AsyncLocalStorage`, so a no-config `invoke()` nests correctly. But the
+    // base `Runnable.stream` calls langchain-core's `ensureConfig`, which
+    // replaces the ambient `configurable` wholesale whenever the caller passes
+    // its own. `createAgent`/`ReactAgent` always passes a `configurable`, so
+    // without this every tool-invoked sub-agent would lose the nesting keys,
+    // run as a fresh root, and flatten its streamed events to the root
+    // namespace. When the ambient marks an active task (`CONFIG_KEY_READ`
+    // present) but the caller's `configurable` is missing it, merge the ambient
+    // `configurable` underneath the caller's (caller keys still win per-key).
+    // Declared subgraph nodes already carry their own `CONFIG_KEY_READ` and are
+    // left untouched; top-level runs (no ambient task) are unaffected.
+    const ambientConfigurable = getConfig()?.configurable;
+    if (
+      ambientConfigurable?.[CONFIG_KEY_READ] !== undefined &&
+      options?.configurable?.[CONFIG_KEY_READ] === undefined
+    ) {
+      options = {
+        ...options,
+        configurable: { ...ambientConfigurable, ...options?.configurable },
+      } as typeof options;
+    }
+
     const config = {
       recursionLimit: this.config?.recursionLimit,
       ...options,

--- a/libs/langgraph-core/src/pregel/utils/config.ts
+++ b/libs/langgraph-core/src/pregel/utils/config.ts
@@ -73,6 +73,43 @@ export function propagateConfigurableToMetadata(
 }
 
 /**
+ * Metadata keys that are langgraph's internal framework bookkeeping and
+ * should not be surfaced as user-meaningful metadata.
+ *
+ * Mirrors `EXCLUDED_METADATA_KEYS` from langgraph's checkpoint base. Used by
+ * the `tasks` stream handler ({@link mapDebugTasks}) to drop framework keys
+ * (which are redundant with a task's own fields and namespace) while keeping
+ * keys like `lc_agent_name`, `ls_integration`, and user-supplied metadata.
+ */
+export const EXCLUDED_METADATA_KEYS: ReadonlySet<string> = new Set([
+  "thread_id",
+  "checkpoint_id",
+  "checkpoint_ns",
+  "checkpoint_map",
+  "langgraph_step",
+  "langgraph_node",
+  "langgraph_triggers",
+  "langgraph_path",
+  "langgraph_checkpoint_ns",
+]);
+
+/**
+ * Drop langgraph's internal `seq:step*` bookkeeping tags.
+ *
+ * `seq:step:N` tags are added internally to mark sequence steps; everything
+ * else (user-supplied tags and any other framework tags) is kept. Returns the
+ * surviving tags, or `undefined` if none remain. Shared by the stream handlers
+ * (e.g. {@link mapDebugTasks}) so the same tag set is surfaced consistently.
+ */
+export function filterToUserTags(
+  tags: readonly string[] | undefined
+): string[] | undefined {
+  if (tags == null || tags.length === 0) return undefined;
+  const filtered = tags.filter((tag) => !tag.startsWith("seq:step"));
+  return filtered.length > 0 ? filtered : undefined;
+}
+
+/**
  * Merge two `callbacks` values across configs.
  *
  * A `callbacks` value may be `undefined`, an array of handlers, or a

--- a/libs/langgraph-core/src/pregel/utils/config.ts
+++ b/libs/langgraph-core/src/pregel/utils/config.ts
@@ -73,27 +73,6 @@ export function propagateConfigurableToMetadata(
 }
 
 /**
- * Metadata keys that are langgraph's internal framework bookkeeping and
- * should not be surfaced as user-meaningful metadata.
- *
- * Mirrors `EXCLUDED_METADATA_KEYS` from langgraph's checkpoint base. Used by
- * the `tasks` stream handler ({@link mapDebugTasks}) to drop framework keys
- * (which are redundant with a task's own fields and namespace) while keeping
- * keys like `lc_agent_name`, `ls_integration`, and user-supplied metadata.
- */
-export const EXCLUDED_METADATA_KEYS: ReadonlySet<string> = new Set([
-  "thread_id",
-  "checkpoint_id",
-  "checkpoint_ns",
-  "checkpoint_map",
-  "langgraph_step",
-  "langgraph_node",
-  "langgraph_triggers",
-  "langgraph_path",
-  "langgraph_checkpoint_ns",
-]);
-
-/**
  * Drop langgraph's internal `seq:step*` bookkeeping tags.
  *
  * `seq:step:N` tags are added internally to mark sequence steps; everything

--- a/libs/langgraph-core/src/stream/transformers/lifecycle.test.ts
+++ b/libs/langgraph-core/src/stream/transformers/lifecycle.test.ts
@@ -362,6 +362,222 @@ describe("createLifecycleTransformer", () => {
     expect(interrupted.length).toBeGreaterThanOrEqual(1);
   });
 
+  it("falls through to the parsed segment when a tasks-start has no metadata", async () => {
+    const mux = new StreamMux();
+    const transformer = createLifecycleTransformer({
+      emitRootOnRegister: false,
+    });
+    installTransformer(mux, transformer);
+
+    mux.push(
+      ["agent:abc"],
+      makeEvent("tasks", ["agent:abc"], {
+        id: "t1",
+        name: "tool",
+        input: null,
+        triggers: [],
+      })
+    );
+    transformer.finalize?.();
+    mux.close();
+
+    const events = await drainEvents(mux);
+    const started = events.find(
+      (e) =>
+        isLifecycle(e) &&
+        e.params.namespace[0] === "agent:abc" &&
+        lifecyclePayload(e).event === "started"
+    );
+    expect(started).toBeDefined();
+    expect(lifecyclePayload(started!).graph_name).toBe("agent");
+    expect(lifecyclePayload(started!).cause).toBeUndefined();
+  });
+
+  it("treats an explicit empty metadata dict like no metadata", async () => {
+    const mux = new StreamMux();
+    const transformer = createLifecycleTransformer({
+      emitRootOnRegister: false,
+    });
+    installTransformer(mux, transformer);
+
+    mux.push(
+      ["agent:abc"],
+      makeEvent("tasks", ["agent:abc"], {
+        id: "t1",
+        name: "tool",
+        input: null,
+        triggers: [],
+        metadata: {},
+      })
+    );
+    transformer.finalize?.();
+    mux.close();
+
+    const events = await drainEvents(mux);
+    const started = events.find(
+      (e) =>
+        isLifecycle(e) &&
+        e.params.namespace[0] === "agent:abc" &&
+        lifecyclePayload(e).event === "started"
+    );
+    expect(started).toBeDefined();
+    expect(lifecyclePayload(started!).graph_name).toBe("agent");
+    expect(lifecyclePayload(started!).cause).toBeUndefined();
+  });
+
+  it("names a subagent from lc_agent_name and recovers the tool-call cause", async () => {
+    const mux = new StreamMux();
+    const transformer = createLifecycleTransformer({
+      emitRootOnRegister: false,
+    });
+    installTransformer(mux, transformer);
+
+    // Supervisor's `tools` push task at scope ns: carries its own
+    // lc_agent_name and a `tool_call_with_context` dict as `input`. The task
+    // id seeds the child segment.
+    mux.push(
+      [],
+      makeEvent("tasks", [], {
+        id: "tools_task_1",
+        name: "tools",
+        triggers: [],
+        metadata: { lc_agent_name: "supervisor" },
+        input: {
+          __type: "tool_call_with_context",
+          tool_call: {
+            name: "call_weather",
+            args: { city: "Boston" },
+            id: "call_w",
+            type: "tool_call",
+          },
+          state: {},
+        },
+      })
+    );
+    // Inner weather_agent's first node task streams under the parent `tools`
+    // task's namespace segment (shared task id) with its own lc_agent_name.
+    mux.push(
+      ["tools:tools_task_1"],
+      makeEvent("tasks", ["tools:tools_task_1"], {
+        id: "inner_model_1",
+        name: "model",
+        input: null,
+        triggers: [],
+        metadata: { lc_agent_name: "weather_agent" },
+      })
+    );
+    transformer.finalize?.();
+    mux.close();
+
+    const events = await drainEvents(mux);
+    const started = events.find(
+      (e) =>
+        isLifecycle(e) &&
+        e.params.namespace[0] === "tools:tools_task_1" &&
+        lifecyclePayload(e).event === "started"
+    );
+    expect(started).toBeDefined();
+    expect(lifecyclePayload(started!).graph_name).toBe("weather_agent");
+    expect(lifecyclePayload(started!).cause).toEqual({
+      type: "toolCall",
+      tool_call_id: "call_w",
+    });
+  });
+
+  it("recovers the tool-call cause from a legacy list input shape", async () => {
+    const mux = new StreamMux();
+    const transformer = createLifecycleTransformer({
+      emitRootOnRegister: false,
+    });
+    installTransformer(mux, transformer);
+
+    mux.push(
+      [],
+      makeEvent("tasks", [], {
+        id: "tools_task_1",
+        name: "tools",
+        triggers: [],
+        metadata: { lc_agent_name: "supervisor" },
+        input: [{ name: "call_weather", args: { city: "SF" }, id: "call_w" }],
+      })
+    );
+    mux.push(
+      ["tools:tools_task_1"],
+      makeEvent("tasks", ["tools:tools_task_1"], {
+        id: "inner_model_1",
+        name: "model",
+        input: null,
+        triggers: [],
+        metadata: { lc_agent_name: "weather_agent" },
+      })
+    );
+    transformer.finalize?.();
+    mux.close();
+
+    const events = await drainEvents(mux);
+    const started = events.find(
+      (e) =>
+        isLifecycle(e) &&
+        e.params.namespace[0] === "tools:tools_task_1" &&
+        lifecyclePayload(e).event === "started"
+    );
+    expect(started).toBeDefined();
+    expect(lifecyclePayload(started!).graph_name).toBe("weather_agent");
+    expect(lifecyclePayload(started!).cause).toEqual({
+      type: "toolCall",
+      tool_call_id: "call_w",
+    });
+  });
+
+  it("surfaces a same-named recursive subagent with its tool-call cause", async () => {
+    const mux = new StreamMux();
+    const transformer = createLifecycleTransformer({
+      emitRootOnRegister: false,
+    });
+    installTransformer(mux, transformer);
+
+    mux.push(
+      [],
+      makeEvent("tasks", [], {
+        id: "tools_task_1",
+        name: "tools",
+        triggers: [],
+        metadata: { lc_agent_name: "weather_agent" },
+        input: {
+          __type: "tool_call_with_context",
+          tool_call: { name: "recurse", args: {}, id: "call_x", type: "tool_call" },
+          state: {},
+        },
+      })
+    );
+    mux.push(
+      ["tools:tools_task_1"],
+      makeEvent("tasks", ["tools:tools_task_1"], {
+        id: "inner_model_1",
+        name: "model",
+        input: null,
+        triggers: [],
+        metadata: { lc_agent_name: "weather_agent" },
+      })
+    );
+    transformer.finalize?.();
+    mux.close();
+
+    const events = await drainEvents(mux);
+    const started = events.find(
+      (e) =>
+        isLifecycle(e) &&
+        e.params.namespace[0] === "tools:tools_task_1" &&
+        lifecyclePayload(e).event === "started"
+    );
+    expect(started).toBeDefined();
+    expect(lifecyclePayload(started!).graph_name).toBe("weather_agent");
+    expect(lifecyclePayload(started!).cause).toEqual({
+      type: "toolCall",
+      tool_call_id: "call_x",
+    });
+  });
+
   it("exposes a _lifecycleLog projection iterable by consumers", async () => {
     const mux = new StreamMux();
     const transformer = createLifecycleTransformer({ rootGraphName: "g" });

--- a/libs/langgraph-core/src/stream/transformers/lifecycle.ts
+++ b/libs/langgraph-core/src/stream/transformers/lifecycle.ts
@@ -190,6 +190,23 @@ export function createLifecycleTransformer(
   const log = StreamChannel.local<LifecycleEntry>();
   const namespaces = new Map<string, NamespaceRecord>();
   const namespaceCause = new Map<string, LifecycleCause>();
+  /**
+   * `lc_agent_name` observed at each namespace (first task event wins). A
+   * nested run carrying an `lc_agent_name` (set by `createAgent`) is treated
+   * as a named subagent: its `graph_name` becomes that name and a tool-call
+   * `cause` is recovered (see {@link deriveToolCallCause}). Namespaces without
+   * one fall back to the parsed namespace segment, preserving the prior
+   * product-agnostic behavior for plain subgraphs.
+   */
+  const lcByNs = new Map<string, string | undefined>();
+  /**
+   * Pregel task id -> triggering LLM `tool_call_id`, harvested from a task
+   * whose `input` is a `tool_call_with_context` dict (current shape) or a list
+   * of tool-call dicts (legacy shape). The child subgraph's namespace segment
+   * `node:<task_id>` shares this task id, so a named subagent recovers the tool
+   * call that spawned it across payloads.
+   */
+  const pendingToolCalls = new Map<string, string>();
   const pendingInterruptIds = new Set<string>();
   /**
    * Child namespaces whose parent just saw an `updates` event with a
@@ -204,8 +221,87 @@ export function createLifecycleTransformer(
   let inSelfEmit = 0;
   let finalized = false;
 
-  const resolveGraphName = (ns: Namespace): string =>
-    ns.length === 0 ? rootGraphName : getGraphName(ns);
+  const resolveGraphName = (ns: Namespace): string => {
+    if (ns.length === 0) return rootGraphName;
+    // A nested run that carried an `lc_agent_name` is a named subagent; its
+    // agent name wins over the parsed namespace segment.
+    const lc = lcByNs.get(nsKey(ns));
+    if (typeof lc === "string" && lc.length > 0) return lc;
+    return getGraphName(ns);
+  };
+
+  /**
+   * Record a namespace's `lc_agent_name` from a task-start payload (first
+   * event wins). The presence of a name is what marks the namespace a named
+   * subagent; the value may be `undefined` for unnamed runs (still recorded so
+   * a later event doesn't re-evaluate it).
+   */
+  const recordIdentity = (ns: Namespace, data: unknown): void => {
+    const key = nsKey(ns);
+    if (lcByNs.has(key)) return;
+    const metadata =
+      isRecord(data) && isRecord(data.metadata) ? data.metadata : undefined;
+    const lc = metadata?.lc_agent_name;
+    lcByNs.set(key, typeof lc === "string" ? lc : undefined);
+  };
+
+  /**
+   * Harvest a task's triggering `tool_call_id` keyed by its task id. The
+   * spawned subgraph's namespace segment `node:<task_id>` shares that id, so a
+   * subagent can later recover the tool call that caused it. Two input shapes
+   * are handled: a `tool_call_with_context` object (`input.tool_call.id`) and a
+   * legacy list of tool-call objects (first with a string `id`).
+   */
+  const recordPendingToolCalls = (data: unknown): void => {
+    if (!isRecord(data)) return;
+    const taskId = data.id;
+    if (typeof taskId !== "string") return;
+    const input = data.input;
+    let toolCallId: string | undefined;
+    if (isRecord(input) && isRecord(input.tool_call)) {
+      const candidate = input.tool_call.id;
+      if (typeof candidate === "string") toolCallId = candidate;
+    } else if (Array.isArray(input)) {
+      for (const toolCall of input) {
+        if (isRecord(toolCall) && typeof toolCall.id === "string") {
+          toolCallId = toolCall.id;
+          break;
+        }
+      }
+    }
+    if (toolCallId != null) pendingToolCalls.set(taskId, toolCallId);
+  };
+
+  /**
+   * Derive a `toolCall` cause for a named subagent namespace by joining the
+   * namespace segment's task id (`node:<task_id>`) to a previously harvested
+   * `tool_call_id`. Only fires for namespaces carrying an `lc_agent_name`, so
+   * plain subgraphs never get a spurious cause.
+   */
+  const deriveToolCallCause = (ns: Namespace): LifecycleCause | undefined => {
+    if (ns.length === 0) return undefined;
+    const lc = lcByNs.get(nsKey(ns));
+    if (typeof lc !== "string" || lc.length === 0) return undefined;
+    const segment = ns[ns.length - 1];
+    const colon = segment.indexOf(":");
+    if (colon === -1) return undefined;
+    const triggerCallId = segment.slice(colon + 1);
+    if (triggerCallId.length === 0) return undefined;
+    const toolCallId = pendingToolCalls.get(triggerCallId);
+    if (typeof toolCallId !== "string" || toolCallId.length === 0) {
+      return undefined;
+    }
+    return { type: "toolCall", tool_call_id: toolCallId };
+  };
+
+  /**
+   * Resolve the `cause` to attach to a namespace's `started`. An upstream
+   * `cause` stashed from a product-specific transformer (e.g. deepagents'
+   * SubagentTransformer) wins; otherwise a tool-call cause is recovered for
+   * named subagents.
+   */
+  const resolveStartCause = (ns: Namespace): LifecycleCause | undefined =>
+    namespaceCause.get(nsKey(ns)) ?? deriveToolCallCause(ns);
 
   const emit = (
     ns: Namespace,
@@ -326,7 +422,7 @@ export function createLifecycleTransformer(
       const key = nsKey(prefix);
       if (namespaces.has(key)) continue;
       trackNamespace(prefix);
-      const cause = namespaceCause.get(key);
+      const cause = resolveStartCause(prefix);
       emit(prefix, "started", cause != null ? { cause } : undefined);
     }
   };
@@ -413,6 +509,14 @@ export function createLifecycleTransformer(
         // Prefer exact task-result attribution over any ambiguous
         // `updates.node` completion deferred from the previous event.
         removePendingNodeCompletions(ns, taskCompletion.name);
+      } else if (event.method === "tasks") {
+        // Task-start event: record the namespace's subagent identity and any
+        // triggering tool call *before* `ensureStarted` synthesizes `started`,
+        // so a named subagent's `graph_name`/`cause` are resolved in time.
+        // Pregel emits parent-namespace tasks before child-namespace tasks, so
+        // the parent's tool-call seed is in place when the child is evaluated.
+        recordIdentity(ns, event.params.data);
+        recordPendingToolCalls(event.params.data);
       }
 
       // Flush any completions deferred by the previous event so the

--- a/libs/langgraph-core/src/tests/nested-invoke-nesting.test.ts
+++ b/libs/langgraph-core/src/tests/nested-invoke-nesting.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod/v4";
+import { StateGraph } from "../graph/index.js";
+import { END, START } from "../constants.js";
+import { StateSchema } from "../state/schema.js";
+import { ReducedValue } from "../state/values/reduced.js";
+import type { LangGraphRunnableConfig } from "../pregel/runnable_types.js";
+import type { ProtocolEvent } from "../stream/types.js";
+
+const State = new StateSchema({
+  value: new ReducedValue(z.string().default(() => ""), {
+    reducer: (_a: string, b: string) => b,
+  }),
+});
+
+/**
+ * Regression tests for nesting preservation when a compiled graph is invoked
+ * imperatively from inside another graph's running task.
+ *
+ * Historically, passing an explicit `configurable` to the nested `invoke()`
+ * (as `createAgent`/`ReactAgent` does via its default config) caused
+ * langchain-core's `ensureConfig` to replace the ambient `configurable`
+ * wholesale, dropping the langgraph-internal nesting keys (`__pregel_read`,
+ * `checkpoint_ns`, ...). The nested run was then treated as a fresh root run
+ * and its streamed events were flattened to the root namespace.
+ */
+describe("nested imperative invoke nesting", () => {
+  function buildChild(captured: { ns?: string }) {
+    return new StateGraph(State)
+      .addNode("child_node", async (_s, config?: LangGraphRunnableConfig) => {
+        captured.ns = config?.configurable?.checkpoint_ns as string | undefined;
+        return { value: "child-done" };
+      })
+      .addEdge(START, "child_node")
+      .addEdge("child_node", END)
+      .compile({ name: "Child" });
+  }
+
+  it("nests the child checkpoint_ns when invoked WITH an explicit configurable", async () => {
+    const captured: { ns?: string } = {};
+    const child = buildChild(captured);
+
+    const parent = new StateGraph(State)
+      .addNode("parent_node", async () => {
+        // Mirrors ReactAgent.invoke: pass an explicit `configurable` that does
+        // NOT carry the langgraph-internal nesting keys.
+        await child.invoke(
+          { value: "go" },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { configurable: { ls_agent_type: "weather" } } as any
+        );
+        return { value: "parent-done" };
+      })
+      .addEdge(START, "parent_node")
+      .addEdge("parent_node", END)
+      .compile({ name: "Parent" });
+
+    await parent.invoke({ value: "input" });
+
+    expect(captured.ns).toBeDefined();
+    // Must nest under the triggering task, not run at the root namespace.
+    expect(captured.ns).toContain("parent_node:");
+    expect(captured.ns).toContain("|child_node:");
+  });
+
+  it("surfaces the child's streamed events nested under the triggering task", async () => {
+    const captured: { ns?: string } = {};
+    const child = buildChild(captured);
+
+    const parent = new StateGraph(State)
+      .addNode("parent_node", async () => {
+        await child.invoke(
+          { value: "go" },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { configurable: { ls_agent_type: "weather" } } as any
+        );
+        return { value: "parent-done" };
+      })
+      .addEdge(START, "parent_node")
+      .addEdge("parent_node", END)
+      .compile({ name: "Parent" });
+
+    const run = await parent.streamEvents({ value: "input" }, { version: "v3" });
+    const events: ProtocolEvent[] = [];
+    for await (const event of run) {
+      events.push(event);
+    }
+
+    // The child's events must appear under the parent_node task namespace,
+    // never at the root namespace as siblings of the parent's own events.
+    const childTasks = events.filter(
+      (e) =>
+        e.method === "tasks" &&
+        e.params.namespace.length === 1 &&
+        e.params.namespace[0].startsWith("parent_node:")
+    );
+    expect(childTasks.length).toBeGreaterThan(0);
+  });
+});

--- a/libs/langgraph-core/src/tests/pregel.test.ts
+++ b/libs/langgraph-core/src/tests/pregel.test.ts
@@ -1450,6 +1450,7 @@ export function runPregelTests(
           input: 2,
           triggers: ["input"],
           interrupts: [],
+          metadata: { ls_integration: "langgraph" },
         },
       },
       {
@@ -1462,6 +1463,7 @@ export function runPregelTests(
           input: [12],
           triggers: ["inbox"],
           interrupts: [],
+          metadata: { ls_integration: "langgraph" },
         },
       },
       {
@@ -1496,6 +1498,7 @@ export function runPregelTests(
           input: [3],
           triggers: ["inbox"],
           interrupts: [],
+          metadata: { ls_integration: "langgraph" },
         },
       },
       {
@@ -5452,6 +5455,7 @@ graph TD;
           input: { my_key: "value", market: "DE" },
           triggers: ["branch:to:prepare"],
           interrupts: [],
+          metadata: { ls_integration: "langgraph" },
         },
       },
       {
@@ -5520,6 +5524,7 @@ graph TD;
           input: { my_key: "value prepared", market: "DE" },
           triggers: ["branch:to:tool_two_slow"],
           interrupts: [],
+          metadata: { ls_integration: "langgraph" },
         },
       },
       {
@@ -5588,6 +5593,7 @@ graph TD;
           input: { my_key: "value prepared slow", market: "DE" },
           triggers: ["branch:to:finish"],
           interrupts: [],
+          metadata: { ls_integration: "langgraph" },
         },
       },
       {

--- a/libs/sdk-vue/vitest.config.ts
+++ b/libs/sdk-vue/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     globalSetup: ["./src/tests/fixtures/mock-server.ts"],
     browser: {
       enabled: true,
-      connectTimeout: 20_000,
+      connectTimeout: 120_000,
       provider: webdriverio(),
       instances: [{ browser: "chrome", headless: true }],
     },


### PR DESCRIPTION
## Summary
- Port of langgraph#7926: `ensureLangGraphConfig` now per-key merges `callbacks`, `tags`, `metadata`, and `configurable` across configs instead of overwriting, so values bound via `.withConfig({...})` are preserved when a later config (e.g. invoke-time `thread_id`) only supplies a subset of keys. Later configs still win per key on collision.
- Merged dicts are fresh objects, fixing a by-reference mutation where `propagateConfigurableToMetadata` could mutate a shared bound config's `metadata` across invocations.
- Removed the now-redundant `combineCallbacks` pre-combine in `Pregel.streamEvents` (v1/v2). Because the config merge now folds in `this.config` callbacks, pre-combining re-registered graph-bound handlers and double-fired them; only call-time callbacks are forwarded now.
