### PR TITLE
fix(langgraph-api): stop wiping graph recursionLimit with undefined

### DIFF
--- a/.changeset/fix-omit-undefined-recursion-limit.md
+++ b/.changeset/fix-omit-undefined-recursion-limit.md
@@ -1,0 +1,12 @@
+---
+"@langchain/langgraph-api": patch
+"@langchain/langgraph-cli": patch
+"@langchain/langgraph-ui": patch
+---
+
+fix(langgraph-api): stop wiping graph recursionLimit with undefined
+
+When a run omitted `config.recursion_limit`, the server still passed
+`recursionLimit: undefined` into `streamEvents`. Pregel spreads that over the
+graph's `withConfig` default, so agents fell back to langchain-core's 25.
+Omit undefined keys so bound limits (and deepagents' 10000) stick.

--- a/libs/langgraph-api/src/api/assistants.mts
+++ b/libs/langgraph-api/src/api/assistants.mts
@@ -15,6 +15,7 @@ import { HTTPException } from "hono/http-exception";
 import * as schemas from "../schemas.mjs";
 import { assistants } from "../storage/context.mjs";
 import { AssistantSelectField } from "../storage/types.mjs";
+import { omitUndefined } from "../utils/runnableConfig.mjs";
 const api = new Hono();
 
 const RunnableConfigSchema = z.object({
@@ -31,7 +32,9 @@ const getRunnableConfig = (
   userConfig: z.infer<typeof RunnableConfigSchema> | null | undefined
 ) => {
   if (!userConfig) return {};
-  return {
+  // Omit undefined keys so callers that spread this into Pregel options do not
+  // wipe graph `withConfig` defaults (notably recursionLimit → 25).
+  return omitUndefined({
     configurable: userConfig.configurable,
     tags: userConfig.tags,
     metadata: userConfig.metadata,
@@ -39,7 +42,7 @@ const getRunnableConfig = (
     maxConcurrency: userConfig.max_concurrency,
     recursionLimit: userConfig.recursion_limit,
     runId: userConfig.run_id,
-  };
+  });
 };
 
 api.post(

--- a/libs/langgraph-api/src/stream.mts
+++ b/libs/langgraph-api/src/stream.mts
@@ -20,6 +20,7 @@ import type { SourceStreamEvent } from "./protocol/types.mjs";
 import { checkLangGraphSemver } from "./semver/index.mjs";
 import type { Checkpoint, Run, RunnableConfig } from "./storage/types.mjs";
 import {
+  omitUndefined,
   runnableConfigToCheckpoint,
   taskRunnableConfigToCheckpoint,
 } from "./utils/runnableConfig.mjs";
@@ -240,7 +241,10 @@ export async function* streamState(
     kwargs.command != null
       ? getLangGraphCommand(kwargs.command)
       : (kwargs.input ?? null),
-    {
+    // Omit undefined keys: Pregel spreads options over the graph's withConfig
+    // defaults, so `recursionLimit: undefined` would wipe a bound limit back
+    // to langchain-core's DEFAULT_RECURSION_LIMIT (25).
+    omitUndefined({
       version: "v2" as const,
 
       interruptAfter: kwargs.interrupt_after,
@@ -257,7 +261,7 @@ export async function* streamState(
       streamMode: [...libStreamMode],
       signal: options?.signal,
       ...(tracer && { callbacks: [tracer] }),
-    }
+    })
   );
 
   const messages: Record<string, BaseMessageChunk> = {};
@@ -521,8 +525,11 @@ export async function* streamStateV2(
     kwargs.command != null
       ? getLangGraphCommand(kwargs.command)
       : (kwargs.input ?? null);
-  const graphOptions = {
-    version: "v3",
+  // Omit undefined keys: Pregel spreads options over the graph's withConfig
+  // defaults, so `recursionLimit: undefined` would wipe a bound limit back
+  // to langchain-core's DEFAULT_RECURSION_LIMIT (25).
+  const graphOptions = omitUndefined({
+    version: "v3" as const,
     interruptAfter: kwargs.interrupt_after,
     interruptBefore: kwargs.interrupt_before,
 
@@ -535,7 +542,7 @@ export async function* streamStateV2(
     runId: run.run_id,
     signal: options?.signal,
     ...(tracer && { callbacks: [tracer] }),
-  } as const;
+  });
 
   let graphRun: AsyncIterable<{
     method: string;

--- a/libs/langgraph-api/src/utils/runnableConfig.mts
+++ b/libs/langgraph-api/src/utils/runnableConfig.mts
@@ -9,13 +9,28 @@ import type { Checkpoint, RunnableConfig } from "../storage/types.mjs";
  * An explicit `recursionLimit: undefined` (e.g. from
  * `kwargs.config?.recursion_limit` when the run omits it) overwrites the
  * graph's `withConfig` default and falls back to langchain-core's 25.
+ *
+ * Keys whose value type cannot be `undefined` stay required so call sites
+ * preserve discriminators like `version: "v2" | "v3"` for streamEvents.
  */
+type OmitUndefinedKeys<T> = {
+  [K in keyof T as undefined extends T[K] ? never : K]: Exclude<
+    T[K],
+    undefined
+  >;
+} & {
+  [K in keyof T as undefined extends T[K] ? K : never]?: Exclude<
+    T[K],
+    undefined
+  >;
+};
+
 export function omitUndefined<T extends Record<string, unknown>>(
   obj: T
-): { [K in keyof T]?: Exclude<T[K], undefined> } {
+): OmitUndefinedKeys<T> {
   return Object.fromEntries(
     Object.entries(obj).filter(([, value]) => value !== undefined)
-  ) as { [K in keyof T]?: Exclude<T[K], undefined> };
+  ) as OmitUndefinedKeys<T>;
 }
 
 const ConfigSchema = z.object({

--- a/libs/langgraph-api/src/utils/runnableConfig.mts
+++ b/libs/langgraph-api/src/utils/runnableConfig.mts
@@ -1,6 +1,23 @@
 import { z } from "zod/v3";
 import type { Checkpoint, RunnableConfig } from "../storage/types.mjs";
 
+/**
+ * Drop keys whose value is `undefined`.
+ *
+ * Pregel merges invoke/stream options roughly as:
+ * `{ recursionLimit: this.config?.recursionLimit, ...options }`.
+ * An explicit `recursionLimit: undefined` (e.g. from
+ * `kwargs.config?.recursion_limit` when the run omits it) overwrites the
+ * graph's `withConfig` default and falls back to langchain-core's 25.
+ */
+export function omitUndefined<T extends Record<string, unknown>>(
+  obj: T
+): { [K in keyof T]?: Exclude<T[K], undefined> } {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, value]) => value !== undefined)
+  ) as { [K in keyof T]?: Exclude<T[K], undefined> };
+}
+
 const ConfigSchema = z.object({
   configurable: z.object({
     thread_id: z.string(),

--- a/libs/langgraph-api/tests/stream.test.mts
+++ b/libs/langgraph-api/tests/stream.test.mts
@@ -60,8 +60,12 @@ describe("streamState", () => {
       attempt: 1,
       getGraph: async () =>
         ({
-          async *streamEvents(_input: unknown, options: Record<string, unknown>) {
+          async *streamEvents(
+            _input: unknown,
+            options: Record<string, unknown>
+          ) {
             seenOptions = options;
+            yield* [];
           },
         }) as never,
     })) {
@@ -90,8 +94,12 @@ describe("streamState", () => {
       attempt: 1,
       getGraph: async () =>
         ({
-          async *streamEvents(_input: unknown, options: Record<string, unknown>) {
+          async *streamEvents(
+            _input: unknown,
+            options: Record<string, unknown>
+          ) {
             seenOptions = options;
+            yield* [];
           },
         }) as never,
     })) {

--- a/libs/langgraph-api/tests/stream.test.mts
+++ b/libs/langgraph-api/tests/stream.test.mts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { PROTOCOL_STREAM_RUN_KEY } from "../src/protocol/constants.mjs";
 import { streamState } from "../src/stream.mjs";
 import type { Run } from "../src/storage/types.mjs";
+import { omitUndefined } from "../src/utils/runnableConfig.mjs";
 
 const createRun = (overrides?: Partial<Run>): Run =>
   ({
@@ -27,7 +28,79 @@ const createRun = (overrides?: Partial<Run>): Run =>
     ...overrides,
   }) satisfies Run;
 
+describe("omitUndefined", () => {
+  it("drops undefined keys so Pregel cannot wipe withConfig defaults", () => {
+    expect(
+      omitUndefined({
+        recursionLimit: undefined,
+        configurable: { thread_id: "t1" },
+        tags: undefined,
+        metadata: { a: 1 },
+      })
+    ).toEqual({
+      configurable: { thread_id: "t1" },
+      metadata: { a: 1 },
+    });
+  });
+
+  it("keeps an explicit recursionLimit", () => {
+    expect(omitUndefined({ recursionLimit: 200, tags: ["x"] })).toEqual({
+      recursionLimit: 200,
+      tags: ["x"],
+    });
+  });
+});
+
 describe("streamState", () => {
+  it("omits recursionLimit from streamEvents options when the run config omits it", async () => {
+    const run = createRun();
+    let seenOptions: Record<string, unknown> | undefined;
+
+    for await (const _chunk of streamState(run, {
+      attempt: 1,
+      getGraph: async () =>
+        ({
+          async *streamEvents(_input: unknown, options: Record<string, unknown>) {
+            seenOptions = options;
+          },
+        }) as never,
+    })) {
+      // drain
+    }
+
+    expect(seenOptions).toBeDefined();
+    expect("recursionLimit" in (seenOptions ?? {})).toBe(false);
+  });
+
+  it("forwards an explicit recursion_limit to streamEvents", async () => {
+    const run = createRun({
+      kwargs: {
+        config: {
+          configurable: { graph_id: "deep-agent" },
+          recursion_limit: 200,
+        },
+        stream_mode: ["messages-tuple"],
+        subgraphs: true,
+        resumable: true,
+      },
+    });
+    let seenOptions: Record<string, unknown> | undefined;
+
+    for await (const _chunk of streamState(run, {
+      attempt: 1,
+      getGraph: async () =>
+        ({
+          async *streamEvents(_input: unknown, options: Record<string, unknown>) {
+            seenOptions = options;
+          },
+        }) as never,
+    })) {
+      // drain
+    }
+
+    expect(seenOptions?.recursionLimit).toBe(200);
+  });
+
   it("includes child on_chain_stream events when subgraphs are enabled", async () => {
     const run = createRun();
     const childRunId = "00000000-0000-7000-8000-000000000099";


### PR DESCRIPTION
When a run omitted `config.recursion_limit`, we still passed `recursionLimit: undefined` into `streamEvents`. Pregel merges that over the graph's `withConfig` default, so agents (including deepagents with a bound 10000) fell back to langchain-core's 25 and hit `GraphRecursionError` early.

Omit undefined keys from stream/assistant config objects so bound limits stick.

## Test plan
- [x] `pnpm test tests/stream.test.mts` in `libs/langgraph-api` (8 passed)
- [x] Changeset added for affected package(s)