### PR TITLE
fix(langgraph-api): support configurable TypeScript loaders in dev server

### DIFF
--- a/.changeset/support-node-loader-dev-server.md
+++ b/.changeset/support-node-loader-dev-server.md
@@ -1,0 +1,8 @@
+---
+"@langchain/langgraph-api": patch
+"@langchain/langgraph-cli": patch
+---
+
+fix(langgraph-api): support configurable TypeScript loaders in dev server
+
+Add `node_loader` to `langgraph.json` (and `LANGGRAPH_NODE_LOADER` env override) so projects using reflect-metadata can use `ts-node/esm` or other Node `--import` loaders instead of the default tsx CLI. Closes #1834.

--- a/.changeset/support-node-loader-dev-server.md
+++ b/.changeset/support-node-loader-dev-server.md
@@ -5,4 +5,4 @@
 
 fix(langgraph-api): support configurable TypeScript loaders in dev server
 
-Add `node_loader` to `langgraph.json` (and `LANGGRAPH_NODE_LOADER` env override) so projects using reflect-metadata can use `ts-node/esm` or other Node `--import` loaders instead of the default tsx CLI. Closes #1834.
+Add `node_loader` to `langgraph.json` (and `LANGGRAPH_NODE_LOADER` env override) so projects using reflect-metadata can use `ts-node` (`--loader ts-node/esm`) instead of the default tsx CLI. Other loaders default to `--import`; only registered shorthands like `ts-node` use `--loader`. `--no-reload` now also disables tsx's internal watch mode. Closes #1834.

--- a/libs/langgraph-api/package.json
+++ b/libs/langgraph-api/package.json
@@ -88,10 +88,14 @@
     "@langchain/langgraph": "^1.3.6",
     "@langchain/langgraph-checkpoint": "~0.0.16 || ^0.1.0 || ^1.0.0",
     "@langchain/langgraph-sdk": "^1.9.3-rc.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5.5.4"
   },
   "peerDependenciesMeta": {
     "@langchain/langgraph-sdk": {
+      "optional": true
+    },
+    "ts-node": {
       "optional": true
     }
   },
@@ -109,6 +113,7 @@
     "jose": "^6.0.10",
     "langchain": "^1.5.1",
     "postgres": "^3.4.5",
+    "ts-node": "^10.9.2",
     "typescript": "^4.9.5 || ^5.4.5",
     "vitest": "^4.1.0",
     "wait-port": "^1.1.0"

--- a/libs/langgraph-api/src/cli/spawn-args.mts
+++ b/libs/langgraph-api/src/cli/spawn-args.mts
@@ -1,0 +1,123 @@
+import { isAbsolute } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Default loader: tsx CLI with built-in watch. */
+export const DEFAULT_NODE_LOADER = "tsx";
+
+/**
+ * Shorthand loader names mapped to Node `--import` specifiers.
+ * Use `"tsx"` (not `"tsx/esm"`) to spawn via the tsx CLI instead.
+ */
+export const LOADER_IMPORT_SHORTCUTS: Record<string, string> = {
+  "ts-node": "ts-node/esm",
+};
+
+export type SpawnServerPayload = {
+  port: number;
+  nWorkers: number;
+  host: string;
+  graphs: Record<string, string | { path: string; description?: string }>;
+  auth?: {
+    path?: string;
+    disable_studio_auth?: boolean;
+  };
+  ui?: Record<string, string>;
+  ui_config?: { shared?: string[] };
+  cwd: string;
+  http?: {
+    app?: string;
+    disable_assistants?: boolean;
+    disable_threads?: boolean;
+    disable_runs?: boolean;
+    disable_store?: boolean;
+    disable_meta?: boolean;
+    cors?: {
+      allow_origins?: string[];
+      allow_methods?: string[];
+      allow_headers?: string[];
+      allow_credentials?: boolean;
+      allow_origin_regex?: string;
+      expose_headers?: string[];
+      max_age?: number;
+    };
+  };
+};
+
+export function resolveNodeLoader(
+  configLoader: string | undefined,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const envLoader = env.LANGGRAPH_NODE_LOADER?.trim();
+  if (envLoader) return envLoader;
+  return configLoader ?? DEFAULT_NODE_LOADER;
+}
+
+export function resolveLoaderImport(
+  loader: string,
+  resolve: (specifier: string) => string
+): string {
+  const specifier = LOADER_IMPORT_SHORTCUTS[loader] ?? loader;
+
+  if (specifier.startsWith("file://")) {
+    return fileURLToPath(specifier);
+  }
+  if (isAbsolute(specifier)) {
+    return specifier;
+  }
+
+  try {
+    return fileURLToPath(new URL(resolve(specifier)));
+  } catch {
+    const hint =
+      loader === "ts-node" || loader.startsWith("ts-node/")
+        ? ' Install "ts-node" and enable "emitDecoratorMetadata" in tsconfig when using reflect-metadata.'
+        : "";
+    throw new Error(
+      `node_loader "${loader}" could not be resolved.${hint} Install the package or provide a valid module specifier, file path, or file:// URL.`
+    );
+  }
+}
+
+export function usesTsxCli(loader: string): boolean {
+  return loader === DEFAULT_NODE_LOADER;
+}
+
+export function buildSpawnArgs(options: {
+  nodeLoader: string;
+  reload: boolean;
+  pid: number;
+  payload: SpawnServerPayload;
+  resolve: (specifier: string) => string;
+}): { command: string; args: string[] } {
+  const payloadArg = JSON.stringify(options.payload);
+  const sharedArgs = [options.pid.toString(), payloadArg] as const;
+
+  if (usesTsxCli(options.nodeLoader)) {
+    const args = [
+      fileURLToPath(
+        new URL("../../cli.mjs", options.resolve("tsx/esm/api"))
+      ),
+      ...(options.reload ? ["watch"] : []),
+      "--clear-screen=false",
+      "--import",
+      new URL(options.resolve("../preload.mjs")).toString(),
+      fileURLToPath(new URL(options.resolve("./entrypoint.mjs"))),
+      ...sharedArgs,
+    ];
+
+    return { command: process.execPath, args };
+  }
+
+  const loaderImport = resolveLoaderImport(options.nodeLoader, options.resolve);
+  const args = [
+    ...(options.reload ? ["--watch"] : []),
+    "--import",
+    loaderImport,
+    "--import",
+    fileURLToPath(new URL(options.resolve("../preload.mjs"))),
+    fileURLToPath(new URL(options.resolve("./entrypoint.mjs"))),
+    ...sharedArgs,
+  ];
+
+  return { command: process.execPath, args };
+}

--- a/libs/langgraph-api/src/cli/spawn-args.mts
+++ b/libs/langgraph-api/src/cli/spawn-args.mts
@@ -6,12 +6,18 @@ import type { StartServerOptions } from "../server.mjs";
 /** Default loader: tsx CLI with built-in watch. */
 export const DEFAULT_NODE_LOADER = "tsx";
 
+type LoaderRegistration = {
+  specifier: string;
+  flag: "--loader" | "--import";
+};
+
 /**
- * Shorthand loader names mapped to Node `--import` specifiers.
+ * Shorthand loader names mapped to Node registration hooks.
  * Use `"tsx"` (not `"tsx/esm"`) to spawn via the tsx CLI instead.
  */
-export const LOADER_IMPORT_SHORTCUTS: Record<string, string> = {
-  "ts-node": "ts-node/esm",
+export const LOADER_REGISTRATIONS: Record<string, LoaderRegistration> = {
+  "ts-node": { specifier: "ts-node/esm", flag: "--loader" },
+  "ts-node/esm": { specifier: "ts-node/esm", flag: "--loader" },
 };
 
 export function resolveNodeLoader(
@@ -23,12 +29,25 @@ export function resolveNodeLoader(
   return configLoader ?? DEFAULT_NODE_LOADER;
 }
 
-export function resolveLoaderImport(
+export function resolveLoaderRegistration(
+  loader: string,
+  resolve: (specifier: string) => string
+): LoaderRegistration & { path: string } {
+  const registration = LOADER_REGISTRATIONS[loader] ?? {
+    specifier: loader,
+    flag: "--import" as const,
+  };
+
+  const path = resolveLoaderPath(registration.specifier, loader, resolve);
+
+  return { ...registration, path };
+}
+
+export function resolveLoaderPath(
+  specifier: string,
   loader: string,
   resolve: (specifier: string) => string
 ): string {
-  const specifier = LOADER_IMPORT_SHORTCUTS[loader] ?? loader;
-
   if (specifier.startsWith("file://")) {
     return fileURLToPath(specifier);
   }
@@ -62,29 +81,40 @@ export function buildSpawnArgs(options: {
 }): { command: string; args: string[] } {
   const payloadArg = JSON.stringify(options.payload);
   const sharedArgs = [options.pid.toString(), payloadArg] as const;
+  const preloadPath = fileURLToPath(
+    new URL(options.resolve("../preload.mjs"))
+  );
+  const entrypointPath = fileURLToPath(
+    new URL(options.resolve("./entrypoint.mjs"))
+  );
 
   if (usesTsxCli(options.nodeLoader)) {
     const args = [
-      fileURLToPath(new URL("../../cli.mjs", options.resolve("tsx/esm/api"))),
+      fileURLToPath(
+        new URL("../../cli.mjs", options.resolve("tsx/esm/api"))
+      ),
       ...(options.reload ? ["watch"] : []),
       "--clear-screen=false",
       "--import",
       new URL(options.resolve("../preload.mjs")).toString(),
-      fileURLToPath(new URL(options.resolve("./entrypoint.mjs"))),
+      entrypointPath,
       ...sharedArgs,
     ];
 
     return { command: process.execPath, args };
   }
 
-  const loaderImport = resolveLoaderImport(options.nodeLoader, options.resolve);
+  const loader = resolveLoaderRegistration(
+    options.nodeLoader,
+    options.resolve
+  );
   const args = [
     ...(options.reload ? ["--watch"] : []),
+    loader.flag,
+    loader.path,
     "--import",
-    loaderImport,
-    "--import",
-    fileURLToPath(new URL(options.resolve("../preload.mjs"))),
-    fileURLToPath(new URL(options.resolve("./entrypoint.mjs"))),
+    preloadPath,
+    entrypointPath,
     ...sharedArgs,
   ];
 

--- a/libs/langgraph-api/src/cli/spawn-args.mts
+++ b/libs/langgraph-api/src/cli/spawn-args.mts
@@ -1,6 +1,8 @@
 import { isAbsolute } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import type { StartServerOptions } from "../server.mjs";
+
 /** Default loader: tsx CLI with built-in watch. */
 export const DEFAULT_NODE_LOADER = "tsx";
 
@@ -10,37 +12,6 @@ export const DEFAULT_NODE_LOADER = "tsx";
  */
 export const LOADER_IMPORT_SHORTCUTS: Record<string, string> = {
   "ts-node": "ts-node/esm",
-};
-
-export type SpawnServerPayload = {
-  port: number;
-  nWorkers: number;
-  host: string;
-  graphs: Record<string, string | { path: string; description?: string }>;
-  auth?: {
-    path?: string;
-    disable_studio_auth?: boolean;
-  };
-  ui?: Record<string, string>;
-  ui_config?: { shared?: string[] };
-  cwd: string;
-  http?: {
-    app?: string;
-    disable_assistants?: boolean;
-    disable_threads?: boolean;
-    disable_runs?: boolean;
-    disable_store?: boolean;
-    disable_meta?: boolean;
-    cors?: {
-      allow_origins?: string[];
-      allow_methods?: string[];
-      allow_headers?: string[];
-      allow_credentials?: boolean;
-      allow_origin_regex?: string;
-      expose_headers?: string[];
-      max_age?: number;
-    };
-  };
 };
 
 export function resolveNodeLoader(
@@ -86,7 +57,7 @@ export function buildSpawnArgs(options: {
   nodeLoader: string;
   reload: boolean;
   pid: number;
-  payload: SpawnServerPayload;
+  payload: StartServerOptions;
   resolve: (specifier: string) => string;
 }): { command: string; args: string[] } {
   const payloadArg = JSON.stringify(options.payload);

--- a/libs/langgraph-api/src/cli/spawn-args.mts
+++ b/libs/langgraph-api/src/cli/spawn-args.mts
@@ -81,18 +81,14 @@ export function buildSpawnArgs(options: {
 }): { command: string; args: string[] } {
   const payloadArg = JSON.stringify(options.payload);
   const sharedArgs = [options.pid.toString(), payloadArg] as const;
-  const preloadPath = fileURLToPath(
-    new URL(options.resolve("../preload.mjs"))
-  );
+  const preloadPath = fileURLToPath(new URL(options.resolve("../preload.mjs")));
   const entrypointPath = fileURLToPath(
     new URL(options.resolve("./entrypoint.mjs"))
   );
 
   if (usesTsxCli(options.nodeLoader)) {
     const args = [
-      fileURLToPath(
-        new URL("../../cli.mjs", options.resolve("tsx/esm/api"))
-      ),
+      fileURLToPath(new URL("../../cli.mjs", options.resolve("tsx/esm/api"))),
       ...(options.reload ? ["watch"] : []),
       "--clear-screen=false",
       "--import",
@@ -104,10 +100,7 @@ export function buildSpawnArgs(options: {
     return { command: process.execPath, args };
   }
 
-  const loader = resolveLoaderRegistration(
-    options.nodeLoader,
-    options.resolve
-  );
+  const loader = resolveLoaderRegistration(options.nodeLoader, options.resolve);
   const args = [
     ...(options.reload ? ["--watch"] : []),
     loader.flag,

--- a/libs/langgraph-api/src/cli/spawn-args.mts
+++ b/libs/langgraph-api/src/cli/spawn-args.mts
@@ -98,9 +98,7 @@ export function buildSpawnArgs(options: {
 
   if (usesTsxCli(options.nodeLoader)) {
     const args = [
-      fileURLToPath(
-        new URL("../../cli.mjs", options.resolve("tsx/esm/api"))
-      ),
+      fileURLToPath(new URL("../../cli.mjs", options.resolve("tsx/esm/api"))),
       ...(options.reload ? ["watch"] : []),
       "--clear-screen=false",
       "--import",
@@ -112,10 +110,7 @@ export function buildSpawnArgs(options: {
     return { command: process.execPath, args };
   }
 
-  const loader = resolveLoaderRegistration(
-    options.nodeLoader,
-    options.resolve
-  );
+  const loader = resolveLoaderRegistration(options.nodeLoader, options.resolve);
   const args = [
     ...(options.reload ? ["--watch"] : []),
     loader.flag,

--- a/libs/langgraph-api/src/cli/spawn-args.mts
+++ b/libs/langgraph-api/src/cli/spawn-args.mts
@@ -1,5 +1,5 @@
 import { isAbsolute } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import type { StartServerOptions } from "../server.mjs";
 
@@ -14,6 +14,10 @@ type LoaderRegistration = {
 /**
  * Shorthand loader names mapped to Node registration hooks.
  * Use `"tsx"` (not `"tsx/esm"`) to spawn via the tsx CLI instead.
+ *
+ * `ts-node` uses `--loader` (not `--import`) because `ts-node/esm` is a
+ * custom ESM loader hook. Node 20+ deprecates `--loader` in favor of
+ * `module.register()`, but ts-node still documents this entrypoint.
  */
 export const LOADER_REGISTRATIONS: Record<string, LoaderRegistration> = {
   "ts-node": { specifier: "ts-node/esm", flag: "--loader" },
@@ -68,6 +72,12 @@ export function resolveLoaderPath(
   }
 }
 
+/** Convert a resolved filesystem path to a Node `--loader`/`--import` URL. */
+export function toNodeModuleUrl(path: string): string {
+  if (path.startsWith("file://")) return path;
+  return pathToFileURL(path).href;
+}
+
 export function usesTsxCli(loader: string): boolean {
   return loader === DEFAULT_NODE_LOADER;
 }
@@ -81,18 +91,20 @@ export function buildSpawnArgs(options: {
 }): { command: string; args: string[] } {
   const payloadArg = JSON.stringify(options.payload);
   const sharedArgs = [options.pid.toString(), payloadArg] as const;
-  const preloadPath = fileURLToPath(new URL(options.resolve("../preload.mjs")));
+  const preloadUrl = new URL(options.resolve("../preload.mjs")).toString();
   const entrypointPath = fileURLToPath(
     new URL(options.resolve("./entrypoint.mjs"))
   );
 
   if (usesTsxCli(options.nodeLoader)) {
     const args = [
-      fileURLToPath(new URL("../../cli.mjs", options.resolve("tsx/esm/api"))),
+      fileURLToPath(
+        new URL("../../cli.mjs", options.resolve("tsx/esm/api"))
+      ),
       ...(options.reload ? ["watch"] : []),
       "--clear-screen=false",
       "--import",
-      new URL(options.resolve("../preload.mjs")).toString(),
+      preloadUrl,
       entrypointPath,
       ...sharedArgs,
     ];
@@ -100,13 +112,16 @@ export function buildSpawnArgs(options: {
     return { command: process.execPath, args };
   }
 
-  const loader = resolveLoaderRegistration(options.nodeLoader, options.resolve);
+  const loader = resolveLoaderRegistration(
+    options.nodeLoader,
+    options.resolve
+  );
   const args = [
     ...(options.reload ? ["--watch"] : []),
     loader.flag,
-    loader.path,
+    toNodeModuleUrl(loader.path),
     "--import",
-    preloadPath,
+    preloadUrl,
     entrypointPath,
     ...sharedArgs,
   ];

--- a/libs/langgraph-api/src/cli/spawn-args.mts
+++ b/libs/langgraph-api/src/cli/spawn-args.mts
@@ -65,9 +65,7 @@ export function buildSpawnArgs(options: {
 
   if (usesTsxCli(options.nodeLoader)) {
     const args = [
-      fileURLToPath(
-        new URL("../../cli.mjs", options.resolve("tsx/esm/api"))
-      ),
+      fileURLToPath(new URL("../../cli.mjs", options.resolve("tsx/esm/api"))),
       ...(options.reload ? ["watch"] : []),
       "--clear-screen=false",
       "--import",

--- a/libs/langgraph-api/src/cli/spawn.mts
+++ b/libs/langgraph-api/src/cli/spawn.mts
@@ -1,10 +1,7 @@
 import { spawn } from "node:child_process";
 
 import { StartServerSchema, type StartServerOptions } from "../server.mjs";
-import {
-  buildSpawnArgs,
-  resolveNodeLoader,
-} from "./spawn-args.mjs";
+import { buildSpawnArgs, resolveNodeLoader } from "./spawn-args.mjs";
 
 export async function spawnServer(
   args: {

--- a/libs/langgraph-api/src/cli/spawn.mts
+++ b/libs/langgraph-api/src/cli/spawn.mts
@@ -1,9 +1,9 @@
 import { spawn } from "node:child_process";
 
+import { StartServerSchema, type StartServerOptions } from "../server.mjs";
 import {
   buildSpawnArgs,
   resolveNodeLoader,
-  type SpawnServerPayload,
 } from "./spawn-args.mjs";
 
 export async function spawnServer(
@@ -20,7 +20,7 @@ export async function spawnServer(
       ui_config?: { shared?: string[] };
       auth?: { path?: string; disable_studio_auth?: boolean };
       node_loader?: string;
-      http?: SpawnServerPayload["http"];
+      http?: StartServerOptions["http"];
     };
     env: NodeJS.ProcessEnv;
     hostUrl: string;
@@ -49,21 +49,22 @@ For production use, please use LangSmith Deployment.
 `);
 
   const nodeLoader = resolveNodeLoader(context.config.node_loader, context.env);
+  const payload: StartServerOptions = StartServerSchema.parse({
+    port: Number.parseInt(args.port, 10),
+    nWorkers: Number.parseInt(args.nJobsPerWorker, 10),
+    host: args.host,
+    graphs: context.config.graphs,
+    auth: context.config.auth,
+    ui: context.config.ui,
+    ui_config: context.config.ui_config,
+    cwd: options.projectCwd,
+    http: context.config.http,
+  });
   const { command, args: spawnArgs } = buildSpawnArgs({
     nodeLoader,
     reload: args.reload ?? true,
     pid: options.pid,
-    payload: {
-      port: Number.parseInt(args.port, 10),
-      nWorkers: Number.parseInt(args.nJobsPerWorker, 10),
-      host: args.host,
-      graphs: context.config.graphs,
-      auth: context.config.auth,
-      ui: context.config.ui,
-      ui_config: context.config.ui_config,
-      cwd: options.projectCwd,
-      http: context.config.http,
-    },
+    payload,
     resolve: (specifier) => import.meta.resolve(specifier),
   });
 

--- a/libs/langgraph-api/src/cli/spawn.mts
+++ b/libs/langgraph-api/src/cli/spawn.mts
@@ -1,11 +1,17 @@
-import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
+
+import {
+  buildSpawnArgs,
+  resolveNodeLoader,
+  type SpawnServerPayload,
+} from "./spawn-args.mjs";
 
 export async function spawnServer(
   args: {
     host: string;
     port: string;
     nJobsPerWorker: string;
+    reload?: boolean;
   },
   context: {
     config: {
@@ -13,23 +19,8 @@ export async function spawnServer(
       ui?: Record<string, string>;
       ui_config?: { shared?: string[] };
       auth?: { path?: string; disable_studio_auth?: boolean };
-      http?: {
-        app?: string;
-        disable_assistants?: boolean;
-        disable_threads?: boolean;
-        disable_runs?: boolean;
-        disable_store?: boolean;
-        disable_meta?: boolean;
-        cors?: {
-          allow_origins?: string[];
-          allow_methods?: string[];
-          allow_headers?: string[];
-          allow_credentials?: boolean;
-          allow_origin_regex?: string;
-          expose_headers?: string[];
-          max_age?: number;
-        };
-      };
+      node_loader?: string;
+      http?: SpawnServerPayload["http"];
     };
     env: NodeJS.ProcessEnv;
     hostUrl: string;
@@ -57,37 +48,31 @@ For production use, please use LangSmith Deployment.
 
 `);
 
-  return spawn(
-    process.execPath,
-    [
-      fileURLToPath(
-        new URL("../../cli.mjs", import.meta.resolve("tsx/esm/api"))
-      ),
-      "watch",
-      "--clear-screen=false",
-      "--import",
-      new URL(import.meta.resolve("../preload.mjs")).toString(),
-      fileURLToPath(new URL(import.meta.resolve("./entrypoint.mjs"))),
-      options.pid.toString(),
-      JSON.stringify({
-        port: Number.parseInt(args.port, 10),
-        nWorkers: Number.parseInt(args.nJobsPerWorker, 10),
-        host: args.host,
-        graphs: context.config.graphs,
-        auth: context.config.auth,
-        ui: context.config.ui,
-        ui_config: context.config.ui_config,
-        cwd: options.projectCwd,
-        http: context.config.http,
-      }),
-    ],
-    {
-      stdio: ["inherit", "inherit", "inherit", "ipc"],
-      env: {
-        ...context.env,
-        NODE_ENV: "development",
-        LANGGRAPH_API_URL: localUrl,
-      },
-    }
-  );
+  const nodeLoader = resolveNodeLoader(context.config.node_loader, context.env);
+  const { command, args: spawnArgs } = buildSpawnArgs({
+    nodeLoader,
+    reload: args.reload ?? true,
+    pid: options.pid,
+    payload: {
+      port: Number.parseInt(args.port, 10),
+      nWorkers: Number.parseInt(args.nJobsPerWorker, 10),
+      host: args.host,
+      graphs: context.config.graphs,
+      auth: context.config.auth,
+      ui: context.config.ui,
+      ui_config: context.config.ui_config,
+      cwd: options.projectCwd,
+      http: context.config.http,
+    },
+    resolve: (specifier) => import.meta.resolve(specifier),
+  });
+
+  return spawn(command, spawnArgs, {
+    stdio: ["inherit", "inherit", "inherit", "ipc"],
+    env: {
+      ...context.env,
+      NODE_ENV: "development",
+      LANGGRAPH_API_URL: localUrl,
+    },
+  });
 }

--- a/libs/langgraph-api/src/server.mts
+++ b/libs/langgraph-api/src/server.mts
@@ -77,8 +77,10 @@ export const StartServerSchema = z.object({
     .optional(),
 });
 
+export type StartServerOptions = z.infer<typeof StartServerSchema>;
+
 export async function startServer(
-  options: z.infer<typeof StartServerSchema>,
+  options: StartServerOptions,
   storage?: { ops?: Ops }
 ) {
   const semver = await checkLangGraphSemver();

--- a/libs/langgraph-api/tests/spawn-args.test.mts
+++ b/libs/langgraph-api/tests/spawn-args.test.mts
@@ -5,11 +5,11 @@ import {
   DEFAULT_NODE_LOADER,
   resolveLoaderImport,
   resolveNodeLoader,
-  type SpawnServerPayload,
   usesTsxCli,
 } from "../src/cli/spawn-args.mjs";
+import type { StartServerOptions } from "../src/server.mjs";
 
-const payload: SpawnServerPayload = {
+const payload: StartServerOptions = {
   port: 2024,
   nWorkers: 10,
   host: "localhost",

--- a/libs/langgraph-api/tests/spawn-args.test.mts
+++ b/libs/langgraph-api/tests/spawn-args.test.mts
@@ -9,6 +9,7 @@ import {
   resolveLoaderPath,
   resolveLoaderRegistration,
   resolveNodeLoader,
+  toNodeModuleUrl,
   usesTsxCli,
 } from "../src/cli/spawn-args.mjs";
 import type { StartServerOptions } from "../src/server.mjs";
@@ -190,9 +191,9 @@ describe("buildSpawnArgs", () => {
     expect(args.slice(0, 5)).toEqual([
       "--watch",
       "--loader",
-      expect.stringContaining("ts-node"),
+      expect.stringMatching(/^file:\/\//),
       "--import",
-      expect.stringContaining("preload.mjs"),
+      expect.stringMatching(/^file:\/\/.*preload\.mjs$/),
     ]);
     expect(args[1]).toBe("--loader");
     expect(args[2]).not.toBe("--import");
@@ -247,6 +248,7 @@ describe("buildSpawnArgs", () => {
     expect(args).not.toContain("watch");
     expect(args).not.toContain("--loader");
     expect(args[0]).toBe("--import");
+    expect(args[1]).toMatch(/^file:\/\//);
     expect(args[1]).toContain("tsx");
   });
 
@@ -261,9 +263,21 @@ describe("buildSpawnArgs", () => {
 
     const preloadIndex = args.indexOf("--import");
     expect(preloadIndex).toBeGreaterThan(args.indexOf("--loader"));
-    expect(args[preloadIndex + 1]).toContain("preload.mjs");
+    expect(args[preloadIndex + 1]).toMatch(/^file:\/\/.*preload\.mjs$/);
     expect(args[preloadIndex + 2]).toContain("entrypoint.mjs");
     expect(args.at(-2)).toBe("7");
     expect(JSON.parse(args.at(-1)!)).toEqual(payload);
+  });
+});
+
+describe("toNodeModuleUrl", () => {
+  it("converts absolute paths to file URLs", () => {
+    const loaderPath = join(tmpdir(), "custom-loader.mjs");
+    expect(toNodeModuleUrl(loaderPath)).toBe(pathToFileURL(loaderPath).href);
+  });
+
+  it("passes through existing file URLs", () => {
+    const loaderUrl = pathToFileURL(join(tmpdir(), "custom-loader.mjs")).href;
+    expect(toNodeModuleUrl(loaderUrl)).toBe(loaderUrl);
   });
 });

--- a/libs/langgraph-api/tests/spawn-args.test.mts
+++ b/libs/langgraph-api/tests/spawn-args.test.mts
@@ -1,9 +1,12 @@
 import { sep } from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   buildSpawnArgs,
   DEFAULT_NODE_LOADER,
-  resolveLoaderImport,
+  LOADER_REGISTRATIONS,
+  resolveLoaderPath,
+  resolveLoaderRegistration,
   resolveNodeLoader,
   usesTsxCli,
 } from "../src/cli/spawn-args.mjs";
@@ -16,6 +19,14 @@ const payload: StartServerOptions = {
   graphs: { agent: "./agent.ts:graph" },
   cwd: "/tmp/project",
 };
+
+const mockResolve =
+  (map: Record<string, string>) =>
+  (specifier: string): string => {
+    const resolved = map[specifier];
+    if (!resolved) throw new Error(`Cannot resolve ${specifier}`);
+    return resolved;
+  };
 
 describe("resolveNodeLoader", () => {
   it("defaults to tsx", () => {
@@ -41,24 +52,114 @@ describe("usesTsxCli", () => {
   });
 });
 
-describe("resolveLoaderImport", () => {
-  it("maps ts-node shorthand to ts-node/esm", () => {
-    const resolved = resolveLoaderImport("ts-node", (specifier) =>
+describe("LOADER_REGISTRATIONS", () => {
+  it("registers ts-node shorthands with --loader", () => {
+    expect(LOADER_REGISTRATIONS["ts-node"]).toEqual({
+      specifier: "ts-node/esm",
+      flag: "--loader",
+    });
+    expect(LOADER_REGISTRATIONS["ts-node/esm"]).toEqual({
+      specifier: "ts-node/esm",
+      flag: "--loader",
+    });
+  });
+});
+
+describe("resolveLoaderRegistration", () => {
+  it("maps ts-node shorthand to ts-node/esm via --loader", () => {
+    const resolved = resolveLoaderRegistration("ts-node", (specifier) =>
       import.meta.resolve(specifier)
     );
-    expect(resolved).toContain(`${sep}ts-node${sep}`);
-    expect(resolved.endsWith(`${sep}esm.mjs`)).toBe(true);
+    expect(resolved.flag).toBe("--loader");
+    expect(resolved.specifier).toBe("ts-node/esm");
+    expect(resolved.path).toContain(`${sep}ts-node${sep}`);
+    expect(resolved.path.endsWith(`${sep}esm.mjs`)).toBe(true);
+  });
+
+  it("maps ts-node/esm explicitly via --loader", () => {
+    const resolved = resolveLoaderRegistration("ts-node/esm", (specifier) =>
+      import.meta.resolve(specifier)
+    );
+    expect(resolved).toMatchObject({
+      flag: "--loader",
+      specifier: "ts-node/esm",
+    });
+  });
+
+  it("defaults unknown loaders to --import", () => {
+    const resolved = resolveLoaderRegistration(
+      "tsx/esm",
+      mockResolve({
+        "tsx/esm": pathToFileURL("/tmp/tsx/esm.mjs").href,
+      })
+    );
+    expect(resolved).toMatchObject({
+      flag: "--import",
+      specifier: "tsx/esm",
+      path: "/tmp/tsx/esm.mjs",
+    });
+  });
+});
+
+describe("resolveLoaderPath", () => {
+  it("resolves absolute paths unchanged", () => {
+    expect(
+      resolveLoaderPath(
+        "/tmp/custom-loader.mjs",
+        "file:///tmp/custom-loader.mjs",
+        () => {
+          throw new Error("should not resolve");
+        }
+      )
+    ).toBe("/tmp/custom-loader.mjs");
+  });
+
+  it("resolves file URLs unchanged", () => {
+    expect(
+      resolveLoaderPath(
+        "file:///tmp/custom-loader.mjs",
+        "file:///tmp/custom-loader.mjs",
+        () => {
+          throw new Error("should not resolve");
+        }
+      )
+    ).toBe("/tmp/custom-loader.mjs");
+  });
+
+  it("includes ts-node setup hint when resolution fails", () => {
+    expect(() =>
+      resolveLoaderPath("ts-node/esm", "ts-node", () => {
+        throw new Error("missing");
+      })
+    ).toThrow(/emitDecoratorMetadata/);
+  });
+
+  it("omits ts-node hint for unrelated loaders", () => {
+    expect(() =>
+      resolveLoaderPath("missing/pkg", "missing/pkg", () => {
+        throw new Error("missing");
+      })
+    ).toThrow(/could not be resolved/);
+
+    expect(() =>
+      resolveLoaderPath("missing/pkg", "missing/pkg", () => {
+        throw new Error("missing");
+      })
+    ).not.toThrow(/emitDecoratorMetadata/);
   });
 });
 
 describe("buildSpawnArgs", () => {
+  const resolveFromSpawn = (specifier: string) =>
+    import.meta.resolve(specifier, import.meta.resolve("../src/cli/spawn.mjs"));
+
   it("builds tsx watch args by default", () => {
     const { command, args } = buildSpawnArgs({
       nodeLoader: "tsx",
       reload: true,
       pid: 42,
       payload,
-      resolve: (specifier) => import.meta.resolve(specifier),
+      resolve: resolveFromSpawn,
     });
 
     expect(command).toBe(process.execPath);
@@ -73,26 +174,67 @@ describe("buildSpawnArgs", () => {
       reload: false,
       pid: 42,
       payload,
-      resolve: (specifier) => import.meta.resolve(specifier),
+      resolve: resolveFromSpawn,
     });
 
     expect(args).not.toContain("watch");
   });
 
-  it("builds node import loader args with node --watch", () => {
+  it("registers ts-node with node --loader before preload --import", () => {
     const { command, args } = buildSpawnArgs({
       nodeLoader: "ts-node",
       reload: true,
       pid: 99,
       payload,
-      resolve: (specifier) => import.meta.resolve(specifier),
+      resolve: resolveFromSpawn,
     });
 
     expect(command).toBe(process.execPath);
-    expect(args[0]).toBe("--watch");
-    expect(args).toContain("--import");
+    expect(args.slice(0, 5)).toEqual([
+      "--watch",
+      "--loader",
+      expect.stringContaining("ts-node"),
+      "--import",
+      expect.stringContaining("preload.mjs"),
+    ]);
+    expect(args[1]).toBe("--loader");
+    expect(args[2]).not.toBe("--import");
     expect(args.at(-2)).toBe("99");
     expect(JSON.parse(args.at(-1)!)).toEqual(payload);
+  });
+
+  it("registers ts-node/esm the same way as ts-node", () => {
+    const tsNode = buildSpawnArgs({
+      nodeLoader: "ts-node",
+      reload: false,
+      pid: 1,
+      payload,
+      resolve: resolveFromSpawn,
+    }).args.slice(0, 3);
+
+    const tsNodeEsm = buildSpawnArgs({
+      nodeLoader: "ts-node/esm",
+      reload: false,
+      pid: 1,
+      payload,
+      resolve: resolveFromSpawn,
+    }).args.slice(0, 3);
+
+    expect(tsNodeEsm).toEqual(tsNode);
+    expect(tsNodeEsm[0]).toBe("--loader");
+  });
+
+  it("omits node --watch for ts-node when reload is disabled", () => {
+    const { args } = buildSpawnArgs({
+      nodeLoader: "ts-node",
+      reload: false,
+      pid: 1,
+      payload,
+      resolve: resolveFromSpawn,
+    });
+
+    expect(args[0]).toBe("--loader");
+    expect(args).not.toContain("--watch");
   });
 
   it("supports arbitrary import loaders like tsx/esm", () => {
@@ -106,7 +248,25 @@ describe("buildSpawnArgs", () => {
 
     expect(command).toBe(process.execPath);
     expect(args).not.toContain("watch");
+    expect(args).not.toContain("--loader");
     expect(args[0]).toBe("--import");
     expect(args[1]).toContain("tsx");
+  });
+
+  it("places entrypoint and IPC payload after preload import", () => {
+    const { args } = buildSpawnArgs({
+      nodeLoader: "ts-node",
+      reload: false,
+      pid: 7,
+      payload,
+      resolve: resolveFromSpawn,
+    });
+
+    const preloadIndex = args.indexOf("--import");
+    expect(preloadIndex).toBeGreaterThan(args.indexOf("--loader"));
+    expect(args[preloadIndex + 1]).toContain("preload.mjs");
+    expect(args[preloadIndex + 2]).toContain("entrypoint.mjs");
+    expect(args.at(-2)).toBe("7");
+    expect(JSON.parse(args.at(-1)!)).toEqual(payload);
   });
 });

--- a/libs/langgraph-api/tests/spawn-args.test.mts
+++ b/libs/langgraph-api/tests/spawn-args.test.mts
@@ -1,5 +1,6 @@
-import { sep } from "node:path";
-import { pathToFileURL } from "node:url";
+import { tmpdir } from "node:os";
+import { join, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   buildSpawnArgs,
@@ -87,43 +88,39 @@ describe("resolveLoaderRegistration", () => {
   });
 
   it("defaults unknown loaders to --import", () => {
+    const loaderPath = join(tmpdir(), "tsx", "esm.mjs");
     const resolved = resolveLoaderRegistration(
       "tsx/esm",
       mockResolve({
-        "tsx/esm": pathToFileURL("/tmp/tsx/esm.mjs").href,
+        "tsx/esm": pathToFileURL(loaderPath).href,
       })
     );
     expect(resolved).toMatchObject({
       flag: "--import",
       specifier: "tsx/esm",
-      path: "/tmp/tsx/esm.mjs",
+      path: loaderPath,
     });
   });
 });
 
 describe("resolveLoaderPath", () => {
   it("resolves absolute paths unchanged", () => {
+    const loaderPath = join(tmpdir(), "custom-loader.mjs");
     expect(
-      resolveLoaderPath(
-        "/tmp/custom-loader.mjs",
-        "file:///tmp/custom-loader.mjs",
-        () => {
-          throw new Error("should not resolve");
-        }
-      )
-    ).toBe("/tmp/custom-loader.mjs");
+      resolveLoaderPath(loaderPath, loaderPath, () => {
+        throw new Error("should not resolve");
+      })
+    ).toBe(loaderPath);
   });
 
   it("resolves file URLs unchanged", () => {
+    const loaderPath = join(tmpdir(), "custom-loader.mjs");
+    const loaderUrl = pathToFileURL(loaderPath).href;
     expect(
-      resolveLoaderPath(
-        "file:///tmp/custom-loader.mjs",
-        "file:///tmp/custom-loader.mjs",
-        () => {
-          throw new Error("should not resolve");
-        }
-      )
-    ).toBe("/tmp/custom-loader.mjs");
+      resolveLoaderPath(loaderUrl, loaderUrl, () => {
+        throw new Error("should not resolve");
+      })
+    ).toBe(fileURLToPath(loaderUrl));
   });
 
   it("includes ts-node setup hint when resolution fails", () => {

--- a/libs/langgraph-api/tests/spawn-args.test.mts
+++ b/libs/langgraph-api/tests/spawn-args.test.mts
@@ -1,0 +1,112 @@
+import { sep } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildSpawnArgs,
+  DEFAULT_NODE_LOADER,
+  resolveLoaderImport,
+  resolveNodeLoader,
+  type SpawnServerPayload,
+  usesTsxCli,
+} from "../src/cli/spawn-args.mjs";
+
+const payload: SpawnServerPayload = {
+  port: 2024,
+  nWorkers: 10,
+  host: "localhost",
+  graphs: { agent: "./agent.ts:graph" },
+  cwd: "/tmp/project",
+};
+
+describe("resolveNodeLoader", () => {
+  it("defaults to tsx", () => {
+    expect(resolveNodeLoader(undefined)).toBe(DEFAULT_NODE_LOADER);
+    expect(resolveNodeLoader("ts-node/esm")).toBe("ts-node/esm");
+  });
+
+  it("prefers LANGGRAPH_NODE_LOADER env override", () => {
+    expect(
+      resolveNodeLoader("tsx", {
+        ...process.env,
+        LANGGRAPH_NODE_LOADER: "tsx/esm",
+      })
+    ).toBe("tsx/esm");
+  });
+});
+
+describe("usesTsxCli", () => {
+  it("only treats the default tsx shorthand as CLI mode", () => {
+    expect(usesTsxCli("tsx")).toBe(true);
+    expect(usesTsxCli("tsx/esm")).toBe(false);
+    expect(usesTsxCli("ts-node")).toBe(false);
+  });
+});
+
+describe("resolveLoaderImport", () => {
+  it("maps ts-node shorthand to ts-node/esm", () => {
+    const resolved = resolveLoaderImport("ts-node", (specifier) =>
+      import.meta.resolve(specifier)
+    );
+    expect(resolved).toContain(`${sep}ts-node${sep}`);
+    expect(resolved.endsWith(`${sep}esm.mjs`)).toBe(true);
+  });
+});
+
+describe("buildSpawnArgs", () => {
+  it("builds tsx watch args by default", () => {
+    const { command, args } = buildSpawnArgs({
+      nodeLoader: "tsx",
+      reload: true,
+      pid: 42,
+      payload,
+      resolve: (specifier) => import.meta.resolve(specifier),
+    });
+
+    expect(command).toBe(process.execPath);
+    expect(args).toContain("watch");
+    expect(args.at(-2)).toBe("42");
+    expect(JSON.parse(args.at(-1)!)).toEqual(payload);
+  });
+
+  it("omits tsx watch when reload is disabled", () => {
+    const { args } = buildSpawnArgs({
+      nodeLoader: "tsx",
+      reload: false,
+      pid: 42,
+      payload,
+      resolve: (specifier) => import.meta.resolve(specifier),
+    });
+
+    expect(args).not.toContain("watch");
+  });
+
+  it("builds node import loader args with node --watch", () => {
+    const { command, args } = buildSpawnArgs({
+      nodeLoader: "ts-node",
+      reload: true,
+      pid: 99,
+      payload,
+      resolve: (specifier) => import.meta.resolve(specifier),
+    });
+
+    expect(command).toBe(process.execPath);
+    expect(args[0]).toBe("--watch");
+    expect(args).toContain("--import");
+    expect(args.at(-2)).toBe("99");
+    expect(JSON.parse(args.at(-1)!)).toEqual(payload);
+  });
+
+  it("supports arbitrary import loaders like tsx/esm", () => {
+    const { command, args } = buildSpawnArgs({
+      nodeLoader: "tsx/esm",
+      reload: false,
+      pid: 1,
+      payload,
+      resolve: (specifier) => import.meta.resolve(specifier),
+    });
+
+    expect(command).toBe(process.execPath);
+    expect(args).not.toContain("watch");
+    expect(args[0]).toBe("--import");
+    expect(args[1]).toContain("tsx");
+  });
+});

--- a/libs/langgraph-cli/src/utils/config.mts
+++ b/libs/langgraph-cli/src/utils/config.mts
@@ -95,7 +95,10 @@ const PythonConfigSchema = BaseConfigSchema.merge(
 );
 
 const NodeConfigSchema = BaseConfigSchema.merge(
-  z.object({ node_version: NodeVersionSchema.default(DEFAULT_NODE_VERSION) })
+  z.object({
+    node_version: NodeVersionSchema.default(DEFAULT_NODE_VERSION),
+    node_loader: z.string().optional(),
+  })
 );
 
 const ConfigSchema = z.union([NodeConfigSchema, PythonConfigSchema]);

--- a/libs/langgraph-cli/tests/config.test.mts
+++ b/libs/langgraph-cli/tests/config.test.mts
@@ -1103,6 +1103,19 @@ it("node config and python config", () => {
     env: {},
   });
 
+  expect(
+    getConfig({
+      node_loader: "ts-node",
+      graphs: { agent: "./agent.ts:graph" },
+    })
+  ).toEqual({
+    node_version: "20",
+    node_loader: "ts-node",
+    dockerfile_lines: [],
+    graphs: { agent: "./agent.ts:graph" },
+    env: {},
+  });
+
   // Default multiplatform
   expect(
     getConfig({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -961,7 +961,7 @@ importers:
     devDependencies:
       '@langchain/classic':
         specifier: ^1.0.34
-        version: 1.0.34(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(cheerio@1.2.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(typeorm@0.3.29(better-sqlite3@12.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1))(ws@8.21.0)
+        version: 1.0.34(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(cheerio@1.2.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(typeorm@0.3.29(better-sqlite3@12.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.6.0)(typescript@5.9.3)))(ws@8.21.0)
       '@langchain/core':
         specifier: ^1.2.1
         version: 1.2.1(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
@@ -988,7 +988,7 @@ importers:
         version: 4.21.0
       typeorm:
         specifier: ^0.3.29
-        version: 0.3.29(better-sqlite3@12.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1)
+        version: 0.3.29(better-sqlite3@12.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.6.0)(typescript@5.9.3))
       zod:
         specifier: ^4.3.5
         version: 4.3.6
@@ -1899,6 +1899,9 @@ importers:
       postgres:
         specifier: ^3.4.5
         version: 3.4.8
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@swc/core@1.15.18)(@types/node@18.19.130)(typescript@5.9.3)
       typescript:
         specifier: ^4.9.5 || ^5.4.5
         version: 5.9.3
@@ -3205,6 +3208,10 @@ packages:
     peerDependencies:
       commander: ~13.1.0
 
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@dabh/diagnostics@2.0.8':
     resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
 
@@ -4043,6 +4050,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
@@ -6613,6 +6623,18 @@ packages:
   '@ts-morph/common@0.22.0':
     resolution: {integrity: sha512-HqNBuV/oIlMKdkLshXd1zKBqNQCsuPEsgQOkfFQ/eUKjRlwndXW1AjN9LVkBEIukm00gGXSRmfkl0Wv5VXLnlw==}
 
+  '@tsconfig/node10@1.0.12':
+    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
   '@tsconfig/recommended@1.0.13':
     resolution: {integrity: sha512-sySRuBfMKyKO/j2ZAhR8kSembhjuPEV4Ra3AHtmWLq51+iGaudr45crPSzNC5b7/Ctrh9dfUpBuTlYrH6rM58Q==}
 
@@ -7289,6 +7311,10 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -7377,6 +7403,9 @@ packages:
   archiver@7.0.1:
     resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
     engines: {node: '>= 14'}
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -8308,6 +8337,10 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
+    engines: {node: '>=0.3.1'}
 
   diffie-hellman@5.0.3:
     resolution: {integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==}
@@ -9798,6 +9831,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
   make-fetch-happen@15.0.6:
     resolution: {integrity: sha512-Je0fLJ0F5atA7F+eIlLzk+Wkcl57JDf4kf+EW8xiP5E31xOQxkIxTbgf1Oi1Lw9tRI9UEMRdI5Vz2xTzoNU1Jw==}
@@ -11738,6 +11774,20 @@ packages:
   ts-morph@21.0.1:
     resolution: {integrity: sha512-dbDtVdEAncKctzrVZ+Nr7kHpHkv+0JDJb2MjjpBaj8bFeCkePU9rHfMklmhuLFnpeq/EJZk2IhStY6NzqgjOkg==}
 
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
   tsdown@0.21.1:
     resolution: {integrity: sha512-2Qgm5Pztm1ZOBr6AfJ4pAlspuufa5SlnBgnUx7a0QSm0a73FrBETiRB422gHtMKbgWf1oUtjBL/eK+po7OXwKw==}
     engines: {node: '>=20.19.0'}
@@ -12109,6 +12159,9 @@ packages:
   uuid@14.0.1:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
@@ -12530,6 +12583,10 @@ packages:
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -13415,6 +13472,10 @@ snapshots:
     dependencies:
       commander: 13.1.0
 
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@dabh/diagnostics@2.0.8':
     dependencies:
       '@so-ric/colorspace': 1.1.6
@@ -14116,6 +14177,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   '@js-sdsl/ordered-map@4.4.2': {}
 
   '@jsdevtools/ono@7.1.3': {}
@@ -14156,7 +14222,7 @@ snapshots:
       '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       zod: 4.4.3
 
-  '@langchain/classic@1.0.34(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(cheerio@1.2.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(typeorm@0.3.29(better-sqlite3@12.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1))(ws@8.21.0)':
+  '@langchain/classic@1.0.34(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(@opentelemetry/api@1.9.0)(cheerio@1.2.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(typeorm@0.3.29(better-sqlite3@12.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.6.0)(typescript@5.9.3)))(ws@8.21.0)':
     dependencies:
       '@langchain/core': 1.2.1(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
       '@langchain/openai': 1.4.7(@langchain/core@1.2.1(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0))(ws@8.21.0)
@@ -14170,7 +14236,7 @@ snapshots:
     optionalDependencies:
       cheerio: 1.2.0
       langsmith: 0.6.0(@opentelemetry/api@1.9.0)(openai@6.42.0(ws@8.21.0)(zod@4.3.6))(ws@8.21.0)
-      typeorm: 0.3.29(better-sqlite3@12.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1)
+      typeorm: 0.3.29(better-sqlite3@12.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.6.0)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -16569,6 +16635,14 @@ snapshots:
       mkdirp: 3.0.1
       path-browserify: 1.0.1
 
+  '@tsconfig/node10@1.0.12': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
+
   '@tsconfig/recommended@1.0.13': {}
 
   '@tslab/typescript-for-tslab@5.0.4': {}
@@ -17874,6 +17948,10 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.16.0
+
   acorn@8.16.0: {}
 
   agent-base@6.0.2:
@@ -17978,6 +18056,8 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
+
+  arg@4.1.3: {}
 
   argparse@2.0.1: {}
 
@@ -18970,6 +19050,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  diff@4.0.4: {}
 
   diffie-hellman@5.0.3:
     dependencies:
@@ -20685,6 +20767,8 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  make-error@1.3.6: {}
 
   make-fetch-happen@15.0.6:
     dependencies:
@@ -23485,6 +23569,47 @@ snapshots:
       '@ts-morph/common': 0.22.0
       code-block-writer: 12.0.0
 
+  ts-node@10.9.2(@swc/core@1.15.18)(@types/node@18.19.130)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 18.19.130
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.15.18
+
+  ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.6.0)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.6.0
+      acorn: 8.16.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.15.18
+    optional: true
+
   tsdown@0.21.1(@arethetypeswrong/core@0.18.2)(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@typescript/native-preview@7.0.0-dev.20260310.1)(publint@0.3.18)(synckit@0.11.12)(typescript@5.9.3)(unplugin-unused@0.5.7):
     dependencies:
       ansis: 4.2.0
@@ -23596,7 +23721,7 @@ snapshots:
       es-errors: 1.3.0
       is-typed-array: 1.1.15
 
-  typeorm@0.3.29(better-sqlite3@12.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1):
+  typeorm@0.3.29(better-sqlite3@12.10.0)(mongodb@6.21.0(socks@2.8.7))(pg@8.20.0)(redis@4.7.1)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.6.0)(typescript@5.9.3)):
     dependencies:
       '@sqltools/formatter': 1.2.5
       ansis: 4.3.1
@@ -23618,6 +23743,7 @@ snapshots:
       mongodb: 6.21.0(socks@2.8.7)
       pg: 8.20.0
       redis: 4.7.1
+      ts-node: 10.9.2(@swc/core@1.15.18)(@types/node@25.6.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -23823,6 +23949,8 @@ snapshots:
   uuid@11.1.1: {}
 
   uuid@14.0.1: {}
+
+  v8-compile-cache-lib@3.0.1: {}
 
   validate-npm-package-name@5.0.1: {}
 
@@ -24589,6 +24717,8 @@ snapshots:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+
+  yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary
- Add configurable TypeScript loader support for the in-memory dev server to fix reflect-metadata / `emitDecoratorMetadata` incompatibility with tsx (esbuild).
- Introduce `node_loader` on Node `langgraph.json` configs and `LANGGRAPH_NODE_LOADER` env override; default remains `tsx` CLI watch mode.
- Generalize non-tsx loaders to `node [--watch] --import <loader> --import preload entrypoint`, with shorthand mapping for `ts-node` → `ts-node/esm`.
- Add `spawn-args` helper + unit tests; add `ts-node` as optional peer dependency of `@langchain/langgraph-api`.

Fixes #1834