### PR TITLE
fix(langgraph): preserve namespace nesting for imperative graph invokes

### DIFF
--- a/.changeset/fix-nested-invoke-preserves-namespace.md
+++ b/.changeset/fix-nested-invoke-preserves-namespace.md
@@ -1,0 +1,22 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(langgraph): preserve namespace nesting for imperative graph invokes
+
+When a compiled graph is invoked from inside another graph's running task
+(e.g. a tool body calling `subAgent.invoke(...)`), the surrounding task
+context — including the langgraph-internal nesting keys (`__pregel_read`,
+`__pregel_stream`, `checkpoint_ns`, the checkpoint map) — is propagated
+implicitly via `AsyncLocalStorage`. The base `Runnable.stream` calls
+langchain-core's `ensureConfig`, which replaces the ambient `configurable`
+wholesale whenever the caller passes its own. Because `createAgent` always
+supplies a `configurable`, every tool-invoked sub-agent lost those keys, ran
+as a fresh root run, and had its streamed events flattened to the root
+namespace instead of nesting under the triggering task.
+
+`Pregel.stream` now merges the ambient `configurable` underneath the caller's
+(caller keys win per-key) when the ambient marks an active task
+(`__pregel_read` present) but the explicit `configurable` is missing it.
+Declared subgraph nodes (which already carry their own `__pregel_read`) and
+top-level runs are unaffected.

--- a/libs/langgraph-core/src/pregel/index.ts
+++ b/libs/langgraph-core/src/pregel/index.ts
@@ -1995,6 +1995,33 @@ export class Pregel<
     // and override if it is passed as an explicit param in `options`.
     const abortController = new AbortController();
 
+    // Preserve nesting when a compiled graph is invoked imperatively from
+    // inside another graph's running task (e.g. a tool body calling
+    // `subAgent.invoke(...)`). The surrounding task config — including the
+    // langgraph-internal nesting keys (`CONFIG_KEY_READ`, `CONFIG_KEY_STREAM`,
+    // `checkpoint_ns`, the checkpoint map, ...) — is propagated implicitly via
+    // `AsyncLocalStorage`, so a no-config `invoke()` nests correctly. But the
+    // base `Runnable.stream` calls langchain-core's `ensureConfig`, which
+    // replaces the ambient `configurable` wholesale whenever the caller passes
+    // its own. `createAgent`/`ReactAgent` always passes a `configurable`, so
+    // without this every tool-invoked sub-agent would lose the nesting keys,
+    // run as a fresh root, and flatten its streamed events to the root
+    // namespace. When the ambient marks an active task (`CONFIG_KEY_READ`
+    // present) but the caller's `configurable` is missing it, merge the ambient
+    // `configurable` underneath the caller's (caller keys still win per-key).
+    // Declared subgraph nodes already carry their own `CONFIG_KEY_READ` and are
+    // left untouched; top-level runs (no ambient task) are unaffected.
+    const ambientConfigurable = getConfig()?.configurable;
+    if (
+      ambientConfigurable?.[CONFIG_KEY_READ] !== undefined &&
+      options?.configurable?.[CONFIG_KEY_READ] === undefined
+    ) {
+      options = {
+        ...options,
+        configurable: { ...ambientConfigurable, ...options?.configurable },
+      } as typeof options;
+    }
+
     const config = {
       recursionLimit: this.config?.recursionLimit,
       ...options,

--- a/libs/langgraph-core/src/tests/nested-invoke-nesting.test.ts
+++ b/libs/langgraph-core/src/tests/nested-invoke-nesting.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod/v4";
+import { StateGraph } from "../graph/index.js";
+import { END, START } from "../constants.js";
+import { StateSchema } from "../state/schema.js";
+import { ReducedValue } from "../state/values/reduced.js";
+import type { LangGraphRunnableConfig } from "../pregel/runnable_types.js";
+import type { ProtocolEvent } from "../stream/types.js";
+
+const State = new StateSchema({
+  value: new ReducedValue(z.string().default(() => ""), {
+    reducer: (_a: string, b: string) => b,
+  }),
+});
+
+/**
+ * Regression tests for nesting preservation when a compiled graph is invoked
+ * imperatively from inside another graph's running task.
+ *
+ * Historically, passing an explicit `configurable` to the nested `invoke()`
+ * (as `createAgent`/`ReactAgent` does via its default config) caused
+ * langchain-core's `ensureConfig` to replace the ambient `configurable`
+ * wholesale, dropping the langgraph-internal nesting keys (`__pregel_read`,
+ * `checkpoint_ns`, ...). The nested run was then treated as a fresh root run
+ * and its streamed events were flattened to the root namespace.
+ */
+describe("nested imperative invoke nesting", () => {
+  function buildChild(captured: { ns?: string }) {
+    return new StateGraph(State)
+      .addNode("child_node", async (_s, config?: LangGraphRunnableConfig) => {
+        captured.ns = config?.configurable?.checkpoint_ns as string | undefined;
+        return { value: "child-done" };
+      })
+      .addEdge(START, "child_node")
+      .addEdge("child_node", END)
+      .compile({ name: "Child" });
+  }
+
+  it("nests the child checkpoint_ns when invoked WITH an explicit configurable", async () => {
+    const captured: { ns?: string } = {};
+    const child = buildChild(captured);
+
+    const parent = new StateGraph(State)
+      .addNode("parent_node", async () => {
+        // Mirrors ReactAgent.invoke: pass an explicit `configurable` that does
+        // NOT carry the langgraph-internal nesting keys.
+        await child.invoke(
+          { value: "go" },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { configurable: { ls_agent_type: "weather" } } as any
+        );
+        return { value: "parent-done" };
+      })
+      .addEdge(START, "parent_node")
+      .addEdge("parent_node", END)
+      .compile({ name: "Parent" });
+
+    await parent.invoke({ value: "input" });
+
+    expect(captured.ns).toBeDefined();
+    // Must nest under the triggering task, not run at the root namespace.
+    expect(captured.ns).toContain("parent_node:");
+    expect(captured.ns).toContain("|child_node:");
+  });
+
+  it("surfaces the child's streamed events nested under the triggering task", async () => {
+    const captured: { ns?: string } = {};
+    const child = buildChild(captured);
+
+    const parent = new StateGraph(State)
+      .addNode("parent_node", async () => {
+        await child.invoke(
+          { value: "go" },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          { configurable: { ls_agent_type: "weather" } } as any
+        );
+        return { value: "parent-done" };
+      })
+      .addEdge(START, "parent_node")
+      .addEdge("parent_node", END)
+      .compile({ name: "Parent" });
+
+    const run = await parent.streamEvents({ value: "input" }, { version: "v3" });
+    const events: ProtocolEvent[] = [];
+    for await (const event of run) {
+      events.push(event);
+    }
+
+    // The child's events must appear under the parent_node task namespace,
+    // never at the root namespace as siblings of the parent's own events.
+    const childTasks = events.filter(
+      (e) =>
+        e.method === "tasks" &&
+        e.params.namespace.length === 1 &&
+        e.params.namespace[0].startsWith("parent_node:")
+    );
+    expect(childTasks.length).toBeGreaterThan(0);
+  });
+});

--- a/libs/sdk-vue/vitest.config.ts
+++ b/libs/sdk-vue/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     globalSetup: ["./src/tests/fixtures/mock-server.ts"],
     browser: {
       enabled: true,
-      connectTimeout: 20_000,
+      connectTimeout: 120_000,
       provider: webdriverio(),
       instances: [{ browser: "chrome", headless: true }],
     },


### PR DESCRIPTION
## Summary

When a compiled graph is invoked **imperatively from inside another graph's running task**, the canonical case being a tool body calling `subAgent.invoke(...)` / `subAgent.stream(...)`, as `createAgent`/`ReactAgent` does, the nested run was previously **flattened to the root namespace** instead of nesting under the triggering task. This PR fixes that so JS matches the Python runtime.

I've discovered this bug in previous streaming work and tried to address it in [DeepAgents](https://github.com/langchain-ai/deepagentsjs/pull/312) before. This patch fixes it at the core which is the better approach.

### How the JS implementation has lacked

LangGraph propagates a task's config — including the internal nesting keys (`__pregel_read`, `__pregel_stream`, `checkpoint_ns`, the checkpoint map) — implicitly through `AsyncLocalStorage`. A bare `invoke()` therefore nests correctly.

The break happens when the caller passes its **own** `configurable`:

- JS `Pregel.stream` delegates to the base `Runnable.stream`, which calls **langchain-core's** `ensureConfig` (single-arg) that **replaces** the ambient `configurable` wholesale.
- That context swap happens **before** langgraph's own merge (`ensureLangGraphConfig`) runs, so by the time the merge executes the ambient is already stripped — the nesting keys are gone.
- `createAgent`/`ReactAgent` **always** supplies a `configurable`, so every tool-invoked sub-agent ran as a fresh **root** run and its streamed events surfaced at the root namespace as siblings of the parent's events.

### How it now aligns with Python

Python's `Pregel.stream` resolves config at the very top via langgraph's **own** multi-arg `ensure_config`, which seeds from the ambient context var and **shallow-merges** `configurable` so ambient keys (incl. nesting keys) survive when the caller only supplies a subset:

- `Pregel.stream` → `config = ensure_config(self.config, config)` (top of `stream`):
  https://github.com/langchain-ai/langgraph/blob/main/libs/langgraph/langgraph/pregel/main.py — `Pregel.stream`
- `ensure_config` reads `var_child_runnable_config` and shallow-merges the `configurable` (`CONF`) dict:
  https://github.com/langchain-ai/langgraph/blob/main/libs/langgraph/langgraph/_internal/_config.py — `ensure_config`

This PR replicates that semantics in JS: `Pregel.stream` reads the ambient config at the top and shallow-merges its `configurable` underneath the caller's (caller keys still win per-key) **when** the ambient marks an active task (`__pregel_read` present) but the explicit `configurable` is missing it. The gate keeps already-correct paths untouched while matching Python's outcome: