### PR TITLE
ci: cover missing Dependabot dependency roots

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -149,3 +149,26 @@ updates:
           - "*"
         update-types:
           - "major"
+
+  # Docker Compose files used by root/package integration tests.
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+      - "/internal/environment_tests"
+      - "/libs/checkpoint-mongodb"
+      - "/libs/checkpoint-postgres"
+      - "/libs/checkpoint-redis"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"


### PR DESCRIPTION
## Summary

- Add Dependabot Docker coverage for Docker Compose roots used by root/package integration tests.
- Cover the root integration-test compose file, internal environment-test compose file, and checkpoint package compose files.
- Keep existing GitHub Actions and root pnpm workspace coverage unchanged.

## Test Plan

- [x] Parse `.github/dependabot.yml` with Ruby YAML.
- [x] Run `git diff --check`.
- [x] Inspect the diff to confirm it only changes `.github/dependabot.yml`.