### PR TITLE
fix(cli): resolve graphs from later faux local dependencies

### DIFF
--- a/libs/langgraph-cli/src/docker/docker.mts
+++ b/libs/langgraph-cli/src/docker/docker.mts
@@ -223,7 +223,9 @@ async function updateGraphPaths(
                 .join("/");
               break find;
             }
+          }
 
+          if (Object.keys(localDeps.fauxPkgs).length) {
             throw new Error(
               `Module '${importStr}' not found in 'dependencies' list. Add its containing package to 'dependencies' list.`
             );

--- a/libs/langgraph-cli/tests/config.test.mts
+++ b/libs/langgraph-cli/tests/config.test.mts
@@ -230,6 +230,24 @@ describe("config to docker", () => {
     `);
   });
 
+  it("resolves graphs from later faux local deps", async () => {
+    const config = getConfig({
+      ...DEFAULT_CONFIG,
+      dependencies: ["./graphs", "."],
+      graphs: { agent: "./agent.py:graph" },
+    });
+
+    const actual = await configToDocker(
+      PATH_TO_CONFIG,
+      config,
+      await assembleLocalDeps(PATH_TO_CONFIG, config)
+    );
+
+    expect(actual).toContain(
+      `ENV LANGSERVE_GRAPHS='{"agent":"/deps/__outer_unit_tests/unit_tests/agent.py:graph"}'`
+    );
+  });
+
   it("pyproject", async () => {
     const pyproject = path.resolve(__dirname, "./unit_tests/pyproject.toml");
     await fs.writeFile(


### PR DESCRIPTION
## Summary

- continue checking faux local dependencies until a graph path matches
- add a regression test for a graph in the second faux local dependency

## Why

`updateGraphPaths` threw after the first non-matching faux package, so dependency order could prevent a valid graph from being resolved.

## Validation

- `pnpm --filter @langchain/langgraph-cli test -- config.test.mts` (78 passed)
- `pnpm exec oxlint libs/langgraph-cli/src/docker/docker.mts libs/langgraph-cli/tests/config.test.mts`
- `pnpm exec oxfmt --check libs/langgraph-cli/src/docker/docker.mts libs/langgraph-cli/tests/config.test.mts`

Package typechecking is currently blocked by unbuilt workspace package declarations for `@langchain/langgraph-api` and `create-langgraph`.
