### PR TITLE
fix(sdk): clear hydrate interrupt allowlist on respond()

### DIFF
--- a/.changeset/fix-respond-clear-interrupt-allowlist.md
+++ b/.changeset/fix-respond-clear-interrupt-allowlist.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): clear hydrate interrupt allowlist on respond()
+
+`submit()` already cleared `#hydratedActiveInterruptIds` so a new run's live `input.requested` events were not dropped as historical. `respond()` / `respondAll()` (via `dispatchResume`) did not, so a follow-on HITL after resume never appeared on `stream.interrupt` and free-text submits could resume with the wrong payload.

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -746,6 +746,82 @@ describe("StreamController", () => {
     await submitPromise;
   });
 
+  it("does not filter genuinely new interrupts after respond() clears the allowlist", async () => {
+    // Fan out to every registered listener — respond()'s background
+    // terminal watch also calls thread.onEvent, and a single-slot
+    // capture would overwrite the wildcard that mirrors interrupts.
+    const eventListeners = new Set<(event: Event) => void>();
+    const respondInput = vi.fn(async () => undefined);
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        eventListeners.add(listener);
+        return vi.fn(() => {
+          eventListeners.delete(listener);
+        });
+      }),
+      close: vi.fn(async () => undefined),
+      interrupts: [
+        {
+          interruptId: "old-interrupt",
+          payload: { prompt: "Approve?" },
+          namespace: [],
+        },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({
+          values: {},
+          tasks: [
+            {
+              interrupts: [
+                { id: "old-interrupt", value: { prompt: "Approve?" } },
+              ],
+            },
+          ],
+        })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, { prompt: string }>({
+      assistantId: "human-in-the-loop",
+      client: client as never,
+      threadId: "thread-respond-new-live",
+    });
+    await controller.hydrationPromise;
+    expect(eventListeners.size).toBeGreaterThan(0);
+
+    // Hydrate seeded allowlist with [old-interrupt]. respond() must
+    // clear it the same way submit() does — otherwise the follow-on
+    // HITL from the resumed run is dropped as "historical" and
+    // stream.interrupt stays empty while the server is still paused.
+    await controller.respond({ approved: true });
+    expect(respondInput).toHaveBeenCalled();
+    expect(
+      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+    ).toEqual([]);
+
+    const followOn = inputRequestedEvent("brand-new-interrupt", {
+      prompt: "Again?",
+    });
+    for (const listener of eventListeners) {
+      listener(followOn);
+    }
+
+    expect(
+      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+    ).toContain("brand-new-interrupt");
+    expect(controller.rootStore.getSnapshot().interrupt?.id).toBe(
+      "brand-new-interrupt"
+    );
+
+    await controller.dispose();
+  });
+
   it("hydrate without tasks does not wipe in-flight interrupt state", async () => {
     let onEvent: ((event: Event) => void) | undefined;
     const thread = {

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -394,9 +394,10 @@ export class StreamController<
         this.#awaitResumedRunTerminal(signal),
       onSubmitStart: () => {
         // Clear the hydrate-window allowlist so genuinely-new live
-        // interrupts on the just-started run aren't filtered. Bump
-        // the generation so any in-flight hydrate skips its
-        // allowlist write on return (see #hydratedActiveInterruptIds).
+        // interrupts on the just-started run (submit *or* respond /
+        // respondAll via dispatchResume) aren't filtered. Bump the
+        // generation so any in-flight hydrate skips its allowlist
+        // write on return (see #hydratedActiveInterruptIds).
         this.#hydratedActiveInterruptIds = null;
         this.#submitGeneration += 1;
       },

--- a/libs/sdk/src/stream/submit-coordinator.ts
+++ b/libs/sdk/src/stream/submit-coordinator.ts
@@ -596,6 +596,12 @@ export class SubmitCoordinator<
   ): Promise<void> {
     if (this.#getDisposed()) return;
 
+    // Same allowlist clear as submit(): a resumed run can pause on a
+    // *new* interrupt id. Without this, the hydrate-window allowlist
+    // still contains only the interrupt being answered and
+    // `#recordRootInterrupt` drops the follow-on `input.requested`.
+    this.#onSubmitStart();
+
     // Rollback any run still tracked as active (mirrors submit()), then
     // claim the in-flight slot so stop()/dispose()/a concurrent submit
     // cancels the terminal watch armed below.


### PR DESCRIPTION
## Summary
- Clear the hydrate-window interrupt allowlist in `dispatchResume()` (same as `submit()`), so `respond()` / `respondAll()` accept genuinely new live `input.requested` events from the resumed run.
- Without this, a second HITL after answering the first never appeared on `stream.interrupt`, and clients could free-text `submit` into an implicit resume with the wrong payload (`KeyError: 'decisions'` on HITL middleware).
- Add a regression test covering hydrate → `respond()` → follow-on interrupt id.
