### PR TITLE
fix(cli): support node_version 24 in langgraph.json

### DIFF
--- a/.changeset/support-node-version-24.md
+++ b/.changeset/support-node-version-24.md
@@ -1,0 +1,10 @@
+---
+"@langchain/langgraph-api": patch
+"@langchain/langgraph-cli": patch
+"@langchain/langgraph-ui": patch
+---
+
+fix(cli): support node_version 24 in langgraph.json
+
+Allow Node 24 in the CLI config schema and Docker base image resolution.
+The langgraphjs-api:24 image is already published from langgraph-api.

--- a/libs/langgraph-cli/README.md
+++ b/libs/langgraph-cli/README.md
@@ -56,7 +56,7 @@ The CLI uses a `langgraph.json` configuration file with these key settings:
   },
 
   // Optional: Node version (supported: "20", "22", "24")
-  node_version: "20",
+  node_version: "24",
 
   // Optional: Environment variables
   env: ".env",

--- a/libs/langgraph-cli/README.md
+++ b/libs/langgraph-cli/README.md
@@ -55,7 +55,7 @@ The CLI uses a `langgraph.json` configuration file with these key settings:
     graph: "./src/graph.ts:graph",
   },
 
-  // Optional: Node version (20 only at the moment)
+  // Optional: Node version (supported: "20", "22", "24")
   node_version: "20",
 
   // Optional: Environment variables

--- a/libs/langgraph-cli/src/utils/config.mts
+++ b/libs/langgraph-cli/src/utils/config.mts
@@ -78,7 +78,11 @@ const DEFAULT_NODE_VERSION = "20" as const;
 const PYTHON_EXTENSIONS = [".py", ".pyx", ".pyd", ".pyi"];
 
 const PythonVersionSchema = z.union([z.literal("3.11"), z.literal("3.12")]);
-const NodeVersionSchema = z.union([z.literal("20"), z.literal("22")]);
+const NodeVersionSchema = z.union([
+  z.literal("20"),
+  z.literal("22"),
+  z.literal("24"),
+]);
 
 const PythonConfigSchema = BaseConfigSchema.merge(
   z.object({

--- a/libs/langgraph-cli/tests/config.test.mts
+++ b/libs/langgraph-cli/tests/config.test.mts
@@ -355,6 +355,31 @@ describe("config to docker", () => {
     `);
   });
 
+  it("js with node_version 24", async () => {
+    const graphs = { agent: "./graphs/agent.js:graph" };
+    const config = getConfig({
+      dockerfile_lines: [],
+      env: {},
+      node_version: "24" as const,
+      graphs,
+    });
+
+    const actual = await configToDocker(
+      PATH_TO_CONFIG,
+      config,
+      await assembleLocalDeps(PATH_TO_CONFIG, config)
+    );
+
+    expect(actual).toEqual(dedenter`
+      FROM langchain/langgraphjs-api:24
+      ADD . /deps/unit_tests
+      ENV LANGSERVE_GRAPHS='{"agent":"./graphs/agent.js:graph"}'
+      WORKDIR /deps/unit_tests
+      RUN npm i
+      RUN (test ! -f /api/langgraph_api/js/build.mts && echo "Prebuild script not found, skipping") || tsx /api/langgraph_api/js/build.mts
+    `);
+  });
+
   it("python with api_version", async () => {
     const graphs = { agent: "./agent.py:graph" };
     const config = getConfig({
@@ -983,6 +1008,25 @@ describe("getBaseImage", () => {
     );
   });
 
+  it("node 24 without api_version", () => {
+    const config = getConfig({
+      node_version: "24",
+      graphs: { agent: "./agent.js:graph" },
+    });
+    expect(getBaseImage(config)).toBe("langchain/langgraphjs-api:24");
+  });
+
+  it("node 24 with api_version", () => {
+    const config = getConfig({
+      node_version: "24",
+      graphs: { agent: "./agent.js:graph" },
+      api_version: "0.7.29",
+    });
+    expect(getBaseImage(config)).toBe(
+      "langchain/langgraphjs-api:0.7.29-node24"
+    );
+  });
+
   it("python without api_version", () => {
     const config = getConfig({
       python_version: "3.11",
@@ -1113,6 +1157,19 @@ it("node config and python config", () => {
     node_loader: "ts-node",
     dockerfile_lines: [],
     graphs: { agent: "./agent.ts:graph" },
+    env: {},
+  });
+
+  // node_version 24 is supported
+  expect(
+    getConfig({
+      node_version: "24",
+      graphs: { agent: "./agent.js:graph" },
+    })
+  ).toEqual({
+    node_version: "24",
+    dockerfile_lines: [],
+    graphs: { agent: "./agent.js:graph" },
     env: {},
   });
 


### PR DESCRIPTION
## Summary
- Add `"24"` to `NodeVersionSchema` in `@langchain/langgraph-cli` so `node_version: "24"` is accepted in `langgraph.json`.
- Add config, `getBaseImage`, and `configToDocker` tests for Node 24 tag resolution (`langchain/langgraphjs-api:24` and `{api_version}-node24`).
- Update CLI README to document supported Node versions (`"20"`, `"22"`, `"24"`).
