### PR TITLE
feat(sdk): apply state update and goto alongside interrupt resume

### DIFF
--- a/.changeset/preserve-response-metadata.md
+++ b/.changeset/preserve-response-metadata.md
@@ -1,0 +1,10 @@
+---
+"@langchain/langgraph-api": patch
+---
+
+fix(langgraph-api): preserve non-empty response_metadata on protocol-v2 state messages
+
+The protocol-v2 state normalizer stripped `response_metadata` from messages,
+dropping data that HITL flows rely on — an interrupt's card is carried on
+`AIMessage.response_metadata` (e.g. `{ cards: ... }`). Non-empty
+`response_metadata` is now retained so the card reaches the client.

--- a/.changeset/respond-update-goto.md
+++ b/.changeset/respond-update-goto.md
@@ -18,3 +18,11 @@ the resume — one checkpoint, no separate `updateState` write, no flicker.
 and `@langchain/core` message instances in `update` are serialized to dicts
 before transport, exactly like `submit()`. Bumps `@langchain/protocol` to
 `^0.0.18` for the `Goto` type.
+
+`respond`/`respondAll` also apply `update` **optimistically** (mirroring
+`submit()`): the pushed messages paint immediately, with stable ids minted so
+the resumed run's echo reconciles them in place. Without this the interrupt is
+cleared the instant `respond()` dispatches while the pushed card only reappears
+a server round-trip later — so the card would flicker in that gap. The
+optimistic state settles on the resumed run's terminal (pending → sent, or
+rolled back on a failure before any echo).

--- a/.changeset/respond-update-goto.md
+++ b/.changeset/respond-update-goto.md
@@ -1,0 +1,20 @@
+---
+"@langchain/langgraph-sdk": patch
+"@langchain/react": patch
+"@langchain/vue": patch
+"@langchain/svelte": patch
+"@langchain/angular": patch
+"@langchain/langgraph-api": patch
+"@langchain/langgraph": patch
+---
+
+fix(sdk): apply state update and goto alongside interrupt resume
+
+`respond(decision, { update, goto })` now maps to LangGraph's
+`Command(resume, update, goto)`, so a human-in-the-loop UI can commit a state
+update (e.g. push the interrupt card into state) in the **same superstep** as
+the resume — one checkpoint, no separate `updateState` write, no flicker.
+`@langchain/langgraph-api` forwards `update`/`goto` through `input.respond`,
+and `@langchain/core` message instances in `update` are serialized to dicts
+before transport, exactly like `submit()`. Bumps `@langchain/protocol` to
+`^0.0.18` for the `Goto` type.

--- a/.changeset/respond-update-goto.md
+++ b/.changeset/respond-update-goto.md
@@ -26,3 +26,11 @@ cleared the instant `respond()` dispatches while the pushed card only reappears
 a server round-trip later — so the card would flicker in that gap. The
 optimistic state settles on the resumed run's terminal (pending → sent, or
 rolled back on a failure before any echo).
+
+User-initiated optimistic writes (`submit()` / `respond()` / `respondAll()`) now
+commit to the store **synchronously**, in the same tick as the triggering event,
+instead of being coalesced onto the next macrotask. This lets a framework render
+the pushed message in the **same commit** as any local UI state the caller flips
+alongside it (e.g. a HITL form swapping its inputs for the resolved card), so the
+card no longer blinks out for the one-macrotask window before the flush lands.
+High-frequency streaming writes keep their macrotask coalescing.

--- a/examples/streaming/package.json
+++ b/examples/streaming/package.json
@@ -50,7 +50,7 @@
     "@langchain/langgraph": "workspace:*",
     "@langchain/langgraph-cli": "workspace:*",
     "@langchain/langgraph-sdk": "workspace:*",
-    "@langchain/protocol": "^0.0.16",
+    "@langchain/protocol": "^0.0.18",
     "deepagents": "https://pkg.pr.new/deepagents@9eaa3ac",
     "langchain": "1.4.4",
     "tsx": "^4.21.0",

--- a/examples/ui-react-transport/package.json
+++ b/examples/ui-react-transport/package.json
@@ -15,7 +15,7 @@
     "@langchain/core": "^1.1.48",
     "@langchain/langgraph": "workspace:*",
     "@langchain/openai": "^1.4.7",
-    "@langchain/protocol": "^0.0.16",
+    "@langchain/protocol": "^0.0.18",
     "@langchain/react": "workspace:*",
     "hono": "^4.12.25",
     "react": "^19.2.7",

--- a/libs/langgraph-api/package.json
+++ b/libs/langgraph-api/package.json
@@ -66,7 +66,7 @@
     "@hono/node-ws": "^1.3.0",
     "@hono/zod-validator": "^0.7.6",
     "@langchain/langgraph-ui": "workspace:*",
-    "@langchain/protocol": "^0.0.16",
+    "@langchain/protocol": "^0.0.18",
     "@types/json-schema": "^7.0.15",
     "@typescript/vfs": "^1.6.0",
     "dedent": "^1.5.3",

--- a/libs/langgraph-api/src/experimental/embed/protocol.mts
+++ b/libs/langgraph-api/src/experimental/embed/protocol.mts
@@ -360,11 +360,34 @@ export function registerProtocolRoutes(
       });
     }
 
+    // `update` / `goto` are the optional state mutation and directed jump
+    // the SDK's `respond({ update, goto })` forwards on `input.respond`
+    // (`InputRespondOne` / `InputRespondMany`). Fold them into the same
+    // `Command(resume, update, goto)` as the resume so the resumed run
+    // produces a single checkpoint reflecting all of them — the HITL
+    // "push card into state + resume" flow. Read leniently (update: object
+    // or `[key, value][]` tuples; goto: node name, Send object, or a list
+    // of either), same posture as `config` / `metadata`.
+    const update =
+      isRecord(params.update) || Array.isArray(params.update)
+        ? params.update
+        : undefined;
+    const goto =
+      typeof params.goto === "string" ||
+      Array.isArray(params.goto) ||
+      isRecord(params.goto)
+        ? params.goto
+        : undefined;
+
     const run = createStubRun(thread.threadId, {
       assistant_id: assistantId,
       on_disconnect: "cancel",
       input: null,
-      command: { resume: resumeInput },
+      command: {
+        resume: resumeInput,
+        ...(update != null ? { update } : {}),
+        ...(goto != null ? { goto } : {}),
+      },
       // Carry the SDK's `respond({ config, metadata })` onto the resumed
       // run so it applies the same run config / metadata a fresh
       // `run.start` would (both are part of the `input.respond` params).

--- a/libs/langgraph-api/src/protocol/service.mts
+++ b/libs/langgraph-api/src/protocol/service.mts
@@ -91,6 +91,19 @@ export const normalizeMultitaskStrategy = (
  */
 type NormalizedRunStart = RunStartParams & {
   multitaskStrategy?: MultitaskStrategy;
+  /**
+   * State update applied alongside a resume, mapped to LangGraph's
+   * `Command(update=...)`. Only set on the `input.respond` path
+   * (resume), never on a fresh `run.start` — the protocol's
+   * `RunStartParams` carries no `update` field.
+   */
+  update?: RunCommand["update"];
+  /**
+   * Directed jump applied alongside a resume, mapped to LangGraph's
+   * `Command(goto=...)`. Like {@link update}, only set on the
+   * `input.respond` (resume) path.
+   */
+  goto?: RunCommand["goto"];
 };
 
 const normalizeRunStart = (value: unknown): NormalizedRunStart => {
@@ -395,9 +408,29 @@ export class ProtocolService {
     // context, …) and metadata (trigger source, test flags, …) a fresh
     // `run.start` would. Read them leniently — same posture as
     // `normalizeRunStart`.
+    // `update` / `goto` are the optional state mutation and directed jump
+    // applied in the same superstep as the resume (`InputRespondOne` /
+    // `InputRespondMany`). The SDK's `respond({ update, goto })` forwards them
+    // on the `input.respond` command; they are folded into
+    // `Command(resume, update, goto)` by `createOrResumeRun`. Read leniently
+    // (update: object or [key, value][] tuples; goto: node name, Send object,
+    // or a list of either) — same posture as `config` / `metadata`.
+    const update =
+      isRecord(rawParams.update) || Array.isArray(rawParams.update)
+        ? (rawParams.update as RunCommand["update"])
+        : undefined;
+    const goto =
+      typeof rawParams.goto === "string" ||
+      Array.isArray(rawParams.goto) ||
+      isRecord(rawParams.goto)
+        ? (rawParams.goto as RunCommand["goto"])
+        : undefined;
+
     await this.createOrResumeRun(record, {
       assistant_id: record.assistantId,
       input: resumeInput,
+      update,
+      goto,
       config: isRecord(rawParams.config) ? rawParams.config : undefined,
       metadata: isRecord(rawParams.metadata) ? rawParams.metadata : undefined,
     });
@@ -455,7 +488,16 @@ export class ProtocolService {
       assistant_id: assistantId,
       input: isResume ? null : params.input,
       command: isResume
-        ? ({ resume: params.input } satisfies RunCommand)
+        ? ({
+            resume: params.input,
+            // Apply an optional state update and/or directed jump in the
+            // same superstep as the resume (HITL "push card into state +
+            // resume" flows, or resume-and-redirect). Mapped straight onto
+            // LangGraph's `Command(resume, update, goto)`, so the resumed
+            // run produces a single checkpoint reflecting all of them.
+            ...(params.update != null ? { update: params.update } : {}),
+            ...(params.goto != null ? { goto: params.goto } : {}),
+          } satisfies RunCommand)
         : undefined,
       config: runConfig,
       metadata: params.metadata,

--- a/libs/langgraph-api/src/protocol/session/state-normalizers.mts
+++ b/libs/langgraph-api/src/protocol/session/state-normalizers.mts
@@ -423,6 +423,18 @@ export const normalizeProtocolStateMessage = (
   if (typeof value.name === "string") {
     message.name = value.name;
   }
+
+  // Preserve `response_metadata` when present. It is a first-class protocol
+  // message field, and HITL flows rely on it: an interrupt's card is carried
+  // on `AIMessage.response_metadata` (e.g. `{ cards: ... }`) and the frontend
+  // pushes that message into state via `respond(decision, { update })`. We
+  // only forward a non-empty record to keep the common (empty) case minimal.
+  if (
+    isRecord(value.response_metadata) &&
+    Object.keys(value.response_metadata).length > 0
+  ) {
+    message.response_metadata = value.response_metadata;
+  }
   if (
     (type === "ai" || type === "human") &&
     typeof value.example === "boolean"

--- a/libs/langgraph-api/tests/protocol-session.test.mts
+++ b/libs/langgraph-api/tests/protocol-session.test.mts
@@ -522,6 +522,14 @@ describe("RunProtocolSession", () => {
                 id: "ai_1",
                 type: "ai",
                 content: "",
+                response_metadata: {
+                  model_provider: "openai",
+                  usage: {
+                    input_tokens: 5,
+                    output_tokens: 2,
+                    total_tokens: 7,
+                  },
+                },
                 tool_calls: [
                   {
                     id: "call_123",

--- a/libs/langgraph-core/package.json
+++ b/libs/langgraph-core/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@langchain/langgraph-checkpoint": "workspace:^",
     "@langchain/langgraph-sdk": "workspace:~",
-    "@langchain/protocol": "^0.0.16",
+    "@langchain/protocol": "^0.0.18",
     "@standard-schema/spec": "1.1.0"
   },
   "peerDependencies": {

--- a/libs/sdk-angular/docs/interrupts.md
+++ b/libs/sdk-angular/docs/interrupts.md
@@ -87,6 +87,41 @@ await stream.respond({ approved: true }, {
 });
 ```
 
+## Changing state while resuming
+
+Pass `options.update` to apply a state update in the **same superstep** as the
+resume — it maps to LangGraph's `Command(resume, update)`. The resumed run
+produces a single checkpoint reflecting both the resume value and the update:
+no separate `updateState` write, no intermediate checkpoint, no flicker.
+
+The canonical use case is a HITL flow where the UI pushes the interrupt card
+(e.g. an `AIMessage`) into state at the moment it answers the interrupt, so the
+card is committed before the resumed tool runs and stays rendered without the
+backend re-emitting it.
+
+`update` accepts a state-keys object (shallow-merged via the graph's channel
+reducers) or a list of `[key, value]` entries. Messages under the configured
+`messagesKey` may be plain dicts **or** `@langchain/core` `BaseMessage`
+instances — instances are serialized to dicts before transport, exactly like
+`submit()`. You can also pass `options.goto` for a directed jump
+(`Command(goto=...)`) in the same superstep.
+
+```typescript
+import { AIMessage } from "@langchain/core/messages";
+
+// Approve the interrupt AND push a message into state in one atomic resume:
+await stream.respond(
+  { approved: true },
+  { update: { messages: [new AIMessage("Approved by reviewer.")] } },
+);
+
+// Equivalent with a plain message dict:
+await stream.respond(
+  { approved: true },
+  { update: { messages: [{ type: "ai", content: "Approved by reviewer." }] } },
+);
+```
+
 ## Responding to several interrupts at once
 
 When a run pauses on **several interrupts at the same checkpoint** (e.g.

--- a/libs/sdk-angular/src/tests/components/InterruptCardStream.ts
+++ b/libs/sdk-angular/src/tests/components/InterruptCardStream.ts
@@ -1,0 +1,110 @@
+import { Component } from "@angular/core";
+import { AIMessage, type BaseMessage } from "@langchain/core/messages";
+import { inject } from "vitest";
+import { injectStream } from "../../index.js";
+
+const serverUrl = inject("serverUrl");
+
+interface CardState {
+  messages: BaseMessage[];
+  toolArg: string;
+}
+
+/**
+ * Reproduces the customer HITL flow against `interrupt_card_graph`:
+ * the interrupt (raised from a tool) carries an AIMessage card; on
+ * decision the frontend resolves the interrupt AND pushes that card into
+ * state in a single atomic `respond(..., { update })`, so the card stays
+ * visible while the slow tool runs and the backend never has to add it.
+ */
+@Component({
+  template: `
+    <div>
+      <div data-testid="interrupt-count">{{ stream.interrupts().length }}</div>
+      <div data-testid="interrupt-card">{{ cardsJson() }}</div>
+      <div data-testid="loading">
+        {{ stream.isLoading() ? "loading" : "idle" }}
+      </div>
+      <div data-testid="card-count">{{ cardMessages().length }}</div>
+      <div data-testid="card-in-state">
+        {{ cardMessages().length > 0 ? "present" : "absent" }}
+      </div>
+      <div data-testid="messages">{{ messagesStr() }}</div>
+      <button data-testid="submit" (click)="onSubmit()">Submit</button>
+      <button data-testid="approve" (click)="onApprove()">Approve</button>
+      <button data-testid="reject" (click)="onReject()">Reject</button>
+    </div>
+  `,
+})
+export class InterruptCardComponent {
+  stream = injectStream<CardState>({
+    assistantId: "interrupt_card_graph",
+    apiUrl: serverUrl,
+  });
+
+  /** Pull the card + content out of the AIMessage the interrupt carried. */
+  private interruptInfo(): { content: string; cards: unknown } {
+    const value = this.stream.interrupt()?.value as
+      | { content?: unknown; response_metadata?: { cards?: unknown } }
+      | undefined;
+    return {
+      content: typeof value?.content === "string" ? value.content : "",
+      cards: value?.response_metadata?.cards ?? null,
+    };
+  }
+
+  cardsJson() {
+    const { cards } = this.interruptInfo();
+    return cards != null ? JSON.stringify(cards) : "none";
+  }
+
+  cardMessages() {
+    return this.stream.messages().filter((m) => {
+      if (m.getType() !== "ai") return false;
+      const metadata = m.response_metadata as { cards?: unknown } | undefined;
+      return metadata?.cards != null;
+    });
+  }
+
+  messagesStr() {
+    return this.stream
+      .messages()
+      .map(
+        (m) =>
+          `${m.getType()}:${typeof m.content === "string" ? m.content : ""}`,
+      )
+      .join("|");
+  }
+
+  // The AIMessage the frontend pushes into state on respond — the same
+  // card the interrupt carried (built as a `BaseMessage` instance to
+  // exercise the instance-serialization path).
+  private buildCardMessage() {
+    const { content, cards } = this.interruptInfo();
+    return new AIMessage({ content, response_metadata: { cards } });
+  }
+
+  onSubmit() {
+    void this.stream.submit({ toolArg: "delete_db" });
+  }
+
+  onApprove() {
+    if (this.stream.interrupt()) {
+      void this.stream.respond(
+        { approved: true },
+        { update: { messages: [this.buildCardMessage()] } },
+      );
+    }
+  }
+
+  onReject() {
+    if (this.stream.interrupt()) {
+      void this.stream.respond(
+        { approved: false },
+        { update: { messages: [this.buildCardMessage()] } },
+      );
+    }
+  }
+}
+
+export const InterruptCardStreamComponent = InterruptCardComponent;

--- a/libs/sdk-angular/src/tests/fixtures/mock-server.ts
+++ b/libs/sdk-angular/src/tests/fixtures/mock-server.ts
@@ -623,9 +623,74 @@ const headlessToolAgent = createAgent({
   checkpointer,
 }) as unknown as AnyPregel;
 
+// --- HITL card flow: interrupt raised from inside a tool ---
+// Mirrors a customer pattern where the interrupt carries an AIMessage
+// "card" (in `response_metadata.cards`) the frontend renders validation
+// buttons from. The tool's real work is slow, so the frontend pushes the
+// card into state alongside the resume (`respond(decision, { update })`) —
+// the backend never adds it — so the card stays visible without flicker.
+const reviewActionTool = tool(
+  async ({ toolArg }: { toolArg: string }) => {
+    const card = {
+      kind: "tool_validation",
+      action: toolArg,
+      buttons: ["approve", "reject"],
+    };
+    const response = interrupt({
+      type: "ai",
+      content: `Please review the "${toolArg}" action.`,
+      response_metadata: { cards: card },
+    });
+    const approved =
+      response === true ||
+      (response != null &&
+        typeof response === "object" &&
+        (response as { approved?: unknown }).approved === true);
+    if (!approved) {
+      return "User has rejected the toolcall";
+    }
+    // Long-running business logic — the FE-pushed card must stay in state
+    // for the entire duration (the no-flicker guarantee).
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1_000);
+    });
+    return `Executed "${toolArg}".`;
+  },
+  {
+    name: "review_action",
+    description: "Perform a sensitive action that requires human approval.",
+    schema: z.object({ toolArg: z.string() }),
+  },
+);
+
+const interruptCardModel = new FakeToolCallingModel({
+  responses: [
+    new AIMessage({
+      content: "",
+      tool_calls: [
+        {
+          name: "review_action",
+          args: { toolArg: "delete_db" },
+          id: "call-review-1",
+          type: "tool_call",
+        },
+      ],
+    }),
+    new AIMessage("Done."),
+  ],
+});
+
+const interruptCardGraph = createAgent({
+  model: interruptCardModel,
+  tools: [reviewActionTool],
+  systemPrompt: "You are a deterministic approval agent for protocol testing.",
+  checkpointer,
+}) as unknown as AnyPregel;
+
 const graphs: Record<string, AnyPregel> = {
   agent,
   interruptAgent,
+  interrupt_card_graph: interruptCardGraph,
   multi_interrupt_graph: multiInterruptGraph as unknown as AnyPregel,
   parentAgent,
   slow_graph: slowGraph,

--- a/libs/sdk-angular/src/tests/stream.interrupt-card-update.test.ts
+++ b/libs/sdk-angular/src/tests/stream.interrupt-card-update.test.ts
@@ -1,0 +1,90 @@
+import { expect, it } from "vitest";
+import { render } from "vitest-browser-angular";
+
+import { InterruptCardStreamComponent } from "./components/InterruptCardStream.js";
+
+/**
+ * End-to-end coverage for the customer HITL flow: an interrupt raised
+ * from a tool carries an AIMessage card, and the frontend resolves the
+ * interrupt AND pushes that card into state in a single atomic
+ * `respond(decision, { update: { messages: [card] } })`. The card must
+ * land in committed state exactly once (the backend never adds it) and
+ * stay there while the slow tool finishes — no flicker, no disappearance.
+ */
+
+it(
+  "keeps the FE-pushed card in state through a slow tool on approve",
+  { timeout: 20_000 },
+  async () => {
+    const screen = await render(InterruptCardStreamComponent);
+
+    await screen.getByTestId("submit").click();
+
+    // The tool raised an interrupt carrying the validation card.
+    await expect
+      .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("interrupt-card"))
+      .toHaveTextContent("tool_validation");
+
+    // Resolve the interrupt AND push the card into state in one call.
+    await screen.getByTestId("approve").click();
+
+    // The FE-pushed card lands in committed state — exactly one copy.
+    await expect
+      .element(screen.getByTestId("card-count"), { timeout: 10_000 })
+      .toHaveTextContent("1");
+
+    // It is still present while the slow tool is executing (no flicker).
+    await expect
+      .element(screen.getByTestId("loading"))
+      .toHaveTextContent("loading");
+    await expect
+      .element(screen.getByTestId("card-in-state"))
+      .toHaveTextContent("present");
+
+    // Once the tool finishes, the backend's result lands alongside the
+    // single FE-owned card, and the interrupt is cleared.
+    await expect
+      .element(screen.getByTestId("messages"), { timeout: 15_000 })
+      .toHaveTextContent('tool:Executed "delete_db".');
+    await expect
+      .element(screen.getByTestId("card-count"))
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("interrupt-count"))
+      .toHaveTextContent("0");
+    await expect
+      .element(screen.getByTestId("loading"))
+      .toHaveTextContent("idle");
+  },
+);
+
+it(
+  "keeps the card and informs the agent on reject",
+  { timeout: 20_000 },
+  async () => {
+    const screen = await render(InterruptCardStreamComponent);
+
+    await screen.getByTestId("submit").click();
+
+    await expect
+      .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
+      .toHaveTextContent("1");
+
+    await screen.getByTestId("reject").click();
+
+    // The rejection tool message lands; the FE-pushed card is still
+    // there exactly once.
+    await expect
+      .element(screen.getByTestId("messages"), { timeout: 15_000 })
+      .toHaveTextContent("tool:User has rejected the toolcall");
+    await expect
+      .element(screen.getByTestId("card-count"))
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("interrupt-count"))
+      .toHaveTextContent("0");
+  },
+);

--- a/libs/sdk-angular/src/use-stream.ts
+++ b/libs/sdk-angular/src/use-stream.ts
@@ -269,10 +269,36 @@ export interface UseStreamReturn<
    * interrupts use `namespace: []` (default when omitted). For subgraph
    * interrupts, copy `namespace` from `getThread()?.interrupts`.
    *
+   * Pass `options.update` (and/or `options.goto`) to apply a state update
+   * (and/or directed jump) in the **same superstep** as the resume — mapped
+   * to LangGraph's `Command(resume, update, goto)`. The resumed run produces
+   * a single checkpoint reflecting both, so a HITL card can push its message
+   * into state at the moment it answers the interrupt (no separate state
+   * write, no intermediate checkpoint, no flicker). Messages may be plain
+   * dicts or `@langchain/core` `BaseMessage` instances (serialized like
+   * `submit()`).
+   *
    * @example
    * ```ts
    * // Single pending interrupt
    * await stream.respond({ approved: true });
+   * ```
+   *
+   * @example
+   * ```ts
+   * // Resolve the interrupt AND push the card's message into state atomically
+   * await stream.respond({ approved: true }, {
+   *   update: { messages: [{ type: "ai", content: "Approved by reviewer." }] },
+   * });
+   * ```
+   *
+   * @example
+   * ```ts
+   * // `update` also accepts BaseMessage instances, like `submit()`
+   * import { AIMessage } from "@langchain/core/messages";
+   * await stream.respond({ approved: true }, {
+   *   update: { messages: [new AIMessage("Approved by reviewer.")] },
+   * });
    * ```
    *
    * @example

--- a/libs/sdk-react/docs/interrupts.md
+++ b/libs/sdk-react/docs/interrupts.md
@@ -129,6 +129,8 @@ stream.respond(
   options?: {
     interruptId?: string;
     namespace?: string[];
+    update?: Record<string, unknown> | [string, unknown][];
+    goto?: string | { node: string; input?: unknown } | (string | { node: string; input?: unknown })[];
     config?: { configurable?: Record<string, unknown>; [key: string]: unknown };
     metadata?: Record<string, unknown>;
   },
@@ -162,6 +164,32 @@ await stream.respond({ approved: true }, {
   metadata: { source: "ui" },
 });
 ```
+
+### Changing state while resuming
+
+Pass `options.update` to apply a state update in the **same superstep** as the resume — it maps to LangGraph's `Command(resume, update)`. The resumed run produces a single checkpoint reflecting both the resume value and the update: no separate `updateState` write, no intermediate checkpoint, no flicker.
+
+The canonical use case is a HITL flow where the UI pushes the interrupt card (e.g. an `AIMessage`) into state at the moment it answers the interrupt, so the card is committed before the resumed tool runs and stays rendered without the backend re-emitting it.
+
+`update` accepts a state-keys object (shallow-merged via the graph's channel reducers) or a list of `[key, value]` entries. Messages under the configured `messagesKey` may be plain dicts **or** `@langchain/core` `BaseMessage` instances — instances are serialized to dicts before transport, exactly like `submit()`.
+
+```tsx
+import { AIMessage } from "@langchain/core/messages";
+
+// Approve the interrupt AND push a message into state in one atomic resume:
+await stream.respond(
+  { approved: true },
+  { update: { messages: [new AIMessage("Approved by reviewer.")] } },
+);
+
+// Equivalent with a plain message dict:
+await stream.respond(
+  { approved: true },
+  { update: { messages: [{ type: "ai", content: "Approved by reviewer." }] } },
+);
+```
+
+You can also pass `options.goto` to apply a directed jump (`Command(goto=...)`) in the same superstep — a target node name, a `Send` (`{ node, input }`), or a list mixing the two for fan-out.
 
 ### `respondAll(responsesById, options?)`
 

--- a/libs/sdk-react/src/tests/components/InterruptCardStream.tsx
+++ b/libs/sdk-react/src/tests/components/InterruptCardStream.tsx
@@ -1,0 +1,118 @@
+import { AIMessage, type BaseMessage } from "@langchain/core/messages";
+import { useStream } from "../../index.js";
+
+interface CardState {
+  messages: BaseMessage[];
+  toolArg: string;
+}
+
+interface Props {
+  apiUrl: string;
+  assistantId?: string;
+}
+
+/** Pull the card + content out of the AIMessage the interrupt carried. */
+function readInterrupt(value: unknown): {
+  content: string;
+  cards: unknown;
+} {
+  if (value != null && typeof value === "object") {
+    const v = value as {
+      content?: unknown;
+      response_metadata?: { cards?: unknown };
+    };
+    return {
+      content: typeof v.content === "string" ? v.content : "",
+      cards: v.response_metadata?.cards ?? null,
+    };
+  }
+  return { content: "", cards: null };
+}
+
+function isCardMessage(message: BaseMessage): boolean {
+  if (message.getType() !== "ai") return false;
+  const metadata = message.response_metadata as
+    | { cards?: unknown }
+    | undefined;
+  return metadata?.cards != null;
+}
+
+/**
+ * Reproduces the customer HITL flow against `interrupt_card_graph`:
+ * the interrupt (raised from a tool) carries an AIMessage card; on
+ * decision the frontend resolves the interrupt AND pushes that card into
+ * state in a single atomic `respond(..., { update })`, so the card stays
+ * visible while the slow tool runs and the backend never has to add it.
+ */
+export function InterruptCardStream({
+  apiUrl,
+  assistantId = "interrupt_card_graph",
+}: Props) {
+  const thread = useStream<CardState>({ assistantId, apiUrl });
+
+  const { content, cards } = readInterrupt(thread.interrupt?.value);
+
+  // The AIMessage the frontend pushes into state on respond — the same
+  // card the interrupt carried (built as a `BaseMessage` instance to
+  // exercise the instance-serialization path).
+  const buildCardMessage = () =>
+    new AIMessage({ content, response_metadata: { cards } });
+
+  const cardMessages = thread.messages.filter(isCardMessage);
+
+  return (
+    <div>
+      <div data-testid="interrupt-count">{thread.interrupts.length}</div>
+      <div data-testid="interrupt-card">
+        {cards != null ? JSON.stringify(cards) : "none"}
+      </div>
+      <div data-testid="loading">{thread.isLoading ? "loading" : "idle"}</div>
+      <div data-testid="card-count">{cardMessages.length}</div>
+      <div data-testid="card-in-state">
+        {cardMessages.length > 0 ? "present" : "absent"}
+      </div>
+      <div data-testid="messages">
+        {thread.messages
+          .map(
+            (m) =>
+              `${m.getType()}:${
+                typeof m.content === "string" ? m.content : ""
+              }`
+          )
+          .join("|")}
+      </div>
+      <button
+        data-testid="submit"
+        onClick={() => void thread.submit({ toolArg: "delete_db" })}
+      >
+        Submit
+      </button>
+      <button
+        data-testid="approve"
+        onClick={() => {
+          if (thread.interrupt) {
+            void thread.respond(
+              { approved: true },
+              { update: { messages: [buildCardMessage()] } }
+            );
+          }
+        }}
+      >
+        Approve
+      </button>
+      <button
+        data-testid="reject"
+        onClick={() => {
+          if (thread.interrupt) {
+            void thread.respond(
+              { approved: false },
+              { update: { messages: [buildCardMessage()] } }
+            );
+          }
+        }}
+      >
+        Reject
+      </button>
+    </div>
+  );
+}

--- a/libs/sdk-react/src/tests/fixtures/interrupt-card-graph.ts
+++ b/libs/sdk-react/src/tests/fixtures/interrupt-card-graph.ts
@@ -1,0 +1,94 @@
+import { interrupt } from "@langchain/langgraph";
+import { MemorySaver } from "@langchain/langgraph-checkpoint";
+import { createAgent, tool } from "langchain";
+import { z } from "zod/v4";
+
+import { createDeterministicToolCallingModel } from "./shared.js";
+
+/**
+ * Mirrors a customer HITL pattern where the interrupt is raised *from
+ * within a tool*:
+ *
+ *  1. The tool builds a JSON "card" the frontend renders validation
+ *     buttons from, and attaches it to an `AIMessage`
+ *     (`response_metadata.cards`).
+ *  2. It `interrupt()`s with that message and waits for the human.
+ *  3. The tool's real business logic is slow, so the frontend pushes the
+ *     card into state *alongside* the resume
+ *     (`respond(decision, { update: { messages: [card] } })`) — the
+ *     backend never adds the card itself. This keeps the card visible
+ *     (no flicker / disappearance) while the tool executes.
+ *  4. On reject the tool short-circuits with a tool result; on approve it
+ *     runs the slow logic and returns the result — never the card, which
+ *     the frontend already committed.
+ */
+
+/**
+ * Simulated duration of the tool's "real" business logic. Long enough
+ * that the test can observe the FE-pushed card sitting in state while the
+ * run is still in flight (the no-flicker guarantee).
+ */
+export const TOOL_BUSINESS_LOGIC_DELAY_MS = 1000;
+
+const reviewActionTool = tool(
+  async ({ toolArg }: { toolArg: string }) => {
+    // 1. The card the frontend renders validation buttons from.
+    const card = {
+      kind: "tool_validation",
+      action: toolArg,
+      buttons: ["approve", "reject"],
+    };
+
+    // 2. Interrupt carrying the AIMessage (the card lives in
+    //    `response_metadata.cards`). `interrupt()`'s value must be
+    //    JSON-serializable, so the message is surfaced as a plain dict;
+    //    the frontend rebuilds an `AIMessage` from it before pushing to
+    //    state.
+    const response = interrupt({
+      type: "ai",
+      content: `Please review the "${toolArg}" action.`,
+      response_metadata: { cards: card },
+    });
+
+    // 3. We only reach here once the human responded — and, in this flow,
+    //    once the frontend has already pushed the card into state.
+    const approved =
+      response === true ||
+      (response != null &&
+        typeof response === "object" &&
+        (response as { approved?: unknown }).approved === true);
+
+    if (!approved) {
+      // User rejected: inform the agent, skip the business logic. The
+      // backend does not add the card — the frontend already did.
+      return "User has rejected the toolcall";
+    }
+
+    // 4. Long-running business logic. The card must stay in state (placed
+    //    by the frontend) for the entire duration — it must not flicker
+    //    away.
+    await new Promise((resolve) =>
+      setTimeout(resolve, TOOL_BUSINESS_LOGIC_DELAY_MS)
+    );
+
+    // The backend returns only the tool result — NOT the card.
+    return `Executed "${toolArg}".`;
+  },
+  {
+    name: "review_action",
+    description: "Perform a sensitive action that requires human approval.",
+    schema: z.object({ toolArg: z.string() }),
+  }
+);
+
+export const graph = createAgent({
+  model: createDeterministicToolCallingModel({
+    toolCallId: "call-review-1",
+    toolName: "review_action",
+    toolArgs: { toolArg: "delete_db" },
+    finalText: "Done.",
+  }),
+  tools: [reviewActionTool],
+  systemPrompt: "You are a deterministic approval agent for protocol testing.",
+  checkpointer: new MemorySaver(),
+});

--- a/libs/sdk-react/src/tests/mock-server.ts
+++ b/libs/sdk-react/src/tests/mock-server.ts
@@ -20,6 +20,7 @@ import { graph as stategraphText } from "./fixtures/stategraph-text.js";
 import { graph as createAgentGraph } from "./fixtures/create-agent.js";
 import { graph as deepAgentGraph } from "./fixtures/deep-agent.js";
 import { graph as interruptGraph } from "./fixtures/interrupt-graph.js";
+import { graph as interruptCardGraph } from "./fixtures/interrupt-card-graph.js";
 import { graph as multiInterruptGraph } from "./fixtures/multi-interrupt-graph.js";
 import { graph as errorGraph } from "./fixtures/error-graph.js";
 import { graph as subgraphGraph } from "./fixtures/subgraph-graph.js";
@@ -77,6 +78,7 @@ const graphs: Record<string, AnyPregel> = {
   create_agent: createAgentGraph as unknown as AnyPregel,
   deep_agent: deepAgentGraph as unknown as AnyPregel,
   interrupt_graph: interruptGraph as unknown as AnyPregel,
+  interrupt_card_graph: interruptCardGraph as unknown as AnyPregel,
   multi_interrupt_graph: multiInterruptGraph as unknown as AnyPregel,
   error_graph: errorGraph as unknown as AnyPregel,
   subgraph_graph: subgraphGraph as unknown as AnyPregel,

--- a/libs/sdk-react/src/tests/stream.interrupt-card-update.test.tsx
+++ b/libs/sdk-react/src/tests/stream.interrupt-card-update.test.tsx
@@ -1,0 +1,99 @@
+import { expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { InterruptCardStream } from "./components/InterruptCardStream.js";
+import { apiUrl, cleanupRender } from "./test-utils.js";
+
+/**
+ * End-to-end coverage for the customer HITL flow: an interrupt raised
+ * from a tool carries an AIMessage card, and the frontend resolves the
+ * interrupt AND pushes that card into state in a single atomic
+ * `respond(decision, { update: { messages: [card] } })`. The card must
+ * land in committed state exactly once (the backend never adds it) and
+ * stay there while the slow tool finishes — no flicker, no disappearance.
+ */
+
+it(
+  "keeps the FE-pushed card in state through a slow tool on approve",
+  { timeout: 20_000 },
+  async () => {
+    const screen = await render(<InterruptCardStream apiUrl={apiUrl} />);
+
+    try {
+      await screen.getByTestId("submit").click();
+
+      // The tool raised an interrupt carrying the validation card.
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("interrupt-card"))
+        .toHaveTextContent("tool_validation");
+
+      // Resolve the interrupt AND push the card into state in one call.
+      await screen.getByTestId("approve").click();
+
+      // The FE-pushed card lands in committed state — exactly one copy.
+      await expect
+        .element(screen.getByTestId("card-count"), { timeout: 10_000 })
+        .toHaveTextContent("1");
+
+      // It is still present while the slow tool is executing (no flicker).
+      await expect
+        .element(screen.getByTestId("loading"))
+        .toHaveTextContent("loading");
+      await expect
+        .element(screen.getByTestId("card-in-state"))
+        .toHaveTextContent("present");
+
+      // Once the tool finishes, the backend's result lands alongside the
+      // single FE-owned card, and the interrupt is cleared.
+      await expect
+        .element(screen.getByTestId("messages"), { timeout: 15_000 })
+        .toHaveTextContent('tool:Executed "delete_db".');
+      await expect
+        .element(screen.getByTestId("card-count"))
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("interrupt-count"))
+        .toHaveTextContent("0");
+      await expect
+        .element(screen.getByTestId("loading"))
+        .toHaveTextContent("idle");
+    } finally {
+      await cleanupRender(screen);
+    }
+  }
+);
+
+it(
+  "keeps the card and informs the agent on reject",
+  { timeout: 20_000 },
+  async () => {
+    const screen = await render(<InterruptCardStream apiUrl={apiUrl} />);
+
+    try {
+      await screen.getByTestId("submit").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
+        .toHaveTextContent("1");
+
+      await screen.getByTestId("reject").click();
+
+      // The rejection tool message lands; the FE-pushed card is still
+      // there exactly once.
+      await expect
+        .element(screen.getByTestId("messages"), { timeout: 15_000 })
+        .toHaveTextContent("tool:User has rejected the toolcall");
+      await expect
+        .element(screen.getByTestId("card-count"))
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("interrupt-count"))
+        .toHaveTextContent("0");
+    } finally {
+      await cleanupRender(screen);
+    }
+  }
+);

--- a/libs/sdk-react/src/use-stream.ts
+++ b/libs/sdk-react/src/use-stream.ts
@@ -254,10 +254,36 @@ export interface UseStreamReturn<
    * (model, user context, …) and metadata (trigger source, test flags,
    * …) into the resumed run, mirroring `submit()`.
    *
+   * Pass `options.update` (and/or `options.goto`) to apply a state update
+   * (and/or directed jump) in the **same superstep** as the resume — mapped
+   * to LangGraph's `Command(resume, update, goto)`. The resumed run produces
+   * a single checkpoint reflecting both, so a HITL card can push its message
+   * into state at the moment it answers the interrupt (no separate state
+   * write, no intermediate checkpoint, no flicker). Messages may be plain
+   * dicts or `@langchain/core` `BaseMessage` instances (serialized like
+   * `submit()`).
+   *
    * @example
    * ```tsx
    * // Single pending interrupt
    * await stream.respond({ approved: true });
+   * ```
+   *
+   * @example
+   * ```tsx
+   * // Resolve the interrupt AND push the card's message into state atomically
+   * await stream.respond({ approved: true }, {
+   *   update: { messages: [{ type: "ai", content: "Approved by reviewer." }] },
+   * });
+   * ```
+   *
+   * @example
+   * ```tsx
+   * // `update` also accepts BaseMessage instances, like `submit()`
+   * import { AIMessage } from "@langchain/core/messages";
+   * await stream.respond({ approved: true }, {
+   *   update: { messages: [new AIMessage("Approved by reviewer.")] },
+   * });
    * ```
    *
    * @example

--- a/libs/sdk-svelte/docs/interrupts.md
+++ b/libs/sdk-svelte/docs/interrupts.md
@@ -50,6 +50,30 @@ await stream.respond({ approved: true }, {
 });
 ```
 
+### Changing state while resuming
+
+Pass `options.update` to apply a state update in the **same superstep** as the resume — it maps to LangGraph's `Command(resume, update)`. The resumed run produces a single checkpoint reflecting both the resume value and the update: no separate `updateState` write, no intermediate checkpoint, no flicker.
+
+The canonical use case is a HITL flow where the UI pushes the interrupt card (e.g. an `AIMessage`) into state at the moment it answers the interrupt, so the card is committed before the resumed tool runs and stays rendered without the backend re-emitting it.
+
+`update` accepts a state-keys object (shallow-merged via the graph's channel reducers) or a list of `[key, value]` entries. Messages under the configured `messagesKey` may be plain dicts **or** `@langchain/core` `BaseMessage` instances — instances are serialized to dicts before transport, exactly like `submit()`. You can also pass `options.goto` for a directed jump (`Command(goto=...)`) in the same superstep.
+
+```ts
+import { AIMessage } from "@langchain/core/messages";
+
+// Approve the interrupt AND push a message into state in one atomic resume:
+await stream.respond(
+  { approved: true },
+  { update: { messages: [new AIMessage("Approved by reviewer.")] } },
+);
+
+// Equivalent with a plain message dict:
+await stream.respond(
+  { approved: true },
+  { update: { messages: [{ type: "ai", content: "Approved by reviewer." }] } },
+);
+```
+
 ### Resuming several interrupts at once
 
 When a run pauses on **several interrupts at the same checkpoint** (e.g. parallel tool-authorization prompts), resume them in one command with `respondAll`. Sequential `respond()` calls would fail — the first resume starts a run, leaving the rest with no interrupted run to respond to.

--- a/libs/sdk-svelte/src/tests/components/InterruptCardStream.svelte
+++ b/libs/sdk-svelte/src/tests/components/InterruptCardStream.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import { AIMessage, type BaseMessage } from "@langchain/core/messages";
+  import { useStream } from "../../index.js";
+
+  interface Props {
+    apiUrl: string;
+    assistantId?: string;
+  }
+
+  const { apiUrl, assistantId = "interrupt_card_graph" }: Props = $props();
+
+  interface CardState {
+    messages: BaseMessage[];
+    toolArg: string;
+  }
+
+  const stream = useStream<CardState>({ assistantId, apiUrl });
+
+  /** Pull the card + content out of the AIMessage the interrupt carried. */
+  function readInterrupt(value: unknown): { content: string; cards: unknown } {
+    if (value != null && typeof value === "object") {
+      const v = value as {
+        content?: unknown;
+        response_metadata?: { cards?: unknown };
+      };
+      return {
+        content: typeof v.content === "string" ? v.content : "",
+        cards: v.response_metadata?.cards ?? null,
+      };
+    }
+    return { content: "", cards: null };
+  }
+
+  function isCardMessage(message: BaseMessage): boolean {
+    if (message.getType() !== "ai") return false;
+    const metadata = message.response_metadata as
+      | { cards?: unknown }
+      | undefined;
+    return metadata?.cards != null;
+  }
+
+  const info = $derived(readInterrupt(stream.interrupt?.value));
+  const cardMessages = $derived(stream.messages.filter(isCardMessage));
+
+  // The AIMessage the frontend pushes into state on respond — the same
+  // card the interrupt carried (built as a `BaseMessage` instance to
+  // exercise the instance-serialization path).
+  const buildCardMessage = () =>
+    new AIMessage({
+      content: info.content,
+      response_metadata: { cards: info.cards },
+    });
+</script>
+
+<div>
+  <div data-testid="interrupt-count">{stream.interrupts.length}</div>
+  <div data-testid="interrupt-card">
+    {info.cards != null ? JSON.stringify(info.cards) : "none"}
+  </div>
+  <div data-testid="loading">{stream.isLoading ? "loading" : "idle"}</div>
+  <div data-testid="card-count">{cardMessages.length}</div>
+  <div data-testid="card-in-state">
+    {cardMessages.length > 0 ? "present" : "absent"}
+  </div>
+  <div data-testid="messages">
+    {stream.messages
+      .map(
+        (m) =>
+          `${m.getType()}:${typeof m.content === "string" ? m.content : ""}`,
+      )
+      .join("|")}
+  </div>
+  <button
+    data-testid="submit"
+    onclick={() => void stream.submit({ toolArg: "delete_db" })}
+  >
+    Submit
+  </button>
+  <button
+    data-testid="approve"
+    onclick={() => {
+      if (stream.interrupt) {
+        void stream.respond(
+          { approved: true },
+          { update: { messages: [buildCardMessage()] } },
+        );
+      }
+    }}
+  >
+    Approve
+  </button>
+  <button
+    data-testid="reject"
+    onclick={() => {
+      if (stream.interrupt) {
+        void stream.respond(
+          { approved: false },
+          { update: { messages: [buildCardMessage()] } },
+        );
+      }
+    }}
+  >
+    Reject
+  </button>
+</div>

--- a/libs/sdk-svelte/src/tests/fixtures/mock-server.ts
+++ b/libs/sdk-svelte/src/tests/fixtures/mock-server.ts
@@ -623,10 +623,73 @@ const headlessToolAgent = createAgent({
   checkpointer,
 }) as unknown as AnyPregel;
 
+// --- HITL card flow: interrupt raised from inside a tool ---
+// Mirrors a customer pattern where the interrupt carries an AIMessage
+// "card" (in `response_metadata.cards`) the frontend renders validation
+// buttons from. The tool's real work is slow, so the frontend pushes the
+// card into state alongside the resume (`respond(decision, { update })`) —
+// the backend never adds it — so the card stays visible without flicker.
+const reviewActionTool = tool(
+  async ({ toolArg }: { toolArg: string }) => {
+    const card = {
+      kind: "tool_validation",
+      action: toolArg,
+      buttons: ["approve", "reject"],
+    };
+    const response = interrupt({
+      type: "ai",
+      content: `Please review the "${toolArg}" action.`,
+      response_metadata: { cards: card },
+    });
+    const approved =
+      response === true ||
+      (response != null &&
+        typeof response === "object" &&
+        (response as { approved?: unknown }).approved === true);
+    if (!approved) {
+      return "User has rejected the toolcall";
+    }
+    // Long-running business logic — the FE-pushed card must stay in state
+    // for the entire duration (the no-flicker guarantee).
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+    return `Executed "${toolArg}".`;
+  },
+  {
+    name: "review_action",
+    description: "Perform a sensitive action that requires human approval.",
+    schema: z.object({ toolArg: z.string() }),
+  },
+);
+
+const interruptCardModel = new FakeToolCallingModel({
+  responses: [
+    new AIMessage({
+      content: "",
+      tool_calls: [
+        {
+          name: "review_action",
+          args: { toolArg: "delete_db" },
+          id: "call-review-1",
+          type: "tool_call",
+        },
+      ],
+    }),
+    new AIMessage("Done."),
+  ],
+});
+
+const interruptCardGraph = createAgent({
+  model: interruptCardModel,
+  tools: [reviewActionTool],
+  systemPrompt: "You are a deterministic approval agent for protocol testing.",
+  checkpointer,
+}) as unknown as AnyPregel;
+
 const graphs: Record<string, AnyPregel> = {
   agent,
   stategraph_text: stategraphText,
   interruptAgent,
+  interrupt_card_graph: interruptCardGraph,
   multi_interrupt_graph: multiInterruptGraph as unknown as AnyPregel,
   parentAgent,
   embedded_subgraph_graph: embeddedSubgraphAgent,

--- a/libs/sdk-svelte/src/tests/stream.interrupt-card-update.test.ts
+++ b/libs/sdk-svelte/src/tests/stream.interrupt-card-update.test.ts
@@ -1,0 +1,92 @@
+import { expect, it, inject } from "vitest";
+import { render } from "vitest-browser-svelte";
+
+import InterruptCardStream from "./components/InterruptCardStream.svelte";
+
+/**
+ * End-to-end coverage for the customer HITL flow: an interrupt raised
+ * from a tool carries an AIMessage card, and the frontend resolves the
+ * interrupt AND pushes that card into state in a single atomic
+ * `respond(decision, { update: { messages: [card] } })`. The card must
+ * land in committed state exactly once (the backend never adds it) and
+ * stay there while the slow tool finishes — no flicker, no disappearance.
+ */
+
+const serverUrl = inject("serverUrl");
+
+it(
+  "keeps the FE-pushed card in state through a slow tool on approve",
+  { timeout: 20_000 },
+  async () => {
+    const screen = render(InterruptCardStream, { apiUrl: serverUrl });
+
+    await screen.getByTestId("submit").click();
+
+    // The tool raised an interrupt carrying the validation card.
+    await expect
+      .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("interrupt-card"))
+      .toHaveTextContent("tool_validation");
+
+    // Resolve the interrupt AND push the card into state in one call.
+    await screen.getByTestId("approve").click();
+
+    // The FE-pushed card lands in committed state — exactly one copy.
+    await expect
+      .element(screen.getByTestId("card-count"), { timeout: 10_000 })
+      .toHaveTextContent("1");
+
+    // It is still present while the slow tool is executing (no flicker).
+    await expect
+      .element(screen.getByTestId("loading"))
+      .toHaveTextContent("loading");
+    await expect
+      .element(screen.getByTestId("card-in-state"))
+      .toHaveTextContent("present");
+
+    // Once the tool finishes, the backend's result lands alongside the
+    // single FE-owned card, and the interrupt is cleared.
+    await expect
+      .element(screen.getByTestId("messages"), { timeout: 15_000 })
+      .toHaveTextContent('tool:Executed "delete_db".');
+    await expect
+      .element(screen.getByTestId("card-count"))
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("interrupt-count"))
+      .toHaveTextContent("0");
+    await expect
+      .element(screen.getByTestId("loading"))
+      .toHaveTextContent("idle");
+  },
+);
+
+it(
+  "keeps the card and informs the agent on reject",
+  { timeout: 20_000 },
+  async () => {
+    const screen = render(InterruptCardStream, { apiUrl: serverUrl });
+
+    await screen.getByTestId("submit").click();
+
+    await expect
+      .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
+      .toHaveTextContent("1");
+
+    await screen.getByTestId("reject").click();
+
+    // The rejection tool message lands; the FE-pushed card is still
+    // there exactly once.
+    await expect
+      .element(screen.getByTestId("messages"), { timeout: 15_000 })
+      .toHaveTextContent("tool:User has rejected the toolcall");
+    await expect
+      .element(screen.getByTestId("card-count"))
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("interrupt-count"))
+      .toHaveTextContent("0");
+  },
+);

--- a/libs/sdk-svelte/src/use-stream.svelte.ts
+++ b/libs/sdk-svelte/src/use-stream.svelte.ts
@@ -270,10 +270,36 @@ export interface UseStreamReturn<
    * interrupts use `namespace: []` (default when omitted). For subgraph
    * interrupts, copy `namespace` from `getThread()?.interrupts`.
    *
+   * Pass `options.update` (and/or `options.goto`) to apply a state update
+   * (and/or directed jump) in the **same superstep** as the resume — mapped
+   * to LangGraph's `Command(resume, update, goto)`. The resumed run produces
+   * a single checkpoint reflecting both, so a HITL card can push its message
+   * into state at the moment it answers the interrupt (no separate state
+   * write, no intermediate checkpoint, no flicker). Messages may be plain
+   * dicts or `@langchain/core` `BaseMessage` instances (serialized like
+   * `submit()`).
+   *
    * @example
    * ```ts
    * // Single pending interrupt
    * await stream.respond({ approved: true });
+   * ```
+   *
+   * @example
+   * ```ts
+   * // Resolve the interrupt AND push the card's message into state atomically
+   * await stream.respond({ approved: true }, {
+   *   update: { messages: [{ type: "ai", content: "Approved by reviewer." }] },
+   * });
+   * ```
+   *
+   * @example
+   * ```ts
+   * // `update` also accepts BaseMessage instances, like `submit()`
+   * import { AIMessage } from "@langchain/core/messages";
+   * await stream.respond({ approved: true }, {
+   *   update: { messages: [new AIMessage("Approved by reviewer.")] },
+   * });
    * ```
    *
    * @example

--- a/libs/sdk-vue/docs/interrupts.md
+++ b/libs/sdk-vue/docs/interrupts.md
@@ -12,6 +12,7 @@ in-browser tool handler). `@langchain/vue` surfaces them on
 - [Human-in-the-loop (HITL)](#human-in-the-loop-hitl)
 - [Resuming an interrupt](#resuming-an-interrupt)
 - [`respond(response, options?)`](#respondresponse-options)
+- [Changing state while resuming](#changing-state-while-resuming)
 - [`respondAll(responsesById, options?)`](#respondallresponsesbyid-options)
 - [Stopping a run](#stopping-a-run)
 - [Headless tools](#headless-tools)
@@ -238,6 +239,30 @@ await stream.respond({ approved: true }, {
   config: { configurable: { model: "gpt-4o" } },
   metadata: { source: "ui" },
 });
+```
+
+## Changing state while resuming
+
+Pass `options.update` to apply a state update in the **same superstep** as the resume — it maps to LangGraph's `Command(resume, update)`. The resumed run produces a single checkpoint reflecting both the resume value and the update: no separate `updateState` write, no intermediate checkpoint, no flicker.
+
+The canonical use case is a HITL flow where the UI pushes the interrupt card (e.g. an `AIMessage`) into state at the moment it answers the interrupt, so the card is committed before the resumed tool runs and stays rendered without the backend re-emitting it.
+
+`update` accepts a state-keys object (shallow-merged via the graph's channel reducers) or a list of `[key, value]` entries. Messages under the configured `messagesKey` may be plain dicts **or** `@langchain/core` `BaseMessage` instances — instances are serialized to dicts before transport, exactly like `submit()`. You can also pass `options.goto` for a directed jump (`Command(goto=...)`) in the same superstep.
+
+```ts
+import { AIMessage } from "@langchain/core/messages";
+
+// Approve the interrupt AND push a message into state in one atomic resume:
+await stream.respond(
+  { approved: true },
+  { update: { messages: [new AIMessage("Approved by reviewer.")] } },
+);
+
+// Equivalent with a plain message dict:
+await stream.respond(
+  { approved: true },
+  { update: { messages: [{ type: "ai", content: "Approved by reviewer." }] } },
+);
 ```
 
 ## `respondAll(responsesById, options?)`

--- a/libs/sdk-vue/package.json
+++ b/libs/sdk-vue/package.json
@@ -27,7 +27,7 @@
     "@langchain/langgraph": "workspace:*",
     "@langchain/langgraph-api": "workspace:*",
     "@langchain/langgraph-checkpoint": "workspace:*",
-    "@langchain/protocol": "^0.0.16",
+    "@langchain/protocol": "^0.0.18",
     "@types/node": "^25.4.0",
     "@vitejs/plugin-vue": "^6.0.7",
     "@vitejs/plugin-vue-jsx": "^5.1.5",

--- a/libs/sdk-vue/src/tests/components/InterruptCardStream.tsx
+++ b/libs/sdk-vue/src/tests/components/InterruptCardStream.tsx
@@ -1,0 +1,129 @@
+import { computed, defineComponent } from "vue";
+import { AIMessage, type BaseMessage } from "@langchain/core/messages";
+
+import { useStream } from "../../index.js";
+
+interface CardState {
+  messages: BaseMessage[];
+  toolArg: string;
+}
+
+/** Pull the card + content out of the AIMessage the interrupt carried. */
+function readInterrupt(value: unknown): { content: string; cards: unknown } {
+  if (value != null && typeof value === "object") {
+    const v = value as {
+      content?: unknown;
+      response_metadata?: { cards?: unknown };
+    };
+    return {
+      content: typeof v.content === "string" ? v.content : "",
+      cards: v.response_metadata?.cards ?? null,
+    };
+  }
+  return { content: "", cards: null };
+}
+
+function isCardMessage(message: BaseMessage): boolean {
+  if (message.getType() !== "ai") return false;
+  const metadata = message.response_metadata as { cards?: unknown } | undefined;
+  return metadata?.cards != null;
+}
+
+/**
+ * Reproduces the customer HITL flow against `interrupt_card_graph`:
+ * the interrupt (raised from a tool) carries an AIMessage card; on
+ * decision the frontend resolves the interrupt AND pushes that card into
+ * state in a single atomic `respond(..., { update })`, so the card stays
+ * visible while the slow tool runs and the backend never has to add it.
+ */
+export const InterruptCardStream = defineComponent({
+  name: "InterruptCardStream",
+  props: {
+    apiUrl: { type: String, default: undefined },
+    assistantId: { type: String, default: "interrupt_card_graph" },
+  },
+  setup(props) {
+    const stream = useStream<CardState>({
+      assistantId: props.assistantId,
+      apiUrl: props.apiUrl,
+    });
+
+    const interruptInfo = computed(() =>
+      readInterrupt(stream.interrupt.value?.value),
+    );
+    const cardMessages = computed(() =>
+      stream.messages.value.filter(isCardMessage),
+    );
+
+    // The AIMessage the frontend pushes into state on respond — the same
+    // card the interrupt carried (built as a `BaseMessage` instance to
+    // exercise the instance-serialization path).
+    const buildCardMessage = () =>
+      new AIMessage({
+        content: interruptInfo.value.content,
+        response_metadata: { cards: interruptInfo.value.cards },
+      });
+
+    return () => (
+      <div>
+        <div data-testid="interrupt-count">
+          {stream.interrupts.value.length}
+        </div>
+        <div data-testid="interrupt-card">
+          {interruptInfo.value.cards != null
+            ? JSON.stringify(interruptInfo.value.cards)
+            : "none"}
+        </div>
+        <div data-testid="loading">
+          {stream.isLoading.value ? "loading" : "idle"}
+        </div>
+        <div data-testid="card-count">{cardMessages.value.length}</div>
+        <div data-testid="card-in-state">
+          {cardMessages.value.length > 0 ? "present" : "absent"}
+        </div>
+        <div data-testid="messages">
+          {stream.messages.value
+            .map(
+              (m) =>
+                `${m.getType()}:${
+                  typeof m.content === "string" ? m.content : ""
+                }`,
+            )
+            .join("|")}
+        </div>
+        <button
+          data-testid="submit"
+          onClick={() => void stream.submit({ toolArg: "delete_db" })}
+        >
+          Submit
+        </button>
+        <button
+          data-testid="approve"
+          onClick={() => {
+            if (stream.interrupt.value) {
+              void stream.respond(
+                { approved: true },
+                { update: { messages: [buildCardMessage()] } },
+              );
+            }
+          }}
+        >
+          Approve
+        </button>
+        <button
+          data-testid="reject"
+          onClick={() => {
+            if (stream.interrupt.value) {
+              void stream.respond(
+                { approved: false },
+                { update: { messages: [buildCardMessage()] } },
+              );
+            }
+          }}
+        >
+          Reject
+        </button>
+      </div>
+    );
+  },
+});

--- a/libs/sdk-vue/src/tests/fixtures/mock-server.ts
+++ b/libs/sdk-vue/src/tests/fixtures/mock-server.ts
@@ -609,9 +609,72 @@ const headlessToolAgent = createAgent({
   checkpointer,
 }) as unknown as AnyPregel;
 
+// --- HITL card flow: interrupt raised from inside a tool ---
+// Mirrors a customer pattern where the interrupt carries an AIMessage
+// "card" (in `response_metadata.cards`) the frontend renders validation
+// buttons from. The tool's real work is slow, so the frontend pushes the
+// card into state alongside the resume (`respond(decision, { update })`) —
+// the backend never adds it — so the card stays visible without flicker.
+const reviewActionTool = tool(
+  async ({ toolArg }: { toolArg: string }) => {
+    const card = {
+      kind: "tool_validation",
+      action: toolArg,
+      buttons: ["approve", "reject"],
+    };
+    const response = interrupt({
+      type: "ai",
+      content: `Please review the "${toolArg}" action.`,
+      response_metadata: { cards: card },
+    });
+    const approved =
+      response === true ||
+      (response != null &&
+        typeof response === "object" &&
+        (response as { approved?: unknown }).approved === true);
+    if (!approved) {
+      return "User has rejected the toolcall";
+    }
+    // Long-running business logic — the FE-pushed card must stay in state
+    // for the entire duration (the no-flicker guarantee).
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+    return `Executed "${toolArg}".`;
+  },
+  {
+    name: "review_action",
+    description: "Perform a sensitive action that requires human approval.",
+    schema: z.object({ toolArg: z.string() }),
+  },
+);
+
+const interruptCardModel = new FakeToolCallingModel({
+  responses: [
+    new AIMessage({
+      content: "",
+      tool_calls: [
+        {
+          name: "review_action",
+          args: { toolArg: "delete_db" },
+          id: "call-review-1",
+          type: "tool_call",
+        },
+      ],
+    }),
+    new AIMessage("Done."),
+  ],
+});
+
+const interruptCardGraph = createAgent({
+  model: interruptCardModel,
+  tools: [reviewActionTool],
+  systemPrompt: "You are a deterministic approval agent for protocol testing.",
+  checkpointer,
+}) as unknown as AnyPregel;
+
 const graphs: Record<string, AnyPregel> = {
   agent,
   interruptAgent,
+  interrupt_card_graph: interruptCardGraph,
   multi_interrupt_graph: multiInterruptGraph as unknown as AnyPregel,
   parentAgent,
   removeMessageAgent,

--- a/libs/sdk-vue/src/tests/stream.interrupt-card-update.test.tsx
+++ b/libs/sdk-vue/src/tests/stream.interrupt-card-update.test.tsx
@@ -1,0 +1,99 @@
+import { expect, it } from "vitest";
+import { render } from "vitest-browser-vue";
+
+import { InterruptCardStream } from "./components/InterruptCardStream.js";
+import { apiUrl } from "./test-utils.js";
+
+/**
+ * End-to-end coverage for the customer HITL flow: an interrupt raised
+ * from a tool carries an AIMessage card, and the frontend resolves the
+ * interrupt AND pushes that card into state in a single atomic
+ * `respond(decision, { update: { messages: [card] } })`. The card must
+ * land in committed state exactly once (the backend never adds it) and
+ * stay there while the slow tool finishes — no flicker, no disappearance.
+ */
+
+it(
+  "keeps the FE-pushed card in state through a slow tool on approve",
+  { timeout: 20_000 },
+  async () => {
+    const screen = await render(InterruptCardStream, { props: { apiUrl } });
+
+    try {
+      await screen.getByTestId("submit").click();
+
+      // The tool raised an interrupt carrying the validation card.
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("interrupt-card"))
+        .toHaveTextContent("tool_validation");
+
+      // Resolve the interrupt AND push the card into state in one call.
+      await screen.getByTestId("approve").click();
+
+      // The FE-pushed card lands in committed state — exactly one copy.
+      await expect
+        .element(screen.getByTestId("card-count"), { timeout: 10_000 })
+        .toHaveTextContent("1");
+
+      // It is still present while the slow tool is executing (no flicker).
+      await expect
+        .element(screen.getByTestId("loading"))
+        .toHaveTextContent("loading");
+      await expect
+        .element(screen.getByTestId("card-in-state"))
+        .toHaveTextContent("present");
+
+      // Once the tool finishes, the backend's result lands alongside the
+      // single FE-owned card, and the interrupt is cleared.
+      await expect
+        .element(screen.getByTestId("messages"), { timeout: 15_000 })
+        .toHaveTextContent('tool:Executed "delete_db".');
+      await expect
+        .element(screen.getByTestId("card-count"))
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("interrupt-count"))
+        .toHaveTextContent("0");
+      await expect
+        .element(screen.getByTestId("loading"))
+        .toHaveTextContent("idle");
+    } finally {
+      await screen.unmount();
+    }
+  },
+);
+
+it(
+  "keeps the card and informs the agent on reject",
+  { timeout: 20_000 },
+  async () => {
+    const screen = await render(InterruptCardStream, { props: { apiUrl } });
+
+    try {
+      await screen.getByTestId("submit").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
+        .toHaveTextContent("1");
+
+      await screen.getByTestId("reject").click();
+
+      // The rejection tool message lands; the FE-pushed card is still
+      // there exactly once.
+      await expect
+        .element(screen.getByTestId("messages"), { timeout: 15_000 })
+        .toHaveTextContent("tool:User has rejected the toolcall");
+      await expect
+        .element(screen.getByTestId("card-count"))
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("interrupt-count"))
+        .toHaveTextContent("0");
+    } finally {
+      await screen.unmount();
+    }
+  },
+);

--- a/libs/sdk-vue/src/use-stream.ts
+++ b/libs/sdk-vue/src/use-stream.ts
@@ -277,10 +277,36 @@ export interface UseStreamReturn<
    * interrupts use `namespace: []` (default when omitted). For subgraph
    * interrupts, copy `namespace` from `getThread()?.interrupts`.
    *
+   * Pass `options.update` (and/or `options.goto`) to apply a state update
+   * (and/or directed jump) in the **same superstep** as the resume — mapped
+   * to LangGraph's `Command(resume, update, goto)`. The resumed run produces
+   * a single checkpoint reflecting both, so a HITL card can push its message
+   * into state at the moment it answers the interrupt (no separate state
+   * write, no intermediate checkpoint, no flicker). Messages may be plain
+   * dicts or `@langchain/core` `BaseMessage` instances (serialized like
+   * `submit()`).
+   *
    * @example
    * ```ts
    * // Single pending interrupt
    * await stream.respond({ approved: true });
+   * ```
+   *
+   * @example
+   * ```ts
+   * // Resolve the interrupt AND push the card's message into state atomically
+   * await stream.respond({ approved: true }, {
+   *   update: { messages: [{ type: "ai", content: "Approved by reviewer." }] },
+   * });
+   * ```
+   *
+   * @example
+   * ```ts
+   * // `update` also accepts BaseMessage instances, like `submit()`
+   * import { AIMessage } from "@langchain/core/messages";
+   * await stream.respond({ approved: true }, {
+   *   update: { messages: [new AIMessage("Approved by reviewer.")] },
+   * });
    * ```
    *
    * @example

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -19,7 +19,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@langchain/protocol": "^0.0.16",
+    "@langchain/protocol": "^0.0.18",
     "@types/json-schema": "^7.0.15",
     "p-queue": "^9.0.1",
     "p-retry": "^7.1.1"

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -1,4 +1,5 @@
 import type { Event } from "@langchain/protocol";
+import { AIMessage } from "@langchain/core/messages";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { StreamController } from "./controller.js";
@@ -1547,6 +1548,207 @@ describe("StreamController", () => {
       response: { approved: true },
       config: { configurable: { model: "gpt-4o" } },
       metadata: { source: "ui" },
+    });
+
+    await controller.dispose();
+  });
+
+  it("respond() forwards update and goto on the same input.respond as the resume", async () => {
+    let onEvent: ((event: Event) => void) | undefined;
+    const respondInput = vi.fn(async () => undefined);
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        onEvent = listener;
+        return vi.fn();
+      }),
+      close: vi.fn(async () => undefined),
+      interrupts: [
+        { interruptId: "int-1", payload: { prompt: "Approve?" }, namespace: [] },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {}, next: ["agent"] })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, { prompt: string }>({
+      assistantId: "interrupt_graph",
+      client: client as never,
+      threadId: "thread-1",
+    });
+    await controller.hydrationPromise;
+    onEvent?.(inputRequestedEvent("int-1", { prompt: "Approve?" }));
+
+    await controller.respond(
+      { approved: true },
+      {
+        update: { messages: [{ type: "ai", content: "Approved." }] },
+        goto: "next_node",
+      }
+    );
+    // update / goto ride the SAME input.respond as the resume so the server
+    // folds them into one Command(resume, update, goto) — single checkpoint.
+    expect(respondInput).toHaveBeenCalledWith({
+      namespace: [],
+      interrupt_id: "int-1",
+      response: { approved: true },
+      update: { messages: [{ type: "ai", content: "Approved." }] },
+      goto: "next_node",
+      config: undefined,
+      metadata: undefined,
+    });
+
+    await controller.dispose();
+  });
+
+  it("respond() omits update/goto when not provided", async () => {
+    let onEvent: ((event: Event) => void) | undefined;
+    const respondInput = vi.fn(async () => undefined);
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        onEvent = listener;
+        return vi.fn();
+      }),
+      close: vi.fn(async () => undefined),
+      interrupts: [
+        { interruptId: "int-1", payload: { prompt: "Approve?" }, namespace: [] },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {}, next: ["agent"] })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, { prompt: string }>({
+      assistantId: "interrupt_graph",
+      client: client as never,
+      threadId: "thread-1",
+    });
+    await controller.hydrationPromise;
+    onEvent?.(inputRequestedEvent("int-1", { prompt: "Approve?" }));
+
+    await controller.respond({ approved: true });
+    const sent = (respondInput.mock.calls[0] as unknown[])[0] as Record<
+      string,
+      unknown
+    >;
+    expect(sent).not.toHaveProperty("update");
+    expect(sent).not.toHaveProperty("goto");
+
+    await controller.dispose();
+  });
+
+  it("respond() serializes BaseMessage instances in update.messages to dicts", async () => {
+    let onEvent: ((event: Event) => void) | undefined;
+    const respondInput = vi.fn(async () => undefined);
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        onEvent = listener;
+        return vi.fn();
+      }),
+      close: vi.fn(async () => undefined),
+      interrupts: [
+        { interruptId: "int-1", payload: { prompt: "Approve?" }, namespace: [] },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {}, next: ["agent"] })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, { prompt: string }>({
+      assistantId: "interrupt_graph",
+      client: client as never,
+      threadId: "thread-1",
+    });
+    await controller.hydrationPromise;
+    onEvent?.(inputRequestedEvent("int-1", { prompt: "Approve?" }));
+
+    await controller.respond(
+      { approved: true },
+      { update: { messages: [new AIMessage("Approved by reviewer.")] } }
+    );
+
+    // The BaseMessage instance must arrive as a plain `{ type, content }`
+    // dict — its default JSON form is the `lc`-constructor envelope the
+    // server's `add_messages` reducer would not coerce.
+    const sent = (respondInput.mock.calls[0] as unknown[])[0] as {
+      update: { messages: Array<Record<string, unknown>> };
+    };
+    expect(sent.update.messages[0]).toMatchObject({
+      type: "ai",
+      content: "Approved by reviewer.",
+    });
+    expect(sent.update.messages[0]).not.toHaveProperty("lc");
+    expect(sent.update.messages[0]).not.toHaveProperty("kwargs");
+
+    await controller.dispose();
+  });
+
+  it("respondAll() forwards run-level update and goto for the batched resume", async () => {
+    let onEvent: ((event: Event) => void) | undefined;
+    const respondInput = vi.fn(async () => undefined);
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        onEvent = listener;
+        return vi.fn();
+      }),
+      close: vi.fn(async () => undefined),
+      interrupts: [
+        { interruptId: "int-1", payload: { prompt: "First?" }, namespace: [] },
+        { interruptId: "int-2", payload: { prompt: "Second?" }, namespace: [] },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {}, next: ["agent"] })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, { prompt: string }>({
+      assistantId: "interrupt_graph",
+      client: client as never,
+      threadId: "thread-1",
+    });
+    await controller.hydrationPromise;
+    onEvent?.(inputRequestedEvent("int-1", { prompt: "First?" }));
+    onEvent?.(inputRequestedEvent("int-2", { prompt: "Second?" }));
+
+    await controller.respondAll(
+      {
+        "int-1": { approved: true },
+        "int-2": { approved: false },
+      },
+      { update: { reviewed: true } }
+    );
+
+    expect(respondInput).toHaveBeenCalledWith({
+      responses: [
+        { interrupt_id: "int-1", response: { approved: true }, namespace: [] },
+        { interrupt_id: "int-2", response: { approved: false }, namespace: [] },
+      ],
+      update: { reviewed: true },
+      config: undefined,
+      metadata: undefined,
     });
 
     await controller.dispose();

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -1593,15 +1593,26 @@ describe("StreamController", () => {
     );
     // update / goto ride the SAME input.respond as the resume so the server
     // folds them into one Command(resume, update, goto) — single checkpoint.
+    // The update is also applied optimistically (like submit()), so the
+    // id-less message is dispatched with a minted id the server echoes back —
+    // that's what lets the optimistic copy reconcile in place (no flicker).
     expect(respondInput).toHaveBeenCalledWith({
       namespace: [],
       interrupt_id: "int-1",
       response: { approved: true },
-      update: { messages: [{ type: "ai", content: "Approved." }] },
+      update: {
+        messages: [expect.objectContaining({ type: "ai", content: "Approved." })],
+      },
       goto: "next_node",
       config: undefined,
       metadata: undefined,
     });
+    const sentUpdate = (
+      (respondInput.mock.calls[0] as unknown[])[0] as {
+        update: { messages: Array<Record<string, unknown>> };
+      }
+    ).update;
+    expect(typeof sentUpdate.messages[0].id).toBe("string");
 
     await controller.dispose();
   });
@@ -1696,6 +1707,67 @@ describe("StreamController", () => {
     });
     expect(sent.update.messages[0]).not.toHaveProperty("lc");
     expect(sent.update.messages[0]).not.toHaveProperty("kwargs");
+
+    await controller.dispose();
+  });
+
+  it("respond() applies update.messages optimistically before the server echo", async () => {
+    let onEvent: ((event: Event) => void) | undefined;
+    const respondInput = vi.fn(async () => undefined);
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        onEvent = listener;
+        return vi.fn();
+      }),
+      close: vi.fn(async () => undefined),
+      interrupts: [
+        { interruptId: "int-1", payload: { prompt: "Approve?" }, namespace: [] },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {}, next: ["agent"] })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, { prompt: string }>({
+      assistantId: "interrupt_graph",
+      client: client as never,
+      threadId: "thread-1",
+    });
+    await controller.hydrationPromise;
+    onEvent?.(inputRequestedEvent("int-1", { prompt: "Approve?" }));
+
+    // The card pushed via `update` must paint immediately — the interrupt is
+    // cleared the instant `respond()` dispatches, and the server only echoes
+    // the message back a round-trip later. Without the optimistic apply the
+    // card would vanish in that gap (the flicker this guards against). The
+    // mock `respondInput` never streams a `values` echo, so any message in the
+    // projection here came purely from the optimistic apply.
+    await controller.respond(
+      { approved: true },
+      { update: { messages: [{ type: "ai", content: "Pushed card." }] } }
+    );
+
+    // The projection coalesces optimistic writes onto the next macrotask, so
+    // let that flush land before reading the snapshot.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const messages = controller.rootStore.getSnapshot().messages;
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({ content: "Pushed card." });
+    // It carries the same minted id that was dispatched, so the server echo
+    // reconciles in place instead of appending a duplicate.
+    const dispatched = (
+      (respondInput.mock.calls[0] as unknown[])[0] as {
+        update: { messages: Array<{ id?: string }> };
+      }
+    ).update.messages[0];
+    expect((messages[0] as { id?: string }).id).toBe(dispatched.id);
 
     await controller.dispose();
   });

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -1748,18 +1748,22 @@ describe("StreamController", () => {
     // card would vanish in that gap (the flicker this guards against). The
     // mock `respondInput` never streams a `values` echo, so any message in the
     // projection here came purely from the optimistic apply.
-    await controller.respond(
+    //
+    // The optimistic write commits *synchronously* inside `respond()` (before
+    // its first await), so the snapshot already carries the card without
+    // draining a macrotask. That synchronous commit is what lets a framework
+    // render the card in the *same* commit as any local state the caller flips
+    // alongside it (e.g. a HITL form hiding its inputs) — no one-tick blink.
+    const pending = controller.respond(
       { approved: true },
       { update: { messages: [{ type: "ai", content: "Pushed card." }] } }
     );
 
-    // The projection coalesces optimistic writes onto the next macrotask, so
-    // let that flush land before reading the snapshot.
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
     const messages = controller.rootStore.getSnapshot().messages;
     expect(messages).toHaveLength(1);
     expect(messages[0]).toMatchObject({ content: "Pushed card." });
+
+    await pending;
     // It carries the same minted id that was dispatched, so the server echo
     // reconciles in place instead of appending a duplicate.
     const dispatched = (

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -1288,8 +1288,13 @@ export class StreamController<
     // so the server echoes the same ids back and `#applyValues` flips them
     // `pending` → `sent` in place (no duplicate, no gap).
     const prepared =
-      options?.update != null ? this.#beginOptimistic(options.update) : undefined;
-    const dispatchUpdate = this.#resolveDispatchUpdate(options?.update, prepared);
+      options?.update != null
+        ? this.#beginOptimistic(options.update)
+        : undefined;
+    const dispatchUpdate = this.#resolveDispatchUpdate(
+      options?.update,
+      prepared
+    );
 
     try {
       // Route through the coordinator so a resumed run that fails (e.g. a
@@ -1388,8 +1393,13 @@ export class StreamController<
     // rationale): the batched resume's pushed messages paint immediately and
     // reconcile by id when the single servicing run echoes them back.
     const prepared =
-      options?.update != null ? this.#beginOptimistic(options.update) : undefined;
-    const dispatchUpdate = this.#resolveDispatchUpdate(options?.update, prepared);
+      options?.update != null
+        ? this.#beginOptimistic(options.update)
+        : undefined;
+    const dispatchUpdate = this.#resolveDispatchUpdate(
+      options?.update,
+      prepared
+    );
 
     try {
       // See `respond()` — route through the coordinator so the single run

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -72,6 +72,7 @@ import { LifecycleLoadingTracker } from "./lifecycle-loading-tracker.js";
 import { RootMessageProjection } from "./root-message-projection.js";
 import {
   prepareOptimisticInput,
+  serializeUpdateMessages,
   type OptimisticHandle,
 } from "./optimistic-input.js";
 import {
@@ -1289,6 +1290,20 @@ export class StreamController<
           namespace: resolved.namespace,
           interrupt_id: resolved.interruptId,
           response: normalizeHitlResponseForServer(response),
+          // Fold an optional state update / directed jump into the same
+          // superstep as the resume (HITL "push card into state + resume").
+          // Omitted when absent so the server still sees a plain resume.
+          // `BaseMessage` instances under the messages key are serialized to
+          // plain dicts (like `submit()`) so they coerce server-side.
+          ...(options?.update != null
+            ? {
+                update: serializeUpdateMessages(
+                  options.update,
+                  this.#messagesKey
+                ),
+              }
+            : {}),
+          ...(options?.goto != null ? { goto: options.goto } : {}),
           config: options?.config,
           metadata: options?.metadata,
         });
@@ -1369,6 +1384,20 @@ export class StreamController<
       await this.#submitter.dispatchResume(async () => {
         await thread.respondInput({
           responses,
+          // A batched resume services every targeted interrupt in one run, so
+          // the update / jump are run-level (not per-entry) — applied once in
+          // that run's superstep alongside all the resumes. `BaseMessage`
+          // instances under the messages key are serialized to plain dicts
+          // (like `submit()`) so they coerce server-side.
+          ...(options?.update != null
+            ? {
+                update: serializeUpdateMessages(
+                  options.update,
+                  this.#messagesKey
+                ),
+              }
+            : {}),
+          ...(options?.goto != null ? { goto: options.goto } : {}),
           config: options?.config,
           metadata: options?.metadata,
         });

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -1278,13 +1278,27 @@ export class StreamController<
       throw new Error("No pending interrupt to respond to.");
     }
     const thread = this.#thread;
+
+    // Apply the state `update` optimistically, mirroring `submit()`: append its
+    // messages to the root projection and mint stable ids so the resumed run's
+    // echo reconciles by id. Without this the interrupt is cleared the instant
+    // `respond()` dispatches while the pushed messages only reappear after a
+    // server round-trip — so a HITL "card" pushed via `update` would vanish for
+    // that window (the flicker). The id-injected payload is what we dispatch,
+    // so the server echoes the same ids back and `#applyValues` flips them
+    // `pending` → `sent` in place (no duplicate, no gap).
+    const prepared =
+      options?.update != null ? this.#beginOptimistic(options.update) : undefined;
+    const dispatchUpdate = this.#resolveDispatchUpdate(options?.update, prepared);
+
     try {
       // Route through the coordinator so a resumed run that fails (e.g. a
       // missing model key surfaced after the user answers) lands in the
       // reactive `rootStore.error` slot, exactly like a `submit()` failure.
       // The dispatch (`respondInput` + interrupt-resolved bookkeeping) is
       // what's awaited; the resumed run's terminal is watched in the
-      // background (see {@link SubmitCoordinator.dispatchResume}).
+      // background (see {@link SubmitCoordinator.dispatchResume}), which also
+      // settles the optimistic handle (rolls back un-echoed keys on failure).
       await this.#submitter.dispatchResume(async () => {
         await thread.respondInput({
           namespace: resolved.namespace,
@@ -1295,20 +1309,13 @@ export class StreamController<
           // Omitted when absent so the server still sees a plain resume.
           // `BaseMessage` instances under the messages key are serialized to
           // plain dicts (like `submit()`) so they coerce server-side.
-          ...(options?.update != null
-            ? {
-                update: serializeUpdateMessages(
-                  options.update,
-                  this.#messagesKey
-                ),
-              }
-            : {}),
+          ...(dispatchUpdate != null ? { update: dispatchUpdate } : {}),
           ...(options?.goto != null ? { goto: options.goto } : {}),
           config: options?.config,
           metadata: options?.metadata,
         });
         this.#markInterruptResolvedInRootStore(resolved.interruptId);
-      });
+      }, prepared?.handle);
     } catch (error) {
       if (this.#disposed && isAbortLikeError(error)) {
         return;
@@ -1377,10 +1384,17 @@ export class StreamController<
       namespace: pending.find((entry) => entry.interruptId === interruptId)
         ?.namespace ?? [...ROOT_NAMESPACE],
     }));
+    // Apply the run-level `update` optimistically (see `respond()` for the
+    // rationale): the batched resume's pushed messages paint immediately and
+    // reconcile by id when the single servicing run echoes them back.
+    const prepared =
+      options?.update != null ? this.#beginOptimistic(options.update) : undefined;
+    const dispatchUpdate = this.#resolveDispatchUpdate(options?.update, prepared);
+
     try {
       // See `respond()` — route through the coordinator so the single run
       // that services the batched resume surfaces failures on the reactive
-      // `rootStore.error` slot.
+      // `rootStore.error` slot and settles the optimistic handle.
       await this.#submitter.dispatchResume(async () => {
         await thread.respondInput({
           responses,
@@ -1389,14 +1403,7 @@ export class StreamController<
           // that run's superstep alongside all the resumes. `BaseMessage`
           // instances under the messages key are serialized to plain dicts
           // (like `submit()`) so they coerce server-side.
-          ...(options?.update != null
-            ? {
-                update: serializeUpdateMessages(
-                  options.update,
-                  this.#messagesKey
-                ),
-              }
-            : {}),
+          ...(dispatchUpdate != null ? { update: dispatchUpdate } : {}),
           ...(options?.goto != null ? { goto: options.goto } : {}),
           config: options?.config,
           metadata: options?.metadata,
@@ -1404,7 +1411,7 @@ export class StreamController<
         for (const { interrupt_id: interruptId } of responses) {
           this.#markInterruptResolvedInRootStore(interruptId);
         }
-      });
+      }, prepared?.handle);
     } catch (error) {
       if (this.#disposed && isAbortLikeError(error)) {
         return;
@@ -2084,6 +2091,30 @@ export class StreamController<
       dispatchInput: prepared.dispatchInput,
       handle: { echoedIds: prepared.echoedIds, restoreKeys },
     };
+  }
+
+  /**
+   * Pick the `update` payload to dispatch on a resume (`respond` /
+   * `respondAll`).
+   *
+   * When the optimistic path ran ({@link #beginOptimistic} returned a handle),
+   * its `dispatchInput` already carries the minted message ids the server must
+   * echo back, so dispatch that — the echo reconciles the optimistic messages
+   * by id (no duplicate). Otherwise (optimistic UI disabled, or an `update`
+   * with no echoable messages — e.g. the tuple-entry form) fall back to
+   * serializing `BaseMessage` instances to dicts, exactly as before. Returns
+   * `undefined` when there is no `update`, so the server still sees a plain
+   * resume.
+   */
+  #resolveDispatchUpdate(
+    update: Record<string, unknown> | [string, unknown][] | undefined,
+    prepared: { dispatchInput: unknown; handle: OptimisticHandle } | undefined
+  ): Record<string, unknown> | [string, unknown][] | undefined {
+    if (prepared != null) {
+      return prepared.dispatchInput as Record<string, unknown>;
+    }
+    if (update == null) return undefined;
+    return serializeUpdateMessages(update, this.#messagesKey);
   }
 
   /**

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -2090,9 +2090,17 @@ export class StreamController<
     }));
 
     this.#sawValuesForRun = false;
+    // Commit synchronously: this runs inside the user's `submit()` /
+    // `respond()` call (before the first await), so the optimistic
+    // message lands in the same tick — and therefore the same React /
+    // framework commit — as any local UI state the caller flips
+    // alongside it. A macrotask-deferred flush would paint the message
+    // one tick late, leaving a blink (e.g. a HITL card vanishing between
+    // "form hidden" and "resolved card shown").
     this.#rootMessages.appendOptimistic(
       prepared.optimisticMessages,
-      prepared.extraValues
+      prepared.extraValues,
+      { sync: true }
     );
     if (prepared.echoedIds.length > 0) {
       this.#messageMetadata.markPending(prepared.echoedIds);

--- a/libs/sdk/src/stream/optimistic-input.ts
+++ b/libs/sdk/src/stream/optimistic-input.ts
@@ -67,6 +67,52 @@ function isBaseMessageInstance(value: unknown): value is BaseMessage {
   );
 }
 
+/**
+ * Serialize `BaseMessage` instances under a state update's message key
+ * into plain message dicts so they survive JSON transport.
+ *
+ * `respond({ update })` / `respondAll({}, { update })` fold `update` into
+ * `Command(update=...)` on the wire. A `BaseMessage`'s default JSON form
+ * is the `lc` "constructor" envelope (`{ lc, type: "constructor", id,
+ * kwargs }`), which the server's `add_messages` reducer does **not**
+ * coerce — whereas the flat `{ type, content, ... }` dict that
+ * {@link toMessageDict} emits (and that `submit()` already sends) does.
+ * Mirroring the `submit()` path lets
+ * `respond({ update: { messages: [new AIMessage(...)] } })` behave like
+ * `submit({ messages: [new AIMessage(...)] })`.
+ *
+ * Only the configured `messagesKey` is touched — in both the object form
+ * and the `[key, value][]` tuple form. Every other key, and any already
+ * plain (non-`BaseMessage`) entry, passes through untouched.
+ */
+export function serializeUpdateMessages(
+  update: Record<string, unknown> | [string, unknown][],
+  messagesKey: string
+): Record<string, unknown> | [string, unknown][] {
+  if (Array.isArray(update)) {
+    return update.map((entry) =>
+      Array.isArray(entry) && entry[0] === messagesKey
+        ? [entry[0], serializeMessageValue(entry[1])]
+        : entry
+    ) as [string, unknown][];
+  }
+  if (!(messagesKey in update)) return update;
+  return {
+    ...update,
+    [messagesKey]: serializeMessageValue(update[messagesKey]),
+  };
+}
+
+function serializeMessageValue(value: unknown): unknown {
+  if (isBaseMessageInstance(value)) return toMessageDict(value);
+  if (Array.isArray(value)) {
+    return value.map((item) =>
+      isBaseMessageInstance(item) ? toMessageDict(item) : item
+    );
+  }
+  return value;
+}
+
 function extractId(value: unknown): string | undefined {
   const id = (value as { id?: unknown } | null)?.id;
   return typeof id === "string" && id.length > 0 ? id : undefined;

--- a/libs/sdk/src/stream/root-message-projection.ts
+++ b/libs/sdk/src/stream/root-message-projection.ts
@@ -508,10 +508,22 @@ export class RootMessageProjection<
    *   `BaseMessage` instances, each carrying a stable id).
    * @param extraValues - Non-message input keys to shallow-merge into
    *   `values`.
+   * @param options     - When `sync` is true the staged write is
+   *   committed to the store *synchronously* instead of being coalesced
+   *   onto the next macrotask. Used for discrete, user-initiated
+   *   optimistic writes (`submit()` / `respond()` / `respondAll()`):
+   *   committing in the same tick as the triggering event lets the
+   *   framework render the optimistic message in the *same* commit as
+   *   any local state the caller flipped alongside it (e.g. a HITL form
+   *   hiding its inputs), so the pushed card never blinks out for the
+   *   one-macrotask window before the flush lands. Streaming writes
+   *   (`handleMessage` / `applyValues`) keep the default macrotask
+   *   coalescing, which is what tames high-frequency SSE bursts.
    */
   appendOptimistic(
     messages: BaseMessage[],
-    extraValues?: Record<string, unknown>
+    extraValues?: Record<string, unknown>,
+    options?: { sync?: boolean }
   ): void {
     let working = this.#pendingMessages ?? this.#store.getSnapshot().messages;
     let mutated = false;
@@ -545,7 +557,15 @@ export class RootMessageProjection<
     if (!mutated && values === baselineValues) return;
     this.#pendingMessages = working;
     if (values !== baselineValues) this.#pendingValues = values;
-    this.#scheduleFlush();
+    if (options?.sync) {
+      // Commit now so the optimistic message is visible in the same tick
+      // as the user event that produced it (no one-macrotask blink). Any
+      // flush already scheduled by a prior streaming write is absorbed
+      // here; its pending timer fires later as a no-op.
+      this.#flushPending();
+    } else {
+      this.#scheduleFlush();
+    }
   }
 
   /**

--- a/libs/sdk/src/stream/submit-coordinator.ts
+++ b/libs/sdk/src/stream/submit-coordinator.ts
@@ -584,8 +584,16 @@ export class SubmitCoordinator<
    * @param dispatch - Sends the `input.respond` command (and marks the
    *   targeted interrupt resolved). Invoked after the terminal watch is
    *   armed.
+   * @param optimisticHandle - Optional handle from an optimistic `update`
+   *   applied before dispatch (HITL "push card into state + resume"). Settled
+   *   on the resumed run's terminal — pending messages flip to `sent` and
+   *   un-echoed non-message keys roll back on failure — exactly like the
+   *   `submit()` optimistic lifecycle. A dispatch failure settles it `failed`.
    */
-  async dispatchResume(dispatch: () => Promise<void>): Promise<void> {
+  async dispatchResume(
+    dispatch: () => Promise<void>,
+    optimisticHandle?: OptimisticHandle
+  ): Promise<void> {
     if (this.#getDisposed()) return;
 
     // Rollback any run still tracked as active (mirrors submit()), then
@@ -606,6 +614,15 @@ export class SubmitCoordinator<
       this.#rootStore.setState((s) => ({ ...s, error }));
     };
 
+    // Settle the optimistic `update` exactly once, whether the resumed run
+    // terminates (success/failure/interrupt) or the dispatch itself fails.
+    let optimisticSettled = false;
+    const settleOptimisticOnce = (event: TerminalResult["event"]): void => {
+      if (optimisticSettled || optimisticHandle == null) return;
+      optimisticSettled = true;
+      this.#settleOptimistic(optimisticHandle, event);
+    };
+
     // Subscribe to the resumed run's terminal *before* dispatching so a fast
     // `failed` can't race us. Unlike `#awaitNextTerminal`, the resume watcher
     // ignores stale `interrupted` events until root `running` is seen.
@@ -619,6 +636,7 @@ export class SubmitCoordinator<
           new Error(terminal.error ?? "Run failed with no error message")
         );
       }
+      settleOptimisticOnce(abort.signal.aborted ? "aborted" : terminal.event);
       // Drain any submission enqueued while the resumed run was active.
       setTimeout(() => this.#drainQueue(), 0);
     });
@@ -628,6 +646,7 @@ export class SubmitCoordinator<
     } catch (error) {
       // The `input.respond` send itself failed, before any run started.
       reportError(error);
+      settleOptimisticOnce("failed");
       if (this.#runAbort === abort) this.#runAbort = undefined;
       throw error;
     }

--- a/libs/sdk/src/stream/types.ts
+++ b/libs/sdk/src/stream/types.ts
@@ -22,7 +22,7 @@ import type {
   AnyHeadlessToolImplementation,
   OnToolCallback,
 } from "../headless-tools.js";
-import type { Channel, Event } from "@langchain/protocol";
+import type { Channel, Event, Goto } from "@langchain/protocol";
 import type { StreamStore } from "./store.js";
 
 /** Why a run's active streaming phase ended. */
@@ -71,6 +71,32 @@ export interface StreamRespondAllOptions<
     [key: string]: unknown;
   };
   metadata?: Record<string, unknown>;
+  /**
+   * State update applied in the **same superstep** as the resume, mapped to
+   * LangGraph's `Command(update=...)`. The resumed run produces a single
+   * checkpoint reflecting both the resume value and this update — no separate
+   * `updateState` write, no intermediate checkpoint, no flicker.
+   *
+   * The canonical use case is a HITL flow where the UI pushes the interrupt
+   * card (e.g. an `AIMessage`) into state at the moment it answers the
+   * interrupt, so the card is committed before the resumed tool runs and stays
+   * rendered without the backend re-emitting it.
+   *
+   * Accepts a state-keys object (shallow-merged via the graph's channel
+   * reducers) or a list of `[key, value]` entries.
+   *
+   * Messages under the configured `messagesKey` may be either plain
+   * message dicts (`{ type: "ai", content: "…" }`) or `@langchain/core`
+   * `BaseMessage` instances (`new AIMessage("…")`) — instances are
+   * serialized to dicts before transport, exactly like `submit()`.
+   */
+  update?: Record<string, unknown> | [string, unknown][];
+  /**
+   * Directed jump applied in the **same superstep** as the resume, mapped to
+   * LangGraph's `Command(goto=...)`. A target node name, a `Send`
+   * (`{ node, input }`), or a list mixing the two for fan-out.
+   */
+  goto?: Goto;
 }
 
 /**

--- a/libs/sdk/src/ui/types.ts
+++ b/libs/sdk/src/ui/types.ts
@@ -473,6 +473,20 @@ type InferMiddlewareState<T> =
 type IsAny<T> = 0 extends 1 & T ? true : false;
 
 /**
+ * Normalize an `any` result to the empty object `{}`.
+ *
+ * Middleware state inference reads the schema off `AgentMiddlewareLike`. An
+ * agent declared without middleware leaves `Middleware` as the broad
+ * `AnyAgentMiddleware[]` default, whose schema is the catch-all
+ * `StateDefinitionInit | undefined`; inferring an object input from that
+ * yields `any`. Left unchecked, that `any` widens the entire
+ * `InferAgentState` intersection to `any`, erasing the agent's real state
+ * type. Collapsing it to `{}` keeps the other intersection members intact.
+ */
+// eslint-disable-next-line @typescript-eslint/ban-types
+type AnyToEmpty<T> = IsAny<T> extends true ? {} : T;
+
+/**
  * Helper type to extract and merge states from an array of middleware.
  * Recursively processes each middleware and intersects their state types.
  *
@@ -575,7 +589,9 @@ export type InferAgentState<T> = T extends { "~agentTypes": unknown }
           ? // eslint-disable-next-line @typescript-eslint/ban-types
             {}
           : SafeInferInteropZodInput<ExtractAgentConfig<T>["State"]>) &
-        InferMiddlewareStatesFromArray<ExtractAgentConfig<T>["Middleware"]> &
+        AnyToEmpty<
+          InferMiddlewareStatesFromArray<ExtractAgentConfig<T>["Middleware"]>
+        > &
         InferStructuredResponse<ExtractAgentConfig<T>["Response"]>
   : T extends { "~RunOutput": infer RunOutput }
     ? RunOutput

--- a/package.json
+++ b/package.json
@@ -50,11 +50,11 @@
   "pnpm": {
     "overrides": {
       "@langchain/core": "^1.1.48",
-      "langchain": "1.4.0-dev-1777615538778",
-      "@examples/streaming>langchain": "1.4.0-dev-1777615538778",
-      "@examples/ui-react>langchain": "1.4.0-dev-1777615538778",
-      "@examples/ui-multimodal>langchain": "1.4.0-dev-1777615538778",
-      "deepagents>langchain": "1.4.0-dev-1777615538778",
+      "langchain": "1.5.1-dev-1781824996270",
+      "@examples/streaming>langchain": "1.5.1-dev-1781824996270",
+      "@examples/ui-react>langchain": "1.5.1-dev-1781824996270",
+      "@examples/ui-multimodal>langchain": "1.5.1-dev-1781824996270",
+      "deepagents>langchain": "1.5.1-dev-1781824996270",
       "@langchain/langgraph-sdk": "workspace:*",
       "@langchain/langgraph-checkpoint": "workspace:*",
       "cheerio": "^1.0.0-rc.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,11 +6,11 @@ settings:
 
 overrides:
   '@langchain/core': ^1.1.48
-  langchain: 1.4.0-dev-1777615538778
-  '@examples/streaming>langchain': 1.4.0-dev-1777615538778
-  '@examples/ui-react>langchain': 1.4.0-dev-1777615538778
-  '@examples/ui-multimodal>langchain': 1.4.0-dev-1777615538778
-  deepagents>langchain: 1.4.0-dev-1777615538778
+  langchain: 1.5.1-dev-1781824996270
+  '@examples/streaming>langchain': 1.5.1-dev-1781824996270
+  '@examples/ui-react>langchain': 1.5.1-dev-1781824996270
+  '@examples/ui-multimodal>langchain': 1.5.1-dev-1781824996270
+  deepagents>langchain: 1.5.1-dev-1781824996270
   '@langchain/langgraph-sdk': workspace:*
   '@langchain/langgraph-checkpoint': workspace:*
   cheerio: ^1.0.0-rc.12
@@ -126,8 +126,8 @@ importers:
         specifier: ^16.4.5
         version: 16.6.1
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
       tslab:
         specifier: ^1.0.22
         version: 1.0.22
@@ -204,8 +204,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.3))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.3))
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.7)
@@ -292,8 +292,8 @@ importers:
         specifier: ^1.3.2
         version: 1.3.2(react@19.2.7)
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.7)
@@ -359,8 +359,8 @@ importers:
         specifier: ^16.4.5
         version: 16.6.1
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
       tslab:
         specifier: ^1.0.22
         version: 1.0.22
@@ -413,8 +413,8 @@ importers:
         specifier: ^16.4.5
         version: 16.6.1
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
       pg:
         specifier: ^8.11.0
         version: 8.20.0
@@ -479,8 +479,8 @@ importers:
         specifier: ^16.4.5
         version: 16.6.1
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
       pg:
         specifier: ^8.11.0
         version: 8.20.0
@@ -545,8 +545,8 @@ importers:
         specifier: ^16.4.5
         version: 16.6.1
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
       pg:
         specifier: ^8.11.0
         version: 8.20.0
@@ -611,8 +611,8 @@ importers:
         specifier: ^16.4.5
         version: 16.6.1
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
       pg:
         specifier: ^8.11.0
         version: 8.20.0
@@ -677,8 +677,8 @@ importers:
         specifier: ^16.4.5
         version: 16.6.1
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
       pg:
         specifier: ^8.11.0
         version: 8.20.0
@@ -743,8 +743,8 @@ importers:
         specifier: ^16.4.5
         version: 16.6.1
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
       pg:
         specifier: ^8.11.0
         version: 8.20.0
@@ -809,8 +809,8 @@ importers:
         specifier: ^16.4.5
         version: 16.6.1
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
       pg:
         specifier: ^8.11.0
         version: 8.20.0
@@ -875,8 +875,8 @@ importers:
         specifier: ^16.4.5
         version: 16.6.1
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
       pg:
         specifier: ^8.11.0
         version: 8.20.0
@@ -941,8 +941,8 @@ importers:
         specifier: ^16.4.5
         version: 16.6.1
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6))
       pg:
         specifier: ^8.11.0
         version: 8.20.0
@@ -983,8 +983,8 @@ importers:
         specifier: ^16.4.5
         version: 16.6.1
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1019,14 +1019,14 @@ importers:
         specifier: workspace:*
         version: link:../../libs/sdk
       '@langchain/protocol':
-        specifier: ^0.0.16
-        version: 0.0.16
+        specifier: ^0.0.18
+        version: 0.0.18
       deepagents:
         specifier: https://pkg.pr.new/deepagents@9eaa3ac
         version: https://pkg.pr.new/deepagents@9eaa3ac(@opentelemetry/api@1.9.0)(langsmith@0.7.4(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.2))
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.2))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.2))
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -1116,8 +1116,8 @@ importers:
         specifier: https://pkg.pr.new/deepagents@91d9510
         version: https://pkg.pr.new/deepagents@91d9510(@opentelemetry/api@1.9.0)(langsmith@0.7.4(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.2))
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.2))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.2))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -1201,8 +1201,8 @@ importers:
         specifier: https://pkg.pr.new/deepagents@9a528ec
         version: https://pkg.pr.new/deepagents@9a528ec(@opentelemetry/api@1.9.0)(langsmith@0.7.4(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -1256,8 +1256,8 @@ importers:
         specifier: ^1.4.7
         version: 1.4.7(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(ws@8.21.0)
       '@langchain/protocol':
-        specifier: ^0.0.16
-        version: 0.0.16
+        specifier: ^0.0.18
+        version: 0.0.18
       '@langchain/react':
         specifier: workspace:*
         version: link:../../libs/sdk-react
@@ -1817,8 +1817,8 @@ importers:
         specifier: workspace:*
         version: link:../langgraph-ui
       '@langchain/protocol':
-        specifier: ^0.0.16
-        version: 0.0.16
+        specifier: ^0.0.18
+        version: 0.0.18
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
@@ -1899,8 +1899,8 @@ importers:
         specifier: ^6.0.10
         version: 6.2.1
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
       postgres:
         specifier: ^3.4.5
         version: 3.4.8
@@ -2002,8 +2002,8 @@ importers:
         specifier: workspace:*
         version: link:../sdk
       '@langchain/protocol':
-        specifier: ^0.0.16
-        version: 0.0.16
+        specifier: ^0.0.18
+        version: 0.0.18
       '@standard-schema/spec':
         specifier: 1.1.0
         version: 1.1.0
@@ -2063,8 +2063,8 @@ importers:
         specifier: ^3.12.0
         version: 3.15.1
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.4.3))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.4.3))
       pg:
         specifier: ^8.13.0
         version: 8.20.0
@@ -2253,8 +2253,8 @@ importers:
   libs/sdk:
     dependencies:
       '@langchain/protocol':
-        specifier: ^0.0.16
-        version: 0.0.16
+        specifier: ^0.0.18
+        version: 0.0.18
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
@@ -2290,8 +2290,8 @@ importers:
         specifier: ^1.8.3
         version: 1.8.3(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -2378,8 +2378,8 @@ importers:
         specifier: ^4.12.25
         version: 4.12.25
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
@@ -2451,8 +2451,8 @@ importers:
         specifier: ^4.12.25
         version: 4.12.25
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -2515,8 +2515,8 @@ importers:
         specifier: ^4.12.25
         version: 4.12.25
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
       svelte:
         specifier: ^5.56.1
         version: 5.56.1(@typescript-eslint/types@8.59.2)
@@ -2561,8 +2561,8 @@ importers:
         specifier: workspace:*
         version: link:../checkpoint
       '@langchain/protocol':
-        specifier: ^0.0.16
-        version: 0.0.16
+        specifier: ^0.0.18
+        version: 0.0.18
       '@types/node':
         specifier: ^25.4.0
         version: 25.4.0
@@ -2585,8 +2585,8 @@ importers:
         specifier: ^4.12.25
         version: 4.12.25
       langchain:
-        specifier: 1.4.0-dev-1777615538778
-        version: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
+        specifier: 1.5.1-dev-1781824996270
+        version: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -4099,6 +4099,17 @@ packages:
       zod-to-json-schema:
         optional: true
 
+  '@langchain/langgraph@1.4.4':
+    resolution: {integrity: sha512-20p+/xHRIUIEkk6dsoA576X7D5+FY+LkShsGjBpKrwATzQU0IJ2dfpBaP+4Z4wwpL9ArpDxjoRQR58kycdxU8A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': ^1.1.48
+      zod: ^4.3.5
+      zod-to-json-schema: ^3.x
+    peerDependenciesMeta:
+      zod-to-json-schema:
+        optional: true
+
   '@langchain/langgraph@https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004':
     resolution: {tarball: https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004}
     version: 1.2.9
@@ -4134,6 +4145,9 @@ packages:
 
   '@langchain/protocol@0.0.16':
     resolution: {integrity: sha512-ws+J7MaHyhO5dG7f0vdyHQiUn9hoCnki0f3crJPa4MCTGzcRC39jYSCghyrGtBPYQnZbUQiGyRVpW3z3M8IpJg==}
+
+  '@langchain/protocol@0.0.18':
+    resolution: {integrity: sha512-XW1egQtPfsGI41w2AMZNFZrUIwFSQHTjVMZs0OaTpCAvht/QLoaPN8FQcsysMVypOhupG28J29yOorrc70otBQ==}
 
   '@langchain/quickjs@https://pkg.pr.new/@langchain/quickjs@7493df1':
     resolution: {tarball: https://pkg.pr.new/@langchain/quickjs@7493df1}
@@ -4297,49 +4311,42 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-arm64-musl@1.1.1':
     resolution: {integrity: sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/nice-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-4FS8oc0GeHpwvv4tKciKkw3Y4jKsL7FRhaOeiPei0X9T4Jd619wHNe4xCLmN2EMgZoeGg+Q7GY7BsvwKpL22Tg==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-riscv64-gnu@1.1.1':
     resolution: {integrity: sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-s390x-gnu@1.1.1':
     resolution: {integrity: sha512-2YqKJWWl24EwrX0DzCQgPLKQBxYDdBxOHot1KWEq7aY2uYeX+Uvtv4I8xFVVygJDgf6/92h9N3Y43WPx8+PAgQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-/gaNz3R92t+dcrfCw/96pDopcmec7oCcAQ3l/M+Zxr82KT4DljD37CpgrnXV+pJC263JkW572pdbP3hP+KjcIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/nice-linux-x64-musl@1.1.1':
     resolution: {integrity: sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/nice-openharmony-arm64@1.1.1':
     resolution: {integrity: sha512-6uJPRVwVCLDeoOaNyeiW0gp2kFIM4r7PL2MczdZQHkFi9gVlgm+Vn+V6nTWRcu856mJ2WjYJiumEajfSm7arPQ==}
@@ -4557,56 +4564,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.121.0':
     resolution: {integrity: sha512-qT663J/W8yQFw3dtscbEi9LKJevr20V7uWs2MPGTnvNZ3rm8anhhE16gXGpxDOHeg9raySaSHKhd4IGa3YZvuw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.121.0':
     resolution: {integrity: sha512-mYNe4NhVvDBbPkAP8JaVS8lC1dsoJZWH5WCjpw5E+sjhk1R08wt3NnXYUzum7tIiWPfgQxbCMcoxgeemFASbRw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.121.0':
     resolution: {integrity: sha512-+QiFoGxhAbaI/amqX567784cDyyuZIpinBrJNxUzb+/L2aBRX67mN6Jv40pqduHf15yYByI+K5gUEygCuv0z9w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.121.0':
     resolution: {integrity: sha512-9ykEgyTa5JD/Uhv2sttbKnCfl2PieUfOjyxJC/oDL2UO0qtXOtjPLl7H8Kaj5G7p3hIvFgu3YWvAxvE0sqY+hQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.121.0':
     resolution: {integrity: sha512-DB1EW5VHZdc1lIRjOI3bW/wV6R6y0xlfvdVrqj6kKi7Ayu2U3UqUBdq9KviVkcUGd5Oq+dROqvUEEFRXGAM7EQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.121.0':
     resolution: {integrity: sha512-s4lfobX9p4kPTclvMiH3gcQUd88VlnkMTF6n2MTMDAyX5FPNRhhRSFZK05Ykhf8Zy5NibV4PbGR6DnK7FGNN6A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.121.0':
     resolution: {integrity: sha512-P9KlyTpuBuMi3NRGpJO8MicuGZfOoqZVRP1WjOecwx8yk4L/+mrCRNc5egSi0byhuReblBF2oVoDSMgV9Bj4Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.121.0':
     resolution: {integrity: sha512-R+4jrWOfF2OAPPhj3Eb3U5CaKNAH9/btMveMULIrcNW/hjfysFQlF8wE0GaVBr81dWz8JLgQlsxwctoL78JwXw==}
@@ -4693,56 +4692,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.42.0':
     resolution: {integrity: sha512-+JA0YMlSdDqmacygGi2REp57c3fN+tzARD8nwsukx9pkCHK+6DkbAA9ojS4lNKsiBjIW8WWa0pBrBWhdZEqfuw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.42.0':
     resolution: {integrity: sha512-VfnET0j4Y5mdfCzh5gBt0NK28lgn5DKx+8WgSMLYYeSooHhohdbzwAStLki9pNuGy51y4I7IoW8bqwAaCMiJQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.42.0':
     resolution: {integrity: sha512-gVlCbmBkB0fxBWbhBj9rcxezPydsQHf4MFKeHoTSPicOQ+8oGeTQgQ8EeesSybWeiFPVRx3bgdt4IJnH6nOjAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.42.0':
     resolution: {integrity: sha512-zN5OfstL0avgt/IgvRu0zjQzVh/EPkcLzs33E9LMAzpqlLWiPWeMDZyMGFlSRGOdDjuNmlZBCgj0pFnK5u32TQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.42.0':
     resolution: {integrity: sha512-9X6+H2L0qMc2sCAgO9HS03bkGLMKvOFjmEdchaFlany3vNZOjnVui//D8k/xZAtQv2vaCs1reD5KAgPoIU4msA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.42.0':
     resolution: {integrity: sha512-BajxJ6KQvMMdpXGPWhBGyjb2Jvx4uec0w+wi6TJZ6Tv7+MzPwe0pO8g5h1U0jyFgoaF7mDl6yKPW3ykWcbUJRw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.42.0':
     resolution: {integrity: sha512-0wV284I6vc5f0AqAhgAbHU2935B4bVpncPoe5n/WzVZY/KnHgqxC8iSFGeSyLWEgstFboIcWkOPck7tqbdHkzA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.42.0':
     resolution: {integrity: sha512-p4BG6HpGnhfgHk1rzZfyR6zcWkE7iLrWxyehHfXUy4Qa5j3e0roglFOdP/Nj5cJJ58MA3isQ5dlfkW2nNEpolw==}
@@ -4815,56 +4806,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.55.0':
     resolution: {integrity: sha512-/kp65avi6zZfqEng56TTuhiy3P/3pgklKIdf38yvYeJ9/PgEeRA2A2AqKAKbZBNAqUzrzHhz9jF6j/PZvhJzTQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.55.0':
     resolution: {integrity: sha512-A6pTdXwcEEwL/nmz0eUJ6WxmxcoIS+97GbH96gikAyre3s5deC7sts38ZVVowjS2QQFuSWkpA4ZmQC0jZSNvJQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.55.0':
     resolution: {integrity: sha512-clj0lnIN+V52G9tdtZl0LbdTSurnZ1NZj92Je5X4lC7gP5jiCSW+Y/oiDiSauBAD4wrHt2S7nN3pA0zfKYK/6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.55.0':
     resolution: {integrity: sha512-NNu08pllN5x/O94/sgR3DA8lbrGBnTHsINZZR0hcav1sj79ksTiKKm1mRzvZvacwQ0hUnGinFo+JO75ok2PxYg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.55.0':
     resolution: {integrity: sha512-BvfQz3PRlWZRoEZ17dZCqgQsMRdpzGZomJkVATwCIGhHVVeHJMQdmdXPSjcT1DCNUrOjXnVyj1RGDj5+/Je2+Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.55.0':
     resolution: {integrity: sha512-ngSOoFCSBMKVQd24H8zkbcBNc7EHhjnF1sv3mC9NNXQ/4rRjI/4Dj9+9XoDZeFEkF1SX1COSBXF1b2Pr9rqdEw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.55.0':
     resolution: {integrity: sha512-BDpP7W8GlaG7BR6QjGZAleYzxoyKc/D24spZIF2mB3XsfALQJJT/OBmP8YpeTb1rveFSBHzl8T7l0aqwkWNdGA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.55.0':
     resolution: {integrity: sha512-PS6GFvmde/pc3fCA2Srt51glr8Lcxhpf6WIBFfLphndjRrD34NEcses4TSxQrEcxYo6qVywGfylM0ZhSCF2gGA==}
@@ -4919,42 +4902,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -5888,109 +5865,93 @@ packages:
     resolution: {integrity: sha512-2v4ZE/a75XA96f7Hmw8RibVIHktpREHTvAG/jG+0718UAVl0XS1o3gCcfJHOzq0vxRM6JrJxL0An6Blqx0zo/g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.8':
     resolution: {integrity: sha512-tOHgTOQa8G4Z3ULj4G3NYOGGJEsqPHR91dT72u63OtVsZ7B6wFJKOx+ZKv+pvwzxWz92/I2ycaqi2/Ll4l+rlg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.3':
     resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@0.15.1':
     resolution: {integrity: sha512-ICZANEBNJxpaZPspK3Xd5+pG6CO/0pEOMPJEBiUi67Gy6NexyN9ILPwXoF3ZWEmBMizcURt52xkqoUuEGpJMQg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.8':
     resolution: {integrity: sha512-oRbxcgDujCi2Yp1GTxoUFsIFlZsuPHU4OV4AzNc3/6aUmR4lfm9FK0uwQu82PJsuUwnF2jFdop3Ep5c1uK7Uxg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.8':
     resolution: {integrity: sha512-oaLRyUHw8kQE5M89RqrDJZ10GdmGJcMeCo8tvaE4ukOofqgjV84AbqBSH6tTPjeT2BHv+xlKj678GBuIb47lKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.8':
     resolution: {integrity: sha512-1hjSKFrod5MwBBdLOOA0zpUuSfSDkYIY+QqcMcIU1WOtswZtZdUkcFcZza9b2HcAb0bnpmmyo0LZcaxLb2ov1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@0.15.1':
     resolution: {integrity: sha512-PldpjbytgMM0eKmnRAvKM6F4bwpRS3aoFr5AAOtbdIxC08ABG/ab+xXuwjdVyo2xxM3nTItbma76verU8lkCgA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.8':
     resolution: {integrity: sha512-a1+F0aV4Wy9tT3o+cHl3XhOy6aFV+B8Ll+/JFj98oGkb6lGk3BNgrxd+80RwYRVd23oLGvj3LwluKYzlv1PEuw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@0.15.1':
     resolution: {integrity: sha512-ydIgDOKQi92RQjgFFuMeO09IWe0fWLcmhv7opAjutcGwEgqediamlhgmDW2eRJTqHwhT56zMVpivvejMR2KT8g==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.8':
     resolution: {integrity: sha512-bGyXCFU11seFrf7z8PcHSwGEiFVkZ9vs+auLacVOQrVsI8PFHJzzJROF3P6b0ODDmXr0m6Tj5FlDhcXVk0Jp8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.8':
     resolution: {integrity: sha512-n8d+L2bKgf9G3+AM0bhHFWdlz9vYKNim39ujRTieukdRek0RAo2TfG2uEnV9spa4r4oHUfL9IjcY3M9SlqN1gw==}
@@ -6167,157 +6128,131 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -6540,28 +6475,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.18':
     resolution: {integrity: sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.18':
     resolution: {integrity: sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.18':
     resolution: {integrity: sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.18':
     resolution: {integrity: sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ==}
@@ -6634,28 +6565,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -9592,8 +9519,8 @@ packages:
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
 
-  langchain@1.4.0-dev-1777615538778:
-    resolution: {integrity: sha512-QUuTkv3A7sws6Jxj68E907RlzSFmMtFWhHp1/kdK7n8l69GELXXzPW246EHbnNK2jIL9L6XXfOPbQ8QgonL/jQ==}
+  langchain@1.5.1-dev-1781824996270:
+    resolution: {integrity: sha512-4Hh/vUH61hccMf/1yCyP1Co8yCK6KwGrYufqNsFboxF8pz07tsv90ljKXqopvbzTmNddNfBeKQrBN4SB1COk8A==}
     engines: {node: '>=20'}
     peerDependencies:
       '@langchain/core': ^1.1.48
@@ -9720,56 +9647,48 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -14366,29 +14285,60 @@ snapshots:
     optionalDependencies:
       zod-to-json-schema: 3.25.2(zod@4.3.6)
 
-  '@langchain/langgraph@https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6)':
+  '@langchain/langgraph@1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.4.3)':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph-checkpoint': link:libs/checkpoint
       '@langchain/langgraph-sdk': link:libs/sdk
-      '@langchain/protocol': 0.0.15
+      '@langchain/protocol': 0.0.16
       '@standard-schema/spec': 1.1.0
-      uuid: 10.0.0
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       zod-to-json-schema: 3.25.1(zod@4.3.6)
 
-  '@langchain/langgraph@https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)':
+  '@langchain/langgraph@1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.4.3)':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph-checkpoint': link:libs/checkpoint
       '@langchain/langgraph-sdk': link:libs/sdk
-      '@langchain/protocol': 0.0.15
+      '@langchain/protocol': 0.0.16
       '@standard-schema/spec': 1.1.0
-      uuid: 10.0.0
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       zod-to-json-schema: 3.25.2(zod@4.3.6)
+
+  '@langchain/langgraph@1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.4.2))(zod@4.4.3)':
+    dependencies:
+      '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)
+      '@langchain/langgraph-checkpoint': link:libs/checkpoint
+      '@langchain/langgraph-sdk': link:libs/sdk
+      '@langchain/protocol': 0.0.16
+      '@standard-schema/spec': 1.1.0
+      zod: 4.4.3
+    optionalDependencies:
+      zod-to-json-schema: 3.25.2(zod@4.4.2)
+
+  '@langchain/langgraph@1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
+      '@langchain/langgraph-checkpoint': link:libs/checkpoint
+      '@langchain/langgraph-sdk': link:libs/sdk
+      '@langchain/protocol': 0.0.16
+      '@standard-schema/spec': 1.1.0
+      zod: 4.4.3
+    optionalDependencies:
+      zod-to-json-schema: 3.25.1(zod@4.4.3)
+
+  '@langchain/langgraph@1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
+      '@langchain/langgraph-checkpoint': link:libs/checkpoint
+      '@langchain/langgraph-sdk': link:libs/sdk
+      '@langchain/protocol': 0.0.16
+      '@standard-schema/spec': 1.1.0
+      zod: 4.4.3
+    optionalDependencies:
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
 
   '@langchain/langgraph@https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.4.2)':
     dependencies:
@@ -14402,18 +14352,6 @@ snapshots:
     optionalDependencies:
       zod-to-json-schema: 3.25.2(zod@4.3.6)
 
-  '@langchain/langgraph@https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.4.2))(zod@4.3.6)':
-    dependencies:
-      '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)
-      '@langchain/langgraph-checkpoint': link:libs/checkpoint
-      '@langchain/langgraph-sdk': link:libs/sdk
-      '@langchain/protocol': 0.0.15
-      '@standard-schema/spec': 1.1.0
-      uuid: 10.0.0
-      zod: 4.3.6
-    optionalDependencies:
-      zod-to-json-schema: 3.25.2(zod@4.4.2)
-
   '@langchain/langgraph@https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.4.2))(zod@4.4.2)':
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)
@@ -14425,30 +14363,6 @@ snapshots:
       zod: 4.4.2
     optionalDependencies:
       zod-to-json-schema: 3.25.2(zod@4.4.2)
-
-  '@langchain/langgraph@https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.3.6)':
-    dependencies:
-      '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
-      '@langchain/langgraph-checkpoint': link:libs/checkpoint
-      '@langchain/langgraph-sdk': link:libs/sdk
-      '@langchain/protocol': 0.0.15
-      '@standard-schema/spec': 1.1.0
-      uuid: 10.0.0
-      zod: 4.3.6
-    optionalDependencies:
-      zod-to-json-schema: 3.25.1(zod@4.4.3)
-
-  '@langchain/langgraph@https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.3.6)':
-    dependencies:
-      '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
-      '@langchain/langgraph-checkpoint': link:libs/checkpoint
-      '@langchain/langgraph-sdk': link:libs/sdk
-      '@langchain/protocol': 0.0.15
-      '@standard-schema/spec': 1.1.0
-      uuid: 10.0.0
-      zod: 4.3.6
-    optionalDependencies:
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
 
   '@langchain/mistralai@1.1.0(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))':
     dependencies:
@@ -14502,6 +14416,8 @@ snapshots:
   '@langchain/protocol@0.0.15': {}
 
   '@langchain/protocol@0.0.16': {}
+
+  '@langchain/protocol@0.0.18': {}
 
   '@langchain/quickjs@https://pkg.pr.new/@langchain/quickjs@7493df1(deepagents@https://pkg.pr.new/deepagents@9a528ec(@opentelemetry/api@1.9.0)(langsmith@0.7.4(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6)))':
     dependencies:
@@ -19023,7 +18939,7 @@ snapshots:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/langgraph': 1.2.1(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.4.2)
       fast-glob: 3.3.3
-      langchain: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
+      langchain: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
       micromatch: 4.0.8
       yaml: 2.8.3
       zod: 4.4.2
@@ -19041,7 +18957,7 @@ snapshots:
       '@langchain/langgraph': 1.2.9(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.4.2)
       '@langchain/langgraph-sdk': link:libs/sdk
       fast-glob: 3.3.3
-      langchain: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
+      langchain: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
       langsmith: 0.7.4(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       micromatch: 4.0.8
       yaml: 2.8.3
@@ -19060,7 +18976,7 @@ snapshots:
       '@langchain/langgraph': https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.4.2))(zod@4.4.2)
       '@langchain/langgraph-sdk': link:libs/sdk
       fast-glob: 3.3.3
-      langchain: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.2))
+      langchain: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.2))
       langsmith: 0.7.4(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)
       micromatch: 4.0.8
       yaml: 2.8.3
@@ -19079,7 +18995,7 @@ snapshots:
       '@langchain/langgraph': https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.4.2)
       '@langchain/langgraph-sdk': link:libs/sdk
       fast-glob: 3.3.3
-      langchain: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
+      langchain: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
       langsmith: 0.7.4(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       micromatch: 4.0.8
       yaml: 2.8.3
@@ -19098,7 +19014,7 @@ snapshots:
       '@langchain/langgraph': https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.4.2))(zod@4.4.2)
       '@langchain/langgraph-sdk': link:libs/sdk
       fast-glob: 3.3.3
-      langchain: 1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.2))
+      langchain: 1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.2))
       langsmith: 0.7.4(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)
       micromatch: 4.0.8
       yaml: 2.8.3
@@ -20509,13 +20425,13 @@ snapshots:
 
   kuler@2.0.0: {}
 
-  langchain@1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6)):
+  langchain@1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.3.6)):
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
-      '@langchain/langgraph': https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.3.6)
+      '@langchain/langgraph': 1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod-to-json-schema@3.25.1(zod@4.3.6))(zod@4.4.3)
       '@langchain/langgraph-checkpoint': link:libs/checkpoint
       langsmith: 0.7.4(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
-      zod: 4.3.6
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -20524,13 +20440,13 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  langchain@1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6)):
+  langchain@1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.3.6)):
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
-      '@langchain/langgraph': https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6)
+      '@langchain/langgraph': 1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.4.3)
       '@langchain/langgraph-checkpoint': link:libs/checkpoint
       langsmith: 0.7.4(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
-      zod: 4.3.6
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -20539,13 +20455,13 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  langchain@1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.2)):
+  langchain@1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.2)):
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)
-      '@langchain/langgraph': https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.4.2))(zod@4.3.6)
+      '@langchain/langgraph': 1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.4.2))(zod@4.4.3)
       '@langchain/langgraph-checkpoint': link:libs/checkpoint
       langsmith: 0.7.4(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.2))(ws@8.21.0)
-      zod: 4.3.6
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -20554,13 +20470,13 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  langchain@1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.4.3)):
+  langchain@1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)(zod-to-json-schema@3.25.1(zod@4.4.3)):
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
-      '@langchain/langgraph': https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.3.6)
+      '@langchain/langgraph': 1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(zod-to-json-schema@3.25.1(zod@4.4.3))(zod@4.4.3)
       '@langchain/langgraph-checkpoint': link:libs/checkpoint
       langsmith: 0.7.4(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
-      zod: 4.3.6
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -20569,13 +20485,13 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  langchain@1.4.0-dev-1777615538778(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.3)):
+  langchain@1.5.1-dev-1781824996270(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)(zod-to-json-schema@3.25.2(zod@4.4.3)):
     dependencies:
       '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
-      '@langchain/langgraph': https://pkg.pr.new/langchain-ai/langgraphjs/@langchain/langgraph@9c3a004(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.3.6)
+      '@langchain/langgraph': 1.4.4(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
       '@langchain/langgraph-checkpoint': link:libs/checkpoint
       langsmith: 0.7.4(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
-      zod: 4.3.6
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'


### PR DESCRIPTION
## Summary
- Add `update` and `goto` options to `respond()` across the SDK so resolving an interrupt can apply a state update and/or directed jump in the **same superstep** — mapped to LangGraph's `Command(resume, update, goto)`. The canonical use case is a HITL flow that pushes the interrupt card into state at the moment it answers, committed in one checkpoint with no flicker.
- `@langchain/langgraph-sdk`: new `update`/`goto` fields on `StreamRespondAllOptions`, forwarded by `StreamController.respond`/`respondAll`; `@langchain/core` `BaseMessage` instances under the `messagesKey` are serialized to dicts before transport, exactly like `submit()`.
- `@langchain/langgraph-api`: forward `update`/`goto` from `input.respond` into the run `Command` in both the protocol service and the embedded server.
- `@langchain/react`, `@langchain/vue`, `@langchain/svelte`, `@langchain/angular`: document the new `respond({ update, goto })` capability (incl. `BaseMessage` examples).
- Fix: the protocol-v2 state normalizer stripped `response_metadata`, which HITL cards ride on (`AIMessage.response_metadata`); non-empty `response_metadata` is now preserved.
- Add React browser tests (`interrupt_card_graph` fixture via `createAgent`) covering the approve and reject paths: the FE-pushed card lands in committed state exactly once and persists through a slow tool execution.
