### PR TITLE
fix: accept compatible api_version ranges

### DIFF
--- a/.changeset/shy-owls-march.md
+++ b/.changeset/shy-owls-march.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-cli": patch
+---
+
+Accept and resolve compatible `api_version` ranges for LangGraph API images.

--- a/libs/langgraph-cli/src/cli/build.mts
+++ b/libs/langgraph-cli/src/cli/build.mts
@@ -2,7 +2,7 @@ import { getDockerCapabilities } from "../docker/compose.mjs";
 import {
   assembleLocalDeps,
   configToDocker,
-  getBaseImage,
+  resolveBaseImage,
 } from "../docker/docker.mjs";
 import { getExecaOptions } from "../docker/shell.mjs";
 import { getConfig } from "../utils/config.mjs";
@@ -60,7 +60,7 @@ builder
 
     let exec = $({ ...opts, input });
     if (params.pull) {
-      await stream(exec`docker pull ${getBaseImage(config)}`);
+      await stream(exec`docker pull ${await resolveBaseImage(config)}`);
     }
 
     exec = $({ ...opts, input });

--- a/libs/langgraph-cli/src/cli/deploy.mts
+++ b/libs/langgraph-cli/src/cli/deploy.mts
@@ -22,7 +22,7 @@ import { getConfig, type Config } from "../utils/config.mjs";
 import {
   assembleLocalDeps,
   configToDocker,
-  getBaseImage,
+  resolveBaseImage,
 } from "../docker/docker.mjs";
 import { getExecaOptions } from "../docker/shell.mjs";
 import {
@@ -812,7 +812,7 @@ async function runLocalBuild(args: LocalBuildArgs): Promise<BuildResult> {
   // neither is supplied this equals the config's own base image, so the
   // rewrite below is a no-op.
   const baseImageRef =
-    args.baseImage ?? getBaseImage(args.config, args.apiVersion);
+    args.baseImage ?? (await resolveBaseImage(args.config, args.apiVersion));
 
   const generatedDockerfile = await configToDocker(
     args.configPath,
@@ -825,7 +825,7 @@ async function runLocalBuild(args: LocalBuildArgs): Promise<BuildResult> {
       buildCommand: args.buildCommand,
     }
   );
-  // `configToDocker` emits `FROM ${getBaseImage(config)}` using the config's
+  // `configToDocker` emits `FROM ${resolveBaseImage(config)}` using the config's
   // own base image; rewrite the first FROM instruction so the resolved base
   // image (including any override) is what gets built.
   const dockerfile = generatedDockerfile.replace(

--- a/libs/langgraph-cli/src/cli/up.mts
+++ b/libs/langgraph-cli/src/cli/up.mts
@@ -5,7 +5,7 @@ import { getConfig } from "../utils/config.mjs";
 import { getProjectPath } from "./utils/project.mjs";
 import { logger } from "../utils/logging.mjs";
 import { createCompose, getDockerCapabilities } from "../docker/compose.mjs";
-import { configToCompose, getBaseImage } from "../docker/docker.mjs";
+import { configToCompose, resolveBaseImage } from "../docker/docker.mjs";
 import { getExecaOptions } from "../docker/shell.mjs";
 import { $ } from "execa";
 import { createHash } from "node:crypto";
@@ -112,9 +112,9 @@ builder
     const exec = $(execOpts);
 
     if (!config._INTERNAL_docker_tag && params.pull) {
-      // pull the image
-      logger.info(`Pulling image ${getBaseImage(config)}...`);
-      await stream(exec`docker pull ${getBaseImage(config)}`);
+      const baseImage = await resolveBaseImage(config);
+      logger.info(`Pulling image ${baseImage}...`);
+      await stream(exec`docker pull ${baseImage}`);
     }
 
     // remove dangling images

--- a/libs/langgraph-cli/src/docker/docker.mts
+++ b/libs/langgraph-cli/src/docker/docker.mts
@@ -2,6 +2,7 @@ import dedent from "dedent";
 import * as path from "node:path";
 import { promises as fs } from "node:fs";
 import type { Config } from "../utils/config.mjs";
+import { resolveApiVersion } from "../utils/api-version.mjs";
 
 const dedenter = dedent.withOptions({ escapeSpecialCharacters: false });
 
@@ -268,6 +269,14 @@ export function getBaseImage(config: Config, apiVersion?: string) {
   throw new Error("Invalid config type");
 }
 
+export async function resolveBaseImage(config: Config, apiVersion?: string) {
+  if (config._INTERNAL_docker_tag) return getBaseImage(config, apiVersion);
+  return getBaseImage(
+    config,
+    await resolveApiVersion(apiVersion ?? config.api_version)
+  );
+}
+
 export async function configToDocker(
   configPath: string,
   config: Config,
@@ -387,7 +396,7 @@ export async function configToDocker(
     : `RUN (test ! -f /api/langgraph_api/js/build.mts && echo "Prebuild script not found, skipping") || tsx /api/langgraph_api/js/build.mts`;
 
   const lines = [
-    `FROM ${getBaseImage(config)}`,
+    `FROM ${await resolveBaseImage(config)}`,
     config.dockerfile_lines,
     pipConfigFile,
     pipPkgs,

--- a/libs/langgraph-cli/src/utils/api-version.mts
+++ b/libs/langgraph-cli/src/utils/api-version.mts
@@ -1,0 +1,176 @@
+type ParsedApiVersion = {
+  release: number[];
+  prerelease: "dev" | "rc" | undefined;
+  prereleaseNumber: number;
+};
+
+type ApiVersionRange = {
+  floor: ParsedApiVersion;
+  allowFutureStable: boolean;
+};
+
+const API_VERSION_PATTERN =
+  /^\d+(?:\.\d+){0,2}(?:(?:-[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*)|(?:(?:\.|)[A-Za-z][0-9A-Za-z.-]*))?$/;
+const API_VERSION_RANGE_PATTERN = /^(~=|>~=)\s*(.+)$/;
+const API_VERSION_PART_PATTERN =
+  /^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:(?:\.|)(dev|rc)(\d+))?$/;
+
+const parseApiVersion = (version: string): ParsedApiVersion | undefined => {
+  const match = API_VERSION_PART_PATTERN.exec(version);
+  if (match == null) return undefined;
+
+  const [, major, minor, patch, prerelease, prereleaseNumber] = match;
+  const release = [major, minor, patch]
+    .filter((part): part is string => part !== undefined)
+    .map((part) => Number.parseInt(part, 10));
+
+  return {
+    release,
+    prerelease: prerelease as "dev" | "rc" | undefined,
+    prereleaseNumber: Number.parseInt(prereleaseNumber ?? "0", 10),
+  };
+};
+
+const parseApiVersionRange = (
+  apiVersion: string
+): ApiVersionRange | undefined => {
+  const match = API_VERSION_RANGE_PATTERN.exec(apiVersion);
+  if (match == null) return undefined;
+
+  const [, operator, floorVersion] = match;
+  const floor = parseApiVersion(floorVersion.trim());
+  if (floor == null) return undefined;
+
+  return {
+    floor,
+    allowFutureStable: operator === ">~=",
+  };
+};
+
+export const isValidApiVersionSpecifier = (apiVersion: string): boolean =>
+  API_VERSION_PATTERN.test(apiVersion) ||
+  parseApiVersionRange(apiVersion) != null;
+
+const prereleaseOrder = (
+  prerelease: ParsedApiVersion["prerelease"]
+): number => {
+  if (prerelease === "dev") return 0;
+  if (prerelease === "rc") return 1;
+  return 2;
+};
+
+const compareTuples = (left: number[], right: number[]): number => {
+  const length = Math.min(left.length, right.length);
+  for (let i = 0; i < length; i += 1) {
+    if (left[i] !== right[i]) return left[i] - right[i];
+  }
+  return left.length - right.length;
+};
+
+const compareApiVersions = (
+  left: ParsedApiVersion,
+  right: ParsedApiVersion
+): number => {
+  const release = compareTuples(left.release, right.release);
+  if (release !== 0) return release;
+
+  const prerelease =
+    prereleaseOrder(left.prerelease) - prereleaseOrder(right.prerelease);
+  if (prerelease !== 0) return prerelease;
+
+  return left.prereleaseNumber - right.prereleaseNumber;
+};
+
+const apiVersionUpperBound = (version: ParsedApiVersion): number[] => {
+  const major = version.release[0] ?? 0;
+  const minor = version.release[1];
+  if (version.release.length <= 2) return [major + 1];
+  return [major, (minor ?? 0) + 1];
+};
+
+const isCompatibleApiVersionCandidate = (
+  candidate: ParsedApiVersion,
+  range: ApiVersionRange,
+  upperBound: number[]
+): boolean => {
+  if (compareApiVersions(candidate, range.floor) < 0) return false;
+
+  const outsideCompatibleRange =
+    compareTuples(candidate.release.slice(0, upperBound.length), upperBound) >=
+    0;
+  if (outsideCompatibleRange && !range.allowFutureStable) return false;
+  if (outsideCompatibleRange && candidate.prerelease != null) return false;
+  if (range.floor.prerelease === "dev" && candidate.prerelease === "dev") {
+    return compareApiVersions(candidate, range.floor) === 0;
+  }
+  return true;
+};
+
+const getPypiVersions = async (packageName: string): Promise<string[]> => {
+  let response: Response;
+  try {
+    response = await fetch(`https://pypi.org/pypi/${packageName}/json`);
+  } catch (error) {
+    throw new Error(
+      `Failed to fetch PyPI versions for ${packageName}: ${error}`
+    );
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch PyPI versions for ${packageName}: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const payload = (await response.json()) as { releases?: unknown };
+  if (
+    payload == null ||
+    typeof payload.releases !== "object" ||
+    payload.releases == null
+  ) {
+    throw new Error(
+      `Failed to fetch PyPI versions for ${packageName}: invalid response.`
+    );
+  }
+
+  return Object.keys(payload.releases);
+};
+
+export const resolveApiVersion = async (
+  apiVersion: string | undefined
+): Promise<string | undefined> => {
+  if (apiVersion == null) return undefined;
+
+  const range = parseApiVersionRange(apiVersion);
+  if (range == null) return apiVersion;
+
+  const candidates = (await getPypiVersions("langgraph-api"))
+    .map((version) => ({ version, parsed: parseApiVersion(version) }))
+    .filter(
+      (candidate): candidate is { version: string; parsed: ParsedApiVersion } =>
+        candidate.parsed != null &&
+        isCompatibleApiVersionCandidate(
+          candidate.parsed,
+          range,
+          apiVersionUpperBound(range.floor)
+        )
+    );
+
+  const best = candidates.reduce<(typeof candidates)[number] | undefined>(
+    (current, candidate) => {
+      if (current == null) return candidate;
+      return compareApiVersions(candidate.parsed, current.parsed) > 0
+        ? candidate
+        : current;
+    },
+    undefined
+  );
+
+  if (best == null) {
+    throw new Error(
+      `No PyPI releases match compatible api_version range ${apiVersion}.`
+    );
+  }
+
+  return best.version;
+};

--- a/libs/langgraph-cli/src/utils/config.mts
+++ b/libs/langgraph-cli/src/utils/config.mts
@@ -1,8 +1,6 @@
 import { z } from "zod/v3";
 import { extname } from "node:path";
-
-const API_VERSION_PATTERN =
-  /^\d+(?:\.\d+){0,2}(?:(?:-[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*)|(?:[A-Za-z][0-9A-Za-z.-]*))?$/;
+import { isValidApiVersionSpecifier } from "./api-version.mjs";
 
 const GraphPathSchema = z.string().refine((i) => i.includes(":"), {
   message: "Import string must be in format '<file>:<export>'",
@@ -25,9 +23,9 @@ const BaseConfigSchema = z.object({
   _INTERNAL_docker_tag: z.string().optional(),
   api_version: z
     .string()
-    .refine((v) => API_VERSION_PATTERN.test(v), {
+    .refine((v) => isValidApiVersionSpecifier(v), {
       message:
-        "api_version must be in format major, major.minor, or major.minor.patch with optional prerelease suffix",
+        "api_version must be in format major, major.minor, major.minor.patch, or a compatible range with optional prerelease suffix",
     })
     .optional(),
   env: z

--- a/libs/langgraph-cli/tests/config.test.mts
+++ b/libs/langgraph-cli/tests/config.test.mts
@@ -6,6 +6,7 @@ import {
   configToDocker,
   configToWatch,
   getBaseImage,
+  resolveBaseImage,
 } from "../src/docker/docker.mjs";
 import { type Config, getConfig } from "../src/utils/config.mjs";
 import { fileURLToPath } from "node:url";
@@ -14,6 +15,24 @@ import * as fs from "node:fs/promises";
 import * as yaml from "yaml";
 
 const dedenter = dedent.withOptions({ escapeSpecialCharacters: false });
+
+const withMockPyPiVersions = async <T,>(
+  versions: string[],
+  run: () => Promise<T>
+): Promise<T> => {
+  const originalFetch = globalThis.fetch;
+  const releases = Object.fromEntries(versions.map((version) => [version, {}]));
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    expect(String(input)).toBe("https://pypi.org/pypi/langgraph-api/json");
+    return new Response(JSON.stringify({ releases }), { status: 200 });
+  }) as typeof fetch;
+
+  try {
+    return await run();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+};
 
 const DEFAULT_CONFIG = {
   dockerfile_lines: [],
@@ -1079,6 +1098,41 @@ describe("getBaseImage", () => {
     );
   });
 
+  it("resolves compatible api_version range for node images", async () => {
+    const config = getConfig({
+      node_version: "20",
+      graphs: { agent: "./agent.js:graph" },
+      api_version: ">~=0.11.0rc2",
+    });
+
+    await withMockPyPiVersions(
+      ["0.11.0rc2", "0.11.0", "0.11.1", "0.12.0rc1", "0.12.0"],
+      async () => {
+        await expect(resolveBaseImage(config)).resolves.toBe(
+          "langchain/langgraphjs-api:0.12.0-node20"
+        );
+      }
+    );
+  });
+
+  it("resolves compatible api_version range within release line", async () => {
+    const config = getConfig({
+      python_version: "3.12",
+      dependencies: ["."],
+      graphs: { agent: "./agent.py:graph" },
+      api_version: "~=0.11.0rc2",
+    });
+
+    await withMockPyPiVersions(
+      ["0.11.0rc2", "0.11.0", "0.11.1", "0.12.0"],
+      async () => {
+        await expect(resolveBaseImage(config)).resolves.toBe(
+          "langchain/langgraph-api:0.11.1-py3.12"
+        );
+      }
+    );
+  });
+
   it("_INTERNAL_docker_tag takes precedence", () => {
     const config = getConfig({
       node_version: "22",
@@ -1308,6 +1362,17 @@ it("node config and python config", () => {
     )
     .toThrow();
 
+  // Invalid api_version range operator
+  expect
+    .soft(() =>
+      getConfig({
+        node_version: "22",
+        graphs: { agent: "./agent.js:graph" },
+        api_version: "~>=0.11.0rc2",
+      })
+    )
+    .toThrow();
+
   // Valid api_version with compact suffix
   expect(
     getConfig({
@@ -1336,5 +1401,20 @@ it("node config and python config", () => {
     graphs: { agent: "./agent.js:graph" },
     env: {},
     api_version: "0.7.29-rc.0",
+  });
+
+  // Valid compatible api_version range
+  expect(
+    getConfig({
+      node_version: "22",
+      graphs: { agent: "./agent.js:graph" },
+      api_version: ">~=0.11.0rc2",
+    })
+  ).toEqual({
+    node_version: "22",
+    dockerfile_lines: [],
+    graphs: { agent: "./agent.js:graph" },
+    env: {},
+    api_version: ">~=0.11.0rc2",
   });
 });


### PR DESCRIPTION
## Description
Ports Python CLI-compatible `api_version` range handling to langgraphjs: validation now accepts `~=` / `>~=` specifiers and Docker image generation resolves them to concrete `langgraph-api` releases before pulling/building.

## Test Plan
- [x] `NO_COLOR=1 pnpm --filter @langchain/langgraph-cli test -- config.test.mts --no-color`
- [x] `NO_COLOR=1 pnpm run lint -- libs/langgraph-cli/src/utils/api-version.mts libs/langgraph-cli/src/utils/config.mts libs/langgraph-cli/src/docker/docker.mts libs/langgraph-cli/src/cli/build.mts libs/langgraph-cli/src/cli/up.mts libs/langgraph-cli/src/cli/deploy.mts libs/langgraph-cli/tests/config.test.mts --no-ignore`
- [x] `pnpm --filter @langchain/langgraph-api build && pnpm --filter create-langgraph build && NO_COLOR=1 pnpm --filter @langchain/langgraph-cli typecheck`

Made by [Open SWE](https://openswe.vercel.app/agents/d633f70f-87f4-ccb4-c7e8-7e4376757fb6)