### PR TITLE
fix(sdk): keep SSE reconnect enabled with custom fetch

### DIFF
--- a/.changeset/fix-sse-reconnect-custom-fetch.md
+++ b/.changeset/fix-sse-reconnect-custom-fetch.md
@@ -1,0 +1,11 @@
+---
+"@langchain/langgraph-sdk": patch
+"@langchain/react": patch
+"@langchain/vue": patch
+"@langchain/svelte": patch
+"@langchain/angular": patch
+---
+
+fix(sdk): keep SSE reconnect enabled with custom fetch
+
+Auth/proxy fetch shims previously forced `maxReconnectAttempts: 0`, so HITL waits that lost `/stream/events` (e.g. `ERR_QUIC_PROTOCOL_ERROR`) never recovered and left `respond()`/`submit()` spinning. Fail-fast test mocks should pass `maxReconnectAttempts: 0` explicitly. Also plumbs reconnect options through framework `useStream` bindings.

--- a/libs/sdk-angular/src/selectors.ts
+++ b/libs/sdk-angular/src/selectors.ts
@@ -10,6 +10,7 @@ import {
 import type { BaseMessage } from "@langchain/core/messages";
 import {
   NAMESPACE_SEPARATOR,
+  DEFAULT_MESSAGES_KEY,
   acquireChannelEffect,
   audioProjection,
   channelProjection,
@@ -271,7 +272,7 @@ export function injectValues(
   target?: SelectorTarget | Signal<SelectorTarget>,
   options?: { messagesKey?: string }
 ): Signal<unknown> {
-  const messagesKey = options?.messagesKey ?? "messages";
+  const messagesKey = options?.messagesKey ?? DEFAULT_MESSAGES_KEY;
   const { namespace, key, isRootSignal } = normalizeTarget(
     target as SelectorTarget | Signal<SelectorTarget>,
     `values|${messagesKey}`

--- a/libs/sdk-angular/src/tests/components/InterruptReconnectStream.ts
+++ b/libs/sdk-angular/src/tests/components/InterruptReconnectStream.ts
@@ -1,88 +1,98 @@
-import {
-  Component,
-  Injectable,
-  computed,
-  inject as angularInject,
-  signal,
-} from "@angular/core";
+import { Component, OnDestroy, OnInit, signal } from "@angular/core";
 import { HumanMessage, type BaseMessage } from "@langchain/core/messages";
-import { inject as vitestInject } from "vitest";
+import { inject } from "vitest";
 import { injectStream } from "../../index.js";
+import { createDroppableAuthFetch } from "../fixtures/droppable-auth-fetch.js";
 
-const serverUrl = vitestInject("serverUrl");
-
-/**
- * Reconnect state shared across remounts of the view. Lives in DI so the
- * captured `threadId` survives the `@for`-driven recreation that simulates
- * a fresh `injectStream` on reconnect.
- */
-@Injectable()
-class InterruptHarnessState {
-  readonly threadId = signal<string | undefined>(undefined);
-  readonly gen = signal(0);
-  readonly genList = computed(() => [this.gen()]);
-
-  readonly onThreadId = (id: string): void => this.threadId.set(id);
-
-  reconnect(): void {
-    this.gen.update((g) => g + 1);
-  }
-}
+const serverUrl = inject("serverUrl");
+const droppable = createDroppableAuthFetch();
 
 @Component({
-  selector: "lg-interrupt-view",
   template: `
     <div>
       <div data-testid="loading">
         {{ stream.isLoading() ? "Loading..." : "Not loading" }}
       </div>
+      <div data-testid="messages">
+        @for (msg of stream.messages(); track msg.id ?? $index) {
+          <div [attr.data-testid]="'message-' + $index">
+            {{ str(msg.content) }}
+          </div>
+        }
+        @if (stream.messages().length > 0) {
+          <div data-testid="last-message">
+            {{
+              str(stream.messages()[stream.messages().length - 1].content)
+            }}
+          </div>
+        }
+      </div>
       <div data-testid="interrupt-count">{{ stream.interrupts().length }}</div>
-      <button data-testid="submit" (click)="submit()">Send</button>
-    </div>
-  `,
-})
-class InterruptViewComponent {
-  readonly stream: ReturnType<
-    typeof injectStream<{ messages: BaseMessage[] }, { nodeName: string }>
-  >;
-
-  constructor() {
-    const state = angularInject(InterruptHarnessState);
-    this.stream = injectStream<
-      { messages: BaseMessage[] },
-      { nodeName: string }
-    >({
-      assistantId: "interruptAgent",
-      apiUrl: serverUrl,
-      threadId: state.threadId,
-      onThreadId: state.onThreadId,
-    });
-  }
-
-  submit(): void {
-    void this.stream.submit({ messages: [new HumanMessage("ship it")] });
-  }
-}
-
-@Component({
-  selector: "lg-interrupt-reconnect",
-  imports: [InterruptViewComponent],
-  providers: [InterruptHarnessState],
-  template: `
-    <div>
-      <button
-        data-testid="reconnect"
-        [disabled]="state.threadId() == null"
-        (click)="state.reconnect()"
-      >
-        Reconnect
-      </button>
-      @for (g of state.genList(); track g) {
-        <lg-interrupt-view />
+      <div data-testid="reconnect-count">{{ reconnectCount() }}</div>
+      <div data-testid="event-stream-opens">{{ eventStreamOpens() }}</div>
+      @if (stream.interrupt()) {
+        <div>
+          <div data-testid="interrupt-node">
+            {{ stream.interrupt()!.value?.nodeName ?? "" }}
+          </div>
+          <div data-testid="interrupt-id">
+            {{ stream.interrupt()!.id }}
+          </div>
+          <button data-testid="resume" (click)="onResume()">Resume</button>
+        </div>
       }
+      <button data-testid="submit" (click)="onSubmit()">Send</button>
+      <button data-testid="drop-events" (click)="onDropEvents()">
+        Drop events
+      </button>
     </div>
   `,
 })
-export class InterruptReconnectHarnessComponent {
-  readonly state = angularInject(InterruptHarnessState);
+export class InterruptReconnectStreamComponent implements OnInit, OnDestroy {
+  reconnectCount = signal(0);
+  eventStreamOpens = signal(0);
+  private timer: number | undefined;
+
+  stream = injectStream<{ messages: BaseMessage[] }, { nodeName: string }>({
+    assistantId: "interruptAgent",
+    apiUrl: serverUrl,
+    fetch: droppable.fetch,
+    maxReconnectAttempts: 5,
+    reconnectDelayMs: () => 0,
+    streamIdleReconnect: 0,
+    onReconnect: () => {
+      this.reconnectCount.update((count) => count + 1);
+      this.eventStreamOpens.set(droppable.eventStreamOpenCount());
+    },
+  });
+
+  ngOnInit() {
+    this.timer = window.setInterval(() => {
+      this.eventStreamOpens.set(droppable.eventStreamOpenCount());
+    }, 50);
+  }
+
+  ngOnDestroy() {
+    if (this.timer != null) window.clearInterval(this.timer);
+  }
+
+  str(v: unknown) {
+    return typeof v === "string" ? v : JSON.stringify(v);
+  }
+
+  onSubmit() {
+    void this.stream.submit({
+      messages: [new HumanMessage("Hello")],
+    });
+    this.eventStreamOpens.set(droppable.eventStreamOpenCount());
+  }
+
+  onDropEvents() {
+    droppable.dropActiveStreams();
+    this.eventStreamOpens.set(droppable.eventStreamOpenCount());
+  }
+
+  onResume() {
+    void this.stream.respond("Resuming");
+  }
 }

--- a/libs/sdk-angular/src/tests/components/InterruptStream.ts
+++ b/libs/sdk-angular/src/tests/components/InterruptStream.ts
@@ -1,4 +1,10 @@
-import { Component } from "@angular/core";
+import {
+  Component,
+  Injectable,
+  computed,
+  inject as angularInject,
+  signal,
+} from "@angular/core";
 import { HumanMessage, type BaseMessage } from "@langchain/core/messages";
 import { inject } from "vitest";
 import { injectStream } from "../../index.js";
@@ -74,3 +80,79 @@ export class InterruptComponent {
 }
 
 export const InterruptStreamComponent = InterruptComponent;
+
+/**
+ * Shared reconnect state for the idle-pumps hydrate harness. Survives the
+ * `@for`-driven remount that simulates a fresh `injectStream` on reconnect.
+ */
+@Injectable()
+class InterruptHarnessState {
+  readonly threadId = signal<string | undefined>(undefined);
+  readonly gen = signal(0);
+  readonly genList = computed(() => [this.gen()]);
+
+  readonly onThreadId = (id: string): void => this.threadId.set(id);
+
+  reconnect(): void {
+    this.gen.update((g) => g + 1);
+  }
+}
+
+@Component({
+  selector: "lg-interrupt-harness-view",
+  template: `
+    <div>
+      <div data-testid="loading">
+        {{ stream.isLoading() ? "Loading..." : "Not loading" }}
+      </div>
+      <div data-testid="interrupt-count">{{ stream.interrupts().length }}</div>
+      @if (stream.interrupt()) {
+        <div data-testid="interrupt-id">{{ stream.interrupt()!.id }}</div>
+      }
+      <button data-testid="submit" (click)="onSubmit()">Send</button>
+    </div>
+  `,
+})
+class InterruptHarnessViewComponent {
+  readonly #state = angularInject(InterruptHarnessState);
+
+  stream = injectStream<{ messages: BaseMessage[] }, { nodeName: string }>({
+    assistantId: "interruptAgent",
+    apiUrl: serverUrl,
+    threadId: this.#state.threadId,
+    onThreadId: this.#state.onThreadId,
+  });
+
+  onSubmit() {
+    void this.stream.submit({
+      messages: [new HumanMessage("Hello")],
+    });
+  }
+}
+
+/**
+ * Hydrate/reconnect harness for idle-pumps: submit until interrupted, then
+ * remount a fresh controller against the same thread id.
+ */
+@Component({
+  selector: "lg-interrupt-reconnect-harness",
+  imports: [InterruptHarnessViewComponent],
+  providers: [InterruptHarnessState],
+  template: `
+    <div>
+      <button
+        data-testid="reconnect"
+        [disabled]="state.threadId() == null"
+        (click)="state.reconnect()"
+      >
+        Reconnect
+      </button>
+      @for (g of state.genList(); track g) {
+        <lg-interrupt-harness-view />
+      }
+    </div>
+  `,
+})
+export class InterruptReconnectHarnessComponent {
+  readonly state = angularInject(InterruptHarnessState);
+}

--- a/libs/sdk-angular/src/tests/fixtures/droppable-auth-fetch.ts
+++ b/libs/sdk-angular/src/tests/fixtures/droppable-auth-fetch.ts
@@ -1,0 +1,108 @@
+/**
+ * Auth-shim style `fetch` wrapper used to reproduce the browser HITL-idle
+ * failure mode: a custom `fetch` (tenant headers / proxy) must keep SSE
+ * reconnect enabled, and mid-stream drops must recover before `respond()`.
+ *
+ * Dropping must *error* the response body (not abort the request signal).
+ * Aborting the fetch signal often ends the SSE `for await` cleanly, which
+ * skips the reconnect loop in {@link ProtocolSseTransportAdapter.openEventStream}.
+ */
+
+function requestHref(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function isEventStreamUrl(href: string): boolean {
+  try {
+    return new URL(href, "http://localhost").pathname.includes(
+      "/stream/events"
+    );
+  } catch {
+    return href.includes("/stream/events");
+  }
+}
+
+export interface DroppableAuthFetch {
+  /** Custom fetch suitable for `useStream({ fetch })`. */
+  fetch: typeof fetch;
+  /** Error every in-flight `/stream/events` body (simulates QUIC/idle drop). */
+  dropActiveStreams: (reason?: unknown) => void;
+  /** Number of `/stream/events` opens observed (includes reconnects). */
+  eventStreamOpenCount: () => number;
+}
+
+export function createDroppableAuthFetch(
+  baseFetch: typeof fetch = globalThis.fetch
+): DroppableAuthFetch {
+  const bodyDroppers = new Set<(reason: unknown) => void>();
+  let eventStreamOpens = 0;
+
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const href = requestHref(input);
+    if (!isEventStreamUrl(href)) {
+      return baseFetch(input, init);
+    }
+
+    eventStreamOpens += 1;
+    const response = await baseFetch(input, init);
+    if (response.body == null) {
+      return response;
+    }
+
+    const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
+    const writer = writable.getWriter();
+    const reader = response.body.getReader();
+    let dropped = false;
+
+    const drop = (reason: unknown) => {
+      if (dropped) return;
+      dropped = true;
+      void writer.abort(reason);
+      void reader.cancel(reason);
+    };
+    bodyDroppers.add(drop);
+
+    void (async () => {
+      try {
+        while (!dropped) {
+          const { done, value } = await reader.read();
+          if (done) {
+            await writer.close();
+            return;
+          }
+          await writer.write(value);
+        }
+      } catch (error) {
+        if (!dropped) {
+          try {
+            await writer.abort(error);
+          } catch {
+            // already closed/aborted
+          }
+        }
+      } finally {
+        bodyDroppers.delete(drop);
+      }
+    })();
+
+    return new Response(readable, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };
+
+  return {
+    fetch: fetchImpl,
+    dropActiveStreams: (
+      reason = new TypeError("net::ERR_QUIC_PROTOCOL_ERROR")
+    ) => {
+      for (const drop of [...bodyDroppers]) {
+        drop(reason);
+      }
+    },
+    eventStreamOpenCount: () => eventStreamOpens,
+  };
+}

--- a/libs/sdk-angular/src/tests/stream.idle-pumps.test.ts
+++ b/libs/sdk-angular/src/tests/stream.idle-pumps.test.ts
@@ -9,7 +9,7 @@ import { expect, it } from "vitest";
 import { render } from "vitest-browser-angular";
 
 import { ParallelFanoutSubagentOpenAllAfterReconnectHarnessComponent } from "./components/ParallelFanoutReconnectStream.js";
-import { InterruptReconnectHarnessComponent } from "./components/InterruptReconnectStream.js";
+import { InterruptReconnectHarnessComponent } from "./components/InterruptStream.js";
 
 const WORKER_COUNT = 6;
 

--- a/libs/sdk-angular/src/tests/stream.interrupts.test.ts
+++ b/libs/sdk-angular/src/tests/stream.interrupts.test.ts
@@ -2,6 +2,7 @@ import { expect, it } from "vitest";
 import { render } from "vitest-browser-angular";
 
 import { InterruptStreamComponent } from "./components/InterruptStream.js";
+import { InterruptReconnectStreamComponent } from "./components/InterruptReconnectStream.js";
 import { MultiInterruptStreamComponent } from "./components/MultiInterruptStream.js";
 
 it("surfaces the first interrupt on submit()", async () => {
@@ -65,6 +66,62 @@ it("responds via the dedicated respond button", async () => {
     .element(screen.getByTestId("interrupt-count"))
     .toHaveTextContent("0");
 });
+
+it(
+  "resumes after a mid-HITL SSE drop when using a custom auth fetch",
+  { timeout: 20_000 },
+  async () => {
+    const screen = await render(InterruptReconnectStreamComponent);
+
+    await screen.getByTestId("submit").click();
+
+    await expect
+      .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("loading"))
+      .toHaveTextContent("Not loading");
+
+    const opensBeforeDrop = Number(
+      screen.getByTestId("event-stream-opens").element().textContent ?? "0"
+    );
+
+    await screen.getByTestId("drop-events").click();
+
+    await expect
+      .poll(
+        () =>
+          Number(
+            screen.getByTestId("event-stream-opens").element().textContent ??
+              "0"
+          ),
+        { timeout: 10_000 }
+      )
+      .toBeGreaterThan(opensBeforeDrop);
+
+    await expect
+      .poll(
+        () =>
+          Number(
+            screen.getByTestId("reconnect-count").element().textContent ?? "0"
+          ),
+        { timeout: 10_000 }
+      )
+      .toBeGreaterThan(0);
+
+    await screen.getByTestId("resume").click();
+
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 10_000 })
+      .toHaveTextContent("Not loading");
+    await expect
+      .element(screen.getByTestId("last-message"))
+      .toHaveTextContent("After interrupt");
+    await expect
+      .element(screen.getByTestId("interrupt-count"))
+      .toHaveTextContent("0");
+  }
+);
 
 it("resumes several parallel interrupts via respondAll()", { timeout: 15_000 }, async () => {
   const screen = await render(MultiInterruptStreamComponent);

--- a/libs/sdk-angular/src/use-stream.ts
+++ b/libs/sdk-angular/src/use-stream.ts
@@ -450,6 +450,10 @@ export function useStream<
     transport?: "sse" | "websocket" | AgentServerAdapter;
     fetch?: typeof fetch;
     webSocketFactory?: (url: string) => WebSocket;
+    maxReconnectAttempts?: number;
+    streamIdleReconnect?: number | "auto";
+    reconnectDelayMs?: (attempt: number) => number;
+    onReconnect?: (options: { attempt: number; cause: unknown }) => void;
     onThreadId?: (threadId: string) => void;
     onCreated?: (info: RunExecutionInfo) => void;
     onCompleted?: (info: RunCompletedInfo) => void;
@@ -510,6 +514,14 @@ export function useStream<
     transport,
     fetch: hasCustomAdapter ? undefined : asBag.fetch,
     webSocketFactory: hasCustomAdapter ? undefined : asBag.webSocketFactory,
+    maxReconnectAttempts: hasCustomAdapter
+      ? undefined
+      : asBag.maxReconnectAttempts,
+    streamIdleReconnect: hasCustomAdapter
+      ? undefined
+      : asBag.streamIdleReconnect,
+    reconnectDelayMs: hasCustomAdapter ? undefined : asBag.reconnectDelayMs,
+    onReconnect: hasCustomAdapter ? undefined : asBag.onReconnect,
     onThreadId: options.onThreadId,
     onCreated: options.onCreated,
     onCompleted: options.onCompleted,

--- a/libs/sdk-react/src/selectors.ts
+++ b/libs/sdk-react/src/selectors.ts
@@ -12,6 +12,7 @@ import type {
 } from "@langchain/langgraph-sdk/stream";
 import {
   NAMESPACE_SEPARATOR,
+  DEFAULT_MESSAGES_KEY,
   acquireChannelEffect,
   audioProjection,
   channelProjection,
@@ -269,7 +270,7 @@ export function useValues(
   options?: { messagesKey?: string }
 ): unknown {
   const namespace = resolveNamespace(target);
-  const messagesKey = options?.messagesKey ?? "messages";
+  const messagesKey = options?.messagesKey ?? DEFAULT_MESSAGES_KEY;
   const key = `values|${messagesKey}|${namespaceKey(namespace)}`;
   const registry = isRoot(namespace) ? null : getRegistry(stream);
   const scoped = useProjection<unknown>(

--- a/libs/sdk-react/src/tests/components/InterruptReconnectStream.tsx
+++ b/libs/sdk-react/src/tests/components/InterruptReconnectStream.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { useStream } from "../../index.js";
+import { createDroppableAuthFetch } from "../fixtures/droppable-auth-fetch.js";
+
+interface InterruptState {
+  request: string;
+  decision: Record<string, unknown> | null;
+  completed: boolean;
+}
+
+interface Props {
+  apiUrl: string;
+  assistantId?: string;
+}
+
+/**
+ * Interrupt + respond harness that routes every request through a custom
+ * auth-style `fetch` and can force-drop active SSE streams mid-HITL.
+ */
+export function InterruptReconnectStream({
+  apiUrl,
+  assistantId = "interrupt_graph",
+}: Props) {
+  const droppable = useMemo(() => createDroppableAuthFetch(), []);
+  const [reconnectCount, setReconnectCount] = useState(0);
+  const [eventOpens, setEventOpens] = useState(0);
+
+  // Keep open-count / reconnect telemetry painted while reconnect races run.
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setEventOpens(droppable.eventStreamOpenCount());
+    }, 50);
+    return () => window.clearInterval(id);
+  }, [droppable]);
+
+  const thread = useStream<InterruptState>({
+    assistantId,
+    apiUrl,
+    fetch: droppable.fetch,
+    maxReconnectAttempts: 5,
+    reconnectDelayMs: () => 0,
+    streamIdleReconnect: 0,
+    onReconnect: () => {
+      setReconnectCount((count) => count + 1);
+      setEventOpens(droppable.eventStreamOpenCount());
+    },
+  });
+
+  const promptValue = thread.interrupt?.value;
+  const interruptPrompt =
+    promptValue != null &&
+    typeof promptValue === "object" &&
+    "prompt" in (promptValue as object)
+      ? String((promptValue as { prompt?: unknown }).prompt ?? "")
+      : "";
+
+  return (
+    <div>
+      <div data-testid="interrupt-count">{thread.interrupts.length}</div>
+      <div data-testid="interrupt-prompt">{interruptPrompt}</div>
+      <div data-testid="completed">
+        {thread.values?.completed ? "true" : "false"}
+      </div>
+      <div data-testid="loading">
+        {thread.isLoading ? "Loading..." : "Not loading"}
+      </div>
+      <div data-testid="reconnect-count">{reconnectCount}</div>
+      <div data-testid="event-stream-opens">{eventOpens}</div>
+      <button
+        data-testid="submit"
+        onClick={() => void thread.submit({ request: "ship it" })}
+      >
+        Submit
+      </button>
+      <button
+        data-testid="drop-events"
+        onClick={() => {
+          droppable.dropActiveStreams();
+          setEventOpens(droppable.eventStreamOpenCount());
+        }}
+      >
+        Drop events
+      </button>
+      <button
+        data-testid="resume"
+        onClick={() => {
+          if (thread.interrupt) {
+            void thread.respond({ approved: true });
+          }
+        }}
+      >
+        Resume
+      </button>
+    </div>
+  );
+}

--- a/libs/sdk-react/src/tests/fixtures/droppable-auth-fetch.ts
+++ b/libs/sdk-react/src/tests/fixtures/droppable-auth-fetch.ts
@@ -1,0 +1,108 @@
+/**
+ * Auth-shim style `fetch` wrapper used to reproduce the browser HITL-idle
+ * failure mode: a custom `fetch` (tenant headers / proxy) must keep SSE
+ * reconnect enabled, and mid-stream drops must recover before `respond()`.
+ *
+ * Dropping must *error* the response body (not abort the request signal).
+ * Aborting the fetch signal often ends the SSE `for await` cleanly, which
+ * skips the reconnect loop in {@link ProtocolSseTransportAdapter.openEventStream}.
+ */
+
+function requestHref(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function isEventStreamUrl(href: string): boolean {
+  try {
+    return new URL(href, "http://localhost").pathname.includes(
+      "/stream/events"
+    );
+  } catch {
+    return href.includes("/stream/events");
+  }
+}
+
+export interface DroppableAuthFetch {
+  /** Custom fetch suitable for `useStream({ fetch })`. */
+  fetch: typeof fetch;
+  /** Error every in-flight `/stream/events` body (simulates QUIC/idle drop). */
+  dropActiveStreams: (reason?: unknown) => void;
+  /** Number of `/stream/events` opens observed (includes reconnects). */
+  eventStreamOpenCount: () => number;
+}
+
+export function createDroppableAuthFetch(
+  baseFetch: typeof fetch = globalThis.fetch
+): DroppableAuthFetch {
+  const bodyDroppers = new Set<(reason: unknown) => void>();
+  let eventStreamOpens = 0;
+
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const href = requestHref(input);
+    if (!isEventStreamUrl(href)) {
+      return baseFetch(input, init);
+    }
+
+    eventStreamOpens += 1;
+    const response = await baseFetch(input, init);
+    if (response.body == null) {
+      return response;
+    }
+
+    const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
+    const writer = writable.getWriter();
+    const reader = response.body.getReader();
+    let dropped = false;
+
+    const drop = (reason: unknown) => {
+      if (dropped) return;
+      dropped = true;
+      void writer.abort(reason);
+      void reader.cancel(reason);
+    };
+    bodyDroppers.add(drop);
+
+    void (async () => {
+      try {
+        while (!dropped) {
+          const { done, value } = await reader.read();
+          if (done) {
+            await writer.close();
+            return;
+          }
+          await writer.write(value);
+        }
+      } catch (error) {
+        if (!dropped) {
+          try {
+            await writer.abort(error);
+          } catch {
+            // already closed/aborted
+          }
+        }
+      } finally {
+        bodyDroppers.delete(drop);
+      }
+    })();
+
+    return new Response(readable, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };
+
+  return {
+    fetch: fetchImpl,
+    dropActiveStreams: (
+      reason = new TypeError("net::ERR_QUIC_PROTOCOL_ERROR")
+    ) => {
+      for (const drop of [...bodyDroppers]) {
+        drop(reason);
+      }
+    },
+    eventStreamOpenCount: () => eventStreamOpens,
+  };
+}

--- a/libs/sdk-react/src/tests/stream.interrupts.test.tsx
+++ b/libs/sdk-react/src/tests/stream.interrupts.test.tsx
@@ -2,6 +2,7 @@ import { expect, it } from "vitest";
 import { render } from "vitest-browser-react";
 
 import { InterruptStream } from "./components/InterruptStream.js";
+import { InterruptReconnectStream } from "./components/InterruptReconnectStream.js";
 import { MultiInterruptStream } from "./components/MultiInterruptStream.js";
 import { apiUrl, cleanupRender } from "./test-utils.js";
 
@@ -53,6 +54,73 @@ it("resumes an interrupt via respond()", async () => {
     await cleanupRender(screen);
   }
 });
+
+it(
+  "resumes after a mid-HITL SSE drop when using a custom auth fetch",
+  { timeout: 20_000 },
+  async () => {
+    // Regression for auth-shim fetch disabling reconnect: waiting on an
+    // interrupt while the events pump dies (QUIC/idle) must recover so
+    // respond() can finish instead of spinning forever.
+    const screen = await render(<InterruptReconnectStream apiUrl={apiUrl} />);
+
+    try {
+      await screen.getByTestId("submit").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("loading"))
+        .toHaveTextContent("Not loading");
+
+      const opensBeforeDrop = Number(
+        screen.getByTestId("event-stream-opens").element().textContent ?? "0"
+      );
+      expect(opensBeforeDrop).toBeGreaterThan(0);
+
+      await screen.getByTestId("drop-events").click();
+
+      // Reconnect must reopen `/stream/events` (custom fetch used to disable
+      // this). Prefer open-count over onReconnect in case multiple pumps drop.
+      await expect
+        .poll(
+          () =>
+            Number(
+              screen.getByTestId("event-stream-opens").element().textContent ??
+                "0"
+            ),
+          { timeout: 10_000 }
+        )
+        .toBeGreaterThan(opensBeforeDrop);
+
+      await expect
+        .poll(
+          () =>
+            Number(
+              screen.getByTestId("reconnect-count").element().textContent ??
+                "0"
+            ),
+          { timeout: 10_000 }
+        )
+        .toBeGreaterThan(0);
+
+      await screen.getByTestId("resume").click();
+
+      await expect
+        .element(screen.getByTestId("completed"), { timeout: 10_000 })
+        .toHaveTextContent("true");
+      await expect
+        .element(screen.getByTestId("loading"))
+        .toHaveTextContent("Not loading");
+      await expect
+        .element(screen.getByTestId("interrupt-count"))
+        .toHaveTextContent("0");
+    } finally {
+      await cleanupRender(screen);
+    }
+  }
+);
 
 it("resumes several parallel interrupts via respondAll()", { timeout: 15_000 }, async () => {
   const screen = await render(<MultiInterruptStream apiUrl={apiUrl} />);

--- a/libs/sdk-react/src/use-stream.ts
+++ b/libs/sdk-react/src/use-stream.ts
@@ -488,6 +488,10 @@ export function useStream<
     transport?: "sse" | "websocket" | AgentServerAdapter;
     fetch?: typeof fetch;
     webSocketFactory?: (url: string) => WebSocket;
+    maxReconnectAttempts?: number;
+    streamIdleReconnect?: number | "auto";
+    reconnectDelayMs?: (attempt: number) => number;
+    onReconnect?: (options: { attempt: number; cause: unknown }) => void;
     onThreadId?: (threadId: string) => void;
     onCreated?: (info: RunExecutionInfo) => void;
     onCompleted?: (info: RunCompletedInfo) => void;
@@ -591,6 +595,16 @@ export function useStream<
         transport,
         fetch: hasCustomAdapter ? undefined : asBag.fetch,
         webSocketFactory: hasCustomAdapter ? undefined : asBag.webSocketFactory,
+        maxReconnectAttempts: hasCustomAdapter
+          ? undefined
+          : asBag.maxReconnectAttempts,
+        streamIdleReconnect: hasCustomAdapter
+          ? undefined
+          : asBag.streamIdleReconnect,
+        reconnectDelayMs: hasCustomAdapter
+          ? undefined
+          : asBag.reconnectDelayMs,
+        onReconnect: hasCustomAdapter ? undefined : asBag.onReconnect,
         onThreadId: options.onThreadId,
         onCreated: options.onCreated,
         onCompleted: options.onCompleted,

--- a/libs/sdk-react/src/use-stream.ts
+++ b/libs/sdk-react/src/use-stream.ts
@@ -601,9 +601,7 @@ export function useStream<
         streamIdleReconnect: hasCustomAdapter
           ? undefined
           : asBag.streamIdleReconnect,
-        reconnectDelayMs: hasCustomAdapter
-          ? undefined
-          : asBag.reconnectDelayMs,
+        reconnectDelayMs: hasCustomAdapter ? undefined : asBag.reconnectDelayMs,
         onReconnect: hasCustomAdapter ? undefined : asBag.onReconnect,
         onThreadId: options.onThreadId,
         onCreated: options.onCreated,

--- a/libs/sdk-svelte/src/selectors.svelte.ts
+++ b/libs/sdk-svelte/src/selectors.svelte.ts
@@ -1,6 +1,7 @@
 import type { BaseMessage } from "@langchain/core/messages";
 import {
   NAMESPACE_SEPARATOR,
+  DEFAULT_MESSAGES_KEY,
   acquireChannelEffect,
   audioProjection,
   channelProjection,
@@ -297,7 +298,7 @@ export function useValues(
       };
     }
   }
-  const messagesKey = options?.messagesKey ?? "messages";
+  const messagesKey = options?.messagesKey ?? DEFAULT_MESSAGES_KEY;
   return selectFromTarget<unknown>(
     stream,
     target,

--- a/libs/sdk-svelte/src/tests/components/InterruptReconnectStream.svelte
+++ b/libs/sdk-svelte/src/tests/components/InterruptReconnectStream.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+  import { useStream } from "../../index.js";
+  import { HumanMessage, type BaseMessage } from "@langchain/core/messages";
+  import { createDroppableAuthFetch } from "../fixtures/droppable-auth-fetch.js";
+  import { formatMessage } from "./format.js";
+
+  interface Props {
+    apiUrl: string;
+    assistantId?: string;
+  }
+
+  const {
+    apiUrl,
+    assistantId = "interruptAgent",
+  }: Props = $props();
+
+  const droppable = createDroppableAuthFetch();
+  let reconnectCount = $state(0);
+  let eventOpens = $state(0);
+  let timer: number | undefined;
+
+  onMount(() => {
+    timer = window.setInterval(() => {
+      eventOpens = droppable.eventStreamOpenCount();
+    }, 50);
+  });
+  onDestroy(() => {
+    if (timer != null) window.clearInterval(timer);
+  });
+
+  const stream = useStream<
+    { messages: BaseMessage[] },
+    { nodeName?: string }
+  >({
+    assistantId,
+    apiUrl,
+    fetch: droppable.fetch,
+    maxReconnectAttempts: 5,
+    reconnectDelayMs: () => 0,
+    streamIdleReconnect: 0,
+    onReconnect: () => {
+      reconnectCount += 1;
+      eventOpens = droppable.eventStreamOpenCount();
+    },
+  });
+
+  const interruptNode = $derived(
+    (stream.interrupt?.value as { nodeName?: string } | undefined)?.nodeName ??
+      "",
+  );
+
+  const lastMessage = $derived(
+    stream.messages.length ? formatMessage(stream.messages.at(-1)!) : "",
+  );
+</script>
+
+<div>
+  <div data-testid="interrupt-count">{stream.interrupts.length}</div>
+  <div data-testid="interrupt-id">{stream.interrupt?.id ?? ""}</div>
+  <div data-testid="interrupt-node">{interruptNode}</div>
+  <div data-testid="last-message">{lastMessage}</div>
+  <div data-testid="loading">
+    {stream.isLoading ? "Loading..." : "Not loading"}
+  </div>
+  <div data-testid="reconnect-count">{reconnectCount}</div>
+  <div data-testid="event-stream-opens">{eventOpens}</div>
+  <button
+    data-testid="submit"
+    onclick={() =>
+      void stream.submit({ messages: [new HumanMessage("ship it")] })}
+  >
+    Send
+  </button>
+  <button
+    data-testid="drop-events"
+    onclick={() => {
+      droppable.dropActiveStreams();
+      eventOpens = droppable.eventStreamOpenCount();
+    }}
+  >
+    Drop events
+  </button>
+  {#if stream.interrupt}
+    <button
+      data-testid="resume"
+      onclick={() => {
+        void stream.respond("approved");
+      }}
+    >
+      Resume
+    </button>
+  {/if}
+</div>

--- a/libs/sdk-svelte/src/tests/fixtures/droppable-auth-fetch.ts
+++ b/libs/sdk-svelte/src/tests/fixtures/droppable-auth-fetch.ts
@@ -1,0 +1,108 @@
+/**
+ * Auth-shim style `fetch` wrapper used to reproduce the browser HITL-idle
+ * failure mode: a custom `fetch` (tenant headers / proxy) must keep SSE
+ * reconnect enabled, and mid-stream drops must recover before `respond()`.
+ *
+ * Dropping must *error* the response body (not abort the request signal).
+ * Aborting the fetch signal often ends the SSE `for await` cleanly, which
+ * skips the reconnect loop in {@link ProtocolSseTransportAdapter.openEventStream}.
+ */
+
+function requestHref(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function isEventStreamUrl(href: string): boolean {
+  try {
+    return new URL(href, "http://localhost").pathname.includes(
+      "/stream/events"
+    );
+  } catch {
+    return href.includes("/stream/events");
+  }
+}
+
+export interface DroppableAuthFetch {
+  /** Custom fetch suitable for `useStream({ fetch })`. */
+  fetch: typeof fetch;
+  /** Error every in-flight `/stream/events` body (simulates QUIC/idle drop). */
+  dropActiveStreams: (reason?: unknown) => void;
+  /** Number of `/stream/events` opens observed (includes reconnects). */
+  eventStreamOpenCount: () => number;
+}
+
+export function createDroppableAuthFetch(
+  baseFetch: typeof fetch = globalThis.fetch
+): DroppableAuthFetch {
+  const bodyDroppers = new Set<(reason: unknown) => void>();
+  let eventStreamOpens = 0;
+
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const href = requestHref(input);
+    if (!isEventStreamUrl(href)) {
+      return baseFetch(input, init);
+    }
+
+    eventStreamOpens += 1;
+    const response = await baseFetch(input, init);
+    if (response.body == null) {
+      return response;
+    }
+
+    const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
+    const writer = writable.getWriter();
+    const reader = response.body.getReader();
+    let dropped = false;
+
+    const drop = (reason: unknown) => {
+      if (dropped) return;
+      dropped = true;
+      void writer.abort(reason);
+      void reader.cancel(reason);
+    };
+    bodyDroppers.add(drop);
+
+    void (async () => {
+      try {
+        while (!dropped) {
+          const { done, value } = await reader.read();
+          if (done) {
+            await writer.close();
+            return;
+          }
+          await writer.write(value);
+        }
+      } catch (error) {
+        if (!dropped) {
+          try {
+            await writer.abort(error);
+          } catch {
+            // already closed/aborted
+          }
+        }
+      } finally {
+        bodyDroppers.delete(drop);
+      }
+    })();
+
+    return new Response(readable, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };
+
+  return {
+    fetch: fetchImpl,
+    dropActiveStreams: (
+      reason = new TypeError("net::ERR_QUIC_PROTOCOL_ERROR")
+    ) => {
+      for (const drop of [...bodyDroppers]) {
+        drop(reason);
+      }
+    },
+    eventStreamOpenCount: () => eventStreamOpens,
+  };
+}

--- a/libs/sdk-svelte/src/tests/stream.interrupts.test.ts
+++ b/libs/sdk-svelte/src/tests/stream.interrupts.test.ts
@@ -2,6 +2,7 @@ import { expect, it, inject } from "vitest";
 import { render } from "vitest-browser-svelte";
 
 import InterruptStream from "./components/InterruptStream.svelte";
+import InterruptReconnectStream from "./components/InterruptReconnectStream.svelte";
 import MultiInterruptStream from "./components/MultiInterruptStream.svelte";
 
 const serverUrl = inject("serverUrl");
@@ -44,6 +45,62 @@ it("resumes an interrupt via respond()", async () => {
     .element(screen.getByTestId("interrupt-count"))
     .toHaveTextContent("0");
 });
+
+it(
+  "resumes after a mid-HITL SSE drop when using a custom auth fetch",
+  { timeout: 20_000 },
+  async () => {
+    const screen = render(InterruptReconnectStream, { apiUrl: serverUrl });
+
+    await screen.getByTestId("submit").click();
+
+    await expect
+      .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("loading"))
+      .toHaveTextContent("Not loading");
+
+    const opensBeforeDrop = Number(
+      screen.getByTestId("event-stream-opens").element().textContent ?? "0"
+    );
+
+    await screen.getByTestId("drop-events").click();
+
+    await expect
+      .poll(
+        () =>
+          Number(
+            screen.getByTestId("event-stream-opens").element().textContent ??
+              "0"
+          ),
+        { timeout: 10_000 }
+      )
+      .toBeGreaterThan(opensBeforeDrop);
+
+    await expect
+      .poll(
+        () =>
+          Number(
+            screen.getByTestId("reconnect-count").element().textContent ?? "0"
+          ),
+        { timeout: 10_000 }
+      )
+      .toBeGreaterThan(0);
+
+    await screen.getByTestId("resume").click();
+
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 10_000 })
+      .toHaveTextContent("Not loading");
+    await expect
+      .element(screen.getByTestId("last-message"))
+      .toHaveTextContent("After interrupt");
+    await expect
+      .element(screen.getByTestId("interrupt-count"))
+      .toHaveTextContent("0");
+  }
+);
 
 it("resumes several parallel interrupts via respondAll()", { timeout: 15_000 }, async () => {
   const screen = render(MultiInterruptStream, { apiUrl: serverUrl });

--- a/libs/sdk-svelte/src/use-stream.svelte.ts
+++ b/libs/sdk-svelte/src/use-stream.svelte.ts
@@ -455,6 +455,10 @@ export function useStream<
     transport?: "sse" | "websocket" | AgentServerAdapter;
     fetch?: typeof fetch;
     webSocketFactory?: (url: string) => WebSocket;
+    maxReconnectAttempts?: number;
+    streamIdleReconnect?: number | "auto";
+    reconnectDelayMs?: (attempt: number) => number;
+    onReconnect?: (options: { attempt: number; cause: unknown }) => void;
     onThreadId?: (threadId: string) => void;
     onCreated?: (info: RunExecutionInfo) => void;
     onCompleted?: (info: RunCompletedInfo) => void;
@@ -508,6 +512,14 @@ export function useStream<
     transport,
     fetch: hasCustomAdapter ? undefined : asBag.fetch,
     webSocketFactory: hasCustomAdapter ? undefined : asBag.webSocketFactory,
+    maxReconnectAttempts: hasCustomAdapter
+      ? undefined
+      : asBag.maxReconnectAttempts,
+    streamIdleReconnect: hasCustomAdapter
+      ? undefined
+      : asBag.streamIdleReconnect,
+    reconnectDelayMs: hasCustomAdapter ? undefined : asBag.reconnectDelayMs,
+    onReconnect: hasCustomAdapter ? undefined : asBag.onReconnect,
     onThreadId: options.onThreadId,
     onCreated: options.onCreated,
     onCompleted: options.onCompleted,

--- a/libs/sdk-vue/src/selectors.ts
+++ b/libs/sdk-vue/src/selectors.ts
@@ -13,6 +13,7 @@ import {
 import type { BaseMessage } from "@langchain/core/messages";
 import {
   NAMESPACE_SEPARATOR,
+  DEFAULT_MESSAGES_KEY,
   acquireChannelEffect,
   audioProjection,
   channelProjection,
@@ -225,7 +226,7 @@ export function useValues(
 ): Readonly<ShallowRef<unknown>> {
   const namespace = resolveNamespace(target);
   if (isRoot(namespace)) return stream.values as Readonly<ShallowRef<unknown>>;
-  const messagesKey = options?.messagesKey ?? "messages";
+  const messagesKey = options?.messagesKey ?? DEFAULT_MESSAGES_KEY;
   const key = `values|${messagesKey}|${namespaceKey(namespace)}`;
   return useProjection<unknown>(
     getRegistry(stream),

--- a/libs/sdk-vue/src/tests/components/InterruptReconnectStream.tsx
+++ b/libs/sdk-vue/src/tests/components/InterruptReconnectStream.tsx
@@ -1,0 +1,104 @@
+import { computed, defineComponent, onMounted, onUnmounted, ref } from "vue";
+import { HumanMessage, type BaseMessage } from "@langchain/core/messages";
+
+import { useStream } from "../../index.js";
+import { createDroppableAuthFetch } from "../fixtures/droppable-auth-fetch.js";
+import { formatMessage } from "./format.js";
+
+interface InterruptState {
+  messages: BaseMessage[];
+}
+
+export const InterruptReconnectStream = defineComponent({
+  name: "InterruptReconnectStream",
+  props: {
+    apiUrl: { type: String, required: true },
+    assistantId: { type: String, default: "interruptAgent" },
+  },
+  setup(props) {
+    const droppable = createDroppableAuthFetch();
+    const reconnectCount = ref(0);
+    const eventOpens = ref(0);
+    let timer: number | undefined;
+
+    onMounted(() => {
+      timer = window.setInterval(() => {
+        eventOpens.value = droppable.eventStreamOpenCount();
+      }, 50);
+    });
+    onUnmounted(() => {
+      if (timer != null) window.clearInterval(timer);
+    });
+
+    const stream = useStream<InterruptState>({
+      assistantId: props.assistantId,
+      apiUrl: props.apiUrl,
+      fetch: droppable.fetch,
+      maxReconnectAttempts: 5,
+      reconnectDelayMs: () => 0,
+      streamIdleReconnect: 0,
+      onReconnect: () => {
+        reconnectCount.value += 1;
+        eventOpens.value = droppable.eventStreamOpenCount();
+      },
+    });
+
+    const interruptNode = computed(() => {
+      const value = stream.interrupt.value?.value as
+        | { nodeName?: string }
+        | undefined;
+      return value?.nodeName ?? "";
+    });
+
+    const lastMessage = computed(() => {
+      const msgs = stream.messages.value;
+      if (msgs.length === 0) return "";
+      return formatMessage(msgs[msgs.length - 1]);
+    });
+
+    return () => (
+      <div>
+        <div data-testid="interrupt-count">
+          {stream.interrupts.value.length}
+        </div>
+        <div data-testid="interrupt-id">
+          {stream.interrupt.value?.id ?? ""}
+        </div>
+        <div data-testid="interrupt-node">{interruptNode.value}</div>
+        <div data-testid="loading">
+          {stream.isLoading.value ? "Loading..." : "Not loading"}
+        </div>
+        <div data-testid="last-message">{lastMessage.value}</div>
+        <div data-testid="reconnect-count">{reconnectCount.value}</div>
+        <div data-testid="event-stream-opens">{eventOpens.value}</div>
+        <button
+          data-testid="submit"
+          onClick={() =>
+            void stream.submit({ messages: [new HumanMessage("ship it")] })
+          }
+        >
+          Submit
+        </button>
+        <button
+          data-testid="drop-events"
+          onClick={() => {
+            droppable.dropActiveStreams();
+            eventOpens.value = droppable.eventStreamOpenCount();
+          }}
+        >
+          Drop events
+        </button>
+        <button
+          data-testid="resume"
+          onClick={() => {
+            if (stream.interrupt.value) {
+              void stream.respond("approved");
+            }
+          }}
+        >
+          Resume
+        </button>
+      </div>
+    );
+  },
+});

--- a/libs/sdk-vue/src/tests/fixtures/droppable-auth-fetch.ts
+++ b/libs/sdk-vue/src/tests/fixtures/droppable-auth-fetch.ts
@@ -1,0 +1,108 @@
+/**
+ * Auth-shim style `fetch` wrapper used to reproduce the browser HITL-idle
+ * failure mode: a custom `fetch` (tenant headers / proxy) must keep SSE
+ * reconnect enabled, and mid-stream drops must recover before `respond()`.
+ *
+ * Dropping must *error* the response body (not abort the request signal).
+ * Aborting the fetch signal often ends the SSE `for await` cleanly, which
+ * skips the reconnect loop in {@link ProtocolSseTransportAdapter.openEventStream}.
+ */
+
+function requestHref(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function isEventStreamUrl(href: string): boolean {
+  try {
+    return new URL(href, "http://localhost").pathname.includes(
+      "/stream/events"
+    );
+  } catch {
+    return href.includes("/stream/events");
+  }
+}
+
+export interface DroppableAuthFetch {
+  /** Custom fetch suitable for `useStream({ fetch })`. */
+  fetch: typeof fetch;
+  /** Error every in-flight `/stream/events` body (simulates QUIC/idle drop). */
+  dropActiveStreams: (reason?: unknown) => void;
+  /** Number of `/stream/events` opens observed (includes reconnects). */
+  eventStreamOpenCount: () => number;
+}
+
+export function createDroppableAuthFetch(
+  baseFetch: typeof fetch = globalThis.fetch
+): DroppableAuthFetch {
+  const bodyDroppers = new Set<(reason: unknown) => void>();
+  let eventStreamOpens = 0;
+
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const href = requestHref(input);
+    if (!isEventStreamUrl(href)) {
+      return baseFetch(input, init);
+    }
+
+    eventStreamOpens += 1;
+    const response = await baseFetch(input, init);
+    if (response.body == null) {
+      return response;
+    }
+
+    const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>();
+    const writer = writable.getWriter();
+    const reader = response.body.getReader();
+    let dropped = false;
+
+    const drop = (reason: unknown) => {
+      if (dropped) return;
+      dropped = true;
+      void writer.abort(reason);
+      void reader.cancel(reason);
+    };
+    bodyDroppers.add(drop);
+
+    void (async () => {
+      try {
+        while (!dropped) {
+          const { done, value } = await reader.read();
+          if (done) {
+            await writer.close();
+            return;
+          }
+          await writer.write(value);
+        }
+      } catch (error) {
+        if (!dropped) {
+          try {
+            await writer.abort(error);
+          } catch {
+            // already closed/aborted
+          }
+        }
+      } finally {
+        bodyDroppers.delete(drop);
+      }
+    })();
+
+    return new Response(readable, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };
+
+  return {
+    fetch: fetchImpl,
+    dropActiveStreams: (
+      reason = new TypeError("net::ERR_QUIC_PROTOCOL_ERROR")
+    ) => {
+      for (const drop of [...bodyDroppers]) {
+        drop(reason);
+      }
+    },
+    eventStreamOpenCount: () => eventStreamOpens,
+  };
+}

--- a/libs/sdk-vue/src/tests/stream.interrupts.test.tsx
+++ b/libs/sdk-vue/src/tests/stream.interrupts.test.tsx
@@ -2,6 +2,7 @@ import { expect, it } from "vitest";
 import { render } from "vitest-browser-vue";
 
 import { InterruptStream } from "./components/InterruptStream.js";
+import { InterruptReconnectStream } from "./components/InterruptReconnectStream.js";
 import { MultiInterruptStream } from "./components/MultiInterruptStream.js";
 import { apiUrl } from "./test-utils.js";
 
@@ -51,6 +52,69 @@ it("resumes an interrupt via respond()", async () => {
     await screen.unmount();
   }
 });
+
+it(
+  "resumes after a mid-HITL SSE drop when using a custom auth fetch",
+  { timeout: 20_000 },
+  async () => {
+    const screen = await render(InterruptReconnectStream, {
+      props: { apiUrl },
+    });
+
+    try {
+      await screen.getByTestId("submit").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("loading"))
+        .toHaveTextContent("Not loading");
+
+      const opensBeforeDrop = Number(
+        screen.getByTestId("event-stream-opens").element().textContent ?? "0"
+      );
+
+      await screen.getByTestId("drop-events").click();
+
+      await expect
+        .poll(
+          () =>
+            Number(
+              screen.getByTestId("event-stream-opens").element().textContent ??
+                "0"
+            ),
+          { timeout: 10_000 }
+        )
+        .toBeGreaterThan(opensBeforeDrop);
+
+      await expect
+        .poll(
+          () =>
+            Number(
+              screen.getByTestId("reconnect-count").element().textContent ??
+                "0"
+            ),
+          { timeout: 10_000 }
+        )
+        .toBeGreaterThan(0);
+
+      await screen.getByTestId("resume").click();
+
+      await expect
+        .element(screen.getByTestId("loading"), { timeout: 10_000 })
+        .toHaveTextContent("Not loading");
+      await expect
+        .element(screen.getByTestId("last-message"))
+        .toHaveTextContent("After interrupt");
+      await expect
+        .element(screen.getByTestId("interrupt-count"))
+        .toHaveTextContent("0");
+    } finally {
+      await screen.unmount();
+    }
+  }
+);
 
 it("resumes several parallel interrupts via respondAll()", { timeout: 15_000 }, async () => {
   const screen = await render(MultiInterruptStream, { props: { apiUrl } });

--- a/libs/sdk-vue/src/use-stream.ts
+++ b/libs/sdk-vue/src/use-stream.ts
@@ -472,6 +472,10 @@ export function useStream<
     transport?: "sse" | "websocket" | AgentServerAdapter;
     fetch?: typeof fetch;
     webSocketFactory?: (url: string) => WebSocket;
+    maxReconnectAttempts?: number;
+    streamIdleReconnect?: number | "auto";
+    reconnectDelayMs?: (attempt: number) => number;
+    onReconnect?: (options: { attempt: number; cause: unknown }) => void;
     onThreadId?: (threadId: string) => void;
     onCreated?: (info: RunExecutionInfo) => void;
     onCompleted?: (info: RunCompletedInfo) => void;
@@ -547,6 +551,14 @@ export function useStream<
     transport,
     fetch: hasCustomAdapter ? undefined : asBag.fetch,
     webSocketFactory: hasCustomAdapter ? undefined : asBag.webSocketFactory,
+    maxReconnectAttempts: hasCustomAdapter
+      ? undefined
+      : asBag.maxReconnectAttempts,
+    streamIdleReconnect: hasCustomAdapter
+      ? undefined
+      : asBag.streamIdleReconnect,
+    reconnectDelayMs: hasCustomAdapter ? undefined : asBag.reconnectDelayMs,
+    onReconnect: hasCustomAdapter ? undefined : asBag.onReconnect,
     onThreadId: options.onThreadId,
     onCreated: options.onCreated,
     onCompleted: options.onCompleted,

--- a/libs/sdk/src/client/base.ts
+++ b/libs/sdk/src/client/base.ts
@@ -7,7 +7,9 @@ import {
   idleReconnectStream,
   type IdleReconnectMode,
   StreamRequestParams,
+  DEFAULT_IDLE_RECONNECT,
 } from "../utils/stream.js";
+import { DEFAULT_MAX_RECONNECT_ATTEMPTS } from "../utils/reconnect.js";
 import type { StreamProtocol } from "../types.js";
 
 export type HeaderValue = string | undefined | null;
@@ -451,7 +453,7 @@ export class BaseClient {
       // decoder and the SSE decoder) so it can both reset on any line and
       // recognise `:` keep-alive heartbeats to drive `"auto"` mode. The SSE
       // decoder downstream discards those comment lines.
-      const idleMode = config.idleReconnect ?? "auto";
+      const idleMode = config.idleReconnect ?? DEFAULT_IDLE_RECONNECT;
       const enableIdle = idleMode === "auto" || idleMode > 0;
 
       const lines = response.body.pipeThrough(BytesLineDecoder());
@@ -466,7 +468,7 @@ export class BaseClient {
     };
 
     yield* streamWithRetry(makeRequest, {
-      maxRetries: config.maxRetries ?? 5,
+      maxRetries: config.maxRetries ?? DEFAULT_MAX_RECONNECT_ATTEMPTS,
       signal: config.signal,
       onReconnect: config.onReconnect,
     });

--- a/libs/sdk/src/client/index.test.ts
+++ b/libs/sdk/src/client/index.test.ts
@@ -97,6 +97,8 @@ describe("Client", () => {
       assistantId: "my-agent",
       transport: "sse",
       fetch: customFetch,
+      maxReconnectAttempts: 0,
+      streamIdleReconnect: 0,
     });
 
     await expect(thread.subscribe(["values"])).rejects.toBe(sentinel);
@@ -131,6 +133,8 @@ describe("Client", () => {
       assistantId: "docs_agent",
       transport: "sse",
       fetch: customFetch,
+      maxReconnectAttempts: 0,
+      streamIdleReconnect: 0,
     });
 
     await expect(thread.subscribe(["values"])).rejects.toBe(sentinel);

--- a/libs/sdk/src/client/stream/test/reconnect.int.test.ts
+++ b/libs/sdk/src/client/stream/test/reconnect.int.test.ts
@@ -101,6 +101,49 @@ describe.skipIf(!hasGlobalWebSocket)(
       }
     });
 
+    it("SSE: custom auth fetch still reconnects after the server drops the connection", async () => {
+      // Auth shims must not disable reconnect — production LangSmith Fleet /
+      // tenant-aware browsers always supply a custom fetch.
+      server = await startMockProtocolServer({
+        threadId: "thread_sse_custom_fetch_reconnect",
+        events: TEST_EVENTS,
+        failSseAfterDelivered: 2,
+      });
+
+      const onReconnect = vi.fn();
+      const authFetch: typeof fetch = (input, init) =>
+        globalThis.fetch(input, init);
+      const client = new Client({ apiUrl: server.apiUrl, apiKey: null });
+      const thread = client.threads.stream(server.threadId, {
+        assistantId: "assistant_mock",
+        transport: "sse",
+        fetch: authFetch,
+        maxReconnectAttempts: 3,
+        reconnectDelayMs: () => 0,
+        onReconnect,
+      });
+
+      const { seqs, off } = collectSeqsFromThread(thread);
+      try {
+        const run = await thread.run.start({ input: { prompt: "hi" } });
+        expect(run).toBeDefined();
+
+        await vi.waitFor(
+          () => {
+            expect(onReconnect).toHaveBeenCalledTimes(1);
+            expect(server.sseConnectionCount()).toBeGreaterThanOrEqual(2);
+            expect(thread.ordering.lastSeenSeq).toBe(4);
+          },
+          { timeout: 10_000 }
+        );
+
+        expect([...new Set(seqs)].sort((a, b) => a - b)).toEqual([1, 2, 3, 4]);
+      } finally {
+        off();
+        await thread.close();
+      }
+    });
+
     it("WebSocket: run.start streams all values after the server drops the connection", async () => {
       server = await startMockProtocolServer({
         threadId: "thread_ws_client_reconnect",

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -38,6 +38,8 @@ describe("ProtocolSseTransportAdapter URL resolution", () => {
       apiUrl: PROXIED_API_URL,
       threadId: THREAD_ID,
       fetch,
+      // Fail-fast mock: custom fetch keeps reconnect on by default.
+      maxReconnectAttempts: 0,
     });
 
     const handle = transport.openEventStream({ channels: ["values"] });
@@ -310,5 +312,112 @@ describe("ProtocolSseTransportAdapter AsyncCaller", () => {
     expect(callSpy.mock.calls.length).toBe(callsAfterCommand);
 
     await transport.close();
+  });
+});
+
+describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
+  it("reconnects after a mid-stream failure when a custom auth fetch is supplied", async () => {
+    let streamOpens = 0;
+    const onReconnect = vi.fn();
+    const encoder = new TextEncoder();
+    const fetchImpl = vi.fn((input: URL | RequestInfo) => {
+      if (!String(input).includes("/stream/events")) {
+        return Promise.resolve(protocolSuccessResponse());
+      }
+      streamOpens += 1;
+      if (streamOpens === 1) {
+        // First open fails after headers — auth-shim browsers hit the same
+        // class of transport error (QUIC / idle proxy drop).
+        return Promise.resolve(
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(
+                  encoder.encode(
+                    'event: values\ndata: {"type":"event","method":"values","seq":1,"event_id":"e1"}\n\n'
+                  )
+                );
+                // Defer the failure so e1 can flush through the SSE decoder
+                // before the reconnect loop starts.
+                setTimeout(() => {
+                  controller.error(
+                    new TypeError("net::ERR_QUIC_PROTOCOL_ERROR")
+                  );
+                }, 10);
+              },
+            }),
+            {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            }
+          )
+        );
+      }
+      return Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  'event: values\ndata: {"type":"event","method":"values","seq":2,"event_id":"e2"}\n\n'
+                )
+              );
+              controller.close();
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          }
+        )
+      );
+    }) as unknown as typeof fetch;
+
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: THREAD_ID,
+      fetch: fetchImpl,
+      maxReconnectAttempts: 3,
+      reconnectDelayMs: () => 0,
+      onReconnect,
+      idleReconnect: 0,
+    });
+
+    const handle = transport.openEventStream({ channels: ["values"] });
+    await handle.ready;
+
+    const received: Array<{ event_id?: string; seq?: number }> = [];
+    for await (const message of handle.events) {
+      received.push(message as { event_id?: string; seq?: number });
+      if (received.some((m) => m.event_id === "e2")) break;
+    }
+
+    expect(received.map((m) => m.event_id)).toContain("e2");
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+    expect(streamOpens).toBe(2);
+
+    await transport.close();
+  });
+
+  it("keeps reconnect disabled when maxReconnectAttempts is explicitly 0", async () => {
+    const sentinel = new TypeError("net::ERR_QUIC_PROTOCOL_ERROR");
+    let streamOpens = 0;
+    const fetchImpl = vi.fn(() => {
+      streamOpens += 1;
+      return Promise.reject(sentinel);
+    }) as unknown as typeof fetch;
+
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: THREAD_ID,
+      fetch: fetchImpl,
+      maxReconnectAttempts: 0,
+      idleReconnect: 0,
+    });
+
+    const handle = transport.openEventStream({ channels: ["values"] });
+    await expect(handle.ready).rejects.toBe(sentinel);
+    expect(streamOpens).toBe(1);
+    handle.close();
   });
 });

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -79,16 +79,14 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
     this.onRequest = options.onRequest;
     this.fetchFactory = options.fetchFactory;
     this.asyncCaller = options.asyncCaller;
-    // Custom fetch (tests/mocks) must not auto-reconnect — same policy as skipping AsyncCaller.
-    this.maxReconnectAttempts =
-      options.fetch != null ? 0 : (options.maxReconnectAttempts ?? 5);
-    // Custom fetch (tests/mocks) also disables the idle watchdog, matching the
-    // no-auto-reconnect policy above — a tripped watchdog would have nothing to
-    // reconnect to and would surface spurious errors in those harnesses.
-    // Otherwise default to heartbeat-adaptive `"auto"`, which stays dormant
-    // unless the server actually emits keep-alive heartbeats.
-    this.idleReconnect =
-      options.fetch != null ? null : (options.idleReconnect ?? "auto");
+    // Custom `fetch` (auth shims, proxies) must keep reconnect enabled — that is
+    // the production path for tenant-aware browsers. Tests that need fail-fast
+    // mocks should pass `maxReconnectAttempts: 0` (and `idleReconnect: 0`)
+    // explicitly rather than relying on `fetch` presence.
+    this.maxReconnectAttempts = options.maxReconnectAttempts ?? 5;
+    // Default to heartbeat-adaptive `"auto"`, which stays dormant unless the
+    // server actually emits keep-alive heartbeats. Pass `0` to disable.
+    this.idleReconnect = options.idleReconnect ?? "auto";
     this.onReconnect = options.onReconnect;
     this.reconnectDelayMs =
       options.reconnectDelayMs ?? webSocketReconnectDelayMs;

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -29,7 +29,11 @@ import {
   idleReconnectStream,
   type IdleReconnectMode,
 } from "../../../utils/stream.js";
-import { webSocketReconnectDelayMs } from "./websocket.js";
+import {
+  DEFAULT_MAX_RECONNECT_ATTEMPTS,
+  reconnectDelayMs,
+} from "../../../utils/reconnect.js";
+import { DEFAULT_IDLE_RECONNECT } from "../../../utils/stream.js";
 
 /**
  * Transport adapter that speaks the thread-centric protocol over HTTP
@@ -83,13 +87,14 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
     // the production path for tenant-aware browsers. Tests that need fail-fast
     // mocks should pass `maxReconnectAttempts: 0` (and `idleReconnect: 0`)
     // explicitly rather than relying on `fetch` presence.
-    this.maxReconnectAttempts = options.maxReconnectAttempts ?? 5;
-    // Default to heartbeat-adaptive `"auto"`, which stays dormant unless the
-    // server actually emits keep-alive heartbeats. Pass `0` to disable.
-    this.idleReconnect = options.idleReconnect ?? "auto";
+    this.maxReconnectAttempts =
+      options.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS;
+    // Default to heartbeat-adaptive idle reconnect, which stays dormant
+    // unless the server actually emits keep-alive heartbeats. Pass `0` to
+    // disable.
+    this.idleReconnect = options.idleReconnect ?? DEFAULT_IDLE_RECONNECT;
     this.onReconnect = options.onReconnect;
-    this.reconnectDelayMs =
-      options.reconnectDelayMs ?? webSocketReconnectDelayMs;
+    this.reconnectDelayMs = options.reconnectDelayMs ?? reconnectDelayMs;
     this.threadId = options.threadId ?? "";
     this.paths = options.paths;
   }

--- a/libs/sdk/src/client/stream/transport/index.ts
+++ b/libs/sdk/src/client/stream/transport/index.ts
@@ -1,8 +1,5 @@
 export { ProtocolSseTransportAdapter } from "./http.js";
-export {
-  ProtocolWebSocketTransportAdapter,
-  webSocketReconnectDelayMs,
-} from "./websocket.js";
+export { ProtocolWebSocketTransportAdapter } from "./websocket.js";
 export { MaxWebSocketReconnectAttemptsError } from "../error.js";
 export type { WebSocketReconnectOptions } from "./websocket.js";
 export {

--- a/libs/sdk/src/client/stream/transport/types.ts
+++ b/libs/sdk/src/client/stream/transport/types.ts
@@ -1,6 +1,13 @@
 import type { CommandResponse, ErrorResponse } from "@langchain/protocol";
 import type { AsyncCaller } from "../../../utils/async_caller.js";
-import type { IdleReconnectMode } from "../../../utils/stream.js";
+import {
+  DEFAULT_IDLE_RECONNECT,
+  type IdleReconnectMode,
+} from "../../../utils/stream.js";
+import {
+  DEFAULT_MAX_RECONNECT_ATTEMPTS,
+  reconnectDelayMs,
+} from "../../../utils/reconnect.js";
 
 export type ProtocolRequestHook = (
   url: URL,
@@ -45,7 +52,8 @@ export interface ProtocolSseTransportOptions {
   paths?: ProtocolTransportPaths;
   /**
    * Maximum reconnect attempts after an unexpected SSE disconnect.
-   * Defaults to 5. Set to 0 to disable automatic reconnection.
+   * Defaults to {@link DEFAULT_MAX_RECONNECT_ATTEMPTS}. Set to 0 to disable
+   * automatic reconnection.
    *
    * Independent of whether a custom {@link ProtocolSseTransportOptions.fetch}
    * is supplied — auth/proxy fetch wrappers keep reconnect enabled. Pass `0`
@@ -59,16 +67,17 @@ export interface ProtocolSseTransportOptions {
    * which the reconnect loop treats like any other disconnect, re-subscribing
    * with `since` from the last seen sequence.
    *
-   * - `"auto"`: arm only once the server's SSE keep-alive heartbeats
-   *   (LangGraph Platform: `: heartbeat` every ~5s) are observed, sizing the
-   *   window from their cadence. Independent of agent activity; stays dormant
-   *   on heartbeat-less servers.
+   * - {@link DEFAULT_IDLE_RECONNECT} (`"auto"`): arm only once the server's
+   *   SSE keep-alive heartbeats (LangGraph Platform: `: heartbeat` every
+   *   ~5s) are observed, sizing the window from their cadence. Independent
+   *   of agent activity; stays dormant on heartbeat-less servers.
    * - a `number`: a fixed idle window in milliseconds.
    * - `0`: disables it.
    *
    * Independent of custom {@link ProtocolSseTransportOptions.fetch}; pass `0`
    * in fail-fast test harnesses.
    *
+   * @default DEFAULT_IDLE_RECONNECT
    * @see {@link IdleReconnectMode}
    */
   idleReconnect?: IdleReconnectMode;
@@ -76,7 +85,7 @@ export interface ProtocolSseTransportOptions {
   onReconnect?: (options: { attempt: number; cause: unknown }) => void;
   /**
    * Backoff before each SSE reconnect attempt. Defaults to
-   * {@link webSocketReconnectDelayMs} from `./websocket.js`.
+   * {@link reconnectDelayMs}.
    */
   reconnectDelayMs?: (attempt: number) => number;
 }
@@ -94,7 +103,8 @@ export interface ProtocolWebSocketTransportOptions {
   paths?: Pick<ProtocolTransportPaths, "stream">;
   /**
    * Maximum reconnect attempts after an unexpected socket close.
-   * Defaults to 5. Set to 0 to disable automatic reconnection.
+   * Defaults to {@link DEFAULT_MAX_RECONNECT_ATTEMPTS}. Set to 0 to disable
+   * automatic reconnection.
    */
   maxReconnectAttempts?: number;
   /**
@@ -108,7 +118,7 @@ export interface ProtocolWebSocketTransportOptions {
   onReconnected?: () => void | Promise<void>;
   /**
    * Backoff before each reconnect attempt. Defaults to
-   * {@link webSocketReconnectDelayMs}.
+   * {@link reconnectDelayMs}.
    */
   reconnectDelayMs?: (attempt: number) => number;
 }

--- a/libs/sdk/src/client/stream/transport/types.ts
+++ b/libs/sdk/src/client/stream/transport/types.ts
@@ -46,6 +46,10 @@ export interface ProtocolSseTransportOptions {
   /**
    * Maximum reconnect attempts after an unexpected SSE disconnect.
    * Defaults to 5. Set to 0 to disable automatic reconnection.
+   *
+   * Independent of whether a custom {@link ProtocolSseTransportOptions.fetch}
+   * is supplied — auth/proxy fetch wrappers keep reconnect enabled. Pass `0`
+   * explicitly in unit tests that mock a failing `fetch` and expect fail-fast.
    */
   maxReconnectAttempts?: number;
   /**
@@ -61,6 +65,9 @@ export interface ProtocolSseTransportOptions {
    *   on heartbeat-less servers.
    * - a `number`: a fixed idle window in milliseconds.
    * - `0`: disables it.
+   *
+   * Independent of custom {@link ProtocolSseTransportOptions.fetch}; pass `0`
+   * in fail-fast test harnesses.
    *
    * @see {@link IdleReconnectMode}
    */

--- a/libs/sdk/src/client/stream/transport/types.ts
+++ b/libs/sdk/src/client/stream/transport/types.ts
@@ -1,13 +1,6 @@
 import type { CommandResponse, ErrorResponse } from "@langchain/protocol";
 import type { AsyncCaller } from "../../../utils/async_caller.js";
-import {
-  DEFAULT_IDLE_RECONNECT,
-  type IdleReconnectMode,
-} from "../../../utils/stream.js";
-import {
-  DEFAULT_MAX_RECONNECT_ATTEMPTS,
-  reconnectDelayMs,
-} from "../../../utils/reconnect.js";
+import type { IdleReconnectMode } from "../../../utils/stream.js";
 
 export type ProtocolRequestHook = (
   url: URL,
@@ -52,8 +45,8 @@ export interface ProtocolSseTransportOptions {
   paths?: ProtocolTransportPaths;
   /**
    * Maximum reconnect attempts after an unexpected SSE disconnect.
-   * Defaults to {@link DEFAULT_MAX_RECONNECT_ATTEMPTS}. Set to 0 to disable
-   * automatic reconnection.
+   * Defaults to `DEFAULT_MAX_RECONNECT_ATTEMPTS` from `utils/reconnect`.
+   * Set to 0 to disable automatic reconnection.
    *
    * Independent of whether a custom {@link ProtocolSseTransportOptions.fetch}
    * is supplied — auth/proxy fetch wrappers keep reconnect enabled. Pass `0`
@@ -67,17 +60,17 @@ export interface ProtocolSseTransportOptions {
    * which the reconnect loop treats like any other disconnect, re-subscribing
    * with `since` from the last seen sequence.
    *
-   * - {@link DEFAULT_IDLE_RECONNECT} (`"auto"`): arm only once the server's
-   *   SSE keep-alive heartbeats (LangGraph Platform: `: heartbeat` every
-   *   ~5s) are observed, sizing the window from their cadence. Independent
-   *   of agent activity; stays dormant on heartbeat-less servers.
+   * - `"auto"` (`DEFAULT_IDLE_RECONNECT` from `utils/stream`): arm only once
+   *   the server's SSE keep-alive heartbeats (LangGraph Platform:
+   *   `: heartbeat` every ~5s) are observed, sizing the window from their
+   *   cadence. Independent of agent activity; stays dormant on
+   *   heartbeat-less servers.
    * - a `number`: a fixed idle window in milliseconds.
    * - `0`: disables it.
    *
    * Independent of custom {@link ProtocolSseTransportOptions.fetch}; pass `0`
    * in fail-fast test harnesses.
    *
-   * @default DEFAULT_IDLE_RECONNECT
    * @see {@link IdleReconnectMode}
    */
   idleReconnect?: IdleReconnectMode;
@@ -85,7 +78,7 @@ export interface ProtocolSseTransportOptions {
   onReconnect?: (options: { attempt: number; cause: unknown }) => void;
   /**
    * Backoff before each SSE reconnect attempt. Defaults to
-   * {@link reconnectDelayMs}.
+   * `reconnectDelayMs` from `utils/reconnect`.
    */
   reconnectDelayMs?: (attempt: number) => number;
 }
@@ -103,8 +96,8 @@ export interface ProtocolWebSocketTransportOptions {
   paths?: Pick<ProtocolTransportPaths, "stream">;
   /**
    * Maximum reconnect attempts after an unexpected socket close.
-   * Defaults to {@link DEFAULT_MAX_RECONNECT_ATTEMPTS}. Set to 0 to disable
-   * automatic reconnection.
+   * Defaults to `DEFAULT_MAX_RECONNECT_ATTEMPTS` from `utils/reconnect`.
+   * Set to 0 to disable automatic reconnection.
    */
   maxReconnectAttempts?: number;
   /**
@@ -118,7 +111,7 @@ export interface ProtocolWebSocketTransportOptions {
   onReconnected?: () => void | Promise<void>;
   /**
    * Backoff before each reconnect attempt. Defaults to
-   * {@link reconnectDelayMs}.
+   * `reconnectDelayMs` from `utils/reconnect`.
    */
   reconnectDelayMs?: (attempt: number) => number;
 }

--- a/libs/sdk/src/client/stream/transport/websocket.test.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.test.ts
@@ -1,9 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  ProtocolWebSocketTransportAdapter,
-  webSocketReconnectDelayMs,
-} from "./websocket.js";
+import { ProtocolWebSocketTransportAdapter } from "./websocket.js";
 import {
   PROXIED_API_URL,
   THREAD_ID,
@@ -164,13 +161,6 @@ describe("ProtocolWebSocketTransportAdapter thread binding", () => {
     expect(sockets[0].readyState).toBe(FakeWebSocket.OPEN);
 
     await transport.close();
-  });
-});
-
-describe("webSocketReconnectDelayMs", () => {
-  it("caps exponential backoff", () => {
-    expect(webSocketReconnectDelayMs(1)).toBeLessThanOrEqual(6000);
-    expect(webSocketReconnectDelayMs(10)).toBeLessThanOrEqual(6000);
   });
 });
 

--- a/libs/sdk/src/client/stream/transport/websocket.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.ts
@@ -23,6 +23,10 @@ import type {
 } from "./types.js";
 import type { TransportAdapter } from "../transport.js";
 import { MaxWebSocketReconnectAttemptsError } from "../error.js";
+import {
+  DEFAULT_MAX_RECONNECT_ATTEMPTS,
+  reconnectDelayMs,
+} from "../../../utils/reconnect.js";
 
 const WEB_SOCKET_CONNECTING = 0;
 const WEB_SOCKET_OPEN = 1;
@@ -35,7 +39,7 @@ const WEB_SOCKET_CLOSED = 3;
 export interface WebSocketReconnectOptions {
   /**
    * Maximum reconnection attempts after an unexpected disconnect.
-   * Defaults to 5.
+   * Defaults to {@link DEFAULT_MAX_RECONNECT_ATTEMPTS}.
    */
   maxReconnectAttempts?: number;
 
@@ -43,16 +47,6 @@ export interface WebSocketReconnectOptions {
    * Invoked before each reconnect attempt (after backoff).
    */
   onReconnect?: (options: { attempt: number; cause: unknown }) => void;
-}
-
-/**
- * Exponential backoff with jitter for WebSocket reconnect. Mirrors
- * {@link streamWithRetry} in `utils/stream.ts` (capped at 5s + 1s jitter).
- */
-export function webSocketReconnectDelayMs(attempt: number): number {
-  const baseDelay = Math.min(1000 * 2 ** (attempt - 1), 5000);
-  const jitter = Math.random() * 1000;
-  return baseDelay + jitter;
 }
 
 /**
@@ -109,11 +103,11 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
     this.webSocketFactory =
       options.webSocketFactory ?? ((url) => new WebSocket(url));
     this.paths = options.paths;
-    this.maxReconnectAttempts = options.maxReconnectAttempts ?? 5;
+    this.maxReconnectAttempts =
+      options.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS;
     this.onReconnect = options.onReconnect;
     this.onReconnected = options.onReconnected;
-    this.reconnectDelayMs =
-      options.reconnectDelayMs ?? webSocketReconnectDelayMs;
+    this.reconnectDelayMs = options.reconnectDelayMs ?? reconnectDelayMs;
   }
 
   /** {@inheritDoc TransportAdapter.setThreadId} */

--- a/libs/sdk/src/client/stream/types.ts
+++ b/libs/sdk/src/client/stream/types.ts
@@ -15,9 +15,22 @@ import type {
   SubscribeParams,
 } from "@langchain/protocol";
 
-import type { IdleReconnectMode } from "../../utils/stream.js";
+import {
+  DEFAULT_IDLE_RECONNECT,
+  type IdleReconnectMode,
+} from "../../utils/stream.js";
 import type { AssembledMessage } from "./messages.js";
 import type { AgentServerAdapter } from "./transport.js";
+import {
+  DEFAULT_MAX_RECONNECT_ATTEMPTS,
+  reconnectDelayMs,
+} from "../../utils/reconnect.js";
+
+export {
+  DEFAULT_IDLE_RECONNECT,
+  DEFAULT_MAX_RECONNECT_ATTEMPTS,
+  reconnectDelayMs,
+};
 
 export interface ExtendedRunStartParams extends RunStartParams {
   forkFrom?: string;
@@ -129,7 +142,8 @@ export interface ThreadStreamOptions {
   webSocketFactory?: (url: string) => WebSocket;
   /**
    * Built-in `"sse"` / `"websocket"` transports only: max reconnect
-   * attempts after an unexpected disconnect. Defaults to 5.
+   * attempts after an unexpected disconnect. Defaults to
+   * {@link DEFAULT_MAX_RECONNECT_ATTEMPTS}.
    */
   maxReconnectAttempts?: number;
   /**
@@ -137,17 +151,19 @@ export interface ThreadStreamOptions {
    * half-open sockets that hang with no error or close (e.g. a platform
    * revision rollover).
    *
-   * - `"auto"` (default): arm only once the server's SSE keep-alive
-   *   heartbeats are observed (LangGraph Platform emits `: heartbeat` every
-   *   ~5s), sizing the window from their cadence. Independent of agent
-   *   activity; stays dormant on heartbeat-less servers.
+   * - {@link DEFAULT_IDLE_RECONNECT} (`"auto"`): arm only once the server's
+   *   SSE keep-alive heartbeats are observed (LangGraph Platform emits
+   *   `: heartbeat` every ~5s), sizing the window from their cadence.
+   *   Independent of agent activity; stays dormant on heartbeat-less servers.
    * - a `number`: a fixed idle window in milliseconds.
    * - `0`: disables it.
+   *
+   * @default DEFAULT_IDLE_RECONNECT
    */
   streamIdleReconnect?: IdleReconnectMode;
   /**
    * Built-in transports only: delay before each reconnect attempt.
-   * Defaults to exponential backoff with jitter.
+   * Defaults to {@link reconnectDelayMs}.
    */
   reconnectDelayMs?: (attempt: number) => number;
   /**

--- a/libs/sdk/src/client/threads/index.ts
+++ b/libs/sdk/src/client/threads/index.ts
@@ -21,6 +21,7 @@ import type {
   ThreadStreamOptions,
   ThreadStreamTransportKind,
 } from "../stream/types.js";
+import { DEFAULT_MAX_RECONNECT_ATTEMPTS } from "../../utils/reconnect.js";
 import { ProtocolSseTransportAdapter } from "../stream/transport/http.js";
 import { ProtocolWebSocketTransportAdapter } from "../stream/transport/websocket.js";
 import type { TransportAdapter } from "../stream/transport.js";
@@ -502,7 +503,8 @@ export class ThreadsClient<
       const transportKind: ThreadStreamTransportKind =
         options.transport ??
         (this.streamProtocol === "v2-websocket" ? "websocket" : "sse");
-      const maxReconnectAttempts = options.maxReconnectAttempts ?? 5;
+      const maxReconnectAttempts =
+        options.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS;
 
       /**
        * Common options for both transports.

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -104,7 +104,7 @@ export type {
   UpdatesStreamEvent,
   ValuesStreamEvent,
 } from "./types.stream.js";
-export { NAMESPACE_SEPARATOR } from "./stream/index.js";
+export { NAMESPACE_SEPARATOR, DEFAULT_MESSAGES_KEY } from "./stream/index.js";
 
 export type { BagTemplate } from "./types.template.js";
 export type * from "./ui/stream/index.js";

--- a/libs/sdk/src/react/stream.custom.tsx
+++ b/libs/sdk/src/react/stream.custom.tsx
@@ -4,6 +4,7 @@
 
 import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { EventStreamEvent, StreamManager } from "../ui/manager.js";
+import { DEFAULT_MESSAGES_KEY } from "../stream/constants.js";
 import type {
   GetUpdateType,
   GetCustomEventType,
@@ -158,14 +159,14 @@ export function useStreamCustom<
   }, [threadId, stream]);
 
   const getMessages = (value: StateType): Message[] => {
-    const messagesKey = options.messagesKey ?? "messages";
+    const messagesKey = options.messagesKey ?? DEFAULT_MESSAGES_KEY;
     return Array.isArray(value[messagesKey])
       ? (value[messagesKey] as Message[])
       : [];
   };
 
   const setMessages = (current: StateType, messages: Message[]): StateType => {
-    const messagesKey = options.messagesKey ?? "messages";
+    const messagesKey = options.messagesKey ?? DEFAULT_MESSAGES_KEY;
     return { ...current, [messagesKey]: messages };
   };
 

--- a/libs/sdk/src/react/stream.lgp.tsx
+++ b/libs/sdk/src/react/stream.lgp.tsx
@@ -34,6 +34,7 @@ import type {
 import type { UseStream, SubmitOptions } from "./types.js";
 
 import { Client, getClientConfigHash } from "../client.js";
+import { DEFAULT_MESSAGES_KEY } from "../stream/constants.js";
 import { type Message } from "../types.messages.js";
 import { getToolCallsWithResults } from "../utils/tools.js";
 import type { Interrupt, ThreadState } from "../schema.js";
@@ -304,14 +305,14 @@ export function useStreamLGP<
   const history = options.thread ?? builtInHistory;
 
   const getMessages = (value: StateType): Message[] => {
-    const messagesKey = options.messagesKey ?? "messages";
+    const messagesKey = options.messagesKey ?? DEFAULT_MESSAGES_KEY;
     return Array.isArray(value[messagesKey])
       ? (value[messagesKey] as Message[])
       : [];
   };
 
   const setMessages = (current: StateType, messages: Message[]): StateType => {
-    const messagesKey = options.messagesKey ?? "messages";
+    const messagesKey = options.messagesKey ?? DEFAULT_MESSAGES_KEY;
     return { ...current, [messagesKey]: messages };
   };
 
@@ -398,7 +399,7 @@ export function useStreamLGP<
       if (historyLimit !== false && threadId) {
         const controller = new AbortController();
         void stream.fetchSubagentHistory(client.threads, threadId, {
-          messagesKey: options.messagesKey ?? "messages",
+          messagesKey: options.messagesKey ?? DEFAULT_MESSAGES_KEY,
           historyLimit:
             typeof historyLimit === "number" ? historyLimit : undefined,
           signal: controller.signal,

--- a/libs/sdk/src/stream/constants.ts
+++ b/libs/sdk/src/stream/constants.ts
@@ -4,3 +4,9 @@
  * which are printable identifiers.
  */
 export const NAMESPACE_SEPARATOR = "\u0000";
+
+/**
+ * Default state / values key that holds the message array for stream
+ * controllers and UI bindings.
+ */
+export const DEFAULT_MESSAGES_KEY = "messages";

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -1571,6 +1571,10 @@ export class StreamController<
       transport: this.#options.transport,
       fetch: this.#options.fetch,
       webSocketFactory: this.#options.webSocketFactory,
+      maxReconnectAttempts: this.#options.maxReconnectAttempts,
+      streamIdleReconnect: this.#options.streamIdleReconnect,
+      reconnectDelayMs: this.#options.reconnectDelayMs,
+      onReconnect: this.#options.onReconnect,
     });
     this.registry.bind(this.#thread);
     if (deferRootPump) {

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -38,7 +38,7 @@ import type { AssembledToolCall } from "../client/stream/handles/tools.js";
 import { normalizeInterruptForClient } from "../ui/interrupts.js";
 import { normalizeHitlResponseForServer } from "../ui/hitl-interrupt-payload.js";
 import type { Message } from "../types.messages.js";
-import { NAMESPACE_SEPARATOR } from "./constants.js";
+import { NAMESPACE_SEPARATOR, DEFAULT_MESSAGES_KEY } from "./constants.js";
 import { StreamStore } from "./store.js";
 import { ChannelRegistry } from "./channel-registry.js";
 import { ensureMessageInstances } from "./message-coercion.js";
@@ -336,7 +336,7 @@ export class StreamController<
    */
   constructor(options: StreamControllerOptions<StateType>) {
     this.#options = options;
-    this.#messagesKey = options.messagesKey ?? "messages";
+    this.#messagesKey = options.messagesKey ?? DEFAULT_MESSAGES_KEY;
     this.#currentThreadId = options.threadId ?? null;
     this.#rootBus = {
       channels: ROOT_PUMP_CHANNELS,
@@ -2470,8 +2470,8 @@ function extractAndCoerceMessagesWithFallback(
   messagesKey: string
 ): BaseMessage[] | null {
   let raw = values[messagesKey];
-  if (!Array.isArray(raw) && messagesKey !== "messages") {
-    raw = values.messages;
+  if (!Array.isArray(raw) && messagesKey !== DEFAULT_MESSAGES_KEY) {
+    raw = values[DEFAULT_MESSAGES_KEY];
   }
   if (!Array.isArray(raw)) return null;
   return ensureMessageInstances(

--- a/libs/sdk/src/stream/discovery/namespace-from-history.ts
+++ b/libs/sdk/src/stream/discovery/namespace-from-history.ts
@@ -22,7 +22,7 @@ import type {
   Metadata,
   ThreadState,
 } from "../../schema.js";
-import { NAMESPACE_SEPARATOR } from "../constants.js";
+import { NAMESPACE_SEPARATOR, DEFAULT_MESSAGES_KEY } from "../constants.js";
 import { namespaceKey } from "../namespace.js";
 import { normalizeAIMessageToolCalls } from "../message-coercion.js";
 
@@ -188,7 +188,7 @@ function applyCollectors(
 export function mapSubagentNamespaces(
   history: AnyCheckpoint[],
   toolCallIds: string[],
-  messagesKey = "messages"
+  messagesKey = DEFAULT_MESSAGES_KEY
 ): Map<string, string> {
   const out = new Map<string, string>();
   const targets = new Set(toolCallIds);
@@ -219,7 +219,7 @@ export async function resolveSubagentNamespaces<TStateType>(
   if (targets.size === 0) return out;
 
   const limit = opts?.limit ?? 20;
-  const messagesKey = opts?.messagesKey ?? "messages";
+  const messagesKey = opts?.messagesKey ?? DEFAULT_MESSAGES_KEY;
   const signal = opts?.signal;
 
   const page1 = await getHistoryPage(client, threadId, { limit, signal });

--- a/libs/sdk/src/stream/index.ts
+++ b/libs/sdk/src/stream/index.ts
@@ -125,7 +125,7 @@ export type {
   TransportAdapter,
 } from "../client/stream/transport.js";
 
-export { NAMESPACE_SEPARATOR } from "./constants.js";
+export { NAMESPACE_SEPARATOR, DEFAULT_MESSAGES_KEY } from "./constants.js";
 
 // Types framework bindings (React, Vue, Svelte, Angular) typically
 // need when wrapping the projection factories. Re-exported here so

--- a/libs/sdk/src/stream/projections/values.ts
+++ b/libs/sdk/src/stream/projections/values.ts
@@ -18,12 +18,13 @@ import {
 } from "../message-coercion.js";
 import type { Message } from "../../types.messages.js";
 import type { ProjectionSpec, ProjectionRuntime } from "../types.js";
+import { DEFAULT_MESSAGES_KEY } from "../constants.js";
 import { isRootNamespace, namespaceKey } from "../namespace.js";
 import { openProjectionSubscription } from "./runtime.js";
 
 export function valuesProjection<T = unknown>(
   namespace: readonly string[],
-  messagesKey: string = "messages"
+  messagesKey: string = DEFAULT_MESSAGES_KEY
 ): ProjectionSpec<T | undefined> {
   const ns = [...namespace];
   const key = `values|${messagesKey}|${namespaceKey(ns)}`;

--- a/libs/sdk/src/stream/types.ts
+++ b/libs/sdk/src/stream/types.ts
@@ -214,6 +214,20 @@ export interface AgentServerOptions<
   fetch?: typeof fetch;
   /** Optional `WebSocket` factory for the built-in WS transport. */
   webSocketFactory?: (url: string) => WebSocket;
+  /**
+   * Built-in transports only: max reconnect attempts after an unexpected
+   * disconnect. Defaults to 5. Independent of whether {@link fetch} is set.
+   */
+  maxReconnectAttempts?: number;
+  /**
+   * Built-in SSE transport only: idle-reconnect policy. Defaults to `"auto"`.
+   * Pass `0` to disable.
+   */
+  streamIdleReconnect?: ThreadStreamOptions["streamIdleReconnect"];
+  /** Built-in transports only: delay before each reconnect attempt. */
+  reconnectDelayMs?: ThreadStreamOptions["reconnectDelayMs"];
+  /** Built-in transports only: invoked before each reconnect attempt. */
+  onReconnect?: ThreadStreamOptions["onReconnect"];
 }
 
 /**
@@ -244,6 +258,10 @@ export interface CustomAdapterOptions<
   defaultHeaders?: never;
   fetch?: never;
   webSocketFactory?: never;
+  maxReconnectAttempts?: never;
+  streamIdleReconnect?: never;
+  reconnectDelayMs?: never;
+  onReconnect?: never;
 }
 
 /**
@@ -342,6 +360,21 @@ export interface StreamControllerOptions<
   fetch?: typeof fetch;
   /** Optional `WebSocket` factory forwarded to the built-in WS transport. */
   webSocketFactory?: (url: string) => WebSocket;
+  /**
+   * Built-in transports only: max reconnect attempts after an unexpected
+   * disconnect. Defaults to 5. Independent of whether {@link fetch} is set —
+   * auth shims keep reconnect enabled. Pass `0` to disable.
+   */
+  maxReconnectAttempts?: number;
+  /**
+   * Built-in SSE transport only: idle-reconnect policy. Defaults to `"auto"`.
+   * Pass `0` to disable. See {@link ThreadStreamOptions.streamIdleReconnect}.
+   */
+  streamIdleReconnect?: ThreadStreamOptions["streamIdleReconnect"];
+  /** Built-in transports only: delay before each reconnect attempt. */
+  reconnectDelayMs?: ThreadStreamOptions["reconnectDelayMs"];
+  /** Built-in transports only: invoked before each reconnect attempt. */
+  onReconnect?: ThreadStreamOptions["onReconnect"];
   /** Called when a thread id is first produced (new-thread submits). */
   onThreadId?: (threadId: string) => void;
   /**

--- a/libs/sdk/src/stream/types.ts
+++ b/libs/sdk/src/stream/types.ts
@@ -18,12 +18,21 @@ import type {
   AgentServerAdapter,
   TransportAdapter,
 } from "../client/stream/transport.js";
+import { DEFAULT_MAX_RECONNECT_ATTEMPTS } from "../utils/reconnect.js";
+import { DEFAULT_IDLE_RECONNECT } from "../utils/stream.js";
 import type {
   AnyHeadlessToolImplementation,
   OnToolCallback,
 } from "../headless-tools.js";
 import type { Channel, Event, Goto } from "@langchain/protocol";
+import { DEFAULT_MESSAGES_KEY } from "./constants.js";
 import type { StreamStore } from "./store.js";
+
+export {
+  DEFAULT_IDLE_RECONNECT,
+  DEFAULT_MAX_RECONNECT_ATTEMPTS,
+  DEFAULT_MESSAGES_KEY,
+};
 
 /** Why a run's active streaming phase ended. */
 export type RunExecutionReason =
@@ -158,7 +167,7 @@ export interface UseStreamCommonOptions<
    */
   onCompleted?: (info: RunCompletedInfo) => void;
   initialValues?: StateType;
-  /** State key holding the message array. Defaults to `"messages"`. */
+  /** State key holding the message array. Defaults to {@link DEFAULT_MESSAGES_KEY}. */
   messagesKey?: string;
   /** Headless tool implementations; auto-resumes matching interrupts. */
   tools?: AnyHeadlessToolImplementation[];
@@ -216,11 +225,13 @@ export interface AgentServerOptions<
   webSocketFactory?: (url: string) => WebSocket;
   /**
    * Built-in transports only: max reconnect attempts after an unexpected
-   * disconnect. Defaults to 5. Independent of whether {@link fetch} is set.
+   * disconnect. Defaults to {@link DEFAULT_MAX_RECONNECT_ATTEMPTS}.
+   * Independent of whether {@link fetch} is set.
    */
   maxReconnectAttempts?: number;
   /**
-   * Built-in SSE transport only: idle-reconnect policy. Defaults to `"auto"`.
+   * Built-in SSE transport only: idle-reconnect policy. Defaults to
+   * {@link DEFAULT_IDLE_RECONNECT}.
    * Pass `0` to disable.
    */
   streamIdleReconnect?: ThreadStreamOptions["streamIdleReconnect"];
@@ -362,12 +373,14 @@ export interface StreamControllerOptions<
   webSocketFactory?: (url: string) => WebSocket;
   /**
    * Built-in transports only: max reconnect attempts after an unexpected
-   * disconnect. Defaults to 5. Independent of whether {@link fetch} is set —
-   * auth shims keep reconnect enabled. Pass `0` to disable.
+   * disconnect. Defaults to {@link DEFAULT_MAX_RECONNECT_ATTEMPTS}.
+   * Independent of whether {@link fetch} is set — auth shims keep reconnect
+   * enabled. Pass `0` to disable.
    */
   maxReconnectAttempts?: number;
   /**
-   * Built-in SSE transport only: idle-reconnect policy. Defaults to `"auto"`.
+   * Built-in SSE transport only: idle-reconnect policy. Defaults to
+   * {@link DEFAULT_IDLE_RECONNECT}.
    * Pass `0` to disable. See {@link ThreadStreamOptions.streamIdleReconnect}.
    */
   streamIdleReconnect?: ThreadStreamOptions["streamIdleReconnect"];
@@ -391,7 +404,7 @@ export interface StreamControllerOptions<
   onCompleted?: (info: RunCompletedInfo) => void;
   /** Initial state for `root.values` before hydration lands. */
   initialValues?: StateType;
-  /** Key inside `values` that holds the message array. Defaults to `"messages"`. */
+  /** Key inside `values` that holds the message array. Defaults to {@link DEFAULT_MESSAGES_KEY}. */
   messagesKey?: string;
   /**
    * Optimistic UI for `submit()`. Defaults to `true`. See

--- a/libs/sdk/src/ui/manager.ts
+++ b/libs/sdk/src/ui/manager.ts
@@ -1,5 +1,6 @@
 import type { BaseMessage } from "@langchain/core/messages";
 
+import { DEFAULT_MESSAGES_KEY } from "../stream/constants.js";
 import type {
   CheckpointsStreamEvent,
   CustomStreamEvent,
@@ -339,7 +340,7 @@ export class StreamManager<
       signal?: AbortSignal;
     }
   ): Promise<void> {
-    const messagesKey = options?.messagesKey ?? "messages";
+    const messagesKey = options?.messagesKey ?? DEFAULT_MESSAGES_KEY;
     const signal = options?.signal;
 
     /**

--- a/libs/sdk/src/ui/messages.ts
+++ b/libs/sdk/src/ui/messages.ts
@@ -10,6 +10,7 @@ import {
 
 import type { Message } from "../types.messages.js";
 import type { ThreadState } from "../schema.js";
+import { DEFAULT_MESSAGES_KEY } from "../stream/constants.js";
 import {
   normalizeAIMessageToolCalls,
   tryCoerceMessageLikeToMessage,
@@ -174,7 +175,7 @@ export function ensureHistoryMessageInstances<
   StateType extends Record<string, unknown>,
 >(
   history: ThreadState<StateType>[],
-  messagesKey: string = "messages"
+  messagesKey: string = DEFAULT_MESSAGES_KEY
 ): ThreadState<StateType>[] {
   return history.map((state) => {
     if (state.values == null) return state;

--- a/libs/sdk/src/ui/orchestrator-custom.ts
+++ b/libs/sdk/src/ui/orchestrator-custom.ts
@@ -1,5 +1,6 @@
 import type { BaseMessage } from "@langchain/core/messages";
 
+import { DEFAULT_MESSAGES_KEY } from "../stream/constants.js";
 import type { ThreadState, Interrupt } from "../schema.js";
 import type { StreamMode } from "../types.stream.js";
 import type { Message } from "../types.messages.js";
@@ -175,14 +176,14 @@ export class CustomStreamOrchestrator<
   }
 
   #getMessages = (value: StateType): Message[] => {
-    const messagesKey = this.#options.messagesKey ?? "messages";
+    const messagesKey = this.#options.messagesKey ?? DEFAULT_MESSAGES_KEY;
     return Array.isArray(value[messagesKey])
       ? (value[messagesKey] as Message[])
       : [];
   };
 
   #setMessages = (current: StateType, messages: Message[]): StateType => {
-    const messagesKey = this.#options.messagesKey ?? "messages";
+    const messagesKey = this.#options.messagesKey ?? DEFAULT_MESSAGES_KEY;
     return { ...current, [messagesKey]: messages };
   };
 

--- a/libs/sdk/src/utils/reconnect.test.ts
+++ b/libs/sdk/src/utils/reconnect.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import { reconnectDelayMs } from "./reconnect.js";
+
+describe("reconnectDelayMs", () => {
+  it("caps exponential backoff", () => {
+    expect(reconnectDelayMs(1)).toBeLessThanOrEqual(6000);
+    expect(reconnectDelayMs(10)).toBeLessThanOrEqual(6000);
+  });
+});

--- a/libs/sdk/src/utils/reconnect.ts
+++ b/libs/sdk/src/utils/reconnect.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared reconnect defaults and backoff for SSE (`streamWithRetry`) and
+ * protocol transports (WebSocket / SSE adapters). Keep these in one place so
+ * legacy and v2 clients do not diverge.
+ */
+
+/** Default max reconnect / retry attempts after an unexpected disconnect. */
+export const DEFAULT_MAX_RECONNECT_ATTEMPTS = 5;
+
+/** Base delay (ms) for exponential reconnect backoff (`base * 2^(attempt-1)`). */
+export const DEFAULT_RECONNECT_BASE_DELAY_MS = 1000;
+
+/** Cap (ms) for exponential reconnect backoff before jitter. */
+export const DEFAULT_RECONNECT_MAX_DELAY_MS = 5000;
+
+/** Max random jitter (ms) added on top of the capped base delay. */
+export const DEFAULT_RECONNECT_JITTER_MS = 1000;
+
+/**
+ * Exponential backoff with jitter for stream reconnect.
+ * `min(base * 2^(attempt-1), max) + random(0, jitter)`.
+ */
+export function reconnectDelayMs(attempt: number): number {
+  const baseDelay = Math.min(
+    DEFAULT_RECONNECT_BASE_DELAY_MS * 2 ** (attempt - 1),
+    DEFAULT_RECONNECT_MAX_DELAY_MS
+  );
+  const jitter = Math.random() * DEFAULT_RECONNECT_JITTER_MS;
+  return baseDelay + jitter;
+}

--- a/libs/sdk/src/utils/stream.ts
+++ b/libs/sdk/src/utils/stream.ts
@@ -1,4 +1,8 @@
 import { isNetworkError } from "./error.js";
+import {
+  DEFAULT_MAX_RECONNECT_ATTEMPTS,
+  reconnectDelayMs,
+} from "./reconnect.js";
 
 // in this case don't quite match.
 type IterableReadableStreamInterface<T> = ReadableStream<T> & AsyncIterable<T>;
@@ -8,7 +12,8 @@ type IterableReadableStreamInterface<T> = ReadableStream<T> & AsyncIterable<T>;
  */
 export interface StreamWithRetryOptions {
   /**
-   * Maximum number of reconnection attempts. Default is 5.
+   * Maximum number of reconnection attempts. Default is
+   * {@link DEFAULT_MAX_RECONNECT_ATTEMPTS}.
    */
   maxRetries?: number;
 
@@ -90,6 +95,13 @@ const SSE_COMMENT_BYTE = 0x3a;
  *   so it can't false-fire during a legitimately quiet period.
  */
 export type IdleReconnectMode = number | "auto";
+
+/**
+ * Default idle-reconnect policy for SSE streams. Heartbeat-adaptive
+ * `"auto"` stays dormant unless the server emits keep-alive heartbeats.
+ * Pass `0` to disable.
+ */
+export const DEFAULT_IDLE_RECONNECT: IdleReconnectMode = "auto";
 
 export interface IdleReconnectStreamOptions {
   /** Fixed timeout (ms) or `"auto"` heartbeat-adaptive. */
@@ -223,7 +235,7 @@ export async function* streamWithRetry<T extends { id?: string }>(
   }>,
   options: StreamWithRetryOptions = {}
 ): AsyncGenerator<T> {
-  const maxRetries = options.maxRetries ?? 5;
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RECONNECT_ATTEMPTS;
   let attempt = 0;
   let lastEventId: string | undefined;
   let reconnectPath: string | undefined;
@@ -319,10 +331,8 @@ export async function* streamWithRetry<T extends { id?: string }>(
       // Notify about reconnection attempt
       options.onReconnect?.({ attempt, lastEventId, cause: lastError });
 
-      // Exponential backoff with jitter: min(1000 * 2^attempt, 5000) + random jitter
-      const baseDelay = Math.min(1000 * 2 ** (attempt - 1), 5000);
-      const jitter = Math.random() * 1000;
-      const delay = baseDelay + jitter;
+      // Exponential backoff with jitter (shared with protocol transports).
+      const delay = reconnectDelayMs(attempt);
 
       await new Promise((resolve) => {
         setTimeout(resolve, delay);


### PR DESCRIPTION
## Summary
- Keep SSE auto-reconnect and idle-reconnect enabled when a custom `fetch` is supplied (auth/proxy shims), instead of silently forcing `maxReconnectAttempts: 0`.
- Plumb `maxReconnectAttempts`, `streamIdleReconnect`, `reconnectDelayMs`, and `onReconnect` through `StreamController` and React/Vue/Svelte/Angular `useStream`.
- Add transport unit coverage plus browser interrupt tests that drop `/stream/events` mid-HITL and assert `respond()` still completes.
