### PR TITLE
fix(langgraph-checkpoint-mongodb): no-op putWrites on empty writes

### DIFF
--- a/.changeset/fix-mongodb-checkpoint-empty-writes.md
+++ b/.changeset/fix-mongodb-checkpoint-empty-writes.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint-mongodb": patch
+---
+
+Fix `MongoDBSaver.putWrites` throwing `MongoServerError: Invalid BulkOperation, Batch cannot be empty` when called with an empty `writes` array. This is reached by human-in-the-loop / `interrupt()` flows, where a task can complete producing zero channel writes and LangGraph calls `putWrites(config, [], taskId)`. `putWrites` now no-ops on empty writes, matching the behavior of the postgres and sqlite savers (which iterate and naturally skip empty batches).

--- a/libs/checkpoint-mongodb/src/checkpoint.ts
+++ b/libs/checkpoint-mongodb/src/checkpoint.ts
@@ -424,9 +424,14 @@ export class MongoDBSaver extends BaseCheckpointSaver {
       })
     );
 
-    await this.db
-      .collection(this.checkpointWritesCollectionName)
-      .bulkWrite(operations);
+    // The MongoDB driver rejects `bulkWrite([])` with "Invalid BulkOperation,
+    // Batch cannot be empty". `writes` can be empty in human-in-the-loop /
+    // `interrupt()` flows, so skip the call when there is nothing to persist.
+    if (operations.length > 0) {
+      await this.db
+        .collection(this.checkpointWritesCollectionName)
+        .bulkWrite(operations);
+    }
   }
 
   async deleteThread(threadId: string) {

--- a/libs/checkpoint-mongodb/src/tests/checkpoints.int.test.ts
+++ b/libs/checkpoint-mongodb/src/tests/checkpoints.int.test.ts
@@ -261,4 +261,38 @@ describe("MongoDBSaver", () => {
       await saver.getTuple({ configurable: { thread_id: "2" } })
     ).toBeDefined();
   });
+
+  it("should no-op on empty writes without throwing", async () => {
+    // Regression test for the empty-batch crash against the real driver:
+    // bulkWrite([]) is rejected with "Invalid BulkOperation, Batch cannot be
+    // empty"; HITL / interrupt() flows can call putWrites with zero writes.
+    const saver = new MongoDBSaver({ client });
+
+    await saver.put(
+      { configurable: { thread_id: "empty-writes" } },
+      checkpoint1,
+      { source: "update", step: -1, parents: {} }
+    );
+
+    await expect(
+      saver.putWrites(
+        {
+          configurable: {
+            thread_id: "empty-writes",
+            checkpoint_ns: "",
+            checkpoint_id: checkpoint1.id,
+          },
+        },
+        [],
+        "task-empty"
+      )
+    ).resolves.toBeUndefined();
+
+    // Nothing should have been persisted to the writes collection.
+    const writeDoc = await client
+      .db()
+      .collection("checkpoint_writes")
+      .findOne({ thread_id: "empty-writes" });
+    expect(writeDoc).toBeNull();
+  });
 });

--- a/libs/checkpoint-mongodb/src/tests/checkpoints.test.ts
+++ b/libs/checkpoint-mongodb/src/tests/checkpoints.test.ts
@@ -576,6 +576,35 @@ describe("MongoDBSaver", () => {
       );
     });
 
+    it("should no-op without calling bulkWrite when writes is empty", async () => {
+      // Regression test: an empty `writes` array used to reach `bulkWrite([])`,
+      // which the MongoDB driver rejects with "Invalid BulkOperation, Batch
+      // cannot be empty" (hit by human-in-the-loop / interrupt() flows).
+      const bulkWriteMock = vi.fn(() => Promise.resolve({}));
+      const client = {
+        appendMetadata: vi.fn(),
+        db: vi.fn(() => ({
+          collection: vi.fn(() => ({ bulkWrite: bulkWriteMock })),
+        })),
+      };
+      const saver = new MongoDBSaver({
+        client: client as unknown as MongoClient,
+      });
+      const config = {
+        configurable: {
+          thread_id: "t",
+          checkpoint_ns: "",
+          checkpoint_id: "c",
+        },
+      };
+
+      await expect(
+        saver.putWrites(config, [], "task_A")
+      ).resolves.toBeUndefined();
+      // Load-bearing assertion: before the fix, putWrites called bulkWrite([]).
+      expect(bulkWriteMock).not.toHaveBeenCalled();
+    });
+
     it("should reject non-string thread_id in putWrites", async () => {
       const client = createMockClient();
       const saver = new MongoDBSaver({


### PR DESCRIPTION
## Summary

`MongoDBSaver.putWrites` builds a `bulkWrite` operations array from `writes` and calls `collection.bulkWrite(operations)`. When `writes` is empty, `operations` is empty and the MongoDB driver throws:

```
MongoServerError: Invalid BulkOperation, Batch cannot be empty
```

This is reached in normal operation by **human-in-the-loop / `interrupt()`** flows: when a graph interrupts to wait for input, a task can complete producing **zero channel writes**, so LangGraph calls `putWrites(config, [], taskId)` and the saver throws.

The other first-party savers don't hit this — `checkpoint-postgres` and `checkpoint-sqlite` iterate over `writes`, so an empty array is a natural no-op. The sibling `store.ts` in this same package already guards its bulk write with `if (bulkOps.length > 0)`. `putWrites` was simply missing the equivalent guard.

## Fix

Skip the `bulkWrite` call when there are no operations, mirroring the existing guard in `store.ts`. The guard is at the call site (not an early return), so the existing `configurable` validation is preserved. This aligns the MongoDB saver's empty-writes behavior with the postgres and sqlite savers.

## Tests

- **Unit** (`checkpoints.test.ts`): asserts `putWrites(config, [], taskId)` resolves and that `bulkWrite` is **not** called. Verified to fail before the fix (`bulkWrite` was called with `[]`).
- **Integration** (`checkpoints.int.test.ts`): asserts `putWrites` with empty writes resolves and persists nothing — the truest repro against the real driver.

`pnpm build`, `pnpm lint`, `pnpm format:check`, and the unit suite all pass locally. A changeset is included (`@langchain/langgraph-checkpoint-mongodb` patch).

## Related

Same class of HITL / `interrupt()` + `putWrites` bug previously fixed for the Redis saver: #1996 / #2026.
