### PR TITLE
feat(sdk): forward hydration capability across frameworks

### DIFF
--- a/.changeset/calm-framework-history.md
+++ b/.changeset/calm-framework-history.md
@@ -1,0 +1,7 @@
+---
+"@langchain/angular": minor
+"@langchain/svelte": minor
+"@langchain/vue": minor
+---
+
+Forward the subgraph hydration capability through the Angular, Svelte, and Vue stream bindings.

--- a/libs/sdk-angular/src/tests/stream.test-d.ts
+++ b/libs/sdk-angular/src/tests/stream.test-d.ts
@@ -51,6 +51,13 @@ describe("useStream return shape", () => {
 
     expectTypeOf(stream.threadId()).toEqualTypeOf<string | null>();
   });
+
+  test("accepts the subgraph hydration capability", () => {
+    expectTypeOf(useStream<BasicState>).toBeCallableWith({
+      assistantId: "agent",
+      discoverSubgraphsOnHydrate: false,
+    });
+  });
 });
 
 describe("companion injectors", () => {

--- a/libs/sdk-angular/src/use-stream.ts
+++ b/libs/sdk-angular/src/use-stream.ts
@@ -459,6 +459,7 @@ export function useStream<
     onCompleted?: (info: RunCompletedInfo) => void;
     initialValues?: StateType;
     messagesKey?: string;
+    discoverSubgraphsOnHydrate?: boolean;
     tools?: AnyHeadlessToolImplementation[];
     onTool?: OnToolCallback;
     optimistic?: boolean;
@@ -527,6 +528,7 @@ export function useStream<
     onCompleted: options.onCompleted,
     initialValues: options.initialValues,
     messagesKey: options.messagesKey,
+    discoverSubgraphsOnHydrate: asBag.discoverSubgraphsOnHydrate,
     optimistic: asBag.optimistic,
   });
 

--- a/libs/sdk-svelte/src/tests/stream.test-d.ts
+++ b/libs/sdk-svelte/src/tests/stream.test-d.ts
@@ -510,6 +510,13 @@ describe("v1 useStream options and submit typing", () => {
     });
   });
 
+  test("accepts the subgraph hydration capability", () => {
+    expectTypeOf(useStream<BedtimeState>).toBeCallableWith({
+      assistantId: "agent",
+      discoverSubgraphsOnHydrate: false,
+    });
+  });
+
   test("submit accepts BaseMessage instances and v1 options", () => {
     const widened: WidenUpdateMessages<Partial<BedtimeState>> = {
       messages: [new HumanMessage("hi")],

--- a/libs/sdk-svelte/src/use-stream.svelte.ts
+++ b/libs/sdk-svelte/src/use-stream.svelte.ts
@@ -464,6 +464,7 @@ export function useStream<
     onCompleted?: (info: RunCompletedInfo) => void;
     initialValues?: StateType;
     messagesKey?: string;
+    discoverSubgraphsOnHydrate?: boolean;
     tools?: AnyHeadlessToolImplementation[];
     onTool?: OnToolCallback;
     optimistic?: boolean;
@@ -525,6 +526,7 @@ export function useStream<
     onCompleted: options.onCompleted,
     initialValues: options.initialValues,
     messagesKey: options.messagesKey,
+    discoverSubgraphsOnHydrate: asBag.discoverSubgraphsOnHydrate,
     optimistic: asBag.optimistic,
   });
 

--- a/libs/sdk-vue/src/tests/stream.test-d.ts
+++ b/libs/sdk-vue/src/tests/stream.test-d.ts
@@ -377,6 +377,13 @@ describe("useStream accepts reactive options for dynamic inputs", () => {
     expectTypeOf(stream.messages).toExtend<Readonly<ShallowRef<BaseMessage[]>>>();
   });
 
+  test("accepts the subgraph hydration capability", () => {
+    expectTypeOf(useStream<BasicState>).toBeCallableWith({
+      assistantId: "agent",
+      discoverSubgraphsOnHydrate: false,
+    });
+  });
+
   test("callbacks remain plain function types", () => {
     useStream<BasicState>({
       assistantId: "agent",

--- a/libs/sdk-vue/src/use-stream.ts
+++ b/libs/sdk-vue/src/use-stream.ts
@@ -481,6 +481,7 @@ export function useStream<
     onCompleted?: (info: RunCompletedInfo) => void;
     initialValues?: StateType;
     messagesKey?: string;
+    discoverSubgraphsOnHydrate?: boolean;
     tools?: AnyHeadlessToolImplementation[];
     onTool?: OnToolCallback;
     optimistic?: boolean;
@@ -564,6 +565,7 @@ export function useStream<
     onCompleted: options.onCompleted,
     initialValues: options.initialValues,
     messagesKey: options.messagesKey,
+    discoverSubgraphsOnHydrate: asBag.discoverSubgraphsOnHydrate,
     optimistic: asBag.optimistic,
   });
 


### PR DESCRIPTION
## Summary
- forward the discovery-history capability through Angular, Svelte, and Vue stream bindings
- keep the three framework option surfaces aligned with the core SDK
- add focused type coverage for each binding

Depends on #2662.

## Test Plan
- [x] Confirm Angular, Svelte, and Vue accept the capability on their public `useStream` surfaces
- [x] Confirm all three framework packages build with the forwarded controller option