### PR TITLE
fix(langgraph-checkpoint-postgres): prevent createAgent failures with PostgresSaver

### DIFF
--- a/.changeset/fix-postgres-saver-createagent-checkpoint.md
+++ b/.changeset/fix-postgres-saver-createagent-checkpoint.md
@@ -1,0 +1,8 @@
+---
+"@langchain/langgraph-checkpoint": patch
+"@langchain/langgraph-checkpoint-postgres": patch
+---
+
+fix(langgraph-checkpoint-postgres): prevent createAgent failures with PostgresSaver
+
+Add BaseCheckpointSaver.toJSON() so ConfigurableModel can stringify runnable config without traversing pg Pool timers, and default missing checkpoint maps on load/copy so resume no longer crashes on undefined versions_seen. Closes #1808.

--- a/libs/checkpoint-postgres/src/index.ts
+++ b/libs/checkpoint-postgres/src/index.ts
@@ -181,6 +181,8 @@ export class PostgresSaver extends BaseCheckpointSaver {
   ): Promise<Checkpoint> {
     return {
       ...checkpoint,
+      channel_versions: checkpoint.channel_versions ?? {},
+      versions_seen: checkpoint.versions_seen ?? {},
       channel_values: await this._loadBlobs(channelValues),
     };
   }

--- a/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
+++ b/libs/checkpoint-postgres/src/tests/checkpoints.int.test.ts
@@ -10,6 +10,7 @@ import pg from "pg";
 import { RunnableConfig } from "@langchain/core/runnables";
 import { PostgresSaver } from "../index.js"; // Adjust the import path as needed
 import { getMigrations } from "../migrations.js";
+import { getTablesWithSchema } from "../sql.js";
 
 const { Pool } = pg;
 
@@ -532,5 +533,54 @@ describe.each([
     expect(
       checkpointTuples[0].checkpoint.channel_versions[TASKS]
     ).toBeDefined();
+  });
+
+  it("should JSON.stringify when referenced from runnable configurable", () => {
+    expect(() =>
+      JSON.stringify({
+        configurable: { __pregel_checkpointer: postgresSaver },
+      })
+    ).not.toThrow();
+    expect(
+      JSON.stringify({
+        configurable: { __pregel_checkpointer: postgresSaver },
+      })
+    ).toContain("[PostgresSaver]");
+  });
+
+  it("should default missing versions_seen when loading a checkpoint", async () => {
+    const threadId = "missing-versions-seen";
+    const checkpointId = uuid6(3);
+    const pool = new Pool({ connectionString: currentDbConnectionString });
+    const tables = getTablesWithSchema(schema ?? "public");
+    try {
+      await pool.query(
+        `INSERT INTO ${tables.checkpoints}
+          (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, checkpoint, metadata)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [
+          threadId,
+          "",
+          checkpointId,
+          null,
+          {
+            v: 4,
+            id: checkpointId,
+            ts: new Date().toISOString(),
+            channel_versions: { messages: 1 },
+          },
+          { source: "input", step: 0, parents: {} },
+        ]
+      );
+
+      const tuple = await postgresSaver.getTuple({
+        configurable: { thread_id: threadId },
+      });
+
+      expect(tuple?.checkpoint.versions_seen).toEqual({});
+      expect(tuple?.checkpoint.channel_versions).toEqual({ messages: 1 });
+    } finally {
+      await pool.end();
+    }
   });
 });

--- a/libs/checkpoint/src/base.ts
+++ b/libs/checkpoint/src/base.ts
@@ -89,9 +89,9 @@ export function copyCheckpoint(checkpoint: ReadonlyCheckpoint): Checkpoint {
     v: checkpoint.v,
     id: checkpoint.id,
     ts: checkpoint.ts,
-    channel_values: { ...checkpoint.channel_values },
-    channel_versions: { ...checkpoint.channel_versions },
-    versions_seen: deepCopy(checkpoint.versions_seen),
+    channel_values: { ...(checkpoint.channel_values ?? {}) },
+    channel_versions: { ...(checkpoint.channel_versions ?? {}) },
+    versions_seen: deepCopy(checkpoint.versions_seen ?? {}),
   };
 }
 
@@ -115,6 +115,14 @@ export abstract class BaseCheckpointSaver<V extends string | number = number> {
 
   constructor(serde?: SerializerProtocol) {
     this.serde = serde || this.serde;
+  }
+
+  /**
+   * Prevent `JSON.stringify` from traversing backend clients (e.g. pg Pool
+   * timers) when a checkpointer is present in runnable `configurable`.
+   */
+  toJSON(): string {
+    return `[${this.constructor.name}]`;
   }
 
   async get(config: RunnableConfig): Promise<Checkpoint | undefined> {

--- a/libs/checkpoint/src/tests/checkpoints.test.ts
+++ b/libs/checkpoint/src/tests/checkpoints.test.ts
@@ -3,7 +3,9 @@ import type { RunnableConfig } from "@langchain/core/runnables";
 import {
   type Checkpoint,
   type CheckpointTuple,
+  BaseCheckpointSaver,
   compareChannelVersions,
+  copyCheckpoint,
   deepCopy,
   emptyCheckpoint,
   maxChannelVersion,
@@ -83,6 +85,49 @@ describe("Base", () => {
     // Check if the nested objects in the array are also deep copied
     expect(copiedArr[0]).toEqual(arr[0]);
     expect(copiedArr[0]).not.toBe(arr[0]);
+  });
+
+  it("copyCheckpoint defaults missing channel maps to empty objects", () => {
+    const partial = {
+      v: 4,
+      id: uuid6(0),
+      ts: "2024-04-19T17:19:07.952Z",
+    } as Checkpoint;
+
+    expect(copyCheckpoint(partial)).toEqual({
+      v: 4,
+      id: partial.id,
+      ts: partial.ts,
+      channel_values: {},
+      channel_versions: {},
+      versions_seen: {},
+    });
+  });
+
+  it("BaseCheckpointSaver.toJSON avoids backend client traversal", () => {
+    class TestSaver extends BaseCheckpointSaver {
+      backend = { timers: setTimeout(() => {}, 10_000) };
+
+      async getTuple() {
+        return undefined;
+      }
+
+      async *list() {}
+
+      async put(config: RunnableConfig) {
+        return config;
+      }
+
+      async putWrites() {}
+
+      async deleteThread() {}
+    }
+
+    const saver = new TestSaver();
+    expect(JSON.stringify({ configurable: { checkpointer: saver } })).toBe(
+      '{"configurable":{"checkpointer":"[TestSaver]"}}'
+    );
+    clearTimeout(saver.backend.timers);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `BaseCheckpointSaver.toJSON()` so runnable `configurable.__pregel_checkpointer` can be JSON-stringified without traversing backend clients (fixes the circular `Timeout` error when using `createAgent` with `PostgresSaver`).
- Harden `copyCheckpoint()` and `PostgresSaver._loadCheckpoint()` to default missing `channel_versions` and `versions_seen` to `{}`, fixing resume crashes on `__input__` after a failed first run.
- Add unit and integration tests covering stringify safety and missing `versions_seen` recovery.

Fixes #1808