### PR TITLE
fix(langgraph-api): restore full message union in generated schemas

### DIFF
--- a/.changeset/fix-studio-chat-tab-message-schema.md
+++ b/.changeset/fix-studio-chat-tab-message-schema.md
@@ -1,0 +1,9 @@
+---
+"@langchain/langgraph-api": patch
+---
+
+fix(langgraph-api): restore the full message union in generated schemas
+
+langchain v1 parameterized the `BaseMessage` hierarchy, which broke three assumptions in the static schema generator and left the `messages` channel with a degenerate `oneOf: [RemoveMessage]`. Studio then stopped recognizing messages graphs and greyed out the Chat tab.
+
+Key the class-hierarchy map on the base name with generic arguments erased, pull the concrete message subclasses into the generated program so they are discovered at all, leave properties whose types cannot be modeled (`$InferToolCalls<TStructure>`) unconstrained instead of failing the whole schema, and emit the message definitions under their bare names. The `messages` schema now matches what the v0 line produced. Fixes #2574.

--- a/libs/langgraph-api/src/graph/parser/parser.mts
+++ b/libs/langgraph-api/src/graph/parser/parser.mts
@@ -27,6 +27,34 @@ const INFER_TEMPLATE_PATH = path.resolve(
   "./schema/types.template.mts"
 );
 
+// langchain v1 parameterized the message classes, so they reach the schema as
+// `AIMessage<TStructure>` rather than `AIMessage`. Consumers (Studio's chat
+// detection) match these definitions by name, so restore the bare names.
+// Deliberately limited to this hierarchy: other generic definitions collide
+// once erased (`Record<string,any>` and `Record<string,string>` both become
+// `Record`), and they carried their type arguments before v1 too.
+const MESSAGE_CLASS_NAMES = new Set([
+  // The only message class with no chunk counterpart.
+  "RemoveMessage",
+  ...[
+    "BaseMessage",
+    "AIMessage",
+    "ChatMessage",
+    "FunctionMessage",
+    "HumanMessage",
+    "SystemMessage",
+    "ToolMessage",
+  ].flatMap((name) => [name, `${name}Chunk`]),
+]);
+
+function stripMessageGenericArgs(name: string): string {
+  const index = name.indexOf("<");
+  if (index === -1) return name;
+
+  const bareName = name.slice(0, index);
+  return MESSAGE_CLASS_NAMES.has(bareName) ? bareName : name;
+}
+
 export class SubgraphExtractor {
   protected program: ts.Program;
   protected checker: ts.TypeChecker;
@@ -618,9 +646,10 @@ export class SubgraphExtractor {
       if (definitions == null) return schema;
 
       const toReplace = Object.keys(definitions).flatMap((key) => {
-        const replacedKey = key.includes("import(")
+        const importStripped = key.includes("import(")
           ? key.replace(/import\(.+@langchain[\\/]core.+\)\./, "")
           : key;
+        const replacedKey = stripMessageGenericArgs(importStripped);
 
         if (key !== replacedKey && definitions[replacedKey] == null) {
           return [

--- a/libs/langgraph-api/src/graph/parser/schema/types.mts
+++ b/libs/langgraph-api/src/graph/parser/schema/types.mts
@@ -22,6 +22,16 @@ import type { JSONSchema7, JSONSchema7TypeName } from "json-schema";
 const REGEX_FILE_NAME_OR_SPACE = /(\bimport\(".*?"\)|".*?")\.| /g;
 const REGEX_TJS_JSDOC = /^-([\w]+)\s+(\S|\S[\s\S]*\S)\s*$/g;
 const REGEX_GROUP_JSDOC = /^[.]?([\w]+)\s+(\S|\S[\s\S]*\S)\s*$/g;
+const REGEX_GENERIC_ARGS = /<[\s\S]*$/;
+
+// Strip generic args so a generic subclass (extends clause keeps its own
+// free type-param names) still keys to the same base as a concrete one
+// (extends clause gets the base's defaults substituted in). Not anchored
+// on a trailing `>` — very long instantiations get "..."-truncated by
+// TS's typeToString before they ever reach here.
+function inheritingTypeKey(name: string): string {
+  return name.replace(REGEX_GENERIC_ARGS, "");
+}
 /**
  * Resolve required file, his path and a property name,
  *      pattern: require([file_path]).[property_name]
@@ -875,13 +885,15 @@ class JsonSchemaGenerator {
             }
           }
         } else {
-          // Report that type could not be processed
-          const error = new TypeError(
-            "Unsupported type: " + propertyTypeString
+          // Type couldn't be modeled as JSON schema (e.g. a deferred
+          // conditional/mapped type left unresolved by a generic class used
+          // without concrete type arguments, like langchain v1's
+          // `AIMessage.tool_calls: $InferToolCalls<TStructure>[]`). Leave it
+          // unconstrained rather than aborting the whole symbol's schema,
+          // same as the Any/Unknown case above.
+          console.warn(
+            "Unsupported type, leaving unconstrained: " + propertyTypeString
           );
-          (error as any).type = propertyType;
-          throw error;
-          // definition = this.getTypeDefinition(propertyType, tc);
         }
       }
     }
@@ -1277,16 +1289,19 @@ class JsonSchemaGenerator {
       undefined,
       ts.TypeFormatFlags.UseFullyQualifiedType
     );
+    const inheritingTypesKey = inheritingTypeKey(fullName);
 
     const modifierFlags = ts.getCombinedModifierFlags(node);
 
     if (
       modifierFlags & ts.ModifierFlags.Abstract &&
-      this.inheritingTypes[fullName]
+      this.inheritingTypes[inheritingTypesKey]
     ) {
-      const oneOf = this.inheritingTypes[fullName].map((typename) => {
-        return this.getTypeDefinition(this.allSymbols[typename]);
-      });
+      const oneOf = this.inheritingTypes[inheritingTypesKey].map(
+        (typename) => {
+          return this.getTypeDefinition(this.allSymbols[typename]);
+        }
+      );
 
       definition.oneOf = oneOf;
     } else {
@@ -1985,10 +2000,12 @@ export function buildGenerator(
         const baseTypes = nodeType.getBaseTypes() || [];
 
         baseTypes.forEach((baseType) => {
-          var baseName = tc.typeToString(
-            baseType,
-            undefined,
-            ts.TypeFormatFlags.UseFullyQualifiedType
+          var baseName = inheritingTypeKey(
+            tc.typeToString(
+              baseType,
+              undefined,
+              ts.TypeFormatFlags.UseFullyQualifiedType
+            )
           );
           if (!inheritingTypes[baseName]) {
             inheritingTypes[baseName] = [];

--- a/libs/langgraph-api/src/graph/parser/schema/types.template.mts
+++ b/libs/langgraph-api/src/graph/parser/schema/types.template.mts
@@ -1,9 +1,33 @@
-import type { BaseMessage } from "@langchain/core/messages";
+import type {
+  AIMessage,
+  BaseMessage,
+  ChatMessage,
+  FunctionMessage,
+  HumanMessage,
+  RemoveMessage,
+  SystemMessage,
+  ToolMessage,
+} from "@langchain/core/messages";
 import type {
   StateType,
   UpdateType,
   StateDefinition,
 } from "@langchain/langgraph";
+
+// Concrete message subclasses are only ever referenced structurally through
+// `BaseMessage` in langgraph's own reducer code (except `RemoveMessage`, which
+// is imported by value there) — nothing pulls their declaration files into
+// the per-graph program the schema generator builds, so its class-hierarchy
+// walker never discovers them as `BaseMessage` subtypes. This export forces
+// them into that program.
+export type EnsureConcreteMessageSubclassesInProgram =
+  | AIMessage
+  | ChatMessage
+  | FunctionMessage
+  | HumanMessage
+  | RemoveMessage
+  | SystemMessage
+  | ToolMessage;
 
 // @ts-ignore
 type AnyPregel = {

--- a/libs/langgraph-api/tests/parser.test.mts
+++ b/libs/langgraph-api/tests/parser.test.mts
@@ -260,6 +260,47 @@ test.concurrent("graph factories", { timeout: 30_000 }, () => {
   }
 });
 
+test.concurrent(
+  "erases generic arguments for message classes only",
+  { timeout: 30_000 },
+  () => {
+    const [schema] = SubgraphExtractor.extractSchemas([
+      {
+        sourceFile: [
+          {
+            path: "graph.mts",
+            main: true,
+            contents: dedent`
+              import { MessagesAnnotation, StateGraph } from "@langchain/langgraph";
+
+              export const graph = new StateGraph(MessagesAnnotation)
+                .addNode("echo", () => ({ messages: [] }))
+                .addEdge("__start__", "echo")
+                .addEdge("echo", "__end__")
+                .compile();
+            `,
+          },
+        ],
+        exportSymbol: "graph",
+      },
+    ]);
+
+    const definitions = schema.graph.state?.definitions ?? {};
+    const names = Object.keys(definitions);
+
+    // langchain v1 parameterized these, so they only appear bare if the
+    // generic arguments are erased. Consumers match them by name.
+    expect(names).toEqual(expect.arrayContaining(["BaseMessage", "AIMessage"]));
+
+    // Erasing arguments off everything would collide `Record<string,any>`
+    // with `Record<string,string>`, so non-message generics keep theirs.
+    expect(names.filter((name) => name.startsWith("Record<"))).not.toHaveLength(
+      0
+    );
+    expect(names).not.toContain("Record");
+  }
+);
+
 describe.concurrent("subgraphs", { timeout: 30_000 }, () => {
   test.concurrent(`basic`, () => {
     const testCases = [

--- a/libs/langgraph-api/tests/schema-expectations.mts
+++ b/libs/langgraph-api/tests/schema-expectations.mts
@@ -1,19 +1,29 @@
 import { expect } from "vitest";
 
 /** JSON Schema $ref for message array items inferred from MessagesAnnotation. */
-export const BASE_MESSAGE_REF =
-  "#/definitions/BaseMessage<MessageStructure<MessageToolSet>,MessageType>";
+export const BASE_MESSAGE_REF = "#/definitions/BaseMessage";
 
 /**
- * Expected BaseMessage definition shape from @langchain/core >= 1.2.1, where
- * RemoveMessage extends plain BaseMessage and the static schema generator emits
- * a oneOf union for the abstract class.
+ * Expected BaseMessage definition shape: a oneOf union of every concrete
+ * subclass, keyed by bare class name. langchain v1 parameterized these
+ * classes, so the names only come out bare if the generic arguments are
+ * erased — matching what the langchain v0 line emitted. Order isn't
+ * guaranteed (it follows module-graph traversal), so match membership.
  */
 export const baseMessageDefinitions = {
-  "BaseMessage<MessageStructure<MessageToolSet>,MessageType>": {
+  BaseMessage: {
     description: expect.stringContaining(
       "Base class for all types of messages",
     ),
-    oneOf: [{ $ref: "#/definitions/RemoveMessage" }],
+    oneOf: expect.arrayContaining([
+      { $ref: "#/definitions/AIMessage" },
+      { $ref: "#/definitions/BaseMessageChunk" },
+      { $ref: "#/definitions/ChatMessage" },
+      { $ref: "#/definitions/FunctionMessage" },
+      { $ref: "#/definitions/HumanMessage" },
+      { $ref: "#/definitions/RemoveMessage" },
+      { $ref: "#/definitions/SystemMessage" },
+      { $ref: "#/definitions/ToolMessage" },
+    ]),
   },
 };


### PR DESCRIPTION
langchain v1 made `BaseMessage` generic, which broke three assumptions in the static schema generator and left the `messages` channel as a degenerate `oneOf: [RemoveMessage]`. Studio matches this schema to detect messages graphs, so its Chat tab was greyed out for every v1 graph, including a vanilla `MessagesAnnotation` one.

- The inheritance map was keyed by a stringified base type. Generic subclasses keep their own type-param names in the extends clause while the one non-generic subclass gets the base's defaults substituted in, so `RemoveMessage` was the only member that matched at lookup time. Key on the base name with generic arguments erased. The erasure is not anchored on a trailing `>`, because long instantiations are already "..."-truncated by `typeToString` before they reach us.
- Only `RemoveMessage` is imported by value in the reducer code, so no other subclass declaration entered the per-graph program and the hierarchy walker never discovered them. Reference them in the template.
- Expanding those subclasses then hit `$InferToolCalls<TStructure>`, a deferred conditional type the generator cannot model, which aborted the whole schema. Leave such properties unconstrained instead, as already done for `any`/`unknown`.
- Emit the message definitions under bare names, since consumers match them by name. Limited to this hierarchy: erasing arguments globally collides (`Record<string,any>` and `Record<string,string>`), and those carried their arguments on v0 too.

Verified against a v0-line baseline: the `messages` ref and its union are now identical to what v0 emitted.

Fixes #2574
