### PR TITLE
fix(langgraph): checkpoint Topic as a flat values list

### DIFF
--- a/.changeset/fix-topic-checkpoint-flat-list.md
+++ b/.changeset/fix-topic-checkpoint-flat-list.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(langgraph): checkpoint Topic as a flat values list
+
+Match Python Topic checkpoints so Host JS graphs no longer put `__pregel_tasks: [[], []]` through the Python checkpointer. Keep reading legacy `[seen, values]` checkpoints for restore compatibility.

--- a/libs/langgraph-core/src/channels/topic.ts
+++ b/libs/langgraph-core/src/channels/topic.ts
@@ -2,12 +2,29 @@ import { EmptyChannelError } from "../errors.js";
 import { BaseChannel } from "./base.js";
 
 /**
+ * Legacy JS Topic checkpoint shape: `[seen, values]`.
+ *
+ * Current checkpoints match Python and store a flat `values` list. Keep reading
+ * the tuple form so threads checkpointed before that change still restore.
+ */
+function isLegacyTopicCheckpoint<Value>(
+  checkpoint: unknown
+): checkpoint is [Value[], Value[]] {
+  return (
+    Array.isArray(checkpoint) &&
+    checkpoint.length === 2 &&
+    Array.isArray(checkpoint[0]) &&
+    Array.isArray(checkpoint[1])
+  );
+}
+
+/**
  * A configurable PubSub Topic.
  */
 export class Topic<Value> extends BaseChannel<
   Array<Value>,
   Value | Value[],
-  [Value[], Value[]]
+  Value[]
 > {
   lc_graph_name = "Topic";
 
@@ -38,15 +55,26 @@ export class Topic<Value> extends BaseChannel<
     this.values = [];
   }
 
-  public fromCheckpoint(checkpoint?: [Value[], Value[]]) {
+  public fromCheckpoint(checkpoint?: Value[] | [Value[], Value[]]) {
     const empty = new Topic<Value>({
       unique: this.unique,
       accumulate: this.accumulate,
     });
-    if (typeof checkpoint !== "undefined") {
+    if (typeof checkpoint === "undefined") {
+      return empty as this;
+    }
+    // Back-compat with pre-flat JS Topic checkpoints (`[seen, values]`),
+    // matching Python Topic.from_checkpoint's tuple handling.
+    if (isLegacyTopicCheckpoint<Value>(checkpoint)) {
       empty.seen = new Set(checkpoint[0]);
-      // eslint-disable-next-line prefer-destructuring
-      empty.values = checkpoint[1];
+      empty.values = [...checkpoint[1]];
+      return empty as this;
+    }
+    empty.values = [...checkpoint];
+    // Flat checkpoints do not carry `seen`. Seed it from restored values so
+    // `unique: true` still de-dupes against the current buffer after restore.
+    if (this.unique) {
+      empty.seen = new Set(empty.values);
     }
     return empty as this;
   }
@@ -82,8 +110,14 @@ export class Topic<Value> extends BaseChannel<
     return this.values;
   }
 
-  public checkpoint(): [Value[], Value[]] {
-    return [[...this.seen], this.values];
+  /**
+   * Checkpoint as a flat values list (Python Topic parity).
+   *
+   * Previously returned `[seen, values]`, which Host's Python checkpointer
+   * treated as a list of non-Send items and rejected for `__pregel_tasks`.
+   */
+  public checkpoint(): Value[] {
+    return [...this.values];
   }
 
   isAvailable(): boolean {

--- a/libs/langgraph-core/src/channels/topic.ts
+++ b/libs/langgraph-core/src/channels/topic.ts
@@ -58,9 +58,7 @@ export class Topic<Value> extends BaseChannel<
     this.values = [];
   }
 
-  public fromCheckpoint(
-    checkpoint?: Value[] | UniqueTopicCheckpoint<Value>
-  ) {
+  public fromCheckpoint(checkpoint?: Value[] | UniqueTopicCheckpoint<Value>) {
     const empty = new Topic<Value>({
       unique: this.unique,
       accumulate: this.accumulate,

--- a/libs/langgraph-core/src/channels/topic.ts
+++ b/libs/langgraph-core/src/channels/topic.ts
@@ -1,15 +1,18 @@
 import { EmptyChannelError } from "../errors.js";
 import { BaseChannel } from "./base.js";
 
+/** JS Topic checkpoint when `unique` is set: `[seen, values]`. */
+type UniqueTopicCheckpoint<Value> = [Value[], Value[]];
+
 /**
- * Legacy JS Topic checkpoint shape: `[seen, values]`.
+ * Detect the `[seen, values]` Topic checkpoint shape.
  *
- * Current checkpoints match Python and store a flat `values` list. Keep reading
- * the tuple form so threads checkpointed before that change still restore.
+ * Used for `unique: true` topics (current) and pre-flat JS checkpoints
+ * (legacy). Flat Python-parity checkpoints are a single values list.
  */
-function isLegacyTopicCheckpoint<Value>(
+function isUniqueTopicCheckpoint<Value>(
   checkpoint: unknown
-): checkpoint is [Value[], Value[]] {
+): checkpoint is UniqueTopicCheckpoint<Value> {
   return (
     Array.isArray(checkpoint) &&
     checkpoint.length === 2 &&
@@ -24,7 +27,7 @@ function isLegacyTopicCheckpoint<Value>(
 export class Topic<Value> extends BaseChannel<
   Array<Value>,
   Value | Value[],
-  Value[]
+  Value[] | UniqueTopicCheckpoint<Value>
 > {
   lc_graph_name = "Topic";
 
@@ -55,7 +58,9 @@ export class Topic<Value> extends BaseChannel<
     this.values = [];
   }
 
-  public fromCheckpoint(checkpoint?: Value[] | [Value[], Value[]]) {
+  public fromCheckpoint(
+    checkpoint?: Value[] | UniqueTopicCheckpoint<Value>
+  ) {
     const empty = new Topic<Value>({
       unique: this.unique,
       accumulate: this.accumulate,
@@ -63,16 +68,15 @@ export class Topic<Value> extends BaseChannel<
     if (typeof checkpoint === "undefined") {
       return empty as this;
     }
-    // Back-compat with pre-flat JS Topic checkpoints (`[seen, values]`),
-    // matching Python Topic.from_checkpoint's tuple handling.
-    if (isLegacyTopicCheckpoint<Value>(checkpoint)) {
+    // `unique: true` (and legacy pre-flat) checkpoints are `[seen, values]`.
+    if (isUniqueTopicCheckpoint<Value>(checkpoint)) {
       empty.seen = new Set(checkpoint[0]);
       empty.values = [...checkpoint[1]];
       return empty as this;
     }
     empty.values = [...checkpoint];
-    // Flat checkpoints do not carry `seen`. Seed it from restored values so
-    // `unique: true` still de-dupes against the current buffer after restore.
+    // Flat checkpoints have no historical `seen`. Seed from the current
+    // buffer so `unique: true` still de-dupes values present after restore.
     if (this.unique) {
       empty.seen = new Set(empty.values);
     }
@@ -111,12 +115,20 @@ export class Topic<Value> extends BaseChannel<
   }
 
   /**
-   * Checkpoint as a flat values list (Python Topic parity).
+   * Checkpoint Topic state.
    *
-   * Previously returned `[seen, values]`, which Host's Python checkpointer
-   * treated as a list of non-Send items and rejected for `__pregel_tasks`.
+   * Default / Host path (`unique: false`, including `__pregel_tasks`): flat
+   * values list, matching Python Topic. Previously this always returned
+   * `[seen, values]`, so empty TASKS became `[[], []]` and Host's Python
+   * checkpointer rejected it.
+   *
+   * When `unique: true`, keep `[seen, values]` so dedupe history that outlives
+   * the current buffer still survives resume.
    */
-  public checkpoint(): Value[] {
+  public checkpoint(): Value[] | UniqueTopicCheckpoint<Value> {
+    if (this.unique) {
+      return [[...this.seen], [...this.values]];
+    }
     return [...this.values];
   }
 

--- a/libs/langgraph-core/src/tests/channels.test.ts
+++ b/libs/langgraph-core/src/tests/channels.test.ts
@@ -199,29 +199,28 @@ describe("Topic with unique: true", () => {
   });
 
   it("should de-dupe from checkpoint", () => {
+    // unique Topics keep [seen, values] so history outside the current buffer
+    // survives resume (unlike the flat Python-parity format).
     const checkpoint = channel.checkpoint();
-    expect(checkpoint).toEqual(["e"]);
+    expect(checkpoint).toEqual([["a", "b", "c", "d", "e"], ["e"]]);
     const newChannel = new Topic<string>({ unique: true }).fromCheckpoint(
       checkpoint
     );
 
     expect(newChannel.get()).toEqual(["e"]);
 
-    // Flat checkpoints only seed `seen` from restored values, so "d" (seen
-    // before checkpoint but not in the current buffer) is accepted again.
-    newChannel.update(["d", "f"]);
-    expect(newChannel.get()).toEqual(["d", "f"]);
-  });
-
-  it("restores legacy [seen, values] checkpoints", () => {
-    const newChannel = new Topic<string>({ unique: true }).fromCheckpoint([
-      ["a", "b", "c", "d", "e"],
-      ["e"],
-    ]);
-
-    expect(newChannel.get()).toEqual(["e"]);
     newChannel.update(["d", "f"]);
     expect(newChannel.get()).toEqual(["f"]);
+  });
+
+  it("still de-dupes when restoring a flat values-only checkpoint", () => {
+    const newChannel = new Topic<string>({ unique: true }).fromCheckpoint([
+      "e",
+    ]);
+    expect(newChannel.get()).toEqual(["e"]);
+    // Flat restore only knows about "e", so "d" is accepted again.
+    newChannel.update(["d", "f"]);
+    expect(newChannel.get()).toEqual(["d", "f"]);
   });
 });
 

--- a/libs/langgraph-core/src/tests/channels.test.ts
+++ b/libs/langgraph-core/src/tests/channels.test.ts
@@ -157,8 +157,16 @@ describe("Topic", () => {
 
   it("should create and use a checkpoint", () => {
     const checkpoint = channel.checkpoint();
+    expect(checkpoint).toEqual(["e"]);
     const newChannel = new Topic<string>().fromCheckpoint(checkpoint);
     expect(newChannel.get()).toEqual(["e"]);
+  });
+
+  it("should checkpoint an empty topic as a flat empty list", () => {
+    const empty = new Topic<string>();
+    expect(empty.checkpoint()).toEqual([]);
+    const restored = new Topic<string>().fromCheckpoint([]);
+    expect(() => restored.get()).toThrow(EmptyChannelError);
   });
 
   it.each([0, "", false, null])("should handle '%s'", (value) => {
@@ -192,12 +200,26 @@ describe("Topic with unique: true", () => {
 
   it("should de-dupe from checkpoint", () => {
     const checkpoint = channel.checkpoint();
+    expect(checkpoint).toEqual(["e"]);
     const newChannel = new Topic<string>({ unique: true }).fromCheckpoint(
       checkpoint
     );
 
     expect(newChannel.get()).toEqual(["e"]);
 
+    // Flat checkpoints only seed `seen` from restored values, so "d" (seen
+    // before checkpoint but not in the current buffer) is accepted again.
+    newChannel.update(["d", "f"]);
+    expect(newChannel.get()).toEqual(["d", "f"]);
+  });
+
+  it("restores legacy [seen, values] checkpoints", () => {
+    const newChannel = new Topic<string>({ unique: true }).fromCheckpoint([
+      ["a", "b", "c", "d", "e"],
+      ["e"],
+    ]);
+
+    expect(newChannel.get()).toEqual(["e"]);
     newChannel.update(["d", "f"]);
     expect(newChannel.get()).toEqual(["f"]);
   });

--- a/libs/langgraph-core/src/tests/pregel.test.ts
+++ b/libs/langgraph-core/src/tests/pregel.test.ts
@@ -180,7 +180,8 @@ export function runPregelTests(
       expect(checkpoint?.channel_values).toEqual({
         input: 1,
         output: 1,
-        [TASKS]: [[], []],
+        // Topic checkpoints a flat values list (Python parity), not [seen, values].
+        [TASKS]: [],
       });
     });
 
@@ -1004,7 +1005,7 @@ export function runPregelTests(
         channel_values: {
           channel1: 1,
           channel2: 2,
-          [TASKS]: [[], pendingSends],
+          [TASKS]: pendingSends,
         },
         channel_versions: {
           channel1: 2,


### PR DESCRIPTION
Topic checkpoints now emit a flat values list like Python, so Host no longer sees empty `__pregel_tasks` as `[[], []]` and fails checkpointer_put. Legacy `[seen, values]` checkpoints still restore.

## Test plan
- [x] `pnpm test src/tests/channels.test.ts` (langgraph-core)
- [x] `pnpm exec vitest run src/tests/pregel.test.ts -t 'obtain correct channel values|PregelExecutableTasks'`
- [x] Changeset added for affected package(s)