### PR TITLE
feat(react): forward subgraph hydration capability

### DIFF
--- a/.changeset/gentle-react-history.md
+++ b/.changeset/gentle-react-history.md
@@ -1,0 +1,5 @@
+---
+"@langchain/react": minor
+---
+
+Forward the subgraph hydration capability to the stream controller.

--- a/libs/sdk-react/src/tests/stream.controller-stability.test.tsx
+++ b/libs/sdk-react/src/tests/stream.controller-stability.test.tsx
@@ -36,7 +36,7 @@ function StabilityProbe({
 }) {
   const [, forceRender] = useState(0);
   const [discoverSubgraphsOnHydrate, setDiscoverSubgraphsOnHydrate] =
-    useState(false);
+    useState<boolean | undefined>(false);
 
   const stream = useStream<{ messages: unknown[] }>({
     assistantId: "stategraph_text",
@@ -64,6 +64,12 @@ function StabilityProbe({
         onClick={() => setDiscoverSubgraphsOnHydrate((enabled) => !enabled)}
       >
         Toggle subgraph discovery
+      </button>
+      <button
+        data-testid="default-subgraph-discovery"
+        onClick={() => setDiscoverSubgraphsOnHydrate(undefined)}
+      >
+        Default subgraph discovery
       </button>
       <div data-testid="thread-loading">
         {stream.isThreadLoading ? "Hydrating..." : "Ready"}
@@ -145,6 +151,16 @@ it("keeps one controller (single hydrate) across re-renders", async () => {
       .toHaveTextContent("Ready");
     await new Promise((resolve) => setTimeout(resolve, 250));
 
+    expect(stateRequests).toBe(2);
+    expect(historyRequests).toBe(1);
+
+    // `undefined` uses the same enabled default as `true`, so this render
+    // must retain the current controller and avoid another hydration.
+    await screen.getByTestId("default-subgraph-discovery").click();
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await expect
+      .element(screen.getByTestId("identity-changes"))
+      .toHaveTextContent("1");
     expect(stateRequests).toBe(2);
     expect(historyRequests).toBe(1);
   } finally {

--- a/libs/sdk-react/src/tests/stream.controller-stability.test.tsx
+++ b/libs/sdk-react/src/tests/stream.controller-stability.test.tsx
@@ -12,7 +12,8 @@
  * The fix pins the controller in a `useRef` (recreated only when its
  * identity inputs actually change). This test forces several re-renders
  * during/after hydration and asserts the controller identity is stable
- * and `getState`/`getHistory` each fired at most once.
+ * and hydration fires only once. It also verifies that changing a controller
+ * capability intentionally creates a new controller with the new behavior.
  *
  * Note: in a normal test env `useMemo` would also stay stable, so this
  * guards primarily against future regressions (e.g. an unstable
@@ -34,11 +35,14 @@ function StabilityProbe({
   threadId: string;
 }) {
   const [, forceRender] = useState(0);
+  const [discoverSubgraphsOnHydrate, setDiscoverSubgraphsOnHydrate] =
+    useState(false);
 
   const stream = useStream<{ messages: unknown[] }>({
     assistantId: "stategraph_text",
     apiUrl,
     threadId,
+    discoverSubgraphsOnHydrate,
   });
 
   // Track controller identity across renders.
@@ -54,6 +58,12 @@ function StabilityProbe({
     <div>
       <button data-testid="rerender" onClick={() => forceRender((n) => n + 1)}>
         Re-render
+      </button>
+      <button
+        data-testid="toggle-subgraph-discovery"
+        onClick={() => setDiscoverSubgraphsOnHydrate((enabled) => !enabled)}
+      >
+        Toggle subgraph discovery
       </button>
       <div data-testid="thread-loading">
         {stream.isThreadLoading ? "Hydrating..." : "Ready"}
@@ -121,7 +131,22 @@ it("keeps one controller (single hydrate) across re-renders", async () => {
       )
     ).toBe(0);
     expect(stateRequests).toBe(1);
-    expect(historyRequests).toBeLessThanOrEqual(1);
+    expect(historyRequests).toBe(0);
+
+    // Controller capabilities are identity inputs. Enabling subgraph
+    // discovery must replace the controller so the next hydrate performs the
+    // history read instead of retaining the previous controller's behavior.
+    await screen.getByTestId("toggle-subgraph-discovery").click();
+    await expect
+      .element(screen.getByTestId("identity-changes"))
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("thread-loading"), { timeout: 20_000 })
+      .toHaveTextContent("Ready");
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    expect(stateRequests).toBe(2);
+    expect(historyRequests).toBe(1);
   } finally {
     globalThis.fetch = originalFetch;
     await cleanupRender(screen);

--- a/libs/sdk-react/src/use-stream.ts
+++ b/libs/sdk-react/src/use-stream.ts
@@ -497,6 +497,7 @@ export function useStream<
     onCompleted?: (info: RunCompletedInfo) => void;
     initialValues?: StateType;
     messagesKey?: string;
+    discoverSubgraphsOnHydrate?: boolean;
     optimistic?: boolean;
   }
   const asBag = options as OptionsBag;
@@ -567,7 +568,12 @@ export function useStream<
   // Recreated only when its identity inputs change; the previous
   // instance is disposed by the `activate()` effect when `controller`
   // changes.
-  const controllerDeps = [client, assistantId, transport] as const;
+  const controllerDeps = [
+    client,
+    assistantId,
+    transport,
+    asBag.discoverSubgraphsOnHydrate,
+  ] as const;
   const controllerRef = useRef<{
     deps: typeof controllerDeps;
     controller: StreamController<StateType, InterruptType, ConfigurableType>;
@@ -608,6 +614,7 @@ export function useStream<
         onCompleted: options.onCompleted,
         initialValues: options.initialValues,
         messagesKey: options.messagesKey,
+        discoverSubgraphsOnHydrate: asBag.discoverSubgraphsOnHydrate,
         optimistic: asBag.optimistic,
       }),
     };

--- a/libs/sdk-react/src/use-stream.ts
+++ b/libs/sdk-react/src/use-stream.ts
@@ -568,11 +568,12 @@ export function useStream<
   // Recreated only when its identity inputs change; the previous
   // instance is disposed by the `activate()` effect when `controller`
   // changes.
+  const discoverSubgraphsOnHydrate = asBag.discoverSubgraphsOnHydrate !== false;
   const controllerDeps = [
     client,
     assistantId,
     transport,
-    asBag.discoverSubgraphsOnHydrate,
+    discoverSubgraphsOnHydrate,
   ] as const;
   const controllerRef = useRef<{
     deps: typeof controllerDeps;
@@ -614,7 +615,7 @@ export function useStream<
         onCompleted: options.onCompleted,
         initialValues: options.initialValues,
         messagesKey: options.messagesKey,
-        discoverSubgraphsOnHydrate: asBag.discoverSubgraphsOnHydrate,
+        discoverSubgraphsOnHydrate,
         optimistic: asBag.optimistic,
       }),
     };


### PR DESCRIPTION
## Summary
- forward the SDK discovery capability through React `useStream`
- treat capability changes as controller identity changes so hydration behavior cannot go stale
- verify disabled hydration removes the history request and re-enabling it recreates the controller

Depends on #2662.

## Test Plan
- [x] Confirm unrelated React re-renders keep one controller and issue no duplicate hydration reads
- [x] Confirm toggling subgraph discovery recreates the controller and restores the history read