### PR TITLE
feat(checkpoint): add setup() to create required MongoDB indexes

### DIFF
--- a/.changeset/icy-results-clap.md
+++ b/.changeset/icy-results-clap.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint-mongodb": patch
+---
+
+feat(checkpoint-mongodb): add setup() to create required indexes

--- a/libs/checkpoint-mongodb/README.md
+++ b/libs/checkpoint-mongodb/README.md
@@ -24,6 +24,10 @@ const readConfig = {
 const client = new MongoClient(process.env.MONGODB_URL);
 
 const checkpointer = new MongoDBSaver({ client });
+
+// NOTE: you need to call .setup() the first time you're using your checkpointer
+await checkpointer.setup();
+
 const checkpoint = {
   v: 1,
   ts: "2024-07-31T20:14:19.804150+00:00",

--- a/libs/checkpoint-mongodb/src/checkpoint.ts
+++ b/libs/checkpoint-mongodb/src/checkpoint.ts
@@ -52,6 +52,14 @@ function getStringConfigValue(
 
 /**
  * A LangGraph checkpoint saver backed by a MongoDB database.
+ *
+ * NOTE: you need to call .setup() the first time you're using your checkpointer.
+ *
+ * @example
+ * ```typescript
+ * const checkpointer = new MongoDBSaver({ client });
+ * await checkpointer.setup();
+ * ```
  */
 export class MongoDBSaver extends BaseCheckpointSaver {
   protected client: MongoClient;
@@ -122,12 +130,16 @@ export class MongoDBSaver extends BaseCheckpointSaver {
           { thread_id: 1, checkpoint_ns: 1, checkpoint_id: -1 },
           { name: "thread_ns_checkpoint_idx" }
         ),
-      this.db
-        .collection(this.checkpointWritesCollectionName)
-        .createIndex(
-          { thread_id: 1, checkpoint_ns: 1, checkpoint_id: -1 },
-          { name: "thread_ns_checkpoint_idx" }
-        ),
+      this.db.collection(this.checkpointWritesCollectionName).createIndex(
+        {
+          thread_id: 1,
+          checkpoint_ns: 1,
+          checkpoint_id: 1,
+          task_id: 1,
+          idx: 1,
+        },
+        { name: "thread_ns_checkpoint_task_idx" }
+      ),
     ];
 
     if (this.ttl != null) {

--- a/libs/checkpoint-mongodb/src/checkpoint.ts
+++ b/libs/checkpoint-mongodb/src/checkpoint.ts
@@ -101,26 +101,49 @@ export class MongoDBSaver extends BaseCheckpointSaver {
   }
 
   /**
-   * Creates TTL indexes on the checkpoint collections if a `ttl` is configured.
-   * This method is idempotent and safe to call multiple times (and concurrently).
-   * Returns an array of errors (empty if successful) so the caller can decide
-   * how to handle failures. No-op when `ttl` is not configured.
+   * Creates the indexes required by the checkpoint saver.
+   *
+   * Always creates compound indexes on the `checkpoints` and
+   * `checkpoint_writes` collections matching the query and upsert patterns so
+   * that lookups don't degrade into full collection scans as the collections
+   * grow. When a `ttl` is configured, additionally creates MongoDB TTL indexes
+   * on `upserted_at` so documents expire after the configured period of
+   * inactivity.
+   *
+   * This method is idempotent and safe to call on every application start (and
+   * concurrently). It returns an array of errors (empty if successful) so the
+   * caller can decide how to handle failures.
    */
   async setup(): Promise<Error[]> {
-    if (this.ttl == null) return [];
-
-    const ttlIndex = { upserted_at: 1 };
-    const options = { expireAfterSeconds: this.ttl };
-
-    const results = await Promise.allSettled([
+    const operations: Promise<unknown>[] = [
       this.db
         .collection(this.checkpointCollectionName)
-        .createIndex(ttlIndex, options),
+        .createIndex(
+          { thread_id: 1, checkpoint_ns: 1, checkpoint_id: -1 },
+          { name: "thread_ns_checkpoint_idx" }
+        ),
       this.db
         .collection(this.checkpointWritesCollectionName)
-        .createIndex(ttlIndex, options),
-    ]);
+        .createIndex(
+          { thread_id: 1, checkpoint_ns: 1, checkpoint_id: -1 },
+          { name: "thread_ns_checkpoint_idx" }
+        ),
+    ];
 
+    if (this.ttl != null) {
+      const ttlIndex = { upserted_at: 1 };
+      const options = { expireAfterSeconds: this.ttl };
+      operations.push(
+        this.db
+          .collection(this.checkpointCollectionName)
+          .createIndex(ttlIndex, options),
+        this.db
+          .collection(this.checkpointWritesCollectionName)
+          .createIndex(ttlIndex, options)
+      );
+    }
+
+    const results = await Promise.allSettled(operations);
     return results
       .filter((r): r is PromiseRejectedResult => r.status === "rejected")
       .map((r) => r.reason as Error);

--- a/libs/checkpoint-mongodb/src/tests/checkpoints.test.ts
+++ b/libs/checkpoint-mongodb/src/tests/checkpoints.test.ts
@@ -102,6 +102,10 @@ describe("MongoDBSaver", () => {
         { thread_id: 1, checkpoint_ns: 1, checkpoint_id: -1 },
         { name: "thread_ns_checkpoint_idx" }
       );
+      expect(createIndexMock).toHaveBeenCalledWith(
+        { thread_id: 1, checkpoint_ns: 1, checkpoint_id: 1, task_id: 1, idx: 1 },
+        { name: "thread_ns_checkpoint_task_idx" }
+      );
     });
 
     it("should create TTL indexes in addition to compound indexes when ttl is configured", async () => {

--- a/libs/checkpoint-mongodb/src/tests/checkpoints.test.ts
+++ b/libs/checkpoint-mongodb/src/tests/checkpoints.test.ts
@@ -69,9 +69,43 @@ describe("MongoDBSaver", () => {
       const op = (saver as any).timestampOp;
       expect(op).toEqual({ $currentDate: { upserted_at: true } });
     });
+  });
 
-    it("setup() should create TTL indexes when ttl is configured", async () => {
-      const mockCreateIndex = vi.fn().mockResolvedValue("upserted_at_1");
+  describe("setup", () => {
+    it("should create compound indexes on both collections", async () => {
+      const createIndexMock = vi.fn().mockResolvedValue("ok");
+      const collectionMock = vi.fn(() => ({
+        createIndex: createIndexMock,
+        find: vi.fn(() => ({
+          sort: vi.fn(() => ({
+            limit: vi.fn(() => ({
+              toArray: vi.fn(() => Promise.resolve([])),
+            })),
+          })),
+        })),
+      }));
+      const client = {
+        appendMetadata: vi.fn(),
+        db: vi.fn(() => ({ collection: collectionMock })),
+      };
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+
+      const errors = await saver.setup();
+
+      expect(errors).toEqual([]);
+      expect(collectionMock).toHaveBeenCalledWith("checkpoints");
+      expect(collectionMock).toHaveBeenCalledWith("checkpoint_writes");
+      expect(createIndexMock).toHaveBeenCalledTimes(2);
+      expect(createIndexMock).toHaveBeenCalledWith(
+        { thread_id: 1, checkpoint_ns: 1, checkpoint_id: -1 },
+        { name: "thread_ns_checkpoint_idx" }
+      );
+    });
+
+    it("should create TTL indexes in addition to compound indexes when ttl is configured", async () => {
+      const mockCreateIndex = vi.fn().mockResolvedValue("ok");
       const mockCollection = vi.fn(() => ({
         createIndex: mockCreateIndex,
       }));
@@ -91,15 +125,20 @@ describe("MongoDBSaver", () => {
 
       expect(mockCollection).toHaveBeenCalledWith("checkpoints");
       expect(mockCollection).toHaveBeenCalledWith("checkpoint_writes");
-      expect(mockCreateIndex).toHaveBeenCalledTimes(2);
+      // 2 compound indexes + 2 TTL indexes
+      expect(mockCreateIndex).toHaveBeenCalledTimes(4);
+      expect(mockCreateIndex).toHaveBeenCalledWith(
+        { thread_id: 1, checkpoint_ns: 1, checkpoint_id: -1 },
+        { name: "thread_ns_checkpoint_idx" }
+      );
       expect(mockCreateIndex).toHaveBeenCalledWith(
         { upserted_at: 1 },
         { expireAfterSeconds: 3600 }
       );
     });
 
-    it("setup() should not create indexes when ttl is not configured", async () => {
-      const mockCreateIndex = vi.fn().mockResolvedValue("upserted_at_1");
+    it("should not create TTL indexes when ttl is not configured", async () => {
+      const mockCreateIndex = vi.fn().mockResolvedValue("ok");
       const mockCollection = vi.fn(() => ({
         createIndex: mockCreateIndex,
       }));
@@ -116,11 +155,16 @@ describe("MongoDBSaver", () => {
 
       await saver.setup();
 
-      expect(mockCreateIndex).not.toHaveBeenCalled();
+      // Only the 2 compound indexes, no TTL index.
+      expect(mockCreateIndex).toHaveBeenCalledTimes(2);
+      expect(mockCreateIndex).not.toHaveBeenCalledWith(
+        { upserted_at: 1 },
+        expect.anything()
+      );
     });
 
-    it("setup() should return empty array on success", async () => {
-      const mockCreateIndex = vi.fn().mockResolvedValue("upserted_at_1");
+    it("should return empty array on success", async () => {
+      const mockCreateIndex = vi.fn().mockResolvedValue("ok");
       const mockCollection = vi.fn(() => ({
         createIndex: mockCreateIndex,
       }));
@@ -140,7 +184,7 @@ describe("MongoDBSaver", () => {
       expect(errors).toEqual([]);
     });
 
-    it("setup() should return errors for caller to handle", async () => {
+    it("should return errors for caller to handle", async () => {
       const mockCreateIndex = vi
         .fn()
         .mockRejectedValue(new Error("Index creation failed"));
@@ -160,7 +204,8 @@ describe("MongoDBSaver", () => {
       });
 
       const errors = await saver.setup();
-      expect(errors).toHaveLength(2);
+      // 2 compound + 2 TTL index creations all fail.
+      expect(errors).toHaveLength(4);
       expect(errors[0].message).toBe("Index creation failed");
     });
   });


### PR DESCRIPTION
## Summary

Fixes #2551

`MongoDBSaver` queries `checkpoints` and `checkpoint_writes` collections by `thread_id`, `checkpoint_ns`, and `checkpoint_id`, but never creates indexes on these fields. As the collections grow, every `getTuple()`, `list()`, and `putWrites()` call triggers a **full collection scan**.

In production with ~450K checkpoints and ~570K checkpoint_writes, this caused:
- `getState` taking **5-10 seconds** per request (scanning all 450K docs each time)
- Total API response times of **30-40 seconds** instead of **3 seconds**

### Changes

- Adds a `setup()` method to `MongoDBSaver` that creates a compound index `{ thread_id: 1, checkpoint_ns: 1, checkpoint_id: -1 }` on both collections
- The method is idempotent (`createIndex` is a no-op when the index already exists), safe to call on every app start
- Follows the same pattern as `MongoDBStore.start()` which already creates indexes

### Before / After (production, 450K checkpoints)

| Metric | Before | After |
|---|---|---|
| Docs examined per query | 445,801 | 1 |
| `checkpoints` query | 5,173ms | <10ms |
| `checkpoint_writes` query | 925ms | <10ms |

### Test plan

- [x] Unit test added verifying `setup()` creates indexes on both collections with correct key spec
- [x] Existing integration tests pass