### PR TITLE
fix(langgraph-checkpoint-redis): treat Valkey FT.CREATE already-exists as no-op

### DIFF
--- a/.changeset/busy-kiwis-happen.md
+++ b/.changeset/busy-kiwis-happen.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint-redis": patch
+---
+
+fix(langgraph-checkpoint-redis): treat Valkey FT.CREATE already-exists as no-op

--- a/libs/checkpoint-redis/src/index.ts
+++ b/libs/checkpoint-redis/src/index.ts
@@ -14,7 +14,11 @@ import {
 } from "@langchain/langgraph-checkpoint";
 import { RunnableConfig } from "@langchain/core/runnables";
 import { createClient, createCluster } from "redis";
-import { assertSafeKeyComponent, escapeRediSearchTagValue } from "./utils.js";
+import {
+  assertSafeKeyComponent,
+  escapeRediSearchTagValue,
+  isIndexAlreadyExistsError,
+} from "./utils.js";
 import { WRITE_KEYS_ZSET_PREFIX } from "./constants.js";
 
 // Type for Redis client - supports both standalone and cluster
@@ -1124,7 +1128,7 @@ export class RedisSaver extends BaseCheckpointSaver {
         });
       } catch (error: any) {
         // Ignore if index already exists
-        if (!error.message?.includes("Index already exists")) {
+        if (!isIndexAlreadyExistsError(error)) {
           console.error(
             `Failed to create index ${schema.index}:`,
             error.message

--- a/libs/checkpoint-redis/src/shallow.ts
+++ b/libs/checkpoint-redis/src/shallow.ts
@@ -10,7 +10,11 @@ import {
 } from "@langchain/langgraph-checkpoint";
 import { RunnableConfig } from "@langchain/core/runnables";
 import { createClient } from "redis";
-import { assertSafeKeyComponent, escapeRediSearchTagValue } from "./utils.js";
+import {
+  assertSafeKeyComponent,
+  escapeRediSearchTagValue,
+  isIndexAlreadyExistsError,
+} from "./utils.js";
 import { WRITE_KEYS_ZSET_PREFIX } from "./constants.js";
 
 export interface TTLConfig {
@@ -725,7 +729,7 @@ export class ShallowRedisSaver extends BaseCheckpointSaver {
         });
       } catch (error: any) {
         // Ignore if index already exists
-        if (!error.message?.includes("Index already exists")) {
+        if (!isIndexAlreadyExistsError(error)) {
           console.error(
             `Failed to create index ${schema.index}:`,
             error.message

--- a/libs/checkpoint-redis/src/store.ts
+++ b/libs/checkpoint-redis/src/store.ts
@@ -18,7 +18,10 @@ import {
   type SearchOperation,
 } from "@langchain/langgraph-checkpoint";
 
-import { escapeRediSearchTagValue } from "./utils.js";
+import {
+  escapeRediSearchTagValue,
+  isIndexAlreadyExistsError,
+} from "./utils.js";
 
 // Type guard functions for operations
 export function isPutOperation(op: Operation): op is PutOperation {
@@ -385,7 +388,7 @@ export class RedisStore {
         PREFIX: SCHEMAS[0].prefix,
       });
     } catch (error: any) {
-      if (!error.message?.includes("Index already exists")) {
+      if (!isIndexAlreadyExistsError(error)) {
         console.error("Failed to create store index:", error.message);
       }
     }
@@ -427,7 +430,7 @@ export class RedisStore {
           PREFIX: SCHEMAS[1].prefix,
         });
       } catch (error: any) {
-        if (!error.message?.includes("Index already exists")) {
+        if (!isIndexAlreadyExistsError(error)) {
           console.error("Failed to create vector index:", error.message);
         }
       }

--- a/libs/checkpoint-redis/src/tests/utils.test.ts
+++ b/libs/checkpoint-redis/src/tests/utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   assertSafeKeyComponent,
   escapeRediSearchTagValue,
+  isIndexAlreadyExistsError,
 } from "../utils.js";
 
 describe("escapeRediSearchTagValue", () => {
@@ -193,5 +194,104 @@ describe("assertSafeKeyComponent", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       assertSafeKeyComponent("task_id", { $gt: "" } as any)
     ).toThrow(/"task_id"/);
+  });
+});
+
+describe('isIndexAlreadyExistsError', () => {
+  describe('Redis (RediSearch)', () => {
+    it('matches the canonical reply', () => {
+      expect(isIndexAlreadyExistsError(new Error('Index already exists'))).toBe(true);
+    });
+
+    it('is case-insensitive', () => {
+      expect(isIndexAlreadyExistsError(new Error('INDEX ALREADY EXISTS'))).toBe(true);
+      expect(isIndexAlreadyExistsError(new Error('index Already Exists'))).toBe(true);
+    });
+
+    it('matches when the reply is embedded in a client wrapper message', () => {
+      expect(
+          isIndexAlreadyExistsError(new Error('ReplyError: Index already exists'))
+      ).toBe(true);
+    });
+  });
+
+  describe('Valkey-search', () => {
+    it('matches the canonical reply with index name and db number', () => {
+      expect(
+          isIndexAlreadyExistsError(
+              new Error('Index myIdx in database 0 already exists.')
+          )
+      ).toBe(true);
+    });
+
+    it('matches other db numbers and index names', () => {
+      expect(
+          isIndexAlreadyExistsError(
+              new Error('Index products in database 2 already exists.')
+          )
+      ).toBe(true);
+    });
+
+    it('is case-insensitive', () => {
+      expect(
+          isIndexAlreadyExistsError(
+              new Error('INDEX MYIDX IN DATABASE 0 ALREADY EXISTS.')
+          )
+      ).toBe(true);
+    });
+  });
+
+  describe('non-Error inputs', () => {
+    it('accepts a bare string', () => {
+      expect(isIndexAlreadyExistsError('Index already exists')).toBe(true);
+      expect(
+          isIndexAlreadyExistsError('Index foo in database 0 already exists.')
+      ).toBe(true);
+    });
+
+    it('accepts objects with a message property', () => {
+      expect(isIndexAlreadyExistsError({ message: 'Index already exists' })).toBe(
+          true
+      );
+    });
+
+    it('handles null and undefined without throwing', () => {
+      expect(isIndexAlreadyExistsError(null)).toBe(false);
+      expect(isIndexAlreadyExistsError(undefined)).toBe(false);
+    });
+  });
+
+  describe('negative cases', () => {
+    it('rejects unrelated errors', () => {
+      expect(isIndexAlreadyExistsError(new Error('Unknown Index name'))).toBe(
+          false
+      );
+      expect(isIndexAlreadyExistsError(new Error('wrong number of arguments'))).toBe(
+          false
+      );
+      expect(isIndexAlreadyExistsError(new Error('OOM command not allowed'))).toBe(
+          false
+      );
+    });
+
+    it('rejects "already exists" without "index"', () => {
+      expect(isIndexAlreadyExistsError(new Error('key already exists'))).toBe(
+          false
+      );
+      expect(isIndexAlreadyExistsError(new Error('already exists'))).toBe(false);
+    });
+
+    it('rejects "index" without "already exists"', () => {
+      expect(isIndexAlreadyExistsError(new Error('No such index myIdx'))).toBe(
+          false
+      );
+      expect(isIndexAlreadyExistsError(new Error('index not found'))).toBe(false);
+    });
+
+    it('rejects empty / non-message values', () => {
+      expect(isIndexAlreadyExistsError('')).toBe(false);
+      expect(isIndexAlreadyExistsError(42)).toBe(false);
+      expect(isIndexAlreadyExistsError({})).toBe(false);
+    });
   });
 });

--- a/libs/checkpoint-redis/src/utils.ts
+++ b/libs/checkpoint-redis/src/utils.ts
@@ -91,3 +91,35 @@ export function assertSafeKeyComponent(
     );
   }
 }
+
+/**
+ * Returns whether an error indicates that an FT index already exists.
+ *
+ * Redis (RediSearch) and Valkey-search use different reply text for the same
+ * condition when `FT.CREATE` is issued against a name that is already
+ * registered:
+ *
+ * - Redis:   `"Index already exists"`
+ * - Valkey:  `"Index <name> in database <db> already exists."`
+ *
+ * Callers that implement "create index if not exists" (there is no native
+ * `IF NOT EXISTS` on `FT.CREATE`) must treat both forms as success-no-op
+ * rather than a hard failure. Matching only the Redis string would miss
+ * Valkey; matching only `"already exists"` would be too broad and could
+ * swallow unrelated errors. This helper accepts either dialect by requiring
+ * both `"index"` and `"already exists"`, with an optional `"database"`
+ * branch for the Valkey wording.
+ *
+ * @param {unknown} err Error thrown by the client (or any value whose string
+ *                      form may contain the server reply).
+ * @returns {boolean} `true` if `err` looks like an index-already-exists reply.
+ */
+export function isIndexAlreadyExistsError(err: any): boolean {
+  const msg = String(err?.message ?? err).toLowerCase();
+  // Redis: "index already exists"
+  // Valkey: "index xxx in database 0 already exists"
+  return (
+    msg.includes("index already exists") ||
+    (msg.includes("index") && msg.includes("already exists"))
+  );
+}


### PR DESCRIPTION
## Description

`RedisStore.setup()` treats an existing RediSearch index as a no-op by checking whether the error message includes `"Index already exists"`. That matches **Redis / RediSearch**, but **Valkey-search** returns a different string:

- Redis: `Index already exists`
- Valkey: `Index <name> in database <db> already exists.` (https://github.com/valkey-io/valkey-search/blob/92efaa60041305ef31b7e20cd6acef523dbd7212/src/schema_manager.cc#L145)

On Valkey, every `setup()` call (including reconnect / multi-instance startup) logs a false failure for the store and vector indexes even though the index is already present.

This PR adds `isIndexAlreadyExistsError()` and uses it in both `FT.CREATE` catch paths so “create if not exists” works for Redis and Valkey. There is no native `IF NOT EXISTS` on `FT.CREATE` in either engine.

## Changes

- Add `isIndexAlreadyExistsError` in `libs/checkpoint-redis/src/utils.ts`
- Use it in `RedisStore.setup()` for the store index and the optional vector index
- Add unit tests covering Redis, Valkey, case-insensitivity, and negative cases