### PR TITLE
docs(langgraph): fix README logo paths

### DIFF
--- a/libs/langgraph-core/README.md
+++ b/libs/langgraph-core/README.md
@@ -1,9 +1,9 @@
 <div align="center">
   <a href="https://www.langchain.com/langgraph">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset=".github/images/logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset=".github/images/logo-light.svg">
-      <img alt="LangGraph Logo" src=".github/images/logo-dark.svg" width="50%">
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/langchain-ai/langgraphjs/HEAD/.github/images/logo-dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/langchain-ai/langgraphjs/HEAD/.github/images/logo-light.svg">
+      <img alt="LangGraph Logo" src="https://raw.githubusercontent.com/langchain-ai/langgraphjs/HEAD/.github/images/logo-dark.svg" width="50%">
     </picture>
   </a>
 </div>


### PR DESCRIPTION
## Summary

Fix the LangGraph README logo references so they render correctly from both the repository root and the `libs/langgraph-core` package directory.

## Changes

- Replace context-dependent relative logo paths with absolute raw GitHub URLs.
- Preserve dark- and light-mode logo selection in the shared README.
