### PR TITLE
fix(sdk): support clearing cron end_time via update({ endTime: null })

### DIFF
--- a/.changeset/sdk-cron-clear-end-time.md
+++ b/.changeset/sdk-cron-clear-end-time.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): support clearing a cron's end time via `crons.update(cronId, { endTime: null })`
+
+`CronsClient.update` now accepts `endTime: null` to clear a previously set cron end time; omitting `endTime` still leaves it unchanged. The field was typed `string`, so callers could not express "clear" even though the request already forwards an explicit `null`.

--- a/libs/sdk/src/client/crons/index.test.ts
+++ b/libs/sdk/src/client/crons/index.test.ts
@@ -65,6 +65,29 @@ describe("crons.update", () => {
     });
   });
 
+  it("sends null end_time to clear a set end time", async () => {
+    const cron = cronPayload();
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(cron),
+      text: () => Promise.resolve(""),
+      headers: new Headers({}),
+    });
+
+    const client = new Client({ apiKey: "test-api-key" });
+    await client.crons.update("cron_123", { endTime: null });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse(options.body);
+
+    expect(url).toContain("/runs/crons/cron_123");
+    expect(options.method).toBe("PATCH");
+    expect(body).toEqual({ end_time: null });
+  });
+
   it("converts camelCase to snake_case", async () => {
     const cron = cronPayload();
 

--- a/libs/sdk/src/client/crons/index.ts
+++ b/libs/sdk/src/client/crons/index.ts
@@ -101,56 +101,25 @@ export class CronsClient extends BaseClient {
    * ```
    */
   async update(cronId: string, payload?: CronsUpdatePayload): Promise<Cron> {
-    const json: Record<string, unknown> = {};
-
-    if (payload?.schedule !== undefined) {
-      json.schedule = payload.schedule;
-    }
-    if (payload?.timezone !== undefined) {
-      json.timezone = payload.timezone;
-    }
-    if (payload?.endTime !== undefined) {
-      json.end_time = payload.endTime;
-    }
-    if (payload?.input !== undefined) {
-      json.input = payload.input;
-    }
-    if (payload?.metadata !== undefined) {
-      json.metadata = payload.metadata;
-    }
-    if (payload?.config !== undefined) {
-      json.config = payload.config;
-    }
-    if (payload?.context !== undefined) {
-      json.context = payload.context;
-    }
-    if (payload?.webhook !== undefined) {
-      json.webhook = payload.webhook;
-    }
-    if (payload?.interruptBefore !== undefined) {
-      json.interrupt_before = payload.interruptBefore;
-    }
-    if (payload?.interruptAfter !== undefined) {
-      json.interrupt_after = payload.interruptAfter;
-    }
-    if (payload?.onRunCompleted !== undefined) {
-      json.on_run_completed = payload.onRunCompleted;
-    }
-    if (payload?.enabled !== undefined) {
-      json.enabled = payload.enabled;
-    }
-    if (payload?.streamMode !== undefined) {
-      json.stream_mode = payload.streamMode;
-    }
-    if (payload?.streamSubgraphs !== undefined) {
-      json.stream_subgraphs = payload.streamSubgraphs;
-    }
-    if (payload?.streamResumable !== undefined) {
-      json.stream_resumable = payload.streamResumable;
-    }
-    if (payload?.durability !== undefined) {
-      json.durability = payload.durability;
-    }
+    const json: Record<string, unknown> = {
+      schedule: payload?.schedule,
+      timezone: payload?.timezone,
+      // `null` clears a set end time; `undefined` (omitted) leaves it unchanged.
+      end_time: payload?.endTime,
+      input: payload?.input,
+      metadata: payload?.metadata,
+      config: payload?.config,
+      context: payload?.context,
+      webhook: payload?.webhook,
+      interrupt_before: payload?.interruptBefore,
+      interrupt_after: payload?.interruptAfter,
+      on_run_completed: payload?.onRunCompleted,
+      enabled: payload?.enabled,
+      stream_mode: payload?.streamMode,
+      stream_subgraphs: payload?.streamSubgraphs,
+      stream_resumable: payload?.streamResumable,
+      durability: payload?.durability,
+    };
 
     return this.fetch<Cron>(`/runs/crons/${cronId}`, {
       method: "PATCH",

--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -273,7 +273,11 @@ export interface CronsCreatePayload extends RunsCreatePayload {
 
 export interface CronsUpdatePayload extends RunsInvokePayload {
   schedule?: string;
-  endTime?: string;
+  /**
+   * ISO 8601 timestamp after which the cron stops scheduling runs.
+   * Pass `null` to clear a previously set end time; omit to leave it unchanged.
+   */
+  endTime?: string | null;
 
   /**
    * IANA timezone string for interpreting the schedule (e.g. "America/New_York").


### PR DESCRIPTION
## What & why

`CronsClient.update` could not clear a cron's `end_time`. The field was typed `endTime?: string`, so a type-checked caller had no way to express "remove the end time" — even though, unlike the Python SDK, the JS request builder was already correct at runtime: it uses per-field `if (payload?.endTime !== undefined)` guards (not a `None`-strip), and `null !== undefined`, so a `null` would already be forwarded and `JSON.stringify` preserves it.

So the defect was purely a **type imprecision**, and the fix is at the source — the model — rather than a workaround in the request logic:

- `CronsUpdatePayload.endTime`: `string` → `string | null`. PATCH semantics are now the standard tri-state:
  - **omit `endTime`** → keep the existing value
  - **`endTime: null`** → clear it
  - **`endTime: "<iso>"`** → set it
- `CronsCreatePayload.endTime` is intentionally left `string` — create never needs to clear.

This mirrors the Python SDK change in langchain-ai/langgraph#8334 (`update(end_time=None)`), and requires an Agent Server that supports clearing `end_time` via `PATCH /runs/crons/{id}` (`end_time: null`). Against an older server, `update(id, { endTime: null })` is a harmless no-op for clearing (the server coalesces `null` back to the stored value), and a clear-only patch may 400.

## Also in this PR (unify `update()`)

While here, `update()`'s payload construction is unified with the existing `create()` / `createForThread()` style: the 16 repetitive `if (payload?.X !== undefined) json.Y = payload.X` guards become a single declarative object literal. `JSON.stringify` drops `undefined` keys and keeps `null`, so the wire output is **identical** — this is a behaviour-preserving refactor, pinned by the pre-existing "only sends defined fields" / "sends all updatable fields" tests. Net −44 lines in the method.

## Test plan

- [x] `vitest run` on `libs/sdk/src/client/crons/index.test.ts` — **9 passed** (8 existing + 1 new: `update(id, { endTime: null })` sends body `{ end_time: null }`), no type errors.
- [x] `pnpm build` (tsc compile + `attw` + `publint`) — clean.
- [x] `oxlint` — 0 warnings / 0 errors; `oxfmt --check` — clean.
- [x] Changeset added (`@langchain/langgraph-sdk`: patch).
