### PR TITLE
fix(sdk): reattach streams for active runs on hydrate

### DIFF
--- a/.changeset/fix-stream-hydrate-active-run.md
+++ b/.changeset/fix-stream-hydrate-active-run.md
@@ -4,4 +4,4 @@
 
 fix(sdk): reattach streams when hydrate sees an active run
 
-Check for a pending or running run when `getState()` returns an idle-looking checkpoint so refreshed clients reconnect instead of rendering an idle chat while the run continues server-side.
+Check for a pending or running run when `getState()` returns an idle-looking checkpoint so refreshed clients reconnect instead of rendering an idle chat while the run continues server-side. Custom adapters can provide the probe through their own transport/auth context.

--- a/.changeset/fix-stream-hydrate-active-run.md
+++ b/.changeset/fix-stream-hydrate-active-run.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): reattach streams when hydrate sees an active run
+
+Check for a pending or running run when `getState()` returns an idle-looking checkpoint so refreshed clients reconnect instead of rendering an idle chat while the run continues server-side.

--- a/libs/sdk-react/src/tests/components/ReattachStream.tsx
+++ b/libs/sdk-react/src/tests/components/ReattachStream.tsx
@@ -1,9 +1,8 @@
 import { useMemo, useState } from "react";
 import { HumanMessage, type BaseMessage } from "@langchain/core/messages";
-import type { Client } from "@langchain/langgraph-sdk";
 import type { AgentServerAdapter } from "@langchain/langgraph-sdk/stream";
 
-import { useStream, type UseStreamOptions } from "../../index.js";
+import { useStream } from "../../index.js";
 
 interface StreamState {
   messages: BaseMessage[];
@@ -13,7 +12,6 @@ interface Props {
   apiUrl?: string;
   assistantId?: string;
   createSecondaryTransport?: (threadId: string) => AgentServerAdapter;
-  createSecondaryClient?: (threadId: string) => Client;
 }
 
 /**
@@ -30,7 +28,6 @@ export function ReattachStream({
   apiUrl,
   assistantId = "slow_graph",
   createSecondaryTransport,
-  createSecondaryClient,
 }: Props) {
   const [threadId, setThreadId] = useState<string | undefined>(undefined);
   const [secondaryMounted, setSecondaryMounted] = useState(false);
@@ -38,10 +35,6 @@ export function ReattachStream({
   const secondaryTransport = useMemo(
     () => (threadId != null ? createSecondaryTransport?.(threadId) : undefined),
     [createSecondaryTransport, threadId],
-  );
-  const secondaryClient = useMemo(
-    () => (threadId != null ? createSecondaryClient?.(threadId) : undefined),
-    [createSecondaryClient, threadId],
   );
 
   const primary = useStream<StreamState>({
@@ -56,7 +49,6 @@ export function ReattachStream({
     secondaryContent =
       secondaryTransport != null ? (
         <SecondaryCustomStream
-          client={secondaryClient}
           transport={secondaryTransport}
           threadId={threadId}
         />
@@ -134,22 +126,15 @@ function SecondaryStream({ apiUrl, assistantId, threadId }: SecondaryProps) {
 }
 
 interface SecondaryCustomProps {
-  client?: Client;
   transport: AgentServerAdapter;
   threadId: string;
 }
 
-function SecondaryCustomStream({
-  client,
-  transport,
-  threadId,
-}: SecondaryCustomProps) {
-  const options = {
-    ...(client != null ? { client } : {}),
+function SecondaryCustomStream({ transport, threadId }: SecondaryCustomProps) {
+  const secondary = useStream<StreamState>({
     transport,
     threadId,
-  } as unknown as UseStreamOptions<StreamState>;
-  const secondary = useStream<StreamState>(options);
+  });
   return (
     <div>
       <div data-testid="secondary-mounted">yes</div>

--- a/libs/sdk-react/src/tests/components/ReattachStream.tsx
+++ b/libs/sdk-react/src/tests/components/ReattachStream.tsx
@@ -1,7 +1,9 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { HumanMessage, type BaseMessage } from "@langchain/core/messages";
+import type { Client } from "@langchain/langgraph-sdk";
+import type { AgentServerAdapter } from "@langchain/langgraph-sdk/stream";
 
-import { useStream } from "../../index.js";
+import { useStream, type UseStreamOptions } from "../../index.js";
 
 interface StreamState {
   messages: BaseMessage[];
@@ -10,6 +12,8 @@ interface StreamState {
 interface Props {
   apiUrl?: string;
   assistantId?: string;
+  createSecondaryTransport?: (threadId: string) => AgentServerAdapter;
+  createSecondaryClient?: (threadId: string) => Client;
 }
 
 /**
@@ -25,21 +29,53 @@ interface Props {
 export function ReattachStream({
   apiUrl,
   assistantId = "slow_graph",
+  createSecondaryTransport,
+  createSecondaryClient,
 }: Props) {
   const [threadId, setThreadId] = useState<string | undefined>(undefined);
   const [secondaryMounted, setSecondaryMounted] = useState(false);
+  const [primaryRunCreated, setPrimaryRunCreated] = useState(false);
+  const secondaryTransport = useMemo(
+    () => (threadId != null ? createSecondaryTransport?.(threadId) : undefined),
+    [createSecondaryTransport, threadId],
+  );
+  const secondaryClient = useMemo(
+    () => (threadId != null ? createSecondaryClient?.(threadId) : undefined),
+    [createSecondaryClient, threadId],
+  );
 
   const primary = useStream<StreamState>({
     assistantId,
     apiUrl,
     threadId,
     onThreadId: (id) => setThreadId(id),
+    onCreated: () => setPrimaryRunCreated(true),
   });
+  let secondaryContent = <div data-testid="secondary-mounted">no</div>;
+  if (secondaryMounted && threadId != null) {
+    secondaryContent =
+      secondaryTransport != null ? (
+        <SecondaryCustomStream
+          client={secondaryClient}
+          transport={secondaryTransport}
+          threadId={threadId}
+        />
+      ) : (
+        <SecondaryStream
+          apiUrl={apiUrl}
+          assistantId={assistantId}
+          threadId={threadId}
+        />
+      );
+  }
 
   return (
     <div>
       <div data-testid="primary-loading">
         {primary.isLoading ? "Loading..." : "Not loading"}
+      </div>
+      <div data-testid="primary-run-created">
+        {primaryRunCreated ? "yes" : "no"}
       </div>
       <div data-testid="primary-thread-id">{primary.threadId ?? "none"}</div>
       <div data-testid="primary-message-count">{primary.messages.length}</div>
@@ -64,11 +100,7 @@ export function ReattachStream({
       >
         Unmount secondary
       </button>
-      {secondaryMounted && threadId != null ? (
-        <SecondaryStream apiUrl={apiUrl} assistantId={assistantId} threadId={threadId} />
-      ) : (
-        <div data-testid="secondary-mounted">no</div>
-      )}
+      {secondaryContent}
     </div>
   );
 }
@@ -85,6 +117,39 @@ function SecondaryStream({ apiUrl, assistantId, threadId }: SecondaryProps) {
     apiUrl,
     threadId,
   });
+  return (
+    <div>
+      <div data-testid="secondary-mounted">yes</div>
+      <div data-testid="secondary-loading">
+        {secondary.isLoading ? "Loading..." : "Not loading"}
+      </div>
+      <div data-testid="secondary-thread-id">
+        {secondary.threadId ?? "none"}
+      </div>
+      <div data-testid="secondary-message-count">
+        {secondary.messages.length}
+      </div>
+    </div>
+  );
+}
+
+interface SecondaryCustomProps {
+  client?: Client;
+  transport: AgentServerAdapter;
+  threadId: string;
+}
+
+function SecondaryCustomStream({
+  client,
+  transport,
+  threadId,
+}: SecondaryCustomProps) {
+  const options = {
+    ...(client != null ? { client } : {}),
+    transport,
+    threadId,
+  } as unknown as UseStreamOptions<StreamState>;
+  const secondary = useStream<StreamState>(options);
   return (
     <div>
       <div data-testid="secondary-mounted">yes</div>

--- a/libs/sdk-react/src/tests/stream.reattach.test.tsx
+++ b/libs/sdk-react/src/tests/stream.reattach.test.tsx
@@ -1,8 +1,79 @@
 import { expect, it } from "vitest";
 import { render } from "vitest-browser-react";
+import {
+  Client,
+  HttpAgentServerAdapter,
+  type AgentServerAdapter,
+} from "@langchain/langgraph-sdk";
 
 import { ReattachStream } from "./components/ReattachStream.js";
 import { apiUrl, cleanupRender } from "./test-utils.js";
+
+function createIdleHydrateAdapter(
+  baseUrl: string,
+  threadId: string,
+  hits?: { getState: number },
+): AgentServerAdapter & { apiUrl: string } {
+  const delegate = new HttpAgentServerAdapter({ apiUrl: baseUrl, threadId });
+  return {
+    apiUrl: baseUrl,
+    get threadId() {
+      return delegate.threadId;
+    },
+    setThreadId(nextThreadId) {
+      delegate.setThreadId(nextThreadId);
+    },
+    getState: async <StateType,>() => {
+      if (hits != null) hits.getState += 1;
+      return {
+        values: { messages: [] } as StateType,
+        next: [],
+        tasks: [],
+        checkpoint: null,
+        parent_checkpoint: null,
+        metadata: { step: 0 },
+      };
+    },
+    open: () => delegate.open(),
+    send: (command) => delegate.send(command),
+    events: () => delegate.events(),
+    openEventStream: (params) => delegate.openEventStream(params),
+    close: () => delegate.close(),
+  };
+}
+
+function createActiveRunFetch(baseUrl: string, threadId: string): {
+  fetch: typeof fetch;
+  hits: { count: number };
+} {
+  const hits = { count: 0 };
+  const wrappedFetch: typeof fetch = async (input, init) => {
+    const rawUrl =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    const url = new URL(
+      rawUrl,
+      rawUrl.startsWith("/") ? baseUrl : undefined,
+    );
+    const method =
+      init?.method ?? (input instanceof Request ? input.method : "GET");
+    if (method === "GET" && url.pathname === `/threads/${threadId}/runs`) {
+      hits.count += 1;
+      return new Response(
+        JSON.stringify([{ run_id: "active-run", status: "running" }]),
+        { headers: { "content-type": "application/json" } },
+      );
+    }
+    return globalThis.fetch(input, init);
+  };
+  return {
+    fetch: wrappedFetch,
+    hits,
+  };
+}
 
 /**
  * R2.7 re-attach harness automation. Boots a slow graph (see
@@ -84,6 +155,81 @@ it("secondary hook attaches to an in-flight run on the same thread", async () =>
     await expect
       .element(screen.getByTestId("secondary-message-count"))
       .toHaveTextContent("4");
+  } finally {
+    await cleanupRender(screen);
+  }
+});
+
+it("reattaches when the hydrated checkpoint looks idle but the run is active", async () => {
+  const adapterHits = { getState: 0 };
+  const activeRunFetchByThread = new Map<
+    string,
+    ReturnType<typeof createActiveRunFetch>
+  >();
+  const screen = await render(
+    <ReattachStream
+      apiUrl={apiUrl}
+      createSecondaryTransport={(threadId) =>
+        createIdleHydrateAdapter(apiUrl, threadId, adapterHits)
+      }
+      createSecondaryClient={(threadId) => {
+        const activeRunFetch = createActiveRunFetch(apiUrl, threadId);
+        activeRunFetchByThread.set(threadId, activeRunFetch);
+        return new Client({
+          apiUrl,
+          callerOptions: { fetch: activeRunFetch.fetch },
+        });
+      }}
+    />,
+  );
+
+  try {
+    await screen.getByTestId("primary-submit").click();
+
+    await expect
+      .element(screen.getByTestId("primary-loading"))
+      .toHaveTextContent("Loading...");
+
+    await expect
+      .poll(() =>
+        screen.getByTestId("primary-thread-id").element().textContent?.trim(),
+      )
+      .not.toBe("none");
+    await expect
+      .element(screen.getByTestId("primary-run-created"))
+      .toHaveTextContent("yes");
+    const threadId = screen
+      .getByTestId("primary-thread-id")
+      .element()
+      .textContent?.trim();
+    expect(threadId).toMatch(/.+/);
+    const activeRunFetch = activeRunFetchByThread.get(threadId!);
+    expect(activeRunFetch).toBeDefined();
+
+    await screen.getByTestId("secondary-mount").click();
+
+    await expect
+      .element(screen.getByTestId("secondary-mounted"))
+      .toHaveTextContent("yes");
+    await expect.poll(() => adapterHits.getState).toBeGreaterThan(0);
+    await expect
+      .poll(() => activeRunFetch?.hits.count ?? 0)
+      .toBeGreaterThan(0);
+
+    // Regression coverage for a page refresh before the new run writes
+    // a state-advancing checkpoint. `getState()` can still return the
+    // previous idle checkpoint, but the controller should discover and
+    // reattach to the active run instead of rendering an idle UI.
+    await expect
+      .element(screen.getByTestId("secondary-loading"), { timeout: 1_000 })
+      .toHaveTextContent("Loading...");
+
+    await expect
+      .element(screen.getByTestId("secondary-loading"))
+      .toHaveTextContent("Not loading");
+    await expect
+      .element(screen.getByTestId("secondary-message-count"))
+      .toHaveTextContent("2");
   } finally {
     await cleanupRender(screen);
   }

--- a/libs/sdk-react/src/tests/stream.reattach.test.tsx
+++ b/libs/sdk-react/src/tests/stream.reattach.test.tsx
@@ -1,7 +1,6 @@
 import { expect, it } from "vitest";
 import { render } from "vitest-browser-react";
 import {
-  Client,
   HttpAgentServerAdapter,
   type AgentServerAdapter,
 } from "@langchain/langgraph-sdk";
@@ -9,19 +8,29 @@ import {
 import { ReattachStream } from "./components/ReattachStream.js";
 import { apiUrl, cleanupRender } from "./test-utils.js";
 
+type ActiveRunAdapter = AgentServerAdapter & {
+  apiUrl: string;
+  hasActiveRun?: () => Promise<boolean>;
+};
+
 function createIdleHydrateAdapter(
   baseUrl: string,
   threadId: string,
   hits?: { getState: number },
-): AgentServerAdapter & { apiUrl: string } {
-  const delegate = new HttpAgentServerAdapter({ apiUrl: baseUrl, threadId });
+  fetch?: typeof globalThis.fetch,
+): ActiveRunAdapter {
+  const delegate = new HttpAgentServerAdapter({
+    apiUrl: baseUrl,
+    threadId,
+    fetch,
+  }) as ActiveRunAdapter;
   return {
     apiUrl: baseUrl,
     get threadId() {
       return delegate.threadId;
     },
     setThreadId(nextThreadId) {
-      delegate.setThreadId(nextThreadId);
+      delegate.setThreadId?.(nextThreadId);
     },
     getState: async <StateType,>() => {
       if (hits != null) hits.getState += 1;
@@ -37,7 +46,14 @@ function createIdleHydrateAdapter(
     open: () => delegate.open(),
     send: (command) => delegate.send(command),
     events: () => delegate.events(),
-    openEventStream: (params) => delegate.openEventStream(params),
+    openEventStream: (params) => {
+      const handle = delegate.openEventStream?.(params);
+      if (handle == null) {
+        throw new Error("Expected test delegate to support event streams.");
+      }
+      return handle;
+    },
+    hasActiveRun: () => delegate.hasActiveRun?.() ?? Promise.resolve(false),
     close: () => delegate.close(),
   };
 }
@@ -162,23 +178,18 @@ it("secondary hook attaches to an in-flight run on the same thread", async () =>
 
 it("reattaches when the hydrated checkpoint looks idle but the run is active", async () => {
   const adapterHits = { getState: 0 };
-  const activeRunFetchByThread = new Map<
-    string,
-    ReturnType<typeof createActiveRunFetch>
-  >();
+  let activeRunFetch: ReturnType<typeof createActiveRunFetch> | undefined;
   const screen = await render(
     <ReattachStream
       apiUrl={apiUrl}
-      createSecondaryTransport={(threadId) =>
-        createIdleHydrateAdapter(apiUrl, threadId, adapterHits)
-      }
-      createSecondaryClient={(threadId) => {
-        const activeRunFetch = createActiveRunFetch(apiUrl, threadId);
-        activeRunFetchByThread.set(threadId, activeRunFetch);
-        return new Client({
+      createSecondaryTransport={(threadId) => {
+        activeRunFetch = createActiveRunFetch(apiUrl, threadId);
+        return createIdleHydrateAdapter(
           apiUrl,
-          callerOptions: { fetch: activeRunFetch.fetch },
-        });
+          threadId,
+          adapterHits,
+          activeRunFetch.fetch,
+        );
       }}
     />,
   );
@@ -203,7 +214,6 @@ it("reattaches when the hydrated checkpoint looks idle but the run is active", a
       .element()
       .textContent?.trim();
     expect(threadId).toMatch(/.+/);
-    const activeRunFetch = activeRunFetchByThread.get(threadId!);
     expect(activeRunFetch).toBeDefined();
 
     await screen.getByTestId("secondary-mount").click();

--- a/libs/sdk/src/client/stream/transport.ts
+++ b/libs/sdk/src/client/stream/transport.ts
@@ -124,6 +124,14 @@ export interface AgentServerAdapter extends TransportAdapter {
     parent_checkpoint?: { checkpoint_id?: string } | null;
   } | null>;
   /**
+   * Check whether the bound thread has a pending or running run.
+   * Used during hydration when checkpoint state looks idle but the
+   * server may have accepted a new run that has not written its first
+   * state-advancing checkpoint yet. Optional adapters should implement
+   * this with the same auth / routing context as their other requests.
+   */
+  hasActiveRun?(): Promise<boolean>;
+  /**
    * Fetch a slice of checkpoint history for the bound thread. Used
    * by branching and time-travel UIs. Optional — omitting it turns
    * those UIs into no-ops rather than surfacing an error.

--- a/libs/sdk/src/client/stream/transport/agent-server.test.ts
+++ b/libs/sdk/src/client/stream/transport/agent-server.test.ts
@@ -28,6 +28,48 @@ describe("HttpAgentServerAdapter hydration", () => {
     });
   });
 
+  it("exposes hasActiveRun through the SSE delegate auth context", async () => {
+    const calls: Array<{ href: string; headers: Headers }> = [];
+    const fetch = (async (input, init) => {
+      const href =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      calls.push({ href, headers: new Headers(init?.headers) });
+      return new Response(JSON.stringify([{ status: "running" }]), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof globalThis.fetch;
+    const adapter = new HttpAgentServerAdapter({
+      apiUrl: "http://localhost:4100/api",
+      threadId: "thread-1",
+      defaultHeaders: {
+        authorization: "Bearer adapter-token",
+      },
+      onRequest: (_url, init) => {
+        const headers = new Headers(init.headers);
+        headers.set("x-request-hook", "yes");
+        return { ...init, headers };
+      },
+      paths: {
+        runs: (threadId) => `/sessions/${threadId}/runs`,
+      },
+      fetch,
+    });
+
+    expect(adapter.hasActiveRun).toEqual(expect.any(Function));
+    await expect(adapter.hasActiveRun?.()).resolves.toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].href).toBe(
+      "http://localhost:4100/api/sessions/thread-1/runs?limit=1"
+    );
+    expect(calls[0].headers.get("authorization")).toBe("Bearer adapter-token");
+    expect(calls[0].headers.get("x-request-hook")).toBe("yes");
+  });
+
   it("omits getState for WebSocket delegates", () => {
     const { webSocketFactory } = createWebSocketUrlRecorder();
     const adapter = new HttpAgentServerAdapter({
@@ -37,6 +79,7 @@ describe("HttpAgentServerAdapter hydration", () => {
     });
 
     expect(adapter.getState).toBeUndefined();
+    expect(adapter.hasActiveRun).toBeUndefined();
   });
 });
 

--- a/libs/sdk/src/client/stream/transport/agent-server.ts
+++ b/libs/sdk/src/client/stream/transport/agent-server.ts
@@ -83,6 +83,12 @@ export class HttpAgentServerAdapter implements AgentServerAdapter {
    */
   getState?: AgentServerAdapter["getState"];
 
+  /**
+   * Active-run reads are SSE-only. WebSocket delegates omit this so
+   * {@link StreamController} falls back to the configured client.
+   */
+  hasActiveRun?: AgentServerAdapter["hasActiveRun"];
+
   constructor(options: HttpAgentServerAdapterOptions) {
     this.threadId = options.threadId ?? "";
     this.apiUrl = options.apiUrl;
@@ -109,6 +115,7 @@ export class HttpAgentServerAdapter implements AgentServerAdapter {
     if (options.webSocketFactory == null) {
       const sse = this.#delegate as ProtocolSseTransportAdapter;
       this.getState = sse.getState.bind(sse);
+      this.hasActiveRun = sse.hasActiveRun.bind(sse);
     }
   }
 

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -130,6 +130,14 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
     );
   }
 
+  private get runsUrl(): string {
+    return resolveProtocolPath(
+      this.paths?.runs,
+      this.threadId,
+      (id) => `/threads/${id}/runs`
+    );
+  }
+
   /**
    * Fetch checkpointed thread state for hydration.
    *
@@ -176,6 +184,19 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
       checkpoint?: { checkpoint_id?: string } | null;
       parent_checkpoint?: { checkpoint_id?: string } | null;
     };
+  }
+
+  /**
+   * Check whether the currently-bound thread has an in-flight run using
+   * the same HTTP auth/proxy context as state reads and stream commands.
+   */
+  async hasActiveRun(): Promise<boolean> {
+    const response = await this.request(`${this.runsUrl}?limit=1`, {
+      method: "GET",
+    });
+    const runs = (await response.json()) as Array<{ status?: unknown }>;
+    const latestRun = Array.isArray(runs) ? runs[0] : undefined;
+    return latestRun?.status === "pending" || latestRun?.status === "running";
   }
 
   private async resolveFetch(): Promise<typeof fetch> {

--- a/libs/sdk/src/client/stream/transport/types.ts
+++ b/libs/sdk/src/client/stream/transport/types.ts
@@ -21,6 +21,8 @@ export interface ProtocolTransportPaths {
   stream?: ProtocolPath;
   /** `GET` path for thread-state hydration. Defaults to `/threads/:threadId/state`. */
   state?: ProtocolPath;
+  /** `GET` path for active-run hydration probes. Defaults to `/threads/:threadId/runs`. */
+  runs?: ProtocolPath;
 }
 
 export interface ProtocolSseTransportOptions {

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -497,10 +497,20 @@ export class StreamController<
    * (`next: []`, no interrupts) after a new run has been accepted but
    * before that run writes its first state-advancing checkpoint. Hydrate
    * uses this to avoid treating that window as a finished thread and
-   * skipping the root pump/lifecycle watcher on page refresh.
+   * skipping the root pump/lifecycle watcher on page refresh. Custom
+   * adapters can provide this probe themselves so authenticated adapter
+   * requests do not fall back to an unauthenticated synthetic client.
    */
   async #hasActiveRun(threadId: string): Promise<boolean> {
     try {
+      const transport = this.#options.transport;
+      if (
+        transport != null &&
+        typeof transport === "object" &&
+        typeof transport.hasActiveRun === "function"
+      ) {
+        return await transport.hasActiveRun();
+      }
       const [latestRun] = await this.#options.client.runs.list(threadId, {
         limit: 1,
       });

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -490,6 +490,29 @@ export class StreamController<
   }
 
   /**
+   * Check whether the server has an in-flight run even when the latest
+   * checkpoint snapshot looks idle.
+   *
+   * `getState()` can briefly return the previous completed checkpoint
+   * (`next: []`, no interrupts) after a new run has been accepted but
+   * before that run writes its first state-advancing checkpoint. Hydrate
+   * uses this to avoid treating that window as a finished thread and
+   * skipping the root pump/lifecycle watcher on page refresh.
+   */
+  async #hasActiveRun(threadId: string): Promise<boolean> {
+    try {
+      const [latestRun] = await this.#options.client.runs.list(threadId, {
+        limit: 1,
+      });
+      return latestRun?.status === "pending" || latestRun?.status === "running";
+    } catch {
+      // Older/custom deployments may not support run listing for hydrate.
+      // Preserve checkpoint-only behavior instead of failing thread load.
+      return false;
+    }
+  }
+
+  /**
    * Fetch the checkpointed thread state and seed the root snapshot.
    * Re-calling with a different `threadId` swaps the underlying
    * {@link ThreadStream}, rewires the registry to the new thread, and
@@ -564,6 +587,18 @@ export class StreamController<
       const state = await this.#fetchHydrationState();
       threadExists = state != null;
       threadActive = isThreadStateActive(state);
+      // A newly accepted run can exist before `getState()` advances past
+      // the previous idle checkpoint. Treat that as active so refresh
+      // reattaches instead of rendering an idle chat until the next reload.
+      if (
+        !threadActive &&
+        threadExists &&
+        this.#currentThreadId != null &&
+        (await this.#hasActiveRun(this.#currentThreadId))
+      ) {
+        threadActive = true;
+        this.rootStore.setState((s) => ({ ...s, isLoading: true }));
+      }
       if (state?.values != null) {
         /**
          * `threads.getState()` returns the legacy `ThreadState` shape


### PR DESCRIPTION
## Summary
- Fixes stream hydration so an idle-looking checkpoint does not prevent reattaching to a pending or running server-side run.
- Adds browser regression coverage for refreshing while a run is active but `getState()` still returns the previous idle checkpoint.
