### PR TITLE
feat(sdk): export HTTPError with isInstance guard

### DIFF
--- a/.changeset/smooth-masks-lose.md
+++ b/.changeset/smooth-masks-lose.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+Export HTTPError with HTTPError.isInstance() for runtime type narrowing.

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -1,5 +1,6 @@
 export { Client, getApiKey } from "./client.js";
 export type { ClientConfig, RequestHook } from "./client.js";
+export { HTTPError } from "./utils/async_caller.js";
 
 export {
   ProtocolError,

--- a/libs/sdk/src/utils/async_caller.test.ts
+++ b/libs/sdk/src/utils/async_caller.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { HTTPError } from "../index.js";
 import { AsyncCaller } from "./async_caller.js";
 
 describe("AsyncCaller", () => {
@@ -154,7 +155,7 @@ describe("AsyncCaller", () => {
 
       const failingCallable = vi.fn(() => Promise.reject(responseError));
 
-      await expect(caller.call(failingCallable)).rejects.toThrow(/HTTP 404/);
+      await expect(caller.call(failingCallable)).rejects.toBeInstanceOf(HTTPError);
     });
 
     it("should include response text in HTTPError message", async () => {
@@ -207,6 +208,33 @@ describe("AsyncCaller", () => {
         expect(error).not.toHaveProperty("response");
         expect(error).not.toHaveProperty("status");
       }
+    });
+
+    it("should identify HTTPError values with HTTPError.isInstance", () => {
+      const response = {
+        status: 503,
+        statusText: "Service Unavailable",
+        text: () => Promise.resolve("Service down"),
+      } as Response;
+
+      const error: unknown = new HTTPError(503, "Service down", response);
+
+      expect(HTTPError.isInstance(error)).toBe(true);
+
+      if (HTTPError.isInstance(error)) {
+        expect(error.status).toBe(503);
+        expect(error.text).toBe("Service down");
+        expect(error.response).toBe(response);
+      }
+
+      expect(HTTPError.isInstance(new Error("Unrelated error"))).toBe(false);
+      expect(
+        HTTPError.isInstance({
+          status: 503,
+          text: "Service down",
+        })
+      ).toBe(false);
+      expect(HTTPError.isInstance(null)).toBe(false);
     });
 
     it("should retry connection errors and throw ConnectionError when retries are exhausted", async () => {

--- a/libs/sdk/src/utils/async_caller.ts
+++ b/libs/sdk/src/utils/async_caller.ts
@@ -67,10 +67,13 @@ function isResponse(x: unknown): x is Response {
   return "status" in x && "statusText" in x && "text" in x;
 }
 
+const HTTP_ERROR_SYMBOL = Symbol.for("langgraph.sdk.http_error");
+
 /**
  * Utility error to properly handle failed requests
  */
-class HTTPError extends Error {
+export class HTTPError extends Error {
+  protected readonly [HTTP_ERROR_SYMBOL] = true as const;
   status: number;
 
   text: string;
@@ -82,6 +85,15 @@ class HTTPError extends Error {
     this.status = status;
     this.text = message;
     this.response = response;
+  }
+
+    static isInstance(error: unknown): error is HTTPError {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      HTTP_ERROR_SYMBOL in error &&
+      (error as Record<symbol, unknown>)[HTTP_ERROR_SYMBOL] === true
+    );
   }
 
   static async fromResponse(
@@ -117,6 +129,8 @@ class HTTPError extends Error {
  * means that by default, each call will be retried up to 5 times, with an
  * exponential backoff between each attempt.
  */
+
+
 export class AsyncCaller {
   protected maxConcurrency: AsyncCallerParams["maxConcurrency"];
 

--- a/libs/sdk/src/utils/async_caller.ts
+++ b/libs/sdk/src/utils/async_caller.ts
@@ -87,7 +87,7 @@ export class HTTPError extends Error {
     this.response = response;
   }
 
-    static isInstance(error: unknown): error is HTTPError {
+  static isInstance(error: unknown): error is HTTPError {
     return (
       typeof error === "object" &&
       error !== null &&
@@ -129,7 +129,6 @@ export class HTTPError extends Error {
  * means that by default, each call will be retried up to 5 times, with an
  * exponential backoff between each attempt.
  */
-
 
 export class AsyncCaller {
   protected maxConcurrency: AsyncCallerParams["maxConcurrency"];


### PR DESCRIPTION
## Summary

Expose the SDK HTTP error through the public package API so consumers can reliably identify and narrow HTTP request failures.

## Changes

* export the existing `HTTPError` class
* add a branded `HTTPError.isInstance()` runtime type guard
* re-export `HTTPError` from the SDK package root
* update the existing HTTP error test to assert the public error class
* add focused coverage for type narrowing, error metadata, retained response access, and unrelated values
* add a patch changeset for `@langchain/langgraph-sdk`

## Motivation

The SDK already throws a structured `HTTPError` containing `status`, `text`, and an optional `response`, but the class is currently private.

Consumers therefore cannot distinguish SDK HTTP failures from unrelated errors without parsing error messages or using unsafe casts.

This change makes the existing error type public without changing request execution, response retention, or retry behavior.

## Test plan

* [x] Run the focused `async_caller.test.ts` suite
* [x] Run the full `@langchain/langgraph-sdk` unit test suite
* [x] Build `@langchain/langgraph-sdk`
* [x] Run oxlint on the changed TypeScript files
* [x] Run oxfmt checks on the changed non-test source files
* [x] Verify ordinary errors, structurally similar objects, and null values are rejected by `HTTPError.isInstance()`

Fixes #2633
