### PR TITLE
fix(sdk): avoid scoped stream resubscribe churn

### DIFF
--- a/.changeset/fix-sdk-projection-disposal-churn.md
+++ b/.changeset/fix-sdk-projection-disposal-churn.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): avoid scoped stream resubscribe churn
+
+Defer final projection disposal by one microtask so framework bindings that release and immediately reacquire the same scoped projection during reactive updates keep the existing stream subscription instead of rotating through root-only and scoped SSE filters.

--- a/libs/sdk/src/stream/channel-registry.test.ts
+++ b/libs/sdk/src/stream/channel-registry.test.ts
@@ -82,7 +82,7 @@ describe("ChannelRegistry", () => {
     expect(trace.threads[0]).toBe(thread);
   });
 
-  it("disposes the runtime only after the last consumer releases", () => {
+  it("disposes the runtime only after the last consumer releases", async () => {
     const registry = new ChannelRegistry(makeRootBus());
     const trace = makeTrace();
     registry.bind(makeThread());
@@ -95,11 +95,43 @@ describe("ChannelRegistry", () => {
     expect(registry.size).toBe(1);
 
     b.release();
+    expect(trace.disposes).toBe(0);
+    expect(registry.size).toBe(0);
+
+    await Promise.resolve();
+
     expect(trace.disposes).toBe(1);
     expect(registry.size).toBe(0);
   });
 
-  it("treats double release as a no-op", () => {
+  it("cancels last-release disposal when the same projection is reacquired", async () => {
+    const registry = new ChannelRegistry(makeRootBus());
+    const trace = makeTrace();
+    registry.bind(makeThread());
+
+    const a = registry.acquire(makeSpec("k", "init", trace));
+    a.store.setValue("evolved");
+    a.release();
+
+    expect(trace.disposes).toBe(0);
+    expect(registry.size).toBe(0);
+
+    const b = registry.acquire(makeSpec("k", "init", trace));
+    await Promise.resolve();
+
+    expect(trace.opens).toBe(1);
+    expect(trace.disposes).toBe(0);
+    expect(b.store.getSnapshot()).toBe("evolved");
+    expect(registry.size).toBe(1);
+
+    b.release();
+    await Promise.resolve();
+
+    expect(trace.disposes).toBe(1);
+    expect(registry.size).toBe(0);
+  });
+
+  it("treats double release as a no-op", async () => {
     const registry = new ChannelRegistry(makeRootBus());
     const trace = makeTrace();
     registry.bind(makeThread());
@@ -109,6 +141,8 @@ describe("ChannelRegistry", () => {
     a.release();
 
     // Second release must not crash and must not double-decrement.
+    await Promise.resolve();
+
     expect(trace.disposes).toBe(1);
     expect(registry.size).toBe(0);
   });

--- a/libs/sdk/src/stream/channel-registry.ts
+++ b/libs/sdk/src/stream/channel-registry.ts
@@ -73,6 +73,12 @@ interface Entry {
    * (no thread bound yet, or a rebind is in progress).
    */
   runtime: ProjectionRuntime | undefined;
+  /**
+   * Token for a deferred last-release disposal. Re-acquiring the same
+   * projection before the microtask runs clears the token and keeps the
+   * runtime alive.
+   */
+  pendingDispose: object | undefined;
 }
 
 /**
@@ -198,6 +204,7 @@ export class ChannelRegistry {
         open: spec.open as ProjectionSpec<unknown>["open"],
         refCount: 0,
         runtime: undefined,
+        pendingDispose: undefined,
       };
       // Open the runtime immediately when a thread is already bound.
       // Otherwise it will be opened lazily by the next `bind()` call.
@@ -211,6 +218,7 @@ export class ChannelRegistry {
       this.#entries.set(spec.key, newEntry);
       entry = newEntry;
     }
+    entry.pendingDispose = undefined;
     entry.refCount += 1;
 
     let released = false;
@@ -223,8 +231,23 @@ export class ChannelRegistry {
         if (current == null) return;
         current.refCount -= 1;
         if (current.refCount <= 0) {
-          this.#entries.delete(spec.key);
-          if (current.runtime != null) void tryDispose(current.runtime);
+          current.refCount = 0;
+          const token = {};
+          current.pendingDispose = token;
+          queueMicrotask(() => {
+            const latest = this.#entries.get(spec.key);
+            if (
+              latest == null ||
+              latest !== current ||
+              latest.pendingDispose !== token ||
+              latest.refCount > 0
+            ) {
+              return;
+            }
+            this.#entries.delete(spec.key);
+            latest.pendingDispose = undefined;
+            if (latest.runtime != null) void tryDispose(latest.runtime);
+          });
         }
       },
     };
@@ -250,12 +273,17 @@ export class ChannelRegistry {
   }
 
   /**
-   * Number of live entries. Diagnostic-only — callers should not
-   * branch on this value at runtime; it exists for tests asserting
-   * that consumers properly release their projections.
+   * Number of actively-held entries. Diagnostic-only — callers should
+   * not branch on this value at runtime; it exists for tests asserting
+   * that consumers properly release their projections. Entries waiting
+   * on cancellable microtask disposal do not count as active.
    */
   get size(): number {
-    return this.#entries.size;
+    let count = 0;
+    for (const entry of this.#entries.values()) {
+      if (entry.refCount > 0) count += 1;
+    }
+    return count;
   }
 }
 


### PR DESCRIPTION
## Summary
- Defer final `ChannelRegistry` projection disposal by one microtask so same-turn reacquires keep the existing projection runtime alive.
- Preserve `registry.size` as an active-consumer diagnostic while allowing pending disposals to be cancelled.
- Add regression coverage for release-then-reacquire behavior.
