### PR TITLE
fix(sdk): declare ESM scope for bundled dependency chunks

### DIFF
--- a/.changeset/fix-bundled-chunk-esm-scope.md
+++ b/.changeset/fix-bundled-chunk-esm-scope.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): declare ESM scope for bundled dependency chunks
+
+Emit a `{"type":"module"}` package.json into each bundled package directory under `dist/node_modules`, so the ESM chunks are no longer parsed as CommonJS on Node 22.0–22.6, which crashed consumers at import time with "Cannot use import statement outside a module".

--- a/internal/build/index.ts
+++ b/internal/build/index.ts
@@ -1,5 +1,6 @@
-import { resolve, extname } from "node:path";
+import { resolve, extname, basename, dirname, join } from "node:path";
 import { existsSync } from "node:fs";
+import { readdir, writeFile } from "node:fs/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { build, type Format, type UserConfig } from "tsdown";
@@ -142,6 +143,55 @@ async function buildProject(
     ...buildChecks,
     ...packageConfig,
   });
+
+  await declareBundledChunkScopes(path, pkg);
+}
+
+/**
+ * `noExternal` dependencies are emitted as chunks under a virtual
+ * `dist/node_modules` tree with no package.json of their own. Node stops its
+ * package scope lookup at a `node_modules` segment, so those `.js` chunks fall
+ * outside the package's `"type": "module"` scope and are parsed as CommonJS on
+ * Node versions without module syntax detection (< 22.7).
+ */
+async function declareBundledChunkScopes(path: string, pkg: PackageJson) {
+  if (pkg.type !== "module") return;
+  const bundledRoot = resolve(path, "dist", "node_modules");
+  if (!existsSync(bundledRoot)) return;
+
+  const scopeRoots = new Set<string>();
+  for (const chunkDir of await collectChunkDirs(bundledRoot)) {
+    let dir = chunkDir;
+    while (dir !== bundledRoot && basename(dirname(dir)) !== "node_modules") {
+      dir = dirname(dir);
+    }
+    // Node never reads a package.json sitting in a node_modules directory
+    // itself, so a chunk at the tree root cannot be given a scope.
+    if (dir !== bundledRoot) scopeRoots.add(dir);
+  }
+
+  await Promise.all(
+    [...scopeRoots]
+      .map((dir) => join(dir, "package.json"))
+      .filter((file) => !existsSync(file))
+      .map((file) => writeFile(file, '{"type":"module"}\n'))
+  );
+}
+
+/**
+ * Directories under `dir` that directly contain a `.js` chunk.
+ */
+async function collectChunkDirs(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const found = entries.some((e) => e.isFile() && e.name.endsWith(".js"))
+    ? [dir]
+    : [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      found.push(...(await collectChunkDirs(join(dir, entry.name))));
+    }
+  }
+  return found;
 }
 
 const PACKAGE_CONFIG_FILES = [

--- a/libs/sdk/src/bundled-deps.test.ts
+++ b/libs/sdk/src/bundled-deps.test.ts
@@ -1,0 +1,74 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const distDir = join(packageDir, "dist");
+const bundledRoot = join(distDir, "node_modules");
+
+function collectChunkDirs(dir: string): string[] {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const found = entries.some((e) => e.isFile() && e.name.endsWith(".js"))
+    ? [dir]
+    : [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      found.push(...collectChunkDirs(join(dir, entry.name)));
+    }
+  }
+  return found;
+}
+
+/**
+ * Mirrors Node's package scope lookup: walk up from `dir` to the nearest
+ * package.json, stopping at a node_modules segment. A `.js` chunk whose
+ * lookup hits that boundary first has no scope and is parsed as CommonJS
+ * on Node versions without module syntax detection.
+ */
+function scopeDeclaresModule(dir: string): boolean {
+  let current = dir;
+  for (;;) {
+    if (basename(current) === "node_modules") return false;
+    const pkgPath = join(current, "package.json");
+    if (existsSync(pkgPath)) {
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as {
+        type?: string;
+      };
+      return pkg.type === "module";
+    }
+    current = dirname(current);
+  }
+}
+
+describe("bundled dependency chunks", () => {
+  it("every directory with a .js chunk sits in a scope that declares ESM", () => {
+    if (!existsSync(bundledRoot)) return;
+    const undeclared = collectChunkDirs(bundledRoot).filter(
+      (dir) => !scopeDeclaresModule(dir)
+    );
+    expect(undeclared).toEqual([]);
+  });
+
+  it("dist entry imports cleanly without module syntax detection", () => {
+    const entry = pathToFileURL(join(distDir, "index.js")).href;
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--no-experimental-detect-module",
+        "--input-type=module",
+        "-e",
+        `await import(${JSON.stringify(entry)});`,
+      ],
+      {
+        cwd: packageDir,
+        encoding: "utf8",
+        timeout: 20_000,
+        env: { ...process.env, NODE_OPTIONS: "" },
+      }
+    );
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
Importing `@langchain/langgraph-sdk` crashes on Node 22.0–22.6 with `SyntaxError: Cannot use import statement outside a module` raised from the bundled `p-retry` chunk. Reported by users in langchain-ai/openwiki#442 against Windows, but it is not Windows-specific — reproduced on macOS with Node 22.2.0.

**Root cause.** `noExternal` dependencies are emitted as ESM `.js` chunks under a virtual `dist/node_modules` tree with no `package.json` of their own. Node stops its package scope lookup at a `node_modules` path segment, so the chunks never inherit the SDK's `"type": "module"` and are parsed as CommonJS on Node versions without module syntax detection (default since 22.7). On newer Node the same layout still fails under `--no-experimental-detect-module` (as `ERR_REQUIRE_CYCLE_MODULE`).

**Change.** After the build, `@langchain/build` writes a `{"type":"module"}` `package.json` into each bundled package directory under `dist/node_modules`. It is a no-op for packages that bundle nothing or are not `type: module` (their ESM chunks already get self-declaring `.mjs` extensions). I chose this over `fixedExtension: true`, which would rename every published `.js` artifact to `.mjs` across all workspace packages and invalidate the hand-written exports maps.

**Verification.**
- Packed the built SDK, installed it fresh, and ran `import`/`require` of the root and `/client` entrypoints on Node 22.2.0 and 24 — all six combinations pass; without the stubs the same commands crash.
- New test in `libs/sdk`: a static check that every directory holding a `.js` chunk sits in a scope declaring ESM (mirroring Node's lookup order, including the node_modules-boundary-first rule), plus a subprocess import of `dist/index.js` under `--no-experimental-detect-module`. Both fail on the unmodified build; both were mutation-tested (wrong stub type, step disabled, stubs deleted — red each time).
- Full workspace build 25/25, sdk suite 750 tests green, lint and format clean. publint/attw run before the stub step and are unaffected; `npm pack` includes the stubs in the tarball.

**Not covered.** Watch mode: tsdown's `build()` resolves before the watcher writes output, so stubs are not written during `--watch` sessions. Dev-only — publish and CI artifacts come from one-shot builds. The emit gap arguably belongs upstream in tsdown (`noExternal` chunks in a virtual `node_modules` carry no scope declaration); this fixes it where this repo builds.
