### PR TITLE
fix(sdk): omit since on SSE reconnect

### DIFF
--- a/.changeset/fix-sse-reconnect-omit-since.md
+++ b/.changeset/fix-sse-reconnect-omit-since.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): omit `since` on SSE reconnect
+
+Protocol `seq` is connection-scoped: a new `POST /stream/events` re-numbers Redis replay from 1, so carrying the previous session's `since` filtered out the full history (heartbeats only after QUIC/idle drops). Reconnects now omit `since` and rely on durable `event_id` dedup.

--- a/.changeset/fix-sse-reconnect-omit-since.md
+++ b/.changeset/fix-sse-reconnect-omit-since.md
@@ -2,6 +2,6 @@
 "@langchain/langgraph-sdk": patch
 ---
 
-fix(sdk): omit `since` on SSE reconnect
+fix(sdk): omit carried `since` on SSE reconnect
 
-Protocol `seq` is connection-scoped: a new `POST /stream/events` re-numbers Redis replay from 1, so carrying the previous session's `since` filtered out the full history (heartbeats only after QUIC/idle drops). Reconnects now omit `since` and rely on durable `event_id` dedup.
+Protocol `seq` is connection-scoped: a new `POST /stream/events` re-numbers Redis replay from 1, so advancing `since` from observed seqs and sending it on reconnect filtered out the full history (heartbeats only). An explicit caller `since` is still honored on the initial open; reconnects omit `since` and rely on durable `event_id` dedup.

--- a/.changeset/fix-sse-reconnect-omit-since.md
+++ b/.changeset/fix-sse-reconnect-omit-since.md
@@ -4,4 +4,4 @@
 
 fix(sdk): omit carried `since` on SSE reconnect
 
-Protocol `seq` is connection-scoped: a new `POST /stream/events` re-numbers Redis replay from 1, so advancing `since` from observed seqs and sending it on reconnect filtered out the full history (heartbeats only). An explicit caller `since` is still honored on the initial open; reconnects omit `since` and rely on durable `event_id` dedup.
+Protocol `seq` is connection-scoped: a new `POST /stream/events` re-numbers Redis replay from 1, so advancing `since` from observed seqs and sending it after a successful open filtered out the full history (heartbeats only). An explicit caller `since` is still sent until the stream connects (including pre-ready retries); post-connect reconnects omit `since` and rely on durable `event_id` dedup.

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -396,14 +396,108 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
     expect(onReconnect).toHaveBeenCalledTimes(1);
     expect(streamOpens).toBe(2);
 
-    const reconnectBodies = fetchImpl.mock.calls
-      .map((call) => call[1] as RequestInit | undefined)
-      .filter((init) => init?.body != null)
-      .map((init) => JSON.parse(String(init!.body)) as Record<string, unknown>);
-    expect(reconnectBodies.length).toBeGreaterThanOrEqual(2);
-    for (const body of reconnectBodies) {
-      expect(body).not.toHaveProperty("since");
+    const streamBodies = fetchImpl.mock.calls
+      .filter((call) => String(call[0]).includes("/stream/events"))
+      .map((call) =>
+        JSON.parse(String((call[1] as RequestInit).body)) as Record<
+          string,
+          unknown
+        >
+      );
+    expect(streamBodies).toHaveLength(2);
+    expect(streamBodies[0]).not.toHaveProperty("since");
+    expect(streamBodies[1]).not.toHaveProperty("since");
+
+    await transport.close();
+  });
+
+  it("honors caller since on the initial open but omits it on reconnect", async () => {
+    let streamOpens = 0;
+    const encoder = new TextEncoder();
+    const fetchImpl = vi.fn((input: URL | RequestInfo) => {
+      if (!String(input).includes("/stream/events")) {
+        return Promise.resolve(protocolSuccessResponse());
+      }
+      streamOpens += 1;
+      if (streamOpens === 1) {
+        return Promise.resolve(
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(
+                  encoder.encode(
+                    'event: values\ndata: {"type":"event","method":"values","seq":6,"event_id":"e6"}\n\n'
+                  )
+                );
+                setTimeout(() => {
+                  controller.error(
+                    new TypeError("net::ERR_QUIC_PROTOCOL_ERROR")
+                  );
+                }, 10);
+              },
+            }),
+            {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            }
+          )
+        );
+      }
+      return Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  'event: values\ndata: {"type":"event","method":"values","seq":1,"event_id":"e1"}\n\n'
+                )
+              );
+              controller.close();
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          }
+        )
+      );
+    }) as unknown as typeof fetch;
+
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: THREAD_ID,
+      fetch: fetchImpl,
+      maxReconnectAttempts: 3,
+      reconnectDelayMs: () => 0,
+      idleReconnect: 0,
+    });
+
+    const handle = transport.openEventStream({
+      channels: ["values"],
+      since: 5,
+    } as { channels: string[]; since: number });
+    await handle.ready;
+
+    const received: Array<{ event_id?: string }> = [];
+    for await (const message of handle.events) {
+      received.push(message as { event_id?: string });
+      if (received.some((m) => m.event_id === "e1")) break;
     }
+
+    const streamBodies = fetchImpl.mock.calls
+      .filter((call) => String(call[0]).includes("/stream/events"))
+      .map((call) =>
+        JSON.parse(String((call[1] as RequestInit).body)) as Record<
+          string,
+          unknown
+        >
+      );
+    expect(streamBodies).toHaveLength(2);
+    expect(streamBodies[0]).toMatchObject({ since: 5 });
+    expect(streamBodies[1]).not.toHaveProperty("since");
+    expect(received.map((m) => m.event_id)).toEqual(
+      expect.arrayContaining(["e6", "e1"])
+    );
 
     await transport.close();
   });

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -502,6 +502,79 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
     await transport.close();
   });
 
+  it("keeps caller since across pre-ready fetch failures", async () => {
+    let streamOpens = 0;
+    const encoder = new TextEncoder();
+    const fetchImpl = vi.fn((input: URL | RequestInfo) => {
+      if (!String(input).includes("/stream/events")) {
+        return Promise.resolve(protocolSuccessResponse());
+      }
+      streamOpens += 1;
+      if (streamOpens === 1) {
+        return Promise.reject(new TypeError("Failed to fetch"));
+      }
+      return Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  'event: values\ndata: {"type":"event","method":"values","seq":6,"event_id":"e6"}\n\n'
+                )
+              );
+              controller.close();
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          }
+        )
+      );
+    }) as unknown as typeof fetch;
+
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: THREAD_ID,
+      fetch: fetchImpl,
+      maxReconnectAttempts: 3,
+      reconnectDelayMs: () => 0,
+      idleReconnect: 0,
+    });
+
+    const handle = transport.openEventStream({
+      channels: ["values"],
+      since: 5,
+    } as { channels: string[]; since: number });
+    await handle.ready;
+
+    const received: Array<{ event_id?: string }> = [];
+    for await (const message of handle.events) {
+      received.push(message as { event_id?: string });
+      if (received.some((m) => m.event_id === "e6")) break;
+    }
+
+    const streamBodies = fetchImpl.mock.calls
+      .filter((call) => String(call[0]).includes("/stream/events"))
+      .map((call) => {
+        const init = call[1] as RequestInit | undefined;
+        return init?.body != null
+          ? (JSON.parse(String(init.body)) as Record<string, unknown>)
+          : null;
+      })
+      .filter((body): body is Record<string, unknown> => body != null);
+    // First open may fail before a body is attached; only successful POSTs
+    // and retries that include a body are asserted. Both attempts that
+    // reach JSON body construction must still carry the caller cursor.
+    expect(streamBodies.length).toBeGreaterThanOrEqual(1);
+    for (const body of streamBodies) {
+      expect(body).toMatchObject({ since: 5 });
+    }
+    expect(received.map((m) => m.event_id)).toContain("e6");
+
+    await transport.close();
+  });
+
   it("keeps reconnect disabled when maxReconnectAttempts is explicitly 0", async () => {
     const sentinel = new TypeError("net::ERR_QUIC_PROTOCOL_ERROR");
     let streamOpens = 0;

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -396,6 +396,15 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
     expect(onReconnect).toHaveBeenCalledTimes(1);
     expect(streamOpens).toBe(2);
 
+    const reconnectBodies = fetchImpl.mock.calls
+      .map((call) => call[1] as RequestInit | undefined)
+      .filter((init) => init?.body != null)
+      .map((init) => JSON.parse(String(init!.body)) as Record<string, unknown>);
+    expect(reconnectBodies.length).toBeGreaterThanOrEqual(2);
+    for (const body of reconnectBodies) {
+      expect(body).not.toHaveProperty("since");
+    }
+
     await transport.close();
   });
 

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { SubscribeParams } from "@langchain/protocol";
 
 import { AsyncCaller } from "../../../utils/async_caller.js";
 import { ProtocolSseTransportAdapter } from "./http.js";
@@ -9,6 +10,20 @@ import {
   createFetchRecorder,
   protocolSuccessResponse,
 } from "./test-helpers.js";
+
+type MockFetch = ReturnType<typeof vi.fn> & typeof fetch;
+
+function streamEventBodies(fetchImpl: MockFetch): Record<string, unknown>[] {
+  return fetchImpl.mock.calls
+    .filter((call: unknown[]) => String(call[0]).includes("/stream/events"))
+    .map((call: unknown[]) => {
+      const init = call[1] as RequestInit | undefined;
+      return init?.body != null
+        ? (JSON.parse(String(init.body)) as Record<string, unknown>)
+        : null;
+    })
+    .filter((body): body is Record<string, unknown> => body != null);
+}
 
 describe("ProtocolSseTransportAdapter URL resolution", () => {
   it("preserves apiUrl path prefix for protocol commands", async () => {
@@ -371,7 +386,7 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
           }
         )
       );
-    }) as unknown as typeof fetch;
+    }) as MockFetch;
 
     const transport = new ProtocolSseTransportAdapter({
       apiUrl: "http://localhost:8123",
@@ -396,14 +411,7 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
     expect(onReconnect).toHaveBeenCalledTimes(1);
     expect(streamOpens).toBe(2);
 
-    const streamBodies = fetchImpl.mock.calls
-      .filter((call) => String(call[0]).includes("/stream/events"))
-      .map((call) =>
-        JSON.parse(String((call[1] as RequestInit).body)) as Record<
-          string,
-          unknown
-        >
-      );
+    const streamBodies = streamEventBodies(fetchImpl);
     expect(streamBodies).toHaveLength(2);
     expect(streamBodies[0]).not.toHaveProperty("since");
     expect(streamBodies[1]).not.toHaveProperty("since");
@@ -461,7 +469,7 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
           }
         )
       );
-    }) as unknown as typeof fetch;
+    }) as MockFetch;
 
     const transport = new ProtocolSseTransportAdapter({
       apiUrl: "http://localhost:8123",
@@ -475,7 +483,7 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
     const handle = transport.openEventStream({
       channels: ["values"],
       since: 5,
-    } as { channels: string[]; since: number });
+    } as SubscribeParams & { since: number });
     await handle.ready;
 
     const received: Array<{ event_id?: string }> = [];
@@ -484,14 +492,7 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
       if (received.some((m) => m.event_id === "e1")) break;
     }
 
-    const streamBodies = fetchImpl.mock.calls
-      .filter((call) => String(call[0]).includes("/stream/events"))
-      .map((call) =>
-        JSON.parse(String((call[1] as RequestInit).body)) as Record<
-          string,
-          unknown
-        >
-      );
+    const streamBodies = streamEventBodies(fetchImpl);
     expect(streamBodies).toHaveLength(2);
     expect(streamBodies[0]).toMatchObject({ since: 5 });
     expect(streamBodies[1]).not.toHaveProperty("since");
@@ -531,7 +532,7 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
           }
         )
       );
-    }) as unknown as typeof fetch;
+    }) as MockFetch;
 
     const transport = new ProtocolSseTransportAdapter({
       apiUrl: "http://localhost:8123",
@@ -545,7 +546,7 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
     const handle = transport.openEventStream({
       channels: ["values"],
       since: 5,
-    } as { channels: string[]; since: number });
+    } as SubscribeParams & { since: number });
     await handle.ready;
 
     const received: Array<{ event_id?: string }> = [];
@@ -554,18 +555,7 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
       if (received.some((m) => m.event_id === "e6")) break;
     }
 
-    const streamBodies = fetchImpl.mock.calls
-      .filter((call) => String(call[0]).includes("/stream/events"))
-      .map((call) => {
-        const init = call[1] as RequestInit | undefined;
-        return init?.body != null
-          ? (JSON.parse(String(init.body)) as Record<string, unknown>)
-          : null;
-      })
-      .filter((body): body is Record<string, unknown> => body != null);
-    // First open may fail before a body is attached; only successful POSTs
-    // and retries that include a body are asserted. Both attempts that
-    // reach JSON body construction must still carry the caller cursor.
+    const streamBodies = streamEventBodies(fetchImpl);
     expect(streamBodies.length).toBeGreaterThanOrEqual(1);
     for (const body of streamBodies) {
       expect(body).toMatchObject({ since: 5 });
@@ -581,7 +571,7 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
     const fetchImpl = vi.fn(() => {
       streamOpens += 1;
       return Promise.reject(sentinel);
-    }) as unknown as typeof fetch;
+    }) as MockFetch;
 
     const transport = new ProtocolSseTransportAdapter({
       apiUrl: "http://localhost:8123",

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -252,12 +252,6 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
       rejectReady = reject;
     });
 
-    let resumeAfterSeq =
-      typeof (params as SubscribeParams & { since?: unknown }).since ===
-      "number"
-        ? (params as SubscribeParams & { since: number }).since
-        : undefined;
-
     let readySettled = false;
 
     const startStream = async () => {
@@ -265,6 +259,12 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
 
       while (!ac.signal.aborted && !this.closed) {
         try {
+          // Do not send `since` on SSE (re)connect. Protocol `seq` is
+          // connection-scoped: a new POST gets a fresh session that
+          // re-numbers Redis history from 1, so a previous connection's
+          // `since` filters out the entire replay (heartbeats only).
+          // Full history is re-delivered; the client dedups by durable
+          // `event_id`. A durable cursor can replace this later.
           const response = await this.request(
             streamUrl,
             {
@@ -277,7 +277,6 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
                 channels: params.channels,
                 ...(params.namespaces ? { namespaces: params.namespaces } : {}),
                 ...(params.depth != null ? { depth: params.depth } : {}),
-                ...(resumeAfterSeq != null ? { since: resumeAfterSeq } : {}),
               }),
               signal: ac.signal,
             },
@@ -301,7 +300,7 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
           // decoding) so it can reset on any line and recognise `:` keep-alive
           // heartbeats to drive `"auto"` mode. On idle it errors the stream,
           // which the catch below treats like any other disconnect and
-          // reconnects with `since` from the last seen sequence.
+          // re-opens the SSE without a `since` cursor.
           const enableIdle =
             this.idleReconnect === "auto" ||
             (typeof this.idleReconnect === "number" && this.idleReconnect > 0);
@@ -319,14 +318,7 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
               break;
             }
             if (isRecord(event.data)) {
-              const msg = event.data as Message & {
-                seq?: number;
-                method?: string;
-              };
-              if (typeof msg.seq === "number") {
-                resumeAfterSeq = msg.seq;
-              }
-              streamQueue.push(msg);
+              streamQueue.push(event.data as Message);
             }
           }
           streamQueue.close();

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -252,6 +252,17 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
       rejectReady = reject;
     });
 
+    // Honor an explicit caller `since` on the initial open only. Do not
+    // advance it from observed `seq` values — those are connection-local,
+    // and carrying them onto a reconnect POST filters out the full Redis
+    // replay (heartbeats only). Reconnects omit `since` and rely on
+    // durable `event_id` dedup until a durable cursor exists.
+    const initialSince =
+      typeof (params as SubscribeParams & { since?: unknown }).since ===
+      "number"
+        ? (params as SubscribeParams & { since: number }).since
+        : undefined;
+
     let readySettled = false;
 
     const startStream = async () => {
@@ -259,12 +270,6 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
 
       while (!ac.signal.aborted && !this.closed) {
         try {
-          // Do not send `since` on SSE (re)connect. Protocol `seq` is
-          // connection-scoped: a new POST gets a fresh session that
-          // re-numbers Redis history from 1, so a previous connection's
-          // `since` filters out the entire replay (heartbeats only).
-          // Full history is re-delivered; the client dedups by durable
-          // `event_id`. A durable cursor can replace this later.
           const response = await this.request(
             streamUrl,
             {
@@ -277,6 +282,9 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
                 channels: params.channels,
                 ...(params.namespaces ? { namespaces: params.namespaces } : {}),
                 ...(params.depth != null ? { depth: params.depth } : {}),
+                ...(attempt === 0 && initialSince != null
+                  ? { since: initialSince }
+                  : {}),
               }),
               signal: ac.signal,
             },
@@ -300,7 +308,7 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
           // decoding) so it can reset on any line and recognise `:` keep-alive
           // heartbeats to drive `"auto"` mode. On idle it errors the stream,
           // which the catch below treats like any other disconnect and
-          // re-opens the SSE without a `since` cursor.
+          // re-opens the SSE without carrying a connection-local `since`.
           const enableIdle =
             this.idleReconnect === "auto" ||
             (typeof this.idleReconnect === "number" && this.idleReconnect > 0);

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -252,11 +252,12 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
       rejectReady = reject;
     });
 
-    // Honor an explicit caller `since` on the initial open only. Do not
-    // advance it from observed `seq` values — those are connection-local,
-    // and carrying them onto a reconnect POST filters out the full Redis
-    // replay (heartbeats only). Reconnects omit `since` and rely on
-    // durable `event_id` dedup until a durable cursor exists.
+    // Honor an explicit caller `since` until the stream has connected
+    // once. Do not advance it from observed `seq` values — those are
+    // connection-local, and carrying them onto a post-connect reconnect
+    // POST filters out the full Redis replay (heartbeats only). Pre-ready
+    // retries still send the caller cursor; only after a successful open
+    // do reconnects omit `since` and rely on durable `event_id` dedup.
     const initialSince =
       typeof (params as SubscribeParams & { since?: unknown }).since ===
       "number"
@@ -282,7 +283,7 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
                 channels: params.channels,
                 ...(params.namespaces ? { namespaces: params.namespaces } : {}),
                 ...(params.depth != null ? { depth: params.depth } : {}),
-                ...(attempt === 0 && initialSince != null
+                ...(!readySettled && initialSince != null
                   ? { since: initialSince }
                   : {}),
               }),

--- a/libs/sdk/src/client/stream/transport/types.ts
+++ b/libs/sdk/src/client/stream/transport/types.ts
@@ -58,7 +58,7 @@ export interface ProtocolSseTransportOptions {
    * indefinitely with no error or close (e.g. a platform revision rollover
    * that hard-kills the serving pod). On idle the underlying read is aborted,
    * which the reconnect loop treats like any other disconnect and re-opens
-   * the SSE without a `since` cursor (`seq` is connection-scoped).
+   * the SSE without carrying a connection-local `since` (`seq` resets).
    *
    * - `"auto"` (`DEFAULT_IDLE_RECONNECT` from `utils/stream`): arm only once
    *   the server's SSE keep-alive heartbeats (LangGraph Platform:

--- a/libs/sdk/src/client/stream/transport/types.ts
+++ b/libs/sdk/src/client/stream/transport/types.ts
@@ -57,8 +57,8 @@ export interface ProtocolSseTransportOptions {
    * Idle-reconnect policy guarding against half-open sockets that hang
    * indefinitely with no error or close (e.g. a platform revision rollover
    * that hard-kills the serving pod). On idle the underlying read is aborted,
-   * which the reconnect loop treats like any other disconnect, re-subscribing
-   * with `since` from the last seen sequence.
+   * which the reconnect loop treats like any other disconnect and re-opens
+   * the SSE without a `since` cursor (`seq` is connection-scoped).
    *
    * - `"auto"` (`DEFAULT_IDLE_RECONNECT` from `utils/stream`): arm only once
    *   the server's SSE keep-alive heartbeats (LangGraph Platform:


### PR DESCRIPTION
## Summary
- Stop sending body `since` on SSE (re)connect in `ProtocolSseTransportAdapter`.
- Protocol `seq` is connection-scoped; a new POST re-numbers Redis history from 1, so a prior session's `since` (e.g. `146`) dropped the entire replay and left only heartbeats after QUIC/idle drops.
- Clients continue to deduplicate via durable `event_id`. A durable cursor can replace this later.
