### PR TITLE
fix(sdk): always attach Response on HTTPError

### DIFF
--- a/.changeset/always-attach-http-error-response.md
+++ b/.changeset/always-attach-http-error-response.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+Always attach the underlying Response on HTTPError.

--- a/libs/sdk/src/utils/async_caller.test.ts
+++ b/libs/sdk/src/utils/async_caller.test.ts
@@ -173,6 +173,42 @@ describe("AsyncCaller", () => {
       );
     });
 
+    it("should attach error.response without onFailedResponseHook", async () => {
+      const caller = new AsyncCaller({ maxRetries: 0 });
+
+      const responseError = {
+        status: 404,
+        statusText: "Not Found",
+        text: () => Promise.resolve("missing"),
+      };
+
+      const failingCallable = vi.fn(() => Promise.reject(responseError));
+
+      await expect(caller.call(failingCallable)).rejects.toMatchObject({
+        status: 404,
+        response: responseError,
+      });
+    });
+
+    it("should not attach a response to failures that carry none", async () => {
+      const caller = new AsyncCaller({ maxRetries: 0 });
+
+      // Only a Response rejection becomes an HTTPError, so these keep no
+      // `response`: a generic failure is rethrown as-is, and a connection
+      // failure is replaced by ConnectionError.
+      for (const failure of [
+        new TypeError("boom"),
+        new TypeError("fetch failed"),
+      ]) {
+        const error = await caller
+          .call(vi.fn(() => Promise.reject(failure)))
+          .catch((caught) => caught);
+
+        expect(error).not.toHaveProperty("response");
+        expect(error).not.toHaveProperty("status");
+      }
+    });
+
     it("should retry connection errors and throw ConnectionError when retries are exhausted", async () => {
       const caller = new AsyncCaller({ maxRetries: 1 });
 

--- a/libs/sdk/src/utils/async_caller.ts
+++ b/libs/sdk/src/utils/async_caller.ts
@@ -160,8 +160,10 @@ export class AsyncCaller {
               if (error instanceof Error) {
                 throw error;
               } else if (isResponse(error)) {
+                // Always attach the failed Response so callers can inspect
+                // error.response without registering onFailedResponseHook.
                 throw await HTTPError.fromResponse(error, {
-                  includeResponse: !!onFailedResponseHook,
+                  includeResponse: true,
                 });
               } else {
                 throw new Error(error);


### PR DESCRIPTION
## Summary
- Always pass `includeResponse: true` when converting failed `Response` objects to `HTTPError`, so `error.response` is available without registering `onFailedResponseHook`.

## Test plan
- [x] New unit test `should attach error.response without onFailedResponseHook` passes with the fix
- [x] Same test fails with `response: undefined` when the fix is stashed (`git stash` A/B)
- [x] Changeset for `@langchain/langgraph-sdk`

Fixes #2632