### PR TITLE
feat(sdk): gate subgraph discovery history hydration

### DIFF
--- a/.changeset/quiet-threads-hydrate.md
+++ b/.changeset/quiet-threads-hydrate.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": minor
+---
+
+Add an option to skip checkpoint-history reads used only for subgraph discovery during stream hydration.

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -2210,7 +2210,34 @@ describe("StreamController", () => {
     await controller.dispose();
   });
 
-  it("hydrate promotes subagent execution namespace from getHistory", async () => {
+  it("skips history when subgraph hydration is disabled without subagents", async () => {
+    const { thread } = discoveryThread();
+    const getHistory = vi.fn(async () => []);
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({
+          values: { messages: [{ type: "human", content: "Hello" }] },
+          next: [],
+          tasks: [],
+        })),
+        getHistory,
+        stream: vi.fn(() => thread),
+      },
+    };
+    const controller = new StreamController<State, unknown>({
+      assistantId: "chat_agent",
+      client: client as never,
+      threadId: "thread-1",
+      discoverSubgraphsOnHydrate: false,
+    });
+    await controller.hydrationPromise;
+
+    expect(getHistory).not.toHaveBeenCalled();
+
+    await controller.dispose();
+  });
+
+  it("still promotes subagents when subgraph hydration is disabled", async () => {
     const { thread } = discoveryThread();
     const getHistory = vi.fn(async () => [
       {
@@ -2237,6 +2264,7 @@ describe("StreamController", () => {
       assistantId: "deep_agent",
       client: client as never,
       threadId: "thread-1",
+      discoverSubgraphsOnHydrate: false,
     });
     await controller.hydrationPromise;
 
@@ -2284,6 +2312,7 @@ describe("StreamController", () => {
         { nodeName: "research", status: "complete" }
       );
     });
+    expect(getHistory).toHaveBeenCalledTimes(1);
 
     await controller.dispose();
   });

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -865,6 +865,7 @@ describe("StreamController", () => {
 
   it("calls thread.startLifecycleWatcher() on hydrate of an existing thread", async () => {
     const startLifecycleWatcher = vi.fn(() => undefined);
+    const getHistory = vi.fn(async () => []);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
       onEvent: vi.fn(() => vi.fn()),
@@ -875,6 +876,7 @@ describe("StreamController", () => {
     const client = {
       threads: {
         getState: vi.fn(async () => ({ values: {}, next: ["agent"] })),
+        getHistory,
         stream: vi.fn(() => thread),
       },
     };
@@ -883,10 +885,12 @@ describe("StreamController", () => {
       assistantId: "deep-agent",
       client: client as never,
       threadId: "thread-existing",
+      discoverSubgraphsOnHydrate: false,
     });
     await controller.hydrationPromise;
 
     expect(startLifecycleWatcher).toHaveBeenCalledOnce();
+    expect(getHistory).not.toHaveBeenCalled();
     await controller.dispose();
   });
 
@@ -1180,6 +1184,7 @@ describe("StreamController", () => {
 
   it("hydrate(null) clears subgraph discovery from the previous thread", async () => {
     let onEvent: ((event: Event) => void) | undefined;
+    const getHistory = vi.fn(async () => []);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
@@ -1193,6 +1198,7 @@ describe("StreamController", () => {
     const client = {
       threads: {
         getState: vi.fn(async () => ({ values: {}, next: ["agent"] })),
+        getHistory,
         stream: vi.fn(() => thread),
       },
     };
@@ -1201,6 +1207,7 @@ describe("StreamController", () => {
       assistantId: "graph-execution-cards",
       client: client as never,
       threadId: "thread-1",
+      discoverSubgraphsOnHydrate: false,
     });
     await controller.hydrationPromise;
     expect(onEvent).toBeDefined();
@@ -1217,6 +1224,7 @@ describe("StreamController", () => {
 
     expect(controller.subgraphStore.getSnapshot().size).toBe(0);
     expect(controller.subgraphByNodeStore.getSnapshot().size).toBe(0);
+    expect(getHistory).not.toHaveBeenCalled();
     await controller.dispose();
   });
 

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -759,7 +759,14 @@ export class StreamController<
     if (threadExists && threadActive) {
       thread.startLifecycleWatcher();
     }
-    if (threadExists) {
+    const hasUnresolvedSubagents = [...this.#subagents.snapshot.values()].some(
+      namespaceIsDefaultOnly
+    );
+    if (
+      threadExists &&
+      (this.#options.discoverSubgraphsOnHydrate !== false ||
+        hasUnresolvedSubagents)
+    ) {
       /**
        * Seed subgraph discovery and promote subagent execution
        * namespaces from a single bounded `getHistory` page. Subgraph
@@ -768,6 +775,10 @@ export class StreamController<
        * history. Fire-and-forget — not awaited into the hydration
        * promise, so Suspense / first paint stay unblocked; cards fill
        * in progressively when it resolves.
+       *
+       * Consumers that do not render subgraphs can disable the otherwise
+       * unconditional history read. Default-only subagents still require this
+       * seed so their execution namespaces resolve correctly after reconnect.
        *
        * Held in `#discoverySeedPromise` so lazy per-card
        * {@link resolveSubagentNamespace} calls coalesce onto this single

--- a/libs/sdk/src/stream/types.ts
+++ b/libs/sdk/src/stream/types.ts
@@ -169,6 +169,16 @@ export interface UseStreamCommonOptions<
   initialValues?: StateType;
   /** State key holding the message array. Defaults to {@link DEFAULT_MESSAGES_KEY}. */
   messagesKey?: string;
+  /**
+   * Whether hydration should read checkpoint history to rediscover subgraph
+   * hosts. Disable when the consumer does not render subgraphs.
+   *
+   * History is still read when the current state contains subagents whose
+   * execution namespaces need promotion.
+   *
+   * @default true
+   */
+  discoverSubgraphsOnHydrate?: boolean;
   /** Headless tool implementations; auto-resumes matching interrupts. */
   tools?: AnyHeadlessToolImplementation[];
   /** Observe lifecycle events for registered {@link tools}. */
@@ -406,6 +416,11 @@ export interface StreamControllerOptions<
   initialValues?: StateType;
   /** Key inside `values` that holds the message array. Defaults to {@link DEFAULT_MESSAGES_KEY}. */
   messagesKey?: string;
+  /**
+   * Whether hydration should read checkpoint history to rediscover subgraph
+   * hosts. Defaults to `true`; subagents can still require history when false.
+   */
+  discoverSubgraphsOnHydrate?: boolean;
   /**
    * Optimistic UI for `submit()`. Defaults to `true`. See
    * {@link UseStreamCommonOptions.optimistic} for the full contract.


### PR DESCRIPTION
## Summary
- add a backward-compatible stream option for consumers that do not render hydrated subgraphs
- skip the bounded checkpoint-history read when current state contains no unresolved subagents
- preserve default subgraph discovery and subagent namespace recovery behavior

## Test Plan
- [x] Confirm ordinary hydrated threads issue no history read when subgraph discovery is disabled
- [x] Confirm hydrated subagents still perform one bounded history read and promote their execution namespace
- [x] Confirm default subgraph discovery remains enabled