### PR TITLE
fix(core): run all Send fan-out tasks when maxConcurrency is 1

### DIFF
--- a/.changeset/fix-send-fan-out-concurrency.md
+++ b/.changeset/fix-send-fan-out-concurrency.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(core): run all Send fan-out tasks when maxConcurrency is 1

--- a/libs/langgraph-core/src/pregel/runner.ts
+++ b/libs/langgraph-core/src/pregel/runner.ts
@@ -320,7 +320,8 @@ export class PregelRunner {
       : undefined;
 
     while (
-      (startedTasksCount === 0 || Object.keys(executingTasksMap).length > 0) &&
+      (startedTasksCount < tasks.length ||
+        Object.keys(executingTasksMap).length > 0) &&
       tasks.length
     ) {
       for (

--- a/libs/langgraph-core/src/tests/python_port/graph_structure.test.ts
+++ b/libs/langgraph-core/src/tests/python_port/graph_structure.test.ts
@@ -1061,7 +1061,7 @@ describe("Graph Structure Tests (Python port)", () => {
     const graph = new StateGraph(State)
       .addNode("start", () => ({}))
       .addNode("worker", (state: typeof State.State) => ({
-        seen: [(state as Record<string, string>).item],
+        seen: [(state as unknown as { item: string }).item],
       }))
       .addConditionalEdges("start", (s) =>
         s.items.map((item) => new Send("worker", { item }))

--- a/libs/langgraph-core/src/tests/python_port/graph_structure.test.ts
+++ b/libs/langgraph-core/src/tests/python_port/graph_structure.test.ts
@@ -1046,6 +1046,35 @@ describe("Graph Structure Tests (Python port)", () => {
     expect(result4.items).toEqual(["0", "1", ...expectedNumbers, "3"]);
   });
 
+  it("should run all Send fan-out tasks with maxConcurrency 1", async () => {
+    const State = Annotation.Root({
+      items: Annotation<string[]>({
+        reducer: (a, b) => a.concat(b),
+        default: () => [],
+      }),
+      seen: Annotation<string[]>({
+        reducer: (a, b) => a.concat(b),
+        default: () => [],
+      }),
+    });
+
+    const graph = new StateGraph(State)
+      .addNode("start", () => ({}))
+      .addNode("worker", (state: typeof State.State) => ({
+        seen: [(state as Record<string, string>).item],
+      }))
+      .addConditionalEdges("start", (s) =>
+        s.items.map((item) => new Send("worker", { item }))
+      )
+      .addEdge(START, "start")
+      .addEdge("worker", END)
+      .compile();
+
+    const items = ["a", "b", "c", "d", "e", "f"];
+    const result = await graph.invoke({ items }, { maxConcurrency: 1 });
+    expect(result.seen.sort()).toEqual(items.sort());
+  });
+
   /**
    * Port of test_max_concurrency_control from test_pregel_async_graph_structure.py
    */


### PR DESCRIPTION
## Summary

- `Send` fan-out tasks were silently dropped when `maxConcurrency: 1` — the while loop in `_executeTasksWithRetry` exited after the first task completed because `startedTasksCount === 0` was false and `executingTasksMap` was empty, even though 5 more tasks remained unstarted.
- One-line fix: replace the initial-entry guard `startedTasksCount === 0` with `startedTasksCount < tasks.length` so the loop continues while there are unstarted tasks.
- Added a regression test that invokes a Send fan-out graph with `maxConcurrency: 1` and verifies all tasks run.

## Root cause

```typescript
// Before (exits after 1st task with maxConcurrency: 1)
while (
  (startedTasksCount === 0 || Object.keys(executingTasksMap).length > 0) &&
  tasks.length
)

// After (continues while tasks remain to start)
while (
  (startedTasksCount < tasks.length ||
    Object.keys(executingTasksMap).length > 0) &&
  tasks.length
)
```

With `maxConcurrency: 1`, only one task is started per inner-loop iteration. When it completes and is removed from `executingTasksMap`, the map is empty and `startedTasksCount` is no longer 0 — so the outer while condition was false. With `maxConcurrency >= 2`, at least one task was always still executing when another finished, masking the bug.

## Test plan

- [x] New test: `should run all Send fan-out tasks with maxConcurrency 1` — 6-item fan-out, all must appear in output
- [x] Existing `should handle maximum concurrency limits` test still validates maxConcurrency: 10 behavior

Closes #2656