### PR TITLE
fix(langgraph): support DeltaChannel fields in StateSchema

### DIFF
--- a/.changeset/state-schema-delta-channel.md
+++ b/.changeset/state-schema-delta-channel.md
@@ -1,0 +1,11 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(langgraph): support DeltaChannel fields in StateSchema
+
+Add a `DeltaValue` state field (and a `MessagesDeltaValue` prebuilt) so a
+`DeltaChannel` can be declared via `StateSchema`, not just `Annotation.Root` or
+a raw channel map. `StateSchema` now maps `DeltaValue` to a `DeltaChannel`
+(forwarding `snapshotFrequency` and the value-schema default) and validates its
+inputs/`Overwrite` updates like `ReducedValue`.

--- a/libs/langgraph-core/src/graph/messages_reducer.ts
+++ b/libs/langgraph-core/src/graph/messages_reducer.ts
@@ -139,11 +139,16 @@ export function messagesStateReducer(
  * This reducer is batching-invariant, as required by `DeltaChannel`:
  * `reducer(reducer(state, xs), ys) === reducer(state, xs.concat(ys))`.
  *
+ * A `RemoveMessage` carrying the {@link REMOVE_ALL_MESSAGES} sentinel id
+ * clears all messages accumulated so far (prior state plus earlier writes in
+ * the same batch) and keeps only the messages that follow it, mirroring
+ * {@link messagesStateReducer}. Clearing happens in the same single linear
+ * pass, so the batching-invariant still holds.
+ *
  * Raw object / string inputs are coerced to typed `BaseMessage` objects so
  * that HTTP-driven graphs work without a separate coercion step. This is not
- * full {@link messagesStateReducer} parity — `REMOVE_ALL_MESSAGES`,
- * unknown-id `RemoveMessage` errors, and missing-id UUID assignment are not
- * handled here.
+ * full {@link messagesStateReducer} parity — unknown-id `RemoveMessage`
+ * errors and missing-id UUID assignment are not handled here.
  *
  * @param state - The current accumulated list of messages.
  * @param writes - Batch of writes, each a single message-like or an array.
@@ -189,7 +194,13 @@ export function messagesDeltaReducer(
   const result: (BaseMessage | null)[] = [...stateMsgs];
   for (const msg of msgs) {
     const mid = msg.id;
-    if (mid == null) {
+    if (RemoveMessage.isInstance(msg) && mid === REMOVE_ALL_MESSAGES) {
+      // Discard everything accumulated so far (prior state and earlier writes
+      // in this batch); only messages following the sentinel are kept. Doing
+      // this inline keeps the reducer batching-invariant.
+      result.length = 0;
+      index.clear();
+    } else if (mid == null) {
       result.push(msg);
     } else if (RemoveMessage.isInstance(msg)) {
       if (index.has(mid)) {

--- a/libs/langgraph-core/src/state/prebuilt/index.ts
+++ b/libs/langgraph-core/src/state/prebuilt/index.ts
@@ -1,1 +1,1 @@
-export { MessagesValue } from "./messages.js";
+export { MessagesValue, MessagesDeltaValue } from "./messages.js";

--- a/libs/langgraph-core/src/state/prebuilt/messages.ts
+++ b/libs/langgraph-core/src/state/prebuilt/messages.ts
@@ -2,8 +2,10 @@ import type { BaseMessage } from "@langchain/core/messages";
 import { z } from "zod/v4";
 
 import { ReducedValue } from "../values/reduced.js";
+import { DeltaValue } from "../values/delta.js";
 import {
   messagesStateReducer,
+  messagesDeltaReducer,
   type Messages,
 } from "../../graph/messages_reducer.js";
 
@@ -25,3 +27,27 @@ export const MessagesValue = new ReducedValue(
     },
   }
 );
+
+/**
+ * **Experimental.** A messages state field backed by a `DeltaChannel`.
+ *
+ * A drop-in alternative to {@link MessagesValue} that persists only per-step
+ * message deltas (plus periodic snapshots) instead of the full accumulated
+ * history in every checkpoint blob. Useful for long-running threads where
+ * re-serializing the entire message list on each step is costly.
+ *
+ * @example
+ * ```ts
+ * import { StateSchema, MessagesDeltaValue } from "@langchain/langgraph";
+ *
+ * const State = new StateSchema({ messages: MessagesDeltaValue });
+ * ```
+ */
+export const MessagesDeltaValue = new DeltaValue(messagesValueSchema, {
+  inputSchema: messagesInputSchema,
+  reducer: messagesDeltaReducer,
+  jsonSchemaExtra: {
+    langgraph_type: "messages",
+    description: "A list of chat messages",
+  },
+});

--- a/libs/langgraph-core/src/state/schema.test.ts
+++ b/libs/langgraph-core/src/state/schema.test.ts
@@ -1,12 +1,18 @@
 import { describe, it, expect, expectTypeOf } from "vitest";
 import { z } from "zod/v4";
 import { MemorySaver } from "@langchain/langgraph-checkpoint";
+import {
+  type BaseMessage,
+  AIMessage,
+  HumanMessage,
+} from "@langchain/core/messages";
 import { StateSchema } from "./schema.js";
-import { ReducedValue, UntrackedValue } from "./values/index.js";
-import { MessagesValue } from "./prebuilt/index.js";
+import { ReducedValue, UntrackedValue, DeltaValue } from "./values/index.js";
+import { MessagesValue, MessagesDeltaValue } from "./prebuilt/index.js";
 import type { SerializableSchema } from "./types.js";
 import {
   BinaryOperatorAggregate,
+  DeltaChannel,
   LastValue,
   UntrackedValueChannel,
 } from "../channels/index.js";
@@ -14,6 +20,7 @@ import { StateGraph } from "../graph/index.js";
 import {
   Command,
   END,
+  Overwrite,
   Send,
   START,
   type OverwriteValue,
@@ -105,6 +112,47 @@ describe("StateSchema", () => {
 
         expectTypeOf<typeof state.Update>().toEqualTypeOf<{
           totals?: number | OverwriteValue<{ sum: number; count: number }>;
+        }>();
+      });
+    });
+
+    describe("DeltaValue types", () => {
+      it("should infer different value vs input types", () => {
+        const state = new StateSchema({
+          // State gets string[], Update takes string (or an Overwrite)
+          history: new DeltaValue(
+            z.array(z.string()).default(() => []),
+            {
+              inputSchema: z.string(),
+              reducer: (current: string[], writes: string[]) => [
+                ...current,
+                ...writes,
+              ],
+            }
+          ),
+        });
+
+        expectTypeOf<typeof state.State>().toEqualTypeOf<{
+          history: string[];
+        }>();
+
+        expectTypeOf<typeof state.Update>().toEqualTypeOf<{
+          history?: string | OverwriteValue<string[]>;
+        }>();
+      });
+
+      it("should use value schema type when input schema not provided", () => {
+        const state = new StateSchema({
+          items: new DeltaValue(
+            z.array(z.number()).default(() => []),
+            {
+              reducer: (current, writes) => [...current, ...writes.flat()],
+            }
+          ),
+        });
+
+        expectTypeOf<typeof state.State>().toEqualTypeOf<{
+          items: number[];
         }>();
       });
     });
@@ -292,6 +340,40 @@ describe("StateSchema", () => {
 
       expect(channels.temp).toBeInstanceOf(UntrackedValueChannel);
     });
+
+    it("should return DeltaChannel for DeltaValue", () => {
+      const state = new StateSchema({
+        history: new DeltaValue(
+          z.array(z.string()).default(() => []),
+          {
+            inputSchema: z.string(),
+            reducer: (current: string[], writes: string[]) => [
+              ...current,
+              ...writes,
+            ],
+            snapshotFrequency: 7,
+          }
+        ),
+      });
+
+      const channels = state.getChannels();
+
+      expect(channels.history).toBeInstanceOf(DeltaChannel);
+      // snapshotFrequency is forwarded to the channel, and the value schema's
+      // default seeds the channel's initial value factory. (A DeltaChannel only
+      // materializes its value on fromCheckpoint/update, so isAvailable() is
+      // false until then.)
+      const channel = channels.history as DeltaChannel<string[], string>;
+      expect(channel.snapshotFrequency).toBe(7);
+      expect(channel.initialValueFactory()).toEqual([]);
+      expect(channel.fromCheckpoint(undefined).get()).toEqual([]);
+    });
+
+    it("should return DeltaChannel for the MessagesDeltaValue prebuilt", () => {
+      const state = new StateSchema({ messages: MessagesDeltaValue });
+      const channels = state.getChannels();
+      expect(channels.messages).toBeInstanceOf(DeltaChannel);
+    });
   });
 
   describe("JSON schema generation", () => {
@@ -358,6 +440,56 @@ describe("StateSchema", () => {
       expect(schema.properties?.history).toMatchObject({
         langgraph_type: "custom_type",
         description: "Custom history field",
+      });
+    });
+
+    it("should preserve custom jsonSchemaExtra on DeltaValue", () => {
+      const state = new StateSchema({
+        history: new DeltaValue(
+          z.array(z.string()).default(() => []),
+          {
+            inputSchema: z.string(),
+            reducer: (current: string[], writes: string[]) => [
+              ...current,
+              ...writes,
+            ],
+            jsonSchemaExtra: {
+              langgraph_type: "custom_type",
+              description: "Custom delta field",
+            },
+          }
+        ),
+      });
+
+      const schema = state.getJsonSchema() as {
+        type: string;
+        properties?: Record<
+          string,
+          { langgraph_type?: string; description?: string }
+        >;
+      };
+
+      expect(schema.properties?.history).toMatchObject({
+        langgraph_type: "custom_type",
+        description: "Custom delta field",
+      });
+    });
+
+    it("should preserve langgraph_type metadata when using MessagesDeltaValue", () => {
+      const state = new StateSchema({ messages: MessagesDeltaValue });
+
+      const schema = state.getJsonSchema() as {
+        properties?: Record<string, { langgraph_type?: string }>;
+      };
+      const inputSchema = state.getInputJsonSchema() as {
+        properties?: Record<string, { langgraph_type?: string }>;
+      };
+
+      expect(schema.properties?.messages).toMatchObject({
+        langgraph_type: "messages",
+      });
+      expect(inputSchema.properties?.messages).toMatchObject({
+        langgraph_type: "messages",
       });
     });
 
@@ -806,6 +938,163 @@ describe("StateSchema", () => {
         // After checkpoint restore, UntrackedValue should be reset
         const state = await graph.getState(config);
         expect(state.values.cache).toBeUndefined();
+      });
+    });
+
+    describe("DeltaValue", () => {
+      let aiCounter = 0;
+      const contentsOf = (msgs: BaseMessage[]) => msgs.map((m) => m.content);
+
+      it("accumulates and reconstructs messages via MessagesDeltaValue", async () => {
+        const State = new StateSchema({ messages: MessagesDeltaValue });
+        const checkpointer = new MemorySaver();
+        const makeGraph = () =>
+          new StateGraph(State)
+            .addNode("chat", (state) => {
+              const last = state.messages[state.messages.length - 1];
+              return {
+                messages: [
+                  new AIMessage({
+                    id: `ai-${aiCounter++}`,
+                    content: `reply:${last.content}`,
+                  }),
+                ],
+              };
+            })
+            .addEdge(START, "chat")
+            .addEdge("chat", END)
+            .compile({ checkpointer });
+
+        const config = { configurable: { thread_id: "delta-msgs" } };
+        await makeGraph().invoke(
+          { messages: [new HumanMessage({ id: "h0", content: "q0" })] },
+          config
+        );
+        await makeGraph().invoke(
+          { messages: [new HumanMessage({ id: "h1", content: "q1" })] },
+          config
+        );
+
+        // Cold read through a brand-new graph instance reconstructs from the
+        // saver by replaying the persisted deltas.
+        const state = await makeGraph().getState(config);
+        expect(contentsOf(state.values.messages)).toEqual([
+          "q0",
+          "reply:q0",
+          "q1",
+          "reply:q1",
+        ]);
+      });
+
+      it("applies Overwrite as a hard reset through a DeltaValue field", async () => {
+        const State = new StateSchema({ messages: MessagesDeltaValue });
+        const checkpointer = new MemorySaver();
+        const makeGraph = () =>
+          new StateGraph(State)
+            .addNode("agent", (state, config) => {
+              const compact = Boolean(
+                (config?.configurable as Record<string, unknown> | undefined)
+                  ?.compact
+              );
+              if (compact) {
+                return {
+                  messages: new Overwrite([
+                    new AIMessage({ id: "sum", content: "summary" }),
+                  ]),
+                };
+              }
+              const last = state.messages[state.messages.length - 1];
+              return {
+                messages: [
+                  new AIMessage({
+                    id: `ai-${aiCounter++}`,
+                    content: `reply:${last.content}`,
+                  }),
+                ],
+              };
+            })
+            .addEdge(START, "agent")
+            .addEdge("agent", END)
+            .compile({ checkpointer });
+
+        const config = { configurable: { thread_id: "delta-overwrite" } };
+        await makeGraph().invoke(
+          { messages: [new HumanMessage({ id: "h0", content: "a" })] },
+          config
+        );
+
+        // Compaction run: the agent overwrites the channel (hard reset).
+        await makeGraph().invoke(
+          { messages: [new HumanMessage({ id: "h1", content: "b" })] },
+          {
+            configurable: { thread_id: "delta-overwrite", compact: true },
+          }
+        );
+
+        const state = await makeGraph().getState(config);
+        expect(contentsOf(state.values.messages)).toEqual(["summary"]);
+      });
+
+      it("accumulates and reconstructs a generic (non-messages) DeltaValue", async () => {
+        const State = new StateSchema({
+          history: new DeltaValue(
+            z.array(z.string()).default(() => []),
+            {
+              inputSchema: z.string(),
+              reducer: (current: string[], writes: string[]) => [
+                ...current,
+                ...writes,
+              ],
+            }
+          ),
+        });
+        const checkpointer = new MemorySaver();
+        const makeGraph = () =>
+          new StateGraph(State)
+            .addNode("step", (state) => ({
+              history: `n${state.history.length}`,
+            }))
+            .addEdge(START, "step")
+            .addEdge("step", END)
+            .compile({ checkpointer });
+
+        const config = { configurable: { thread_id: "delta-generic" } };
+        await makeGraph().invoke({ history: "a" }, config);
+        await makeGraph().invoke({ history: "b" }, config);
+
+        const state = await makeGraph().getState(config);
+        expect(state.values.history).toEqual(["a", "n1", "b", "n3"]);
+      });
+
+      it("persists manual updateState writes to a DeltaValue field", async () => {
+        const State = new StateSchema({
+          history: new DeltaValue(
+            z.array(z.string()).default(() => []),
+            {
+              inputSchema: z.string(),
+              reducer: (current: string[], writes: string[]) => [
+                ...current,
+                ...writes,
+              ],
+            }
+          ),
+        });
+        const checkpointer = new MemorySaver();
+        const makeGraph = () =>
+          new StateGraph(State)
+            .addNode("step", (state) => ({
+              history: `n${state.history.length}`,
+            }))
+            .addEdge(START, "step")
+            .addEdge("step", END)
+            .compile({ checkpointer });
+
+        const config = { configurable: { thread_id: "delta-update" } };
+        await makeGraph().invoke({ history: "a" }, config);
+        await makeGraph().updateState(config, { history: "manual" });
+
+        const state = await makeGraph().getState(config);
+        expect(state.values.history).toEqual(["a", "n1", "manual"]);
       });
     });
   });

--- a/libs/langgraph-core/src/state/schema.ts
+++ b/libs/langgraph-core/src/state/schema.ts
@@ -7,6 +7,7 @@ import {
   BaseChannel,
   LastValue,
   BinaryOperatorAggregate,
+  DeltaChannel,
 } from "../channels/index.js";
 import { UntrackedValueChannel } from "../channels/untracked_value.js";
 
@@ -20,6 +21,7 @@ import {
 } from "../constants.js";
 import { ReducedValue } from "./values/reduced.js";
 import { UntrackedValue } from "./values/untracked.js";
+import { DeltaValue } from "./values/delta.js";
 
 const STATE_SCHEMA_SYMBOL = Symbol.for("langgraph.state.state_schema");
 
@@ -30,6 +32,8 @@ const STATE_SCHEMA_SYMBOL = Symbol.for("langgraph.state.state_schema");
  * `BaseChannel` type, parameterized with the state "value" and "input" types according to the field's shape.
  *
  * Rules:
+ * - If the field (`F`) is a `DeltaValue<V, I>`, the channel will store values of type `V`
+ *   and accept input of type `I` (or an `Overwrite`).
  * - If the field (`F`) is a `ReducedValue<V, I>`, the channel will store values of type `V`
  *   and accept input of type `I`.
  * - If the field is a `UntrackedValue<V>`, the channel will store and accept values of type `V`.
@@ -47,13 +51,15 @@ const STATE_SCHEMA_SYMBOL = Symbol.for("langgraph.state.state_schema");
  * ```
  */
 export type StateSchemaFieldToChannel<F> =
-  F extends ReducedValue<infer V, infer I>
+  F extends DeltaValue<infer V, infer I>
     ? BaseChannel<V, OverwriteValue<V> | I>
-    : F extends UntrackedValue<infer V>
-      ? BaseChannel<V, V>
-      : F extends SerializableSchema<infer I, infer O>
-        ? BaseChannel<O, I>
-        : BaseChannel<unknown, unknown>;
+    : F extends ReducedValue<infer V, infer I>
+      ? BaseChannel<V, OverwriteValue<V> | I>
+      : F extends UntrackedValue<infer V>
+        ? BaseChannel<V, V>
+        : F extends SerializableSchema<infer I, infer O>
+          ? BaseChannel<O, I>
+          : BaseChannel<unknown, unknown>;
 
 /**
  * Converts StateSchema fields into a strongly-typed
@@ -95,6 +101,7 @@ export type StateSchemaFieldsToStateDefinition<
  * Either a LangGraph state value type or a raw schema (e.g., Zod schema).
  */
 export type StateSchemaField<Input = unknown, Output = Input> =
+  | DeltaValue<Input, Output>
   | ReducedValue<Input, Output>
   | UntrackedValue<Output>
   | SerializableSchema<Input, Output>;
@@ -116,13 +123,15 @@ export type StateSchemaFields = {
  * - SerializableSchema<Input, Output> → Output (the validated type)
  */
 export type InferStateSchemaValue<TFields extends StateSchemaFields> = {
-  [K in keyof TFields]: TFields[K] extends ReducedValue<any, any>
+  [K in keyof TFields]: TFields[K] extends DeltaValue<any, any>
     ? TFields[K]["ValueType"]
-    : TFields[K] extends UntrackedValue<any>
+    : TFields[K] extends ReducedValue<any, any>
       ? TFields[K]["ValueType"]
-      : TFields[K] extends SerializableSchema<any, infer TOutput>
-        ? TOutput
-        : never;
+      : TFields[K] extends UntrackedValue<any>
+        ? TFields[K]["ValueType"]
+        : TFields[K] extends SerializableSchema<any, infer TOutput>
+          ? TOutput
+          : never;
 };
 
 /**
@@ -134,13 +143,15 @@ export type InferStateSchemaValue<TFields extends StateSchemaFields> = {
  * - SerializableSchema<Input, Output> → Input (what you provide)
  */
 export type InferStateSchemaUpdate<TFields extends StateSchemaFields> = {
-  [K in keyof TFields]?: TFields[K] extends ReducedValue<infer V, infer I>
+  [K in keyof TFields]?: TFields[K] extends DeltaValue<infer V, infer I>
     ? OverwriteValue<V> | I
-    : TFields[K] extends UntrackedValue<any>
-      ? TFields[K]["ValueType"]
-      : TFields[K] extends SerializableSchema<infer TInput, any>
-        ? TInput
-        : never;
+    : TFields[K] extends ReducedValue<infer V, infer I>
+      ? OverwriteValue<V> | I
+      : TFields[K] extends UntrackedValue<any>
+        ? TFields[K]["ValueType"]
+        : TFields[K] extends SerializableSchema<infer TInput, any>
+          ? TInput
+          : never;
 };
 
 /**
@@ -226,7 +237,15 @@ export class StateSchema<TFields extends StateSchemaFields> {
     const channels: Record<string, BaseChannel> = {};
 
     for (const [key, value] of Object.entries(this.fields)) {
-      if (ReducedValue.isInstance(value)) {
+      if (DeltaValue.isInstance(value)) {
+        // DeltaValue -> DeltaChannel. The value schema's default (if any) seeds
+        // the channel's initial value; otherwise DeltaChannel falls back to [].
+        const defaultGetter = getSchemaDefaultGetter(value.valueSchema);
+        channels[key] = new DeltaChannel(value.reducer, {
+          snapshotFrequency: value.snapshotFrequency,
+          initialValueFactory: defaultGetter,
+        });
+      } else if (ReducedValue.isInstance(value)) {
         // ReducedValue -> BinaryOperatorAggregate
         const defaultGetter = getSchemaDefaultGetter(value.valueSchema);
         channels[key] = new BinaryOperatorAggregate(
@@ -248,7 +267,7 @@ export class StateSchema<TFields extends StateSchemaFields> {
         channels[key] = new LastValue(defaultGetter);
       } else {
         throw new Error(
-          `Invalid state field "${key}": must be a schema, ReducedValue, UntrackedValue, or ManagedValue`
+          `Invalid state field "${key}": must be a schema, ReducedValue, DeltaValue, UntrackedValue, or ManagedValue`
         );
       }
     }
@@ -267,7 +286,7 @@ export class StateSchema<TFields extends StateSchemaFields> {
     for (const [key, value] of Object.entries(this.fields)) {
       let fieldSchema: JSONSchema | undefined;
 
-      if (ReducedValue.isInstance(value)) {
+      if (DeltaValue.isInstance(value) || ReducedValue.isInstance(value)) {
         fieldSchema = getJsonSchemaFromSchema(value.valueSchema) as JSONSchema;
         // Merge jsonSchemaExtra (e.g. langgraph_type) into the field schema,
         // even if base schema is undefined
@@ -287,7 +306,7 @@ export class StateSchema<TFields extends StateSchemaFields> {
 
         // Field is required if it doesn't have a default
         let hasDefault = false;
-        if (ReducedValue.isInstance(value)) {
+        if (DeltaValue.isInstance(value) || ReducedValue.isInstance(value)) {
           hasDefault = getSchemaDefaultGetter(value.valueSchema) !== undefined;
         } else if (UntrackedValue.isInstance(value)) {
           hasDefault = value.schema
@@ -320,7 +339,7 @@ export class StateSchema<TFields extends StateSchemaFields> {
     for (const [key, value] of Object.entries(this.fields)) {
       let fieldSchema: JSONSchema | undefined;
 
-      if (ReducedValue.isInstance(value)) {
+      if (DeltaValue.isInstance(value) || ReducedValue.isInstance(value)) {
         // Use input schema for updates
         fieldSchema = getJsonSchemaFromSchema(value.inputSchema) as JSONSchema;
         // Merge jsonSchemaExtra (e.g. langgraph_type) into the field schema,
@@ -387,7 +406,10 @@ export class StateSchema<TFields extends StateSchemaFields> {
       // Get the schema to use for validation
       let schema: StandardSchemaV1 | undefined;
 
-      if (ReducedValue.isInstance(fieldDef)) {
+      if (
+        DeltaValue.isInstance(fieldDef) ||
+        ReducedValue.isInstance(fieldDef)
+      ) {
         const [isOverwrite, overwriteValue] = _getOverwriteValue(value);
         if (isOverwrite) {
           schema = fieldDef.valueSchema;

--- a/libs/langgraph-core/src/state/values/delta.test.ts
+++ b/libs/langgraph-core/src/state/values/delta.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { z } from "zod/v4";
+import { MemorySaver } from "@langchain/langgraph-checkpoint";
+import { DeltaValue } from "./delta.js";
+import { ReducedValue } from "./reduced.js";
+import { UntrackedValue } from "./untracked.js";
+import { DeltaChannel } from "../../channels/index.js";
+import { StateGraph } from "../../graph/state.js";
+import { StateSchema } from "../schema.js";
+import {
+  END,
+  Overwrite,
+  START,
+  type OverwriteValue,
+} from "../../constants.js";
+
+describe("DeltaValue", () => {
+  it("should store value and input schemas", () => {
+    const delta = new DeltaValue(
+      z.array(z.string()).default(() => []),
+      {
+        inputSchema: z.string(),
+        reducer: (current: string[], writes: string[]) => [
+          ...current,
+          ...writes,
+        ],
+      }
+    );
+
+    expect(DeltaValue.isInstance(delta)).toBe(true);
+    expect(delta.valueSchema).toBeDefined();
+    expect(delta.inputSchema).toBeDefined();
+  });
+
+  it("should store reducer and snapshotFrequency", () => {
+    const reducer = (a: string[], b: string[]) => [...a, ...b];
+    const delta = new DeltaValue(
+      z.array(z.string()).default(() => []),
+      {
+        inputSchema: z.string(),
+        reducer,
+        snapshotFrequency: 13,
+      }
+    );
+
+    expect(delta.reducer).toBe(reducer);
+    expect(delta.snapshotFrequency).toBe(13);
+  });
+
+  it("should default inputSchema to valueSchema when omitted", () => {
+    const valueSchema = z.array(z.number()).default(() => []);
+    const delta = new DeltaValue(valueSchema, {
+      reducer: (current, writes) => [...current, ...writes.flat()],
+    });
+
+    expect(delta.inputSchema).toBe(valueSchema);
+    expect(delta.snapshotFrequency).toBeUndefined();
+  });
+
+  describe("isInstance", () => {
+    it("should identify DeltaValue instances", () => {
+      const delta = new DeltaValue(z.array(z.number()).default(() => []), {
+        reducer: (a, b) => [...a, ...b.flat()],
+      });
+      expect(DeltaValue.isInstance(delta)).toBe(true);
+    });
+
+    it("should reject non-DeltaValue objects", () => {
+      expect(DeltaValue.isInstance({})).toBe(false);
+      expect(DeltaValue.isInstance(null)).toBe(false);
+      expect(DeltaValue.isInstance(undefined)).toBe(false);
+      expect(DeltaValue.isInstance(new UntrackedValue())).toBe(false);
+      expect(
+        DeltaValue.isInstance(
+          new ReducedValue(z.number().default(0), {
+            reducer: (a: number, b: number) => a + b,
+          })
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe("getChannels", () => {
+    it("should map a DeltaValue to a DeltaChannel and forward snapshotFrequency", () => {
+      const state = new StateSchema({
+        history: new DeltaValue(
+          z.array(z.string()).default(() => []),
+          {
+            inputSchema: z.string(),
+            reducer: (current: string[], writes: string[]) => [
+              ...current,
+              ...writes,
+            ],
+            snapshotFrequency: 5,
+          }
+        ),
+      });
+
+      const channels = state.getChannels();
+      expect(channels.history).toBeInstanceOf(DeltaChannel);
+      const channel = channels.history as DeltaChannel<string[], string>;
+      expect(channel.snapshotFrequency).toBe(5);
+      // The value schema default seeds the initial value factory.
+      expect(channel.initialValueFactory()).toEqual([]);
+    });
+  });
+
+  describe("StateGraph usage", () => {
+    it("should handle a reducer where input type differs from value type", async () => {
+      const AgentState = new StateSchema({
+        items: new DeltaValue(
+          z.array(z.string()).default(() => []),
+          {
+            inputSchema: z.string(),
+            reducer: (current: string[], writes: string[]) => [
+              ...current,
+              ...writes,
+            ],
+          }
+        ),
+      });
+
+      const graph = new StateGraph(AgentState)
+        .addNode("add_item", () => ({ items: "new_item" }))
+        .addEdge(START, "add_item")
+        .addEdge("add_item", END)
+        .compile();
+
+      const result = await graph.invoke({});
+      expect(result.items).toEqual(["new_item"]);
+    });
+
+    it("should reconstruct accumulated state from a checkpointer", async () => {
+      const AgentState = new StateSchema({
+        items: new DeltaValue(
+          z.array(z.string()).default(() => []),
+          {
+            inputSchema: z.string(),
+            reducer: (current: string[], writes: string[]) => [
+              ...current,
+              ...writes,
+            ],
+          }
+        ),
+      });
+
+      const checkpointer = new MemorySaver();
+      const makeGraph = () =>
+        new StateGraph(AgentState)
+          .addNode("step", (state) => ({ items: `n${state.items.length}` }))
+          .addEdge(START, "step")
+          .addEdge("step", END)
+          .compile({ checkpointer });
+
+      const config = { configurable: { thread_id: "1" } };
+      await makeGraph().invoke({ items: "a" }, config);
+      await makeGraph().invoke({ items: "b" }, config);
+
+      // Cold read from a fresh graph reconstructs purely from the saver.
+      const state = await makeGraph().getState(config);
+      expect(state.values.items).toEqual(["a", "n1", "b", "n3"]);
+    });
+
+    it("should apply an Overwrite as a hard reset", async () => {
+      const AgentState = new StateSchema({
+        items: new DeltaValue(
+          z.array(z.string()).default(() => []),
+          {
+            inputSchema: z.string(),
+            reducer: (current: string[], writes: string[]) => [
+              ...current,
+              ...writes,
+            ],
+          }
+        ),
+      });
+
+      const graph = new StateGraph(AgentState)
+        .addNode("reset", () => ({ items: new Overwrite(["fresh"]) }))
+        .addEdge(START, "reset")
+        .addEdge("reset", END)
+        .compile();
+
+      const result = await graph.invoke({ items: "dropped" });
+      expect(result.items).toEqual(["fresh"]);
+    });
+
+    it("should validate inputs against inputSchema on invoke", async () => {
+      const AgentState = new StateSchema({
+        emails: new DeltaValue(
+          z.array(z.string()).default(() => []),
+          {
+            inputSchema: z.string().email(),
+            reducer: (current: string[], writes: string[]) => [
+              ...current,
+              ...writes,
+            ],
+          }
+        ),
+      });
+
+      const graph = new StateGraph(AgentState)
+        .addNode("add_email", () => ({ emails: "test@example.com" }))
+        .addEdge(START, "add_email")
+        .addEdge("add_email", END)
+        .compile();
+
+      const result = await graph.invoke({});
+      expect(result.emails).toEqual(["test@example.com"]);
+
+      await expect(graph.invoke({ emails: "not-an-email" })).rejects.toThrow();
+    });
+
+    it("should correctly type state vs update", () => {
+      const AgentState = new StateSchema({
+        items: new DeltaValue(
+          z.array(z.string()).default(() => []),
+          {
+            inputSchema: z.string(),
+            reducer: (current: string[], writes: string[]) => [
+              ...current,
+              ...writes,
+            ],
+          }
+        ),
+        count: z.number().default(0),
+      });
+
+      type State = typeof AgentState.State;
+      type Update = typeof AgentState.Update;
+
+      expectTypeOf<State["items"]>().toEqualTypeOf<string[]>();
+      expectTypeOf<State["count"]>().toEqualTypeOf<number>();
+
+      expectTypeOf<Update["items"]>().toEqualTypeOf<
+        string | OverwriteValue<string[]> | undefined
+      >();
+    });
+  });
+});

--- a/libs/langgraph-core/src/state/values/delta.test.ts
+++ b/libs/langgraph-core/src/state/values/delta.test.ts
@@ -1,12 +1,19 @@
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { z } from "zod/v4";
 import { MemorySaver } from "@langchain/langgraph-checkpoint";
+import {
+  AIMessage,
+  HumanMessage,
+  RemoveMessage,
+} from "@langchain/core/messages";
 import { DeltaValue } from "./delta.js";
 import { ReducedValue } from "./reduced.js";
 import { UntrackedValue } from "./untracked.js";
 import { DeltaChannel } from "../../channels/index.js";
 import { StateGraph } from "../../graph/state.js";
 import { StateSchema } from "../schema.js";
+import { MessagesDeltaValue } from "../prebuilt/messages.js";
+import { REMOVE_ALL_MESSAGES } from "../../graph/messages_reducer.js";
 import {
   END,
   Overwrite,
@@ -209,6 +216,89 @@ describe("DeltaValue", () => {
       expect(result.emails).toEqual(["test@example.com"]);
 
       await expect(graph.invoke({ emails: "not-an-email" })).rejects.toThrow();
+    });
+
+    it("clears history on REMOVE_ALL_MESSAGES via MessagesDeltaValue", async () => {
+      const AgentState = new StateSchema({ messages: MessagesDeltaValue });
+
+      const checkpointer = new MemorySaver();
+      const graph = new StateGraph(AgentState)
+        .addNode("clear", () => ({
+          messages: [
+            new RemoveMessage({ id: REMOVE_ALL_MESSAGES }),
+            new HumanMessage({ id: "fresh", content: "fresh start" }),
+          ],
+        }))
+        .addEdge(START, "clear")
+        .addEdge("clear", END)
+        .compile({ checkpointer });
+
+      const config = { configurable: { thread_id: "clear-all" } };
+      const result = await graph.invoke(
+        {
+          messages: [
+            new HumanMessage({ id: "1", content: "old question" }),
+            new AIMessage({ id: "2", content: "old answer" }),
+          ],
+        },
+        config
+      );
+
+      // Prior history must be wiped, keeping only what follows the sentinel.
+      expect(result.messages.map((m) => m.id)).toEqual(["fresh"]);
+      expect(result.messages.map((m) => m.content)).toEqual(["fresh start"]);
+
+      // Cold read from a fresh graph reconstructs the same cleared state.
+      const cold = await new StateGraph(AgentState)
+        .addNode("noop", () => ({}))
+        .addEdge(START, "noop")
+        .addEdge("noop", END)
+        .compile({ checkpointer })
+        .getState(config);
+      expect(cold.values.messages.map((m: { id?: string }) => m.id)).toEqual([
+        "fresh",
+      ]);
+    });
+
+    it("clears history on Overwrite via MessagesDeltaValue", async () => {
+      // Overwrite is handled by DeltaChannel before the reducer runs, so it is
+      // a channel-level reset that is orthogonal to REMOVE_ALL_MESSAGES.
+      const AgentState = new StateSchema({ messages: MessagesDeltaValue });
+
+      const checkpointer = new MemorySaver();
+      const graph = new StateGraph(AgentState)
+        .addNode("reset", () => ({
+          messages: new Overwrite([
+            new HumanMessage({ id: "fresh", content: "fresh start" }),
+          ]),
+        }))
+        .addEdge(START, "reset")
+        .addEdge("reset", END)
+        .compile({ checkpointer });
+
+      const config = { configurable: { thread_id: "overwrite" } };
+      const result = await graph.invoke(
+        {
+          messages: [
+            new HumanMessage({ id: "1", content: "old question" }),
+            new AIMessage({ id: "2", content: "old answer" }),
+          ],
+        },
+        config
+      );
+
+      expect(result.messages.map((m) => m.id)).toEqual(["fresh"]);
+
+      // Cold read reconstructs the overwritten state from the saver alone.
+      const cold = await new StateGraph(AgentState)
+        .addNode("noop", () => ({}))
+        .addEdge(START, "noop")
+        .addEdge("noop", END)
+        .compile({ checkpointer })
+        .getState(config);
+      expect(cold.values.messages.map((m: { id?: string }) => m.id)).toEqual([
+        "fresh",
+      ]);
     });
 
     it("should correctly type state vs update", () => {

--- a/libs/langgraph-core/src/state/values/delta.ts
+++ b/libs/langgraph-core/src/state/values/delta.ts
@@ -1,0 +1,206 @@
+import type { SerializableSchema } from "../types.js";
+import type { DeltaReducer } from "../../channels/delta.js";
+
+/**
+ * Symbol for runtime identification of DeltaValue instances.
+ */
+export const DELTA_VALUE_SYMBOL: symbol = Symbol.for(
+  "langgraph.state.delta_value"
+);
+
+interface DeltaValueInitBase<Value = unknown> {
+  /**
+   * Batch reducer that combines the current accumulated value with a batch of
+   * writes in a single call: `reducer(state, [w1, w2, ...]) -> newState`.
+   *
+   * Reducers must be deterministic and batching-invariant (associative across
+   * folds), because {@link DeltaChannel} replays checkpointed writes in larger
+   * batches than they were originally produced:
+   * `reducer(reducer(state, xs), ys) === reducer(state, xs.concat(ys))`.
+   */
+  reducer: DeltaReducer<Value, Value>;
+
+  /**
+   * How often (in per-channel updates) to persist a full `DeltaSnapshot` blob
+   * instead of relying purely on replayed deltas. Defaults to the channel's
+   * own default (1000) when omitted.
+   */
+  snapshotFrequency?: number;
+
+  /**
+   * Optional extra fields merged into the generated JSON Schema (e.g.
+   * `langgraph_type`) for documentation, Studio hints, or external tooling.
+   */
+  jsonSchemaExtra?: Record<string, unknown>;
+}
+
+interface DeltaValueInitWithSchema<Value = unknown, Input = Value> {
+  /**
+   * Schema describing the type and validation logic for reducer input values.
+   *
+   * When provided, the reducer may accept inputs distinct from the stored
+   * (output) type. Each write is validated against this schema before reduction.
+   */
+  inputSchema: SerializableSchema<unknown, Input>;
+
+  /**
+   * Batch reducer that combines the current accumulated value with a batch of
+   * validated writes: `reducer(state, [w1, w2, ...]) -> newState`.
+   *
+   * Must be deterministic and batching-invariant — see
+   * {@link DeltaValueInitBase.reducer}.
+   */
+  reducer: DeltaReducer<Value, Input>;
+
+  /**
+   * How often (in per-channel updates) to persist a full `DeltaSnapshot` blob.
+   * Defaults to the channel's own default (1000) when omitted.
+   */
+  snapshotFrequency?: number;
+
+  /**
+   * Optional extra fields merged into the generated JSON Schema (e.g.
+   * `langgraph_type`) for documentation, Studio hints, or external tooling.
+   */
+  jsonSchemaExtra?: Record<string, unknown>;
+}
+
+/**
+ * Initialization options for {@link DeltaValue}.
+ *
+ * Two forms are supported:
+ * 1. Provide only a reducer (and optionally `snapshotFrequency` /
+ *    `jsonSchemaExtra`) — the reducer's inputs are validated using the value
+ *    schema.
+ * 2. Provide an explicit `inputSchema` to distinguish the reducer's input type
+ *    from the stored/output type.
+ *
+ * @template Value - The type of value stored and produced after reduction.
+ * @template Input - The type of inputs accepted by the reducer.
+ */
+export type DeltaValueInit<Value = unknown, Input = Value> =
+  | DeltaValueInitWithSchema<Value, Input>
+  | DeltaValueInitBase<Value>;
+
+/**
+ * Represents a state field backed by a {@link DeltaChannel}.
+ *
+ * Unlike {@link ReducedValue} (which stores the full accumulated value in every
+ * checkpoint blob via `BinaryOperatorAggregate`), a `DeltaValue` field persists
+ * only per-step deltas (plus periodic snapshots) and reconstructs its state on
+ * read by replaying ancestor writes through a batch reducer. This avoids
+ * re-serializing large accumulators (e.g. long message histories) at every step.
+ *
+ * @remarks Beta. The on-disk representation backing `DeltaChannel` may change in
+ * future releases.
+ *
+ * @template Value - The type of the value stored in state and produced by reduction.
+ * @template Input - The type of updates accepted by the reducer.
+ *
+ * @example
+ * ```ts
+ * import { z } from "zod";
+ * import { StateSchema, DeltaValue } from "@langchain/langgraph";
+ *
+ * const State = new StateSchema({
+ *   history: new DeltaValue(z.array(z.string()).default(() => []), {
+ *     inputSchema: z.string(),
+ *     reducer: (current, writes) => [...current, ...writes],
+ *   }),
+ * });
+ * ```
+ */
+export class DeltaValue<Value = unknown, Input = Value> {
+  /**
+   * Instance marker for runtime identification.
+   * @internal
+   */
+  protected readonly [DELTA_VALUE_SYMBOL] = true as const;
+
+  /**
+   * The schema that describes the type of value stored in state (after
+   * reduction). Its default (if any) seeds the channel's initial value.
+   */
+  readonly valueSchema: SerializableSchema<unknown, Value>;
+
+  /**
+   * The schema used to validate reducer inputs. Defaults to `valueSchema` when
+   * not specified explicitly.
+   */
+  readonly inputSchema: SerializableSchema<unknown, Input | Value>;
+
+  /**
+   * The batch reducer that folds a list of incoming writes into the current
+   * accumulated value.
+   */
+  readonly reducer: DeltaReducer<Value, Input>;
+
+  /**
+   * Snapshot cadence forwarded to the underlying {@link DeltaChannel}.
+   */
+  readonly snapshotFrequency?: number;
+
+  /**
+   * Optional extra fields to merge into the generated JSON Schema.
+   */
+  readonly jsonSchemaExtra?: Record<string, unknown>;
+
+  /**
+   * Represents the value stored after all reductions.
+   */
+  declare ValueType: Value;
+
+  /**
+   * Represents the type that may be provided as input on each update.
+   */
+  declare InputType: Input;
+
+  /**
+   * Constructs a DeltaValue, pairing a value schema with a batch reducer (and an
+   * optional distinct input schema).
+   *
+   * @param valueSchema - The schema describing the stored/output value.
+   * @param init - The reducer (required), `inputSchema`, `snapshotFrequency`,
+   *   and `jsonSchemaExtra` (all optional except the reducer).
+   */
+  constructor(
+    valueSchema: SerializableSchema<unknown, Value>,
+    init: DeltaValueInitWithSchema<Value, Input>
+  );
+
+  constructor(
+    valueSchema: SerializableSchema<Input, Value>,
+    init: DeltaValueInitBase<Value>
+  );
+
+  constructor(
+    valueSchema: SerializableSchema<unknown, Value>,
+    init: DeltaValueInit<Value, Input>
+  ) {
+    this.reducer = init.reducer as DeltaReducer<Value, Input>;
+    this.valueSchema = valueSchema;
+    this.inputSchema = "inputSchema" in init ? init.inputSchema : valueSchema;
+    this.snapshotFrequency = init.snapshotFrequency;
+    this.jsonSchemaExtra = init.jsonSchemaExtra;
+  }
+
+  /**
+   * Type guard to check if a value is a DeltaValue instance.
+   */
+  static isInstance<Value = unknown, Input = Value>(
+    value: DeltaValue<Value, Input>
+  ): value is DeltaValue<Value, Input>;
+
+  static isInstance(value: unknown): value is DeltaValue;
+
+  static isInstance<Value = unknown, Input = Value>(
+    value: DeltaValue<Value, Input> | unknown
+  ): value is DeltaValue<Value, Input> {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      DELTA_VALUE_SYMBOL in value &&
+      (value as Record<symbol, unknown>)[DELTA_VALUE_SYMBOL] === true
+    );
+  }
+}

--- a/libs/langgraph-core/src/state/values/index.ts
+++ b/libs/langgraph-core/src/state/values/index.ts
@@ -1,2 +1,3 @@
 export { ReducedValue, type ReducedValueInit } from "./reduced.js";
 export { UntrackedValue, type UntrackedValueInit } from "./untracked.js";
+export { DeltaValue, type DeltaValueInit } from "./delta.js";

--- a/libs/langgraph-core/src/tests/delta_channel.test.ts
+++ b/libs/langgraph-core/src/tests/delta_channel.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../channels/base.js";
 import {
   messagesDeltaReducer,
+  REMOVE_ALL_MESSAGES,
   type Messages,
 } from "../graph/messages_reducer.js";
 import { Annotation } from "../graph/index.js";
@@ -196,6 +197,60 @@ describe("messagesDeltaReducer", () => {
     const b = new AIMessage({ id: "b", content: "y" });
     const out = messagesDeltaReducer([], [[a, b], b]);
     expect(out.map((m) => m.id)).toEqual(["a", "b"]);
+  });
+
+  it("clears prior state on REMOVE_ALL_MESSAGES sentinel", () => {
+    const m1 = new HumanMessage({ id: "1", content: "a" });
+    const m2 = new AIMessage({ id: "2", content: "b" });
+    const out = messagesDeltaReducer(
+      [m1, m2],
+      [[new RemoveMessage({ id: REMOVE_ALL_MESSAGES })]]
+    );
+    expect(out).toEqual([]);
+  });
+
+  it("keeps messages following the REMOVE_ALL_MESSAGES sentinel", () => {
+    const m1 = new HumanMessage({ id: "1", content: "a" });
+    const m2 = new AIMessage({ id: "2", content: "b" });
+    const fresh = new HumanMessage({ id: "3", content: "c" });
+    const out = messagesDeltaReducer(
+      [m1, m2],
+      [[new RemoveMessage({ id: REMOVE_ALL_MESSAGES }), fresh]]
+    );
+    expect(out.map((m) => m.id)).toEqual(["3"]);
+    expect(out.map((m) => m.content)).toEqual(["c"]);
+  });
+
+  it("clears earlier writes in the same batch as the sentinel", () => {
+    const existing = new HumanMessage({ id: "1", content: "old" });
+    const stale = new AIMessage({ id: "2", content: "stale" });
+    const kept = new HumanMessage({ id: "3", content: "kept" });
+    const out = messagesDeltaReducer(
+      [existing],
+      [[stale, new RemoveMessage({ id: REMOVE_ALL_MESSAGES }), kept]]
+    );
+    expect(out.map((m) => m.id)).toEqual(["3"]);
+  });
+
+  it("is batching-invariant across the REMOVE_ALL_MESSAGES sentinel", () => {
+    const m1 = new HumanMessage({ id: "1", content: "a" });
+    const m2 = new AIMessage({ id: "2", content: "b" });
+    const fresh = new HumanMessage({ id: "3", content: "c" });
+    const writes: Messages[] = [
+      [m1],
+      [new RemoveMessage({ id: REMOVE_ALL_MESSAGES })],
+      [m2],
+      [fresh],
+    ];
+
+    const once = messagesDeltaReducer([], writes);
+    const split = messagesDeltaReducer(
+      messagesDeltaReducer([], writes.slice(0, 2)),
+      writes.slice(2)
+    );
+    expect(once.map((m) => m.id)).toEqual(["2", "3"]);
+    expect(split.map((m) => m.id)).toEqual(once.map((m) => m.id));
+    expect(split.map((m) => m.content)).toEqual(once.map((m) => m.content));
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `DeltaValue<Value, Input>` (`state/values/delta.ts`), a `StateSchema` field backed by a `DeltaChannel`'s batch reducer + `snapshotFrequency` — distinct from `ReducedValue`'s single-value reducer.
- Wire `DeltaValue` into `StateSchema`: `getChannels()` maps it to a `DeltaChannel` (forwarding `snapshotFrequency` and seeding the initial value from the value-schema default); `getJsonSchema()`/`getInputJsonSchema()`/`validateInput()` handle it (incl. `Overwrite`) like `ReducedValue`; and the type helpers infer `State`/`Update` correctly.
- Add the `MessagesDeltaValue` prebuilt (a `DeltaChannel`-backed drop-in for `MessagesValue`); export `DeltaValue` and `MessagesDeltaValue` from `@langchain/langgraph`.
- Previously `DeltaChannel` was only usable via `Annotation.Root` / raw channel maps; the `StateSchema` class and Zod paths threw. This closes the `StateSchema` gap (Zod remains a separate follow-up).
