### PR TITLE
fix(api): inject langgraph_auth_user on protocol-v2 run.start

### DIFF
--- a/.changeset/fix-protocol-v2-auth-user-config.md
+++ b/.changeset/fix-protocol-v2-auth-user-config.md
@@ -1,0 +1,11 @@
+---
+"@langchain/langgraph-api": patch
+"@langchain/langgraph-cli": patch
+"@langchain/langgraph-ui": patch
+---
+
+fix(api): inject langgraph_auth_user on protocol-v2 run.start
+
+Stamp authenticated user fields onto run config in createOrResumeRun so
+v2 streaming matches the REST runs API. Shared helpers also dedupe REST
+run config auth/header enrichment.

--- a/libs/langgraph-api/src/api/runs.mts
+++ b/libs/langgraph-api/src/api/runs.mts
@@ -15,6 +15,10 @@ import {
   jsonExtra,
   waitKeepAlive,
 } from "../utils/hono.mjs";
+import {
+  applyAuthToRunConfig,
+  applyRequestHeadersToRunConfig,
+} from "../utils/run-auth.mjs";
 import { serialiseAsDict } from "../utils/serde.mjs";
 
 const api = new Hono();
@@ -61,31 +65,8 @@ const createValidRun = async (
     });
   }
 
-  if (headers) {
-    for (const [rawKey, value] of headers.entries()) {
-      const key = rawKey.toLowerCase();
-      if (key.startsWith("x-")) {
-        if (["x-api-key", "x-tenant-id", "x-service-key"].includes(key)) {
-          continue;
-        }
-
-        config.configurable ??= {};
-        config.configurable[key] = value;
-      } else if (key === "user-agent") {
-        config.configurable ??= {};
-        config.configurable[key] = value;
-      }
-    }
-  }
-
-  let userId: string | undefined;
-  if (auth) {
-    userId = auth.user.identity ?? auth.user.id;
-    config.configurable ??= {};
-    config.configurable["langgraph_auth_user"] = auth.user;
-    config.configurable["langgraph_auth_user_id"] = userId;
-    config.configurable["langgraph_auth_permissions"] = auth.scopes;
-  }
+  applyRequestHeadersToRunConfig(config, headers);
+  const userId = applyAuthToRunConfig(config, auth);
 
   let feedbackKeys =
     run.feedback_keys != null

--- a/libs/langgraph-api/src/protocol/service.mts
+++ b/libs/langgraph-api/src/protocol/service.mts
@@ -23,6 +23,7 @@ import type {
   ProtocolTransportName,
   StateGetResult,
 } from "./types.mjs";
+import { applyAuthToRunConfig } from "../utils/run-auth.mjs";
 import { PROTOCOL_STREAM_RUN_KEY } from "./constants.mjs";
 import { RunProtocolSession } from "./session/index.mjs";
 
@@ -483,6 +484,7 @@ export class ProtocolService {
         thread_id: record.threadId,
       },
     };
+    const userId = applyAuthToRunConfig(runConfig, record.auth);
 
     const runPayload = {
       assistant_id: assistantId,
@@ -530,6 +532,7 @@ export class ProtocolService {
       },
       {
         threadId: record.threadId,
+        userId,
         metadata: runPayload.metadata,
         status: "pending",
         multitaskStrategy: runPayload.multitask_strategy,

--- a/libs/langgraph-api/src/utils/run-auth.mts
+++ b/libs/langgraph-api/src/utils/run-auth.mts
@@ -1,0 +1,54 @@
+import type { AuthContext } from "../auth/index.mjs";
+import type { RunnableConfig } from "../storage/types.mjs";
+
+const BLOCKED_CONFIGURABLE_HEADERS = new Set([
+  "x-api-key",
+  "x-tenant-id",
+  "x-service-key",
+]);
+
+/**
+ * Copy allowed request headers into `config.configurable`, matching the REST
+ * runs API (`createValidRun`). Used by both REST and protocol-v2 run creation.
+ */
+export function applyRequestHeadersToRunConfig(
+  config: RunnableConfig,
+  headers: Headers | undefined
+): void {
+  if (!headers) return;
+
+  for (const [rawKey, value] of headers.entries()) {
+    const key = rawKey.toLowerCase();
+    if (key.startsWith("x-")) {
+      if (BLOCKED_CONFIGURABLE_HEADERS.has(key)) continue;
+      config.configurable ??= {};
+      config.configurable[key] = value;
+    } else if (key === "user-agent") {
+      config.configurable ??= {};
+      config.configurable[key] = value;
+    }
+  }
+}
+
+/**
+ * Stamp the authenticated user onto `config.configurable` so graph nodes and
+ * tools can read `langgraph_auth_user`. Returns the resolved user id for run
+ * metadata when auth is present.
+ */
+export function applyAuthToRunConfig(
+  config: RunnableConfig,
+  auth: AuthContext | undefined
+): string | undefined {
+  if (!auth) return undefined;
+
+  const userId =
+    auth.user.identity ??
+    (typeof auth.user.id === "string" ? auth.user.id : undefined);
+
+  config.configurable ??= {};
+  config.configurable.langgraph_auth_user = auth.user;
+  config.configurable.langgraph_auth_user_id = userId;
+  config.configurable.langgraph_auth_permissions = auth.scopes;
+
+  return userId;
+}

--- a/libs/langgraph-api/tests/run-auth.test.mts
+++ b/libs/langgraph-api/tests/run-auth.test.mts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import type { AuthContext } from "../src/auth/index.mjs";
+import {
+  applyAuthToRunConfig,
+  applyRequestHeadersToRunConfig,
+} from "../src/utils/run-auth.mjs";
+
+describe("applyAuthToRunConfig", () => {
+  it("stamps langgraph_auth_user onto config.configurable", () => {
+    const auth: AuthContext = {
+      user: {
+        identity: "user-123",
+        permissions: [],
+        display_name: "Test User",
+        is_authenticated: true,
+        mda_actor_id: "user-123",
+      },
+      scopes: ["threads:read", "threads:create_run"],
+    };
+
+    const config: { configurable?: Record<string, unknown> } = {
+      configurable: { thread_id: "t1" },
+    };
+    const userId = applyAuthToRunConfig(config, auth);
+
+    expect(userId).toBe("user-123");
+    expect(config.configurable?.langgraph_auth_user).toEqual(auth.user);
+    expect(config.configurable?.langgraph_auth_user_id).toBe("user-123");
+    expect(config.configurable?.langgraph_auth_permissions).toEqual(
+      auth.scopes
+    );
+  });
+
+  it("returns undefined when auth is absent", () => {
+    const config: { configurable?: Record<string, unknown> } = {};
+    expect(applyAuthToRunConfig(config, undefined)).toBeUndefined();
+    expect(config.configurable?.langgraph_auth_user).toBeUndefined();
+  });
+});
+
+describe("applyRequestHeadersToRunConfig", () => {
+  it("copies allowed x- headers and user-agent into configurable", () => {
+    const config: { configurable?: Record<string, unknown> } = {};
+    const headers = new Headers({
+      "x-configurable-header": "hello",
+      "x-api-key": "secret",
+      "user-agent": "vitest",
+    });
+
+    applyRequestHeadersToRunConfig(config, headers);
+
+    expect(config.configurable?.["x-configurable-header"]).toBe("hello");
+    expect(config.configurable?.["user-agent"]).toBe("vitest");
+    expect(config.configurable?.["x-api-key"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Inject `langgraph_auth_user`, `langgraph_auth_user_id`, and `langgraph_auth_permissions` into run config in protocol v2 `createOrResumeRun`, matching the REST `createValidRun` behavior.
- Extract shared `applyAuthToRunConfig` / `applyRequestHeadersToRunConfig` helpers and use them from both REST and protocol paths.
- Pass `userId` into `runs.put()` from the protocol path for parity with REST.
