### PR TITLE
fix(api): widen the scheduled-run window in the in-flight cancel test

### DIFF
--- a/libs/langgraph-api/tests/api.test.mts
+++ b/libs/langgraph-api/tests/api.test.mts
@@ -548,7 +548,9 @@ describe("threads crud", () => {
     const thread = await client.threads.create();
     const run = await client.runs.create(thread.thread_id, "agent_simple", {
       input: { messages: [{ role: "human", content: "foo" }] },
-      afterSeconds: 2,
+      // wide enough that update + cancel land before the run starts, even
+      // when client-side dispatch is slow under the concurrent test load
+      afterSeconds: 5,
     });
 
     // make sure that the run has been created


### PR DESCRIPTION
Fixes #2648.

`update state while run in flight` schedules a run 2 seconds out and assumes the create, update-state, and cancel round trips finish inside that window. Since the GitHub runners moved to Node 26.5.1 (undici 8.9.0), client-side fetch dispatch under the suite's concurrent load can stall ~1.5s, the cancel misses the window, and the run ends `"error"` instead of `"interrupted"` — every CI run since Aug 1 is red on 26.x. Full analysis with the undici A/B and `diagnostics_channel` trace is in the issue.

Scheduling the run 5 seconds out fits the sequence even with slow dispatch. The happy path cancels the run before it starts, so the test's duration is unchanged.

Verified locally on unmodified logic: 3/3 failing runs on Node 26.5.1 before the change, 3/3 green after, still green on 26.5.0.

Not covered: the underlying undici 8.8.0 dispatch regression (needs a standalone repro before an upstream report) and the question of whether cancelling an already-running run should end it as `"interrupted"` — both noted in the issue.
