### PR TITLE
fix(langgraph): run all tasks when maxConcurrency is 1

### DIFF
--- a/.changeset/fix-max-concurrency-one-drops-tasks.md
+++ b/.changeset/fix-max-concurrency-one-drops-tasks.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(langgraph): run all tasks when maxConcurrency is 1
+
+The runner's scheduling loop exited as soon as its only in-flight task settled, silently dropping every remaining task in the superstep. Keep scheduling while unstarted tasks remain, so `maxConcurrency: 1` executes the full fan-out sequentially.

--- a/libs/langgraph-core/src/pregel/runner.ts
+++ b/libs/langgraph-core/src/pregel/runner.ts
@@ -320,7 +320,8 @@ export class PregelRunner {
       : undefined;
 
     while (
-      (startedTasksCount === 0 || Object.keys(executingTasksMap).length > 0) &&
+      (startedTasksCount < tasks.length ||
+        Object.keys(executingTasksMap).length > 0) &&
       tasks.length
     ) {
       for (

--- a/libs/langgraph-core/src/tests/python_port/graph_structure.test.ts
+++ b/libs/langgraph-core/src/tests/python_port/graph_structure.test.ts
@@ -1047,6 +1047,53 @@ describe("Graph Structure Tests (Python port)", () => {
   });
 
   /**
+   * Regression test for #2656: Send fan-out tasks were silently dropped when
+   * maxConcurrency was 1, because the runner's scheduling loop exited as soon
+   * as the single in-flight task settled.
+   */
+  it("should run all Send tasks sequentially when maxConcurrency is 1", async () => {
+    const StateAnnotation = Annotation.Root({
+      items: Annotation<unknown[]>({
+        reducer: (a, b) => a.concat(b),
+        default: () => [],
+      }),
+    });
+
+    let currently = 0;
+    let maxCurrently = 0;
+
+    const worker = async (state: unknown): Promise<{ items: unknown[] }> => {
+      currently += 1;
+      if (currently > maxCurrently) {
+        maxCurrently = currently;
+      }
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 1);
+      });
+      currently -= 1;
+      return { items: [state] };
+    };
+
+    const sendToMany = (): Send[] => {
+      return Array.from({ length: 6 }, (_, idx) => new Send("worker", idx));
+    };
+
+    const graph = new StateGraph(StateAnnotation)
+      .addNode("fanout", () => ({ items: ["fanout"] }))
+      .addNode("worker", worker)
+      .addEdge(START, "fanout")
+      .addConditionalEdges("fanout", sendToMany)
+      .compile();
+
+    const result = await graph.invoke({ items: [] }, { maxConcurrency: 1 });
+
+    const expectedNumbers = Array.from({ length: 6 }, (_, i) => i);
+    expect(result.items).toEqual(["fanout", ...expectedNumbers]);
+    expect(maxCurrently).toBe(1);
+    expect(currently).toBe(0);
+  });
+
+  /**
    * Port of test_max_concurrency_control from test_pregel_async_graph_structure.py
    */
   it("should handle maximum concurrency limits with commands", async () => {


### PR DESCRIPTION
Fixes #2656

Invoking a graph that fans out with `Send` under `maxConcurrency: 1` silently skips every task after the first. No error is raised and the output is structurally valid, so the lost work leaves no signal downstream.

## Root cause

The scheduling loop in `PregelRunner._executeTasksWithRetry` continues while:

```ts
(startedTasksCount === 0 || Object.keys(executingTasksMap).length > 0) && tasks.length
```

With a limit of 1, `executingTasksMap` holds a single task. When it settles and is deleted at the bottom of the loop, the map is empty and `startedTasksCount` is non-zero, so the loop exits with the remaining tasks never scheduled. Any limit >= 2 keeps at least one task in flight across a settle, which is why only `1` is affected.

The condition conflates "nothing in flight" with "nothing left to start".

## Fix

Continue while unstarted tasks remain **or** tasks are in flight. The inner top-up loop already caps in-flight work at `maxConcurrency`, so the limit itself is unchanged. Tasks injected mid-tick (error handlers, PUSH tasks via `call`) still keep the loop alive through the barrier exactly as before.

Reproduction from the issue:

| maxConcurrency | before | after |
|---|---|---|
| 1 | ran=0 | ran=6 |
| 2 | ran=6 | ran=6 |
| 4 | ran=6 | ran=6 |
| unset | ran=6 | ran=6 |

## Test

Regression test added beside the existing `test_max_concurrency` port: a 6-way `Send` fan-out at `maxConcurrency: 1` must complete all six tasks **and** observe a peak concurrency of exactly 1 — so a future change can't "fix" this by quietly widening the limit. Fails on `main` (0 of 6 tasks run), passes with this change.

`libs/langgraph-core`: 79 files, 1639 tests passed, 0 type errors. `oxlint` and `oxfmt --check` clean.
