### PR TITLE
fix(sdk): surface nested interrupts on stream.interrupts

### DIFF
--- a/.changeset/fix-nested-interrupt-surfacing.md
+++ b/.changeset/fix-nested-interrupt-surfacing.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): surface nested interrupts on stream.interrupts
+
+`input.requested` events from subgraphs/subagents were dropped live by a root-only filter, while hydrate seeded them from `state.tasks`, so HITL UIs saw nested interrupts only after reload. Mirror every namespace onto `rootStore.interrupts` (with `Interrupt.namespace`), and resolve that namespace in `respond({ interruptId })` when callers omit it.

--- a/libs/sdk-angular/src/tests/components/NestedInterruptStream.ts
+++ b/libs/sdk-angular/src/tests/components/NestedInterruptStream.ts
@@ -1,0 +1,112 @@
+import { Component, computed, input } from "@angular/core";
+import { inject } from "vitest";
+import { injectStream } from "../../index.js";
+
+const serverUrl = inject("serverUrl");
+
+interface NestedInterruptState {
+  request?: string;
+  decision?: Record<string, unknown> | null;
+  completed?: boolean;
+  messages?: unknown[];
+}
+
+const nestedTemplate = `
+  <div>
+    <div data-testid="interrupt-count">{{ stream.interrupts().length }}</div>
+    <div data-testid="interrupt-prompt">{{ interruptPrompt() }}</div>
+    <div data-testid="interrupt-id">{{ stream.interrupt()?.id ?? "" }}</div>
+    <div data-testid="interrupt-namespace">{{ namespaceJson() }}</div>
+    <div data-testid="completed">
+      {{ stream.values()?.completed ? "true" : "false" }}
+    </div>
+    <div data-testid="loading">
+      {{ stream.isLoading() ? "Loading..." : "Not loading" }}
+    </div>
+    <button data-testid="submit" (click)="onSubmit()">Submit</button>
+    <button data-testid="resume" (click)="onResume()">Resume</button>
+  </div>
+`;
+
+/**
+ * Nested StateGraph interrupt harness (`nested_interrupt_graph`).
+ * `assistantId` is fixed at construction because `injectStream` does not
+ * accept an `InputSignal` for it; `threadId` remains reactive for hydrate.
+ */
+@Component({ template: nestedTemplate })
+export class NestedInterruptGraphStreamComponent {
+  threadId = input<string | undefined>(undefined);
+  onThreadIdCallback = input<((id: string) => void) | undefined>(undefined);
+
+  stream = injectStream<NestedInterruptState>({
+    assistantId: "nested_interrupt_graph",
+    apiUrl: serverUrl,
+    threadId: this.threadId,
+    onThreadId: (id) => this.onThreadIdCallback()?.(id),
+  });
+
+  interruptPrompt = computed(() => {
+    const promptValue = this.stream.interrupt()?.value;
+    if (
+      promptValue != null &&
+      typeof promptValue === "object" &&
+      "prompt" in (promptValue as object)
+    ) {
+      return String((promptValue as { prompt?: unknown }).prompt ?? "");
+    }
+    return "";
+  });
+
+  namespaceJson = computed(() =>
+    JSON.stringify(this.stream.interrupt()?.namespace ?? [])
+  );
+
+  onSubmit() {
+    void this.stream.submit({ request: "ship nested change" });
+  }
+
+  onResume() {
+    const id = this.stream.interrupt()?.id;
+    if (id != null) {
+      void this.stream.respond({ approved: true }, { interruptId: id });
+    }
+  }
+}
+
+/** createDeepAgent subagent interrupt harness (`deep_agent_interrupt`). */
+@Component({ template: nestedTemplate })
+export class DeepAgentInterruptStreamComponent {
+  stream = injectStream<NestedInterruptState>({
+    assistantId: "deep_agent_interrupt",
+    apiUrl: serverUrl,
+  });
+
+  interruptPrompt = computed(() => {
+    const promptValue = this.stream.interrupt()?.value;
+    if (
+      promptValue != null &&
+      typeof promptValue === "object" &&
+      "prompt" in (promptValue as object)
+    ) {
+      return String((promptValue as { prompt?: unknown }).prompt ?? "");
+    }
+    return "";
+  });
+
+  namespaceJson = computed(() =>
+    JSON.stringify(this.stream.interrupt()?.namespace ?? [])
+  );
+
+  onSubmit() {
+    void this.stream.submit({
+      messages: [{ role: "user", content: "Please get approval" }],
+    });
+  }
+
+  onResume() {
+    const id = this.stream.interrupt()?.id;
+    if (id != null) {
+      void this.stream.respond({ approved: true }, { interruptId: id });
+    }
+  }
+}

--- a/libs/sdk-angular/src/tests/fixtures/deep-agent-interrupt.ts
+++ b/libs/sdk-angular/src/tests/fixtures/deep-agent-interrupt.ts
@@ -1,0 +1,147 @@
+import {
+  AIMessage,
+  AIMessageChunk,
+  type BaseMessage,
+} from "@langchain/core/messages";
+import {
+  BaseChatModel,
+  type BaseChatModelParams,
+} from "@langchain/core/language_models/chat_models";
+import { ChatGenerationChunk, type ChatResult } from "@langchain/core/outputs";
+import { interrupt } from "@langchain/langgraph";
+import { createDeepAgent, type DeepAgent } from "deepagents";
+import { tool } from "langchain";
+import { z } from "zod/v4";
+
+/** Deterministic tool-calling model for Node-side fixtures only. */
+class FakeToolCallingModel extends BaseChatModel {
+  responses: BaseMessage[];
+  callCount = 0;
+
+  constructor(fields: { responses: BaseMessage[] } & BaseChatModelParams) {
+    super(fields);
+    this.responses = fields.responses;
+  }
+
+  _llmType() {
+    return "fake-tool-calling";
+  }
+
+  _combineLLMOutput() {
+    return [];
+  }
+
+  async _generate(): Promise<ChatResult> {
+    const baseMsg = this.responses[this.callCount % this.responses.length];
+    this.callCount += 1;
+    return {
+      generations: [
+        { text: (baseMsg.content as string) || "", message: baseMsg },
+      ],
+    };
+  }
+
+  async *_streamResponseChunks() {
+    const baseMsg = this.responses[this.callCount % this.responses.length];
+    const toolCalls = (baseMsg as AIMessage).tool_calls;
+    const chunkFields: Record<string, unknown> = {
+      content: (baseMsg.content as string) || "",
+    };
+    if (toolCalls?.length) {
+      chunkFields.tool_call_chunks = toolCalls.map(
+        (
+          tc: { name: string; args: Record<string, unknown>; id?: string },
+          index: number
+        ) => ({
+          name: tc.name,
+          args: JSON.stringify(tc.args),
+          id: tc.id,
+          index,
+          type: "tool_call_chunk" as const,
+        })
+      );
+    }
+    yield new ChatGenerationChunk({
+      message: new AIMessageChunk(chunkFields),
+      text: (baseMsg.content as string) || "",
+    });
+    this.callCount += 1;
+  }
+
+  bindTools() {
+    return this;
+  }
+}
+
+const requestApprovalTool = tool(
+  async () => {
+    const decision = interrupt({
+      prompt: "Approve subagent tool action?",
+    });
+    return JSON.stringify(decision ?? { approved: true });
+  },
+  {
+    name: "request_approval",
+    description: "Request human approval before proceeding.",
+    schema: z.object({}),
+  }
+);
+
+const orchestratorModel = new FakeToolCallingModel({
+  responses: [
+    new AIMessage({
+      id: "deep-interrupt-orchestrator",
+      content: "",
+      tool_calls: [
+        {
+          id: "task-approve-1",
+          name: "task",
+          args: {
+            description: "Request approval for the pending change",
+            subagent_type: "approver",
+          },
+          type: "tool_call" as const,
+        },
+      ],
+    }),
+    new AIMessage({
+      id: "deep-interrupt-final",
+      content: "Subagent approval completed.",
+    }),
+  ],
+});
+
+const approverModel = new FakeToolCallingModel({
+  responses: [
+    new AIMessage({
+      id: "approver-call",
+      content: "",
+      tool_calls: [
+        {
+          id: "approval-1",
+          name: "request_approval",
+          args: {},
+          type: "tool_call" as const,
+        },
+      ],
+    }),
+    new AIMessage({
+      id: "approver-done",
+      content: "Approval recorded.",
+    }),
+  ],
+});
+
+export const graph = createDeepAgent({
+  model: orchestratorModel,
+  subagents: [
+    {
+      name: "approver",
+      description: "Requests human approval before acting.",
+      systemPrompt: "You must request approval before proceeding.",
+      tools: [requestApprovalTool],
+      model: approverModel,
+    },
+  ],
+  systemPrompt: "Delegate approval work to the approver subagent.",
+}) as DeepAgent;

--- a/libs/sdk-angular/src/tests/fixtures/deep-agent-interrupt.ts
+++ b/libs/sdk-angular/src/tests/fixtures/deep-agent-interrupt.ts
@@ -1,76 +1,24 @@
-import {
-  AIMessage,
-  AIMessageChunk,
-  type BaseMessage,
-} from "@langchain/core/messages";
-import {
-  BaseChatModel,
-  type BaseChatModelParams,
-} from "@langchain/core/language_models/chat_models";
-import { ChatGenerationChunk, type ChatResult } from "@langchain/core/outputs";
+import { AIMessage } from "@langchain/core/messages";
 import { interrupt } from "@langchain/langgraph";
 import { createDeepAgent, type DeepAgent } from "deepagents";
-import { tool } from "langchain";
+import { fakeModel, tool } from "langchain";
 import { z } from "zod/v4";
 
-/** Deterministic tool-calling model for Node-side fixtures only. */
-class FakeToolCallingModel extends BaseChatModel {
-  responses: BaseMessage[];
-  callCount = 0;
-
-  constructor(fields: { responses: BaseMessage[] } & BaseChatModelParams) {
-    super(fields);
-    this.responses = fields.responses;
-  }
-
-  _llmType() {
-    return "fake-tool-calling";
-  }
-
-  _combineLLMOutput() {
-    return [];
-  }
-
-  async _generate(): Promise<ChatResult> {
-    const baseMsg = this.responses[this.callCount % this.responses.length];
-    this.callCount += 1;
-    return {
-      generations: [
-        { text: (baseMsg.content as string) || "", message: baseMsg },
-      ],
-    };
-  }
-
-  async *_streamResponseChunks() {
-    const baseMsg = this.responses[this.callCount % this.responses.length];
-    const toolCalls = (baseMsg as AIMessage).tool_calls;
-    const chunkFields: Record<string, unknown> = {
-      content: (baseMsg.content as string) || "",
-    };
-    if (toolCalls?.length) {
-      chunkFields.tool_call_chunks = toolCalls.map(
-        (
-          tc: { name: string; args: Record<string, unknown>; id?: string },
-          index: number
-        ) => ({
-          name: tc.name,
-          args: JSON.stringify(tc.args),
-          id: tc.id,
-          index,
-          type: "tool_call_chunk" as const,
-        })
-      );
-    }
-    yield new ChatGenerationChunk({
-      message: new AIMessageChunk(chunkFields),
-      text: (baseMsg.content as string) || "",
+/**
+ * {@link fakeModel} that replays responses in a loop so the shared
+ * mock-server graph survives multiple suite tests.
+ */
+function scriptedFakeModel(responses: AIMessage[], capacity = 512) {
+  let turn = 0;
+  let model = fakeModel();
+  for (let i = 0; i < capacity; i++) {
+    model = model.respond(() => {
+      const message = responses[turn % responses.length]!;
+      turn += 1;
+      return message;
     });
-    this.callCount += 1;
   }
-
-  bindTools() {
-    return this;
-  }
+  return model;
 }
 
 const requestApprovalTool = tool(
@@ -87,50 +35,46 @@ const requestApprovalTool = tool(
   }
 );
 
-const orchestratorModel = new FakeToolCallingModel({
-  responses: [
-    new AIMessage({
-      id: "deep-interrupt-orchestrator",
-      content: "",
-      tool_calls: [
-        {
-          id: "task-approve-1",
-          name: "task",
-          args: {
-            description: "Request approval for the pending change",
-            subagent_type: "approver",
-          },
-          type: "tool_call" as const,
+const orchestratorModel = scriptedFakeModel([
+  new AIMessage({
+    id: "deep-interrupt-orchestrator",
+    content: "",
+    tool_calls: [
+      {
+        id: "task-approve-1",
+        name: "task",
+        args: {
+          description: "Request approval for the pending change",
+          subagent_type: "approver",
         },
-      ],
-    }),
-    new AIMessage({
-      id: "deep-interrupt-final",
-      content: "Subagent approval completed.",
-    }),
-  ],
-});
+        type: "tool_call" as const,
+      },
+    ],
+  }),
+  new AIMessage({
+    id: "deep-interrupt-final",
+    content: "Subagent approval completed.",
+  }),
+]);
 
-const approverModel = new FakeToolCallingModel({
-  responses: [
-    new AIMessage({
-      id: "approver-call",
-      content: "",
-      tool_calls: [
-        {
-          id: "approval-1",
-          name: "request_approval",
-          args: {},
-          type: "tool_call" as const,
-        },
-      ],
-    }),
-    new AIMessage({
-      id: "approver-done",
-      content: "Approval recorded.",
-    }),
-  ],
-});
+const approverModel = scriptedFakeModel([
+  new AIMessage({
+    id: "approver-call",
+    content: "",
+    tool_calls: [
+      {
+        id: "approval-1",
+        name: "request_approval",
+        args: {},
+        type: "tool_call" as const,
+      },
+    ],
+  }),
+  new AIMessage({
+    id: "approver-done",
+    content: "Approval recorded.",
+  }),
+]);
 
 export const graph = createDeepAgent({
   model: orchestratorModel,

--- a/libs/sdk-angular/src/tests/fixtures/mock-server.ts
+++ b/libs/sdk-angular/src/tests/fixtures/mock-server.ts
@@ -47,6 +47,8 @@ import type { TestProject } from "vitest/node";
 
 import { getLocationTool } from "./browser-fixtures.js";
 import { graph as multiInterruptGraph } from "./multi-interrupt-graph.js";
+import { graph as nestedInterruptGraph } from "./nested-interrupt-graph.js";
+import { graph as deepAgentInterruptGraph } from "./deep-agent-interrupt.js";
 
 declare module "vitest" {
   export interface ProvidedContext {
@@ -692,6 +694,8 @@ const graphs: Record<string, AnyPregel> = {
   interruptAgent,
   interrupt_card_graph: interruptCardGraph,
   multi_interrupt_graph: multiInterruptGraph as unknown as AnyPregel,
+  nested_interrupt_graph: nestedInterruptGraph as unknown as AnyPregel,
+  deep_agent_interrupt: deepAgentInterruptGraph as unknown as AnyPregel,
   parentAgent,
   slow_graph: slowGraph,
   stateful_values_graph: statefulValuesGraph,

--- a/libs/sdk-angular/src/tests/fixtures/nested-interrupt-graph.ts
+++ b/libs/sdk-angular/src/tests/fixtures/nested-interrupt-graph.ts
@@ -1,0 +1,59 @@
+import {
+  Annotation,
+  END,
+  interrupt,
+  START,
+  StateGraph,
+} from "@langchain/langgraph";
+
+/**
+ * Parent → child → grandchild StateGraph where the innermost node
+ * calls `interrupt()`. Used to assert that nested
+ * `input.requested` events surface on `useStream().interrupts` live
+ * (not only after hydrate).
+ */
+const GraphState = Annotation.Root({
+  request: Annotation<string>(),
+  decision: Annotation<Record<string, unknown> | null>({
+    reducer: (_, next) => next,
+    default: () => null,
+  }),
+  completed: Annotation<boolean>({
+    reducer: (_, next) => next,
+    default: () => false,
+  }),
+});
+
+const reviewNode = (state: typeof GraphState.State) => {
+  const decision = interrupt({
+    prompt: "Approve nested subgraph action?",
+    request: state.request,
+  });
+
+  return {
+    decision:
+      decision != null && typeof decision === "object"
+        ? (decision as Record<string, unknown>)
+        : { value: decision },
+    completed: true,
+  };
+};
+
+const grandchild = new StateGraph(GraphState)
+  .addNode("review", reviewNode)
+  .addEdge(START, "review")
+  .addEdge("review", END)
+  .compile();
+
+const child = new StateGraph(GraphState)
+  .addNode("inner", grandchild, { subgraphs: [grandchild] })
+  .addEdge(START, "inner")
+  .addEdge("inner", END)
+  .compile();
+
+const workflow = new StateGraph(GraphState)
+  .addNode("child", child, { subgraphs: [child] })
+  .addEdge(START, "child")
+  .addEdge("child", END);
+
+export const graph = workflow.compile();

--- a/libs/sdk-angular/src/tests/stream.nested-interrupts.test.ts
+++ b/libs/sdk-angular/src/tests/stream.nested-interrupts.test.ts
@@ -1,0 +1,131 @@
+import { expect, it } from "vitest";
+import { render } from "vitest-browser-angular";
+
+import {
+  DeepAgentInterruptStreamComponent,
+  NestedInterruptGraphStreamComponent,
+} from "./components/NestedInterruptStream.js";
+
+it(
+  "surfaces a nested StateGraph interrupt live on injectStream().interrupts",
+  { timeout: 20_000 },
+  async () => {
+    const screen = await render(NestedInterruptGraphStreamComponent);
+
+    await screen.getByTestId("submit").click();
+
+    await expect
+      .element(screen.getByTestId("interrupt-count"), { timeout: 15_000 })
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("interrupt-prompt"))
+      .toHaveTextContent("Approve nested subgraph action?");
+    await expect
+      .element(screen.getByTestId("interrupt-id"))
+      .not.toHaveTextContent("");
+
+    const namespaceText =
+      screen.getByTestId("interrupt-namespace").element().textContent ?? "[]";
+    const namespace = JSON.parse(namespaceText) as string[];
+    expect(namespace.length).toBeGreaterThan(0);
+
+    await screen.getByTestId("resume").click();
+
+    await expect
+      .element(screen.getByTestId("interrupt-count"), { timeout: 15_000 })
+      .toHaveTextContent("0");
+    await expect
+      .element(screen.getByTestId("completed"), { timeout: 15_000 })
+      .toHaveTextContent("true");
+  }
+);
+
+it(
+  "surfaces a createDeepAgent subagent interrupt live on injectStream().interrupts",
+  { timeout: 30_000 },
+  async () => {
+    const screen = await render(DeepAgentInterruptStreamComponent);
+
+    await screen.getByTestId("submit").click();
+
+    await expect
+      .element(screen.getByTestId("interrupt-count"), { timeout: 20_000 })
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("interrupt-prompt"))
+      .toHaveTextContent("Approve subagent tool action?");
+    await expect
+      .element(screen.getByTestId("interrupt-id"))
+      .not.toHaveTextContent("");
+
+    const namespaceText =
+      screen.getByTestId("interrupt-namespace").element().textContent ?? "[]";
+    const namespace = JSON.parse(namespaceText) as string[];
+    expect(namespace.length).toBeGreaterThan(0);
+
+    await screen.getByTestId("resume").click();
+
+    await expect
+      .element(screen.getByTestId("interrupt-count"), { timeout: 20_000 })
+      .toHaveTextContent("0");
+    await expect
+      .element(screen.getByTestId("loading"), { timeout: 20_000 })
+      .toHaveTextContent("Not loading");
+  }
+);
+
+// Split across two `it`s: Angular's TestBed cannot reconfigure within a
+// single test after the first `render()` (same pattern as stream.client.test.ts).
+let nestedHydrateThreadId: string | undefined;
+
+it(
+  "seeds a nested StateGraph interrupt for the hydrate assertion",
+  { timeout: 20_000 },
+  async () => {
+    const screen = await render(NestedInterruptGraphStreamComponent, {
+      inputs: {
+        onThreadIdCallback: (id: string) => {
+          nestedHydrateThreadId = id;
+        },
+      },
+    });
+
+    await screen.getByTestId("submit").click();
+    await expect
+      .element(screen.getByTestId("interrupt-count"), { timeout: 15_000 })
+      .toHaveTextContent("1");
+    expect(nestedHydrateThreadId).toMatch(/.+/);
+  }
+);
+
+it(
+  "hydrates a nested StateGraph interrupt after remount",
+  { timeout: 30_000 },
+  async () => {
+    expect(nestedHydrateThreadId).toMatch(/.+/);
+
+    const screen = await render(NestedInterruptGraphStreamComponent, {
+      inputs: {
+        threadId: nestedHydrateThreadId,
+      },
+    });
+
+    await expect
+      .element(screen.getByTestId("interrupt-count"), { timeout: 15_000 })
+      .toHaveTextContent("1");
+
+    const namespaceText =
+      screen.getByTestId("interrupt-namespace").element().textContent ?? "[]";
+    const namespace = JSON.parse(namespaceText) as string[];
+    expect(namespace.length).toBeGreaterThan(0);
+
+    await screen.getByTestId("resume").click();
+
+    await expect
+      .element(screen.getByTestId("interrupt-count"), { timeout: 15_000 })
+      .toHaveTextContent("0");
+    await expect
+      .element(screen.getByTestId("completed"), { timeout: 15_000 })
+      .toHaveTextContent("true");
+  }
+);

--- a/libs/sdk-angular/vitest.config.ts
+++ b/libs/sdk-angular/vitest.config.ts
@@ -7,6 +7,8 @@ import { fileURLToPath } from "node:url";
 const nonAngularFiles = [
   /mock-server\.ts/,
   /multi-interrupt-graph\.ts/,
+  /nested-interrupt-graph\.ts/,
+  /deep-agent-interrupt\.ts/,
   /vitest-browser-shim\.ts/,
   /\.test-d\.ts$/,
 ];

--- a/libs/sdk-react/src/tests/components/NestedInterruptStream.tsx
+++ b/libs/sdk-react/src/tests/components/NestedInterruptStream.tsx
@@ -1,0 +1,80 @@
+import { useStream } from "../../index.js";
+
+interface NestedInterruptState {
+  request?: string;
+  decision?: Record<string, unknown> | null;
+  completed?: boolean;
+  messages?: unknown[];
+}
+
+interface Props {
+  apiUrl: string;
+  assistantId: string;
+  threadId?: string;
+  onThreadId?: (threadId: string) => void;
+  /** Payload passed to `submit()` — graph-specific. */
+  submitInput: Record<string, unknown>;
+}
+
+/**
+ * HITL harness for nested / subagent interrupts.
+ *
+ * Exposes namespace and resumes via `respond({ interruptId })` without
+ * an explicit `namespace` so the controller lookup path is covered.
+ */
+export function NestedInterruptStream({
+  apiUrl,
+  assistantId,
+  threadId,
+  onThreadId,
+  submitInput,
+}: Props) {
+  const thread = useStream<NestedInterruptState>({
+    assistantId,
+    apiUrl,
+    threadId,
+    onThreadId,
+  });
+
+  const promptValue = thread.interrupt?.value;
+  const interruptPrompt =
+    promptValue != null &&
+    typeof promptValue === "object" &&
+    "prompt" in (promptValue as object)
+      ? String((promptValue as { prompt?: unknown }).prompt ?? "")
+      : "";
+
+  const namespace = thread.interrupt?.namespace ?? [];
+
+  return (
+    <div>
+      <div data-testid="interrupt-count">{thread.interrupts.length}</div>
+      <div data-testid="interrupt-prompt">{interruptPrompt}</div>
+      <div data-testid="interrupt-id">{thread.interrupt?.id ?? ""}</div>
+      <div data-testid="interrupt-namespace">{JSON.stringify(namespace)}</div>
+      <div data-testid="completed">
+        {thread.values?.completed ? "true" : "false"}
+      </div>
+      <div data-testid="loading">
+        {thread.isLoading ? "Loading..." : "Not loading"}
+      </div>
+      <button
+        data-testid="submit"
+        onClick={() => void thread.submit(submitInput)}
+      >
+        Submit
+      </button>
+      <button
+        data-testid="resume"
+        onClick={() => {
+          const id = thread.interrupt?.id;
+          if (id != null) {
+            void thread.respond({ approved: true }, { interruptId: id });
+          }
+        }}
+      >
+        Resume
+      </button>
+    </div>
+  );
+}

--- a/libs/sdk-react/src/tests/fixtures/deep-agent-interrupt.ts
+++ b/libs/sdk-react/src/tests/fixtures/deep-agent-interrupt.ts
@@ -1,0 +1,89 @@
+import { AIMessage } from "@langchain/core/messages";
+import { interrupt } from "@langchain/langgraph";
+import { createDeepAgent, type DeepAgent } from "deepagents";
+import { tool } from "langchain";
+import { z } from "zod/v4";
+
+import { DeterministicToolCallingModel } from "./shared.js";
+
+/**
+ * Tool that pauses the run with `interrupt()` so the subagent's
+ * tool-execution namespace emits a nested `input.requested`.
+ */
+const requestApprovalTool = tool(
+  async () => {
+    const decision = interrupt({
+      prompt: "Approve subagent tool action?",
+    });
+    return JSON.stringify(decision ?? { approved: true });
+  },
+  {
+    name: "request_approval",
+    description: "Request human approval before proceeding.",
+    schema: z.object({}),
+  }
+);
+
+/**
+ * Orchestrator that deterministically fans out a single `task` call to
+ * the `approver` subagent, then emits a final summary after resume.
+ */
+const orchestratorModel = new DeterministicToolCallingModel({
+  responses: [
+    new AIMessage({
+      id: "deep-interrupt-orchestrator",
+      content: "",
+      tool_calls: [
+        {
+          id: "task-approve-1",
+          name: "task",
+          args: {
+            description: "Request approval for the pending change",
+            subagent_type: "approver",
+          },
+          type: "tool_call" as const,
+        },
+      ],
+    }),
+    new AIMessage({
+      id: "deep-interrupt-final",
+      content: "Subagent approval completed.",
+    }),
+  ],
+});
+
+/** Subagent that immediately calls `request_approval` (which interrupts). */
+const approverModel = new DeterministicToolCallingModel({
+  responses: [
+    new AIMessage({
+      id: "approver-call",
+      content: "",
+      tool_calls: [
+        {
+          id: "approval-1",
+          name: "request_approval",
+          args: {},
+          type: "tool_call" as const,
+        },
+      ],
+    }),
+    new AIMessage({
+      id: "approver-done",
+      content: "Approval recorded.",
+    }),
+  ],
+});
+
+export const graph = createDeepAgent({
+  model: orchestratorModel,
+  subagents: [
+    {
+      name: "approver",
+      description: "Requests human approval before acting.",
+      systemPrompt: "You must request approval before proceeding.",
+      tools: [requestApprovalTool],
+      model: approverModel,
+    },
+  ],
+  systemPrompt: "Delegate approval work to the approver subagent.",
+}) as DeepAgent;

--- a/libs/sdk-react/src/tests/fixtures/deep-agent-interrupt.ts
+++ b/libs/sdk-react/src/tests/fixtures/deep-agent-interrupt.ts
@@ -4,7 +4,7 @@ import { createDeepAgent, type DeepAgent } from "deepagents";
 import { tool } from "langchain";
 import { z } from "zod/v4";
 
-import { DeterministicToolCallingModel } from "./shared.js";
+import { scriptedFakeModel } from "./shared.js";
 
 /**
  * Tool that pauses the run with `interrupt()` so the subagent's
@@ -28,51 +28,47 @@ const requestApprovalTool = tool(
  * Orchestrator that deterministically fans out a single `task` call to
  * the `approver` subagent, then emits a final summary after resume.
  */
-const orchestratorModel = new DeterministicToolCallingModel({
-  responses: [
-    new AIMessage({
-      id: "deep-interrupt-orchestrator",
-      content: "",
-      tool_calls: [
-        {
-          id: "task-approve-1",
-          name: "task",
-          args: {
-            description: "Request approval for the pending change",
-            subagent_type: "approver",
-          },
-          type: "tool_call" as const,
+const orchestratorModel = scriptedFakeModel([
+  new AIMessage({
+    id: "deep-interrupt-orchestrator",
+    content: "",
+    tool_calls: [
+      {
+        id: "task-approve-1",
+        name: "task",
+        args: {
+          description: "Request approval for the pending change",
+          subagent_type: "approver",
         },
-      ],
-    }),
-    new AIMessage({
-      id: "deep-interrupt-final",
-      content: "Subagent approval completed.",
-    }),
-  ],
-});
+        type: "tool_call" as const,
+      },
+    ],
+  }),
+  new AIMessage({
+    id: "deep-interrupt-final",
+    content: "Subagent approval completed.",
+  }),
+]);
 
 /** Subagent that immediately calls `request_approval` (which interrupts). */
-const approverModel = new DeterministicToolCallingModel({
-  responses: [
-    new AIMessage({
-      id: "approver-call",
-      content: "",
-      tool_calls: [
-        {
-          id: "approval-1",
-          name: "request_approval",
-          args: {},
-          type: "tool_call" as const,
-        },
-      ],
-    }),
-    new AIMessage({
-      id: "approver-done",
-      content: "Approval recorded.",
-    }),
-  ],
-});
+const approverModel = scriptedFakeModel([
+  new AIMessage({
+    id: "approver-call",
+    content: "",
+    tool_calls: [
+      {
+        id: "approval-1",
+        name: "request_approval",
+        args: {},
+        type: "tool_call" as const,
+      },
+    ],
+  }),
+  new AIMessage({
+    id: "approver-done",
+    content: "Approval recorded.",
+  }),
+]);
 
 export const graph = createDeepAgent({
   model: orchestratorModel,

--- a/libs/sdk-react/src/tests/fixtures/nested-interrupt-graph.ts
+++ b/libs/sdk-react/src/tests/fixtures/nested-interrupt-graph.ts
@@ -1,0 +1,59 @@
+import {
+  Annotation,
+  END,
+  interrupt,
+  START,
+  StateGraph,
+} from "@langchain/langgraph";
+
+/**
+ * Parent → child → grandchild StateGraph where the innermost node
+ * calls `interrupt()`. Used to assert that nested
+ * `input.requested` events surface on `useStream().interrupts` live
+ * (not only after hydrate).
+ */
+const GraphState = Annotation.Root({
+  request: Annotation<string>(),
+  decision: Annotation<Record<string, unknown> | null>({
+    reducer: (_, next) => next,
+    default: () => null,
+  }),
+  completed: Annotation<boolean>({
+    reducer: (_, next) => next,
+    default: () => false,
+  }),
+});
+
+const reviewNode = (state: typeof GraphState.State) => {
+  const decision = interrupt({
+    prompt: "Approve nested subgraph action?",
+    request: state.request,
+  });
+
+  return {
+    decision:
+      decision != null && typeof decision === "object"
+        ? (decision as Record<string, unknown>)
+        : { value: decision },
+    completed: true,
+  };
+};
+
+const grandchild = new StateGraph(GraphState)
+  .addNode("review", reviewNode)
+  .addEdge(START, "review")
+  .addEdge("review", END)
+  .compile();
+
+const child = new StateGraph(GraphState)
+  .addNode("inner", grandchild, { subgraphs: [grandchild] })
+  .addEdge(START, "inner")
+  .addEdge("inner", END)
+  .compile();
+
+const workflow = new StateGraph(GraphState)
+  .addNode("child", child, { subgraphs: [child] })
+  .addEdge(START, "child")
+  .addEdge("child", END);
+
+export const graph = workflow.compile();

--- a/libs/sdk-react/src/tests/fixtures/parallel-fanout.ts
+++ b/libs/sdk-react/src/tests/fixtures/parallel-fanout.ts
@@ -1,7 +1,7 @@
 import { AIMessage } from "@langchain/core/messages";
 import { createDeepAgent, type DeepAgent } from "deepagents";
 
-import { DeterministicToolCallingModel, createStableTextModel } from "./shared.js";
+import { createStableTextModel, scriptedFakeModel } from "./shared.js";
 import { FANOUT_WORKER_COUNT } from "./parallel-constants.js";
 
 export { FANOUT_WORKER_COUNT };
@@ -12,30 +12,28 @@ export { FANOUT_WORKER_COUNT };
  * `description` so every worker gets a unique `taskInput` (drives the
  * subagent namespace binding / FIFO de-dup), then a final summary turn.
  */
-const orchestratorModel = new DeterministicToolCallingModel({
-  responses: [
-    new AIMessage({
-      id: "fanout-orchestrator",
-      content: "",
-      tool_calls: Array.from({ length: FANOUT_WORKER_COUNT }, (_, i) => {
-        const label = `worker-${String(i + 1).padStart(3, "0")}`;
-        return {
-          id: `task-${i + 1}`,
-          name: "task",
-          args: {
-            description: `Worker ${label} covering topic ${i + 1}`,
-            subagent_type: "worker",
-          },
-          type: "tool_call" as const,
-        };
-      }),
+const orchestratorModel = scriptedFakeModel([
+  new AIMessage({
+    id: "fanout-orchestrator",
+    content: "",
+    tool_calls: Array.from({ length: FANOUT_WORKER_COUNT }, (_, i) => {
+      const label = `worker-${String(i + 1).padStart(3, "0")}`;
+      return {
+        id: `task-${i + 1}`,
+        name: "task",
+        args: {
+          description: `Worker ${label} covering topic ${i + 1}`,
+          subagent_type: "worker",
+        },
+        type: "tool_call" as const,
+      };
     }),
-    new AIMessage({
-      id: "fanout-final",
-      content: "All workers completed.",
-    }),
-  ],
-});
+  }),
+  new AIMessage({
+    id: "fanout-final",
+    content: "All workers completed.",
+  }),
+]);
 
 /** Each worker subagent deterministically replies with a single text turn. */
 const workerModel = createStableTextModel(

--- a/libs/sdk-react/src/tests/fixtures/shared.ts
+++ b/libs/sdk-react/src/tests/fixtures/shared.ts
@@ -1,34 +1,17 @@
-import { AIMessage, AIMessageChunk, type BaseMessage } from "@langchain/core/messages";
-import {
-  BaseChatModel,
-  type BaseChatModelParams,
-} from "@langchain/core/language_models/chat_models";
+import { AIMessage, type BaseMessage } from "@langchain/core/messages";
 import { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
-import { ChatGenerationChunk, type ChatResult } from "@langchain/core/outputs";
+import { ChatGenerationChunk } from "@langchain/core/outputs";
 import { FakeListChatModel } from "@langchain/core/utils/testing";
 import { ToolMessage } from "@langchain/core/messages";
 import { Command } from "@langchain/langgraph";
-import { tool } from "langchain";
+import { fakeModel, tool } from "langchain";
 import { z } from "zod/v4";
 
-type ToolCall = {
-  id: string;
-  name: string;
-  args: Record<string, unknown>;
-  type: "tool_call";
-};
-
-const splitText = (text: string) => {
-  const parts = text.match(/\S+\s*/g);
-  return parts && parts.length > 0 ? parts : [text];
-};
-
-const splitJson = (value: string) => {
-  if (value.length < 2) return [value];
-  const midpoint = Math.ceil(value.length / 2);
-  return [value.slice(0, midpoint), value.slice(midpoint)];
-};
-
+/**
+ * FakeListChatModel subclass that keeps a stable message id across the
+ * streamed token chunks of a single response (needed by message-metadata /
+ * stategraph text fixtures).
+ */
 export class StableFakeListChatModel extends FakeListChatModel {
   private streamIndex = 0;
 
@@ -59,122 +42,66 @@ export class StableFakeListChatModel extends FakeListChatModel {
   }
 }
 
-export class DeterministicToolCallingModel extends BaseChatModel {
-  responses: AIMessage[];
-
-  callCount = 0;
-
-  constructor(fields: { responses: AIMessage[] } & BaseChatModelParams) {
-    super(fields);
-    this.responses = fields.responses;
-  }
-
-  _llmType() {
-    return "deterministic-tool-calling";
-  }
-
-  _combineLLMOutput() {
-    return [];
-  }
-
-  private currentResponse() {
-    return this.responses[this.callCount % this.responses.length];
-  }
-
-  async _generate(): Promise<ChatResult> {
-    const response = this.currentResponse();
-    this.callCount += 1;
-    return {
-      generations: [
-        {
-          text: typeof response.content === "string" ? response.content : "",
-          message: response,
-        },
-      ],
-    };
-  }
-
-  async *_streamResponseChunks(): AsyncGenerator<ChatGenerationChunk> {
-    const response = this.currentResponse();
-    const messageId =
-      typeof response.id === "string"
-        ? response.id
-        : `deterministic-message-${this.callCount + 1}`;
-
-    if (response.tool_calls && response.tool_calls.length > 0) {
-      for (const [index, toolCall] of response.tool_calls.entries()) {
-        const parts = splitJson(JSON.stringify((toolCall as ToolCall).args));
-        for (const part of parts) {
-          yield new ChatGenerationChunk({
-            message: new AIMessageChunk({
-              id: messageId,
-              content: "",
-              tool_call_chunks: [
-                {
-                  type: "tool_call_chunk",
-                  id: (toolCall as ToolCall).id,
-                  name: (toolCall as ToolCall).name,
-                  args: part,
-                  index,
-                },
-              ],
-            }),
-            text: "",
-          });
-        }
-      }
-    } else {
-      const text = typeof response.content === "string" ? response.content : "";
-      for (const part of splitText(text)) {
-        yield new ChatGenerationChunk({
-          message: new AIMessageChunk({
-            id: messageId,
-            content: part,
-          }),
-          text: part,
-        });
-      }
-    }
-
-    this.callCount += 1;
-  }
-
-  bindTools() {
-    return this;
-  }
-}
-
 export const createStableTextModel = (responses: string[]) =>
   new StableFakeListChatModel({
     responses,
   });
 
-export const createDeterministicToolCallingModel = (options: {
+/**
+ * {@link fakeModel} wrapper that replays `responses` in a loop.
+ *
+ * Mock-server graphs are compiled once and shared across the suite, so a
+ * one-shot FIFO queue would dry up after the first test. Each slot is a
+ * factory that advances a shared turn counter — see
+ * https://docs.langchain.com/oss/javascript/langchain/test/unit-testing
+ */
+export function scriptedFakeModel(
+  responses: AIMessage[],
+  capacity = 512
+): ReturnType<typeof fakeModel> {
+  if (responses.length === 0) {
+    throw new Error("scriptedFakeModel requires at least one response");
+  }
+  let turn = 0;
+  let model = fakeModel();
+  for (let i = 0; i < capacity; i++) {
+    model = model.respond(() => {
+      const message = responses[turn % responses.length]!;
+      turn += 1;
+      return message;
+    });
+  }
+  return model;
+}
+
+/**
+ * Scripted tool-calling model for Node-side graph fixtures.
+ */
+export function createDeterministicToolCallingModel(options: {
   toolCallId: string;
   toolName: string;
   toolArgs: Record<string, unknown>;
   finalText: string;
-}) =>
-  new DeterministicToolCallingModel({
-    responses: [
-      new AIMessage({
-        id: `${options.toolCallId}-message`,
-        content: "",
-        tool_calls: [
-          {
-            id: options.toolCallId,
-            name: options.toolName,
-            args: options.toolArgs,
-            type: "tool_call",
-          },
-        ],
-      }),
-      new AIMessage({
-        id: `${options.toolCallId}-final`,
-        content: options.finalText,
-      }),
-    ],
-  });
+}) {
+  return scriptedFakeModel([
+    new AIMessage({
+      id: `${options.toolCallId}-message`,
+      content: "",
+      tool_calls: [
+        {
+          id: options.toolCallId,
+          name: options.toolName,
+          args: options.toolArgs,
+          type: "tool_call",
+        },
+      ],
+    }),
+    new AIMessage({
+      id: `${options.toolCallId}-final`,
+      content: options.finalText,
+    }),
+  ]);
+}
 
 export const searchWebTool = tool(
   async ({ query }: { query: string }) =>
@@ -228,38 +155,36 @@ export const queryDatabaseTool = tool(
   }
 );
 
-export const deepOrchestratorModel = new DeterministicToolCallingModel({
-  responses: [
-    new AIMessage({
-      id: "deep-orchestrator-tool-call",
-      content: "",
-      tool_calls: [
-        {
-          name: "task",
-          args: {
-            description: "Search the web for protocol risks",
-            subagent_type: "researcher",
-          },
-          id: "task-1",
-          type: "tool_call",
+export const deepOrchestratorModel = scriptedFakeModel([
+  new AIMessage({
+    id: "deep-orchestrator-tool-call",
+    content: "",
+    tool_calls: [
+      {
+        name: "task",
+        args: {
+          description: "Search the web for protocol risks",
+          subagent_type: "researcher",
         },
-        {
-          name: "task",
-          args: {
-            description: "Inspect the sample dataset",
-            subagent_type: "data-analyst",
-          },
-          id: "task-2",
-          type: "tool_call",
+        id: "task-1",
+        type: "tool_call",
+      },
+      {
+        name: "task",
+        args: {
+          description: "Inspect the sample dataset",
+          subagent_type: "data-analyst",
         },
-      ],
-    }),
-    new AIMessage({
-      id: "deep-orchestrator-final",
-      content: "Both subagents completed their tasks successfully.",
-    }),
-  ],
-});
+        id: "task-2",
+        type: "tool_call",
+      },
+    ],
+  }),
+  new AIMessage({
+    id: "deep-orchestrator-final",
+    content: "Both subagents completed their tasks successfully.",
+  }),
+]);
 
 export const deepResearcherModel = createDeterministicToolCallingModel({
   toolCallId: "search-1",

--- a/libs/sdk-react/src/tests/mock-server.ts
+++ b/libs/sdk-react/src/tests/mock-server.ts
@@ -22,6 +22,8 @@ import { graph as deepAgentGraph } from "./fixtures/deep-agent.js";
 import { graph as interruptGraph } from "./fixtures/interrupt-graph.js";
 import { graph as interruptCardGraph } from "./fixtures/interrupt-card-graph.js";
 import { graph as multiInterruptGraph } from "./fixtures/multi-interrupt-graph.js";
+import { graph as nestedInterruptGraph } from "./fixtures/nested-interrupt-graph.js";
+import { graph as deepAgentInterruptGraph } from "./fixtures/deep-agent-interrupt.js";
 import { graph as errorGraph } from "./fixtures/error-graph.js";
 import { graph as subgraphGraph } from "./fixtures/subgraph-graph.js";
 import { graph as embeddedSubgraphGraph } from "./fixtures/embedded-subgraph-graph.js";
@@ -80,6 +82,8 @@ const graphs: Record<string, AnyPregel> = {
   interrupt_graph: interruptGraph as unknown as AnyPregel,
   interrupt_card_graph: interruptCardGraph as unknown as AnyPregel,
   multi_interrupt_graph: multiInterruptGraph as unknown as AnyPregel,
+  nested_interrupt_graph: nestedInterruptGraph as unknown as AnyPregel,
+  deep_agent_interrupt: deepAgentInterruptGraph as unknown as AnyPregel,
   error_graph: errorGraph as unknown as AnyPregel,
   subgraph_graph: subgraphGraph as unknown as AnyPregel,
   embedded_subgraph_graph: embeddedSubgraphGraph as unknown as AnyPregel,

--- a/libs/sdk-react/src/tests/stream.nested-interrupts.test.tsx
+++ b/libs/sdk-react/src/tests/stream.nested-interrupts.test.tsx
@@ -1,0 +1,156 @@
+import { expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+
+import { NestedInterruptStream } from "./components/NestedInterruptStream.js";
+import { apiUrl, cleanupRender } from "./test-utils.js";
+
+const nestedSubmitInput = { request: "ship nested change" };
+const deepAgentSubmitInput = {
+  messages: [{ role: "user", content: "Please get approval" }],
+};
+
+it(
+  "surfaces a nested StateGraph interrupt live on useStream().interrupts",
+  { timeout: 20_000 },
+  async () => {
+    const screen = await render(
+      <NestedInterruptStream
+        apiUrl={apiUrl}
+        assistantId="nested_interrupt_graph"
+        submitInput={nestedSubmitInput}
+      />
+    );
+
+    try {
+      await screen.getByTestId("submit").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 15_000 })
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("interrupt-prompt"))
+        .toHaveTextContent("Approve nested subgraph action?");
+      await expect
+        .element(screen.getByTestId("interrupt-id"))
+        .not.toHaveTextContent("");
+
+      const namespaceText =
+        screen.getByTestId("interrupt-namespace").element().textContent ?? "[]";
+      const namespace = JSON.parse(namespaceText) as string[];
+      expect(namespace.length).toBeGreaterThan(0);
+
+      await screen.getByTestId("resume").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 15_000 })
+        .toHaveTextContent("0");
+      await expect
+        .element(screen.getByTestId("completed"), { timeout: 15_000 })
+        .toHaveTextContent("true");
+    } finally {
+      await cleanupRender(screen);
+    }
+  }
+);
+
+it(
+  "surfaces a createDeepAgent subagent interrupt live on useStream().interrupts",
+  { timeout: 30_000 },
+  async () => {
+    const screen = await render(
+      <NestedInterruptStream
+        apiUrl={apiUrl}
+        assistantId="deep_agent_interrupt"
+        submitInput={deepAgentSubmitInput}
+      />
+    );
+
+    try {
+      await screen.getByTestId("submit").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 20_000 })
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("interrupt-prompt"))
+        .toHaveTextContent("Approve subagent tool action?");
+      await expect
+        .element(screen.getByTestId("interrupt-id"))
+        .not.toHaveTextContent("");
+
+      const namespaceText =
+        screen.getByTestId("interrupt-namespace").element().textContent ?? "[]";
+      const namespace = JSON.parse(namespaceText) as string[];
+      expect(namespace.length).toBeGreaterThan(0);
+
+      await screen.getByTestId("resume").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 20_000 })
+        .toHaveTextContent("0");
+      await expect
+        .element(screen.getByTestId("loading"), { timeout: 20_000 })
+        .toHaveTextContent("Not loading");
+    } finally {
+      await cleanupRender(screen);
+    }
+  }
+);
+
+it(
+  "hydrates a nested StateGraph interrupt after remount",
+  { timeout: 30_000 },
+  async () => {
+    let capturedThreadId: string | undefined;
+
+    const seed = await render(
+      <NestedInterruptStream
+        apiUrl={apiUrl}
+        assistantId="nested_interrupt_graph"
+        submitInput={nestedSubmitInput}
+        onThreadId={(id) => {
+          capturedThreadId = id;
+        }}
+      />
+    );
+    try {
+      await seed.getByTestId("submit").click();
+      await expect
+        .element(seed.getByTestId("interrupt-count"), { timeout: 15_000 })
+        .toHaveTextContent("1");
+    } finally {
+      await cleanupRender(seed);
+    }
+    expect(capturedThreadId).toMatch(/.+/);
+
+    const screen = await render(
+      <NestedInterruptStream
+        apiUrl={apiUrl}
+        assistantId="nested_interrupt_graph"
+        threadId={capturedThreadId}
+        submitInput={nestedSubmitInput}
+      />
+    );
+    try {
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 15_000 })
+        .toHaveTextContent("1");
+
+      const namespaceText =
+        screen.getByTestId("interrupt-namespace").element().textContent ?? "[]";
+      const namespace = JSON.parse(namespaceText) as string[];
+      expect(namespace.length).toBeGreaterThan(0);
+
+      await screen.getByTestId("resume").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 15_000 })
+        .toHaveTextContent("0");
+      await expect
+        .element(screen.getByTestId("completed"), { timeout: 15_000 })
+        .toHaveTextContent("true");
+    } finally {
+      await cleanupRender(screen);
+    }
+  }
+);

--- a/libs/sdk-svelte/src/tests/components/NestedInterruptStream.svelte
+++ b/libs/sdk-svelte/src/tests/components/NestedInterruptStream.svelte
@@ -1,0 +1,79 @@
+<script lang="ts">
+  import { useStream } from "../../index.js";
+
+  interface NestedInterruptState {
+    request?: string;
+    decision?: Record<string, unknown> | null;
+    completed?: boolean;
+    messages?: unknown[];
+  }
+
+  interface Props {
+    apiUrl: string;
+    assistantId: string;
+    threadId?: string;
+    onThreadId?: (threadId: string) => void;
+    submitInput: Record<string, unknown>;
+  }
+
+  const {
+    apiUrl,
+    assistantId,
+    threadId,
+    onThreadId,
+    submitInput,
+  }: Props = $props();
+
+  const stream = useStream<NestedInterruptState>({
+    assistantId,
+    apiUrl,
+    threadId,
+    onThreadId,
+  });
+
+  const interruptPrompt = $derived.by(() => {
+    const promptValue = stream.interrupt?.value;
+    if (
+      promptValue != null &&
+      typeof promptValue === "object" &&
+      "prompt" in (promptValue as object)
+    ) {
+      return String((promptValue as { prompt?: unknown }).prompt ?? "");
+    }
+    return "";
+  });
+
+  const namespaceJson = $derived(
+    JSON.stringify(stream.interrupt?.namespace ?? []),
+  );
+</script>
+
+<div>
+  <div data-testid="interrupt-count">{stream.interrupts.length}</div>
+  <div data-testid="interrupt-prompt">{interruptPrompt}</div>
+  <div data-testid="interrupt-id">{stream.interrupt?.id ?? ""}</div>
+  <div data-testid="interrupt-namespace">{namespaceJson}</div>
+  <div data-testid="completed">
+    {stream.values?.completed ? "true" : "false"}
+  </div>
+  <div data-testid="loading">
+    {stream.isLoading ? "Loading..." : "Not loading"}
+  </div>
+  <button
+    data-testid="submit"
+    onclick={() => void stream.submit(submitInput)}
+  >
+    Submit
+  </button>
+  <button
+    data-testid="resume"
+    onclick={() => {
+      const id = stream.interrupt?.id;
+      if (id != null) {
+        void stream.respond({ approved: true }, { interruptId: id });
+      }
+    }}
+  >
+    Resume
+  </button>
+</div>

--- a/libs/sdk-svelte/src/tests/fixtures/deep-agent-interrupt.ts
+++ b/libs/sdk-svelte/src/tests/fixtures/deep-agent-interrupt.ts
@@ -1,0 +1,147 @@
+import {
+  AIMessage,
+  AIMessageChunk,
+  type BaseMessage,
+} from "@langchain/core/messages";
+import {
+  BaseChatModel,
+  type BaseChatModelParams,
+} from "@langchain/core/language_models/chat_models";
+import { ChatGenerationChunk, type ChatResult } from "@langchain/core/outputs";
+import { interrupt } from "@langchain/langgraph";
+import { createDeepAgent, type DeepAgent } from "deepagents";
+import { tool } from "langchain";
+import { z } from "zod/v4";
+
+/** Deterministic tool-calling model for Node-side fixtures only. */
+class FakeToolCallingModel extends BaseChatModel {
+  responses: BaseMessage[];
+  callCount = 0;
+
+  constructor(fields: { responses: BaseMessage[] } & BaseChatModelParams) {
+    super(fields);
+    this.responses = fields.responses;
+  }
+
+  _llmType() {
+    return "fake-tool-calling";
+  }
+
+  _combineLLMOutput() {
+    return [];
+  }
+
+  async _generate(): Promise<ChatResult> {
+    const baseMsg = this.responses[this.callCount % this.responses.length];
+    this.callCount += 1;
+    return {
+      generations: [
+        { text: (baseMsg.content as string) || "", message: baseMsg },
+      ],
+    };
+  }
+
+  async *_streamResponseChunks() {
+    const baseMsg = this.responses[this.callCount % this.responses.length];
+    const toolCalls = (baseMsg as AIMessage).tool_calls;
+    const chunkFields: Record<string, unknown> = {
+      content: (baseMsg.content as string) || "",
+    };
+    if (toolCalls?.length) {
+      chunkFields.tool_call_chunks = toolCalls.map(
+        (
+          tc: { name: string; args: Record<string, unknown>; id?: string },
+          index: number
+        ) => ({
+          name: tc.name,
+          args: JSON.stringify(tc.args),
+          id: tc.id,
+          index,
+          type: "tool_call_chunk" as const,
+        })
+      );
+    }
+    yield new ChatGenerationChunk({
+      message: new AIMessageChunk(chunkFields),
+      text: (baseMsg.content as string) || "",
+    });
+    this.callCount += 1;
+  }
+
+  bindTools() {
+    return this;
+  }
+}
+
+const requestApprovalTool = tool(
+  async () => {
+    const decision = interrupt({
+      prompt: "Approve subagent tool action?",
+    });
+    return JSON.stringify(decision ?? { approved: true });
+  },
+  {
+    name: "request_approval",
+    description: "Request human approval before proceeding.",
+    schema: z.object({}),
+  }
+);
+
+const orchestratorModel = new FakeToolCallingModel({
+  responses: [
+    new AIMessage({
+      id: "deep-interrupt-orchestrator",
+      content: "",
+      tool_calls: [
+        {
+          id: "task-approve-1",
+          name: "task",
+          args: {
+            description: "Request approval for the pending change",
+            subagent_type: "approver",
+          },
+          type: "tool_call" as const,
+        },
+      ],
+    }),
+    new AIMessage({
+      id: "deep-interrupt-final",
+      content: "Subagent approval completed.",
+    }),
+  ],
+});
+
+const approverModel = new FakeToolCallingModel({
+  responses: [
+    new AIMessage({
+      id: "approver-call",
+      content: "",
+      tool_calls: [
+        {
+          id: "approval-1",
+          name: "request_approval",
+          args: {},
+          type: "tool_call" as const,
+        },
+      ],
+    }),
+    new AIMessage({
+      id: "approver-done",
+      content: "Approval recorded.",
+    }),
+  ],
+});
+
+export const graph = createDeepAgent({
+  model: orchestratorModel,
+  subagents: [
+    {
+      name: "approver",
+      description: "Requests human approval before acting.",
+      systemPrompt: "You must request approval before proceeding.",
+      tools: [requestApprovalTool],
+      model: approverModel,
+    },
+  ],
+  systemPrompt: "Delegate approval work to the approver subagent.",
+}) as DeepAgent;

--- a/libs/sdk-svelte/src/tests/fixtures/deep-agent-interrupt.ts
+++ b/libs/sdk-svelte/src/tests/fixtures/deep-agent-interrupt.ts
@@ -1,76 +1,24 @@
-import {
-  AIMessage,
-  AIMessageChunk,
-  type BaseMessage,
-} from "@langchain/core/messages";
-import {
-  BaseChatModel,
-  type BaseChatModelParams,
-} from "@langchain/core/language_models/chat_models";
-import { ChatGenerationChunk, type ChatResult } from "@langchain/core/outputs";
+import { AIMessage } from "@langchain/core/messages";
 import { interrupt } from "@langchain/langgraph";
 import { createDeepAgent, type DeepAgent } from "deepagents";
-import { tool } from "langchain";
+import { fakeModel, tool } from "langchain";
 import { z } from "zod/v4";
 
-/** Deterministic tool-calling model for Node-side fixtures only. */
-class FakeToolCallingModel extends BaseChatModel {
-  responses: BaseMessage[];
-  callCount = 0;
-
-  constructor(fields: { responses: BaseMessage[] } & BaseChatModelParams) {
-    super(fields);
-    this.responses = fields.responses;
-  }
-
-  _llmType() {
-    return "fake-tool-calling";
-  }
-
-  _combineLLMOutput() {
-    return [];
-  }
-
-  async _generate(): Promise<ChatResult> {
-    const baseMsg = this.responses[this.callCount % this.responses.length];
-    this.callCount += 1;
-    return {
-      generations: [
-        { text: (baseMsg.content as string) || "", message: baseMsg },
-      ],
-    };
-  }
-
-  async *_streamResponseChunks() {
-    const baseMsg = this.responses[this.callCount % this.responses.length];
-    const toolCalls = (baseMsg as AIMessage).tool_calls;
-    const chunkFields: Record<string, unknown> = {
-      content: (baseMsg.content as string) || "",
-    };
-    if (toolCalls?.length) {
-      chunkFields.tool_call_chunks = toolCalls.map(
-        (
-          tc: { name: string; args: Record<string, unknown>; id?: string },
-          index: number
-        ) => ({
-          name: tc.name,
-          args: JSON.stringify(tc.args),
-          id: tc.id,
-          index,
-          type: "tool_call_chunk" as const,
-        })
-      );
-    }
-    yield new ChatGenerationChunk({
-      message: new AIMessageChunk(chunkFields),
-      text: (baseMsg.content as string) || "",
+/**
+ * {@link fakeModel} that replays responses in a loop so the shared
+ * mock-server graph survives multiple suite tests.
+ */
+function scriptedFakeModel(responses: AIMessage[], capacity = 512) {
+  let turn = 0;
+  let model = fakeModel();
+  for (let i = 0; i < capacity; i++) {
+    model = model.respond(() => {
+      const message = responses[turn % responses.length]!;
+      turn += 1;
+      return message;
     });
-    this.callCount += 1;
   }
-
-  bindTools() {
-    return this;
-  }
+  return model;
 }
 
 const requestApprovalTool = tool(
@@ -87,50 +35,46 @@ const requestApprovalTool = tool(
   }
 );
 
-const orchestratorModel = new FakeToolCallingModel({
-  responses: [
-    new AIMessage({
-      id: "deep-interrupt-orchestrator",
-      content: "",
-      tool_calls: [
-        {
-          id: "task-approve-1",
-          name: "task",
-          args: {
-            description: "Request approval for the pending change",
-            subagent_type: "approver",
-          },
-          type: "tool_call" as const,
+const orchestratorModel = scriptedFakeModel([
+  new AIMessage({
+    id: "deep-interrupt-orchestrator",
+    content: "",
+    tool_calls: [
+      {
+        id: "task-approve-1",
+        name: "task",
+        args: {
+          description: "Request approval for the pending change",
+          subagent_type: "approver",
         },
-      ],
-    }),
-    new AIMessage({
-      id: "deep-interrupt-final",
-      content: "Subagent approval completed.",
-    }),
-  ],
-});
+        type: "tool_call" as const,
+      },
+    ],
+  }),
+  new AIMessage({
+    id: "deep-interrupt-final",
+    content: "Subagent approval completed.",
+  }),
+]);
 
-const approverModel = new FakeToolCallingModel({
-  responses: [
-    new AIMessage({
-      id: "approver-call",
-      content: "",
-      tool_calls: [
-        {
-          id: "approval-1",
-          name: "request_approval",
-          args: {},
-          type: "tool_call" as const,
-        },
-      ],
-    }),
-    new AIMessage({
-      id: "approver-done",
-      content: "Approval recorded.",
-    }),
-  ],
-});
+const approverModel = scriptedFakeModel([
+  new AIMessage({
+    id: "approver-call",
+    content: "",
+    tool_calls: [
+      {
+        id: "approval-1",
+        name: "request_approval",
+        args: {},
+        type: "tool_call" as const,
+      },
+    ],
+  }),
+  new AIMessage({
+    id: "approver-done",
+    content: "Approval recorded.",
+  }),
+]);
 
 export const graph = createDeepAgent({
   model: orchestratorModel,

--- a/libs/sdk-svelte/src/tests/fixtures/mock-server.ts
+++ b/libs/sdk-svelte/src/tests/fixtures/mock-server.ts
@@ -46,6 +46,8 @@ import type { TestProject } from "vitest/node";
 
 import { getLocationTool } from "./browser-fixtures.js";
 import { graph as multiInterruptGraph } from "./multi-interrupt-graph.js";
+import { graph as nestedInterruptGraph } from "./nested-interrupt-graph.js";
+import { graph as deepAgentInterruptGraph } from "./deep-agent-interrupt.js";
 
 declare module "vitest" {
   export interface ProvidedContext {
@@ -691,6 +693,8 @@ const graphs: Record<string, AnyPregel> = {
   interruptAgent,
   interrupt_card_graph: interruptCardGraph,
   multi_interrupt_graph: multiInterruptGraph as unknown as AnyPregel,
+  nested_interrupt_graph: nestedInterruptGraph as unknown as AnyPregel,
+  deep_agent_interrupt: deepAgentInterruptGraph as unknown as AnyPregel,
   parentAgent,
   embedded_subgraph_graph: embeddedSubgraphAgent,
   removeMessageAgent,

--- a/libs/sdk-svelte/src/tests/fixtures/nested-interrupt-graph.ts
+++ b/libs/sdk-svelte/src/tests/fixtures/nested-interrupt-graph.ts
@@ -1,0 +1,59 @@
+import {
+  Annotation,
+  END,
+  interrupt,
+  START,
+  StateGraph,
+} from "@langchain/langgraph";
+
+/**
+ * Parent → child → grandchild StateGraph where the innermost node
+ * calls `interrupt()`. Used to assert that nested
+ * `input.requested` events surface on `useStream().interrupts` live
+ * (not only after hydrate).
+ */
+const GraphState = Annotation.Root({
+  request: Annotation<string>(),
+  decision: Annotation<Record<string, unknown> | null>({
+    reducer: (_, next) => next,
+    default: () => null,
+  }),
+  completed: Annotation<boolean>({
+    reducer: (_, next) => next,
+    default: () => false,
+  }),
+});
+
+const reviewNode = (state: typeof GraphState.State) => {
+  const decision = interrupt({
+    prompt: "Approve nested subgraph action?",
+    request: state.request,
+  });
+
+  return {
+    decision:
+      decision != null && typeof decision === "object"
+        ? (decision as Record<string, unknown>)
+        : { value: decision },
+    completed: true,
+  };
+};
+
+const grandchild = new StateGraph(GraphState)
+  .addNode("review", reviewNode)
+  .addEdge(START, "review")
+  .addEdge("review", END)
+  .compile();
+
+const child = new StateGraph(GraphState)
+  .addNode("inner", grandchild, { subgraphs: [grandchild] })
+  .addEdge(START, "inner")
+  .addEdge("inner", END)
+  .compile();
+
+const workflow = new StateGraph(GraphState)
+  .addNode("child", child, { subgraphs: [child] })
+  .addEdge(START, "child")
+  .addEdge("child", END);
+
+export const graph = workflow.compile();

--- a/libs/sdk-svelte/src/tests/stream.nested-interrupts.test.ts
+++ b/libs/sdk-svelte/src/tests/stream.nested-interrupts.test.ts
@@ -1,0 +1,149 @@
+import { expect, it, inject } from "vitest";
+import { render } from "vitest-browser-svelte";
+
+import NestedInterruptStream from "./components/NestedInterruptStream.svelte";
+
+const serverUrl = inject("serverUrl");
+
+const nestedSubmitInput = { request: "ship nested change" };
+const deepAgentSubmitInput = {
+  messages: [{ role: "user", content: "Please get approval" }],
+};
+
+it(
+  "surfaces a nested StateGraph interrupt live on useStream().interrupts",
+  { timeout: 20_000 },
+  async () => {
+    const screen = await render(NestedInterruptStream, {
+      apiUrl: serverUrl,
+      assistantId: "nested_interrupt_graph",
+      submitInput: nestedSubmitInput,
+    });
+
+    try {
+      await screen.getByTestId("submit").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 15_000 })
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("interrupt-prompt"))
+        .toHaveTextContent("Approve nested subgraph action?");
+      await expect
+        .element(screen.getByTestId("interrupt-id"))
+        .not.toHaveTextContent("");
+
+      const namespaceText =
+        screen.getByTestId("interrupt-namespace").element().textContent ?? "[]";
+      const namespace = JSON.parse(namespaceText) as string[];
+      expect(namespace.length).toBeGreaterThan(0);
+
+      await screen.getByTestId("resume").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 15_000 })
+        .toHaveTextContent("0");
+      await expect
+        .element(screen.getByTestId("completed"), { timeout: 15_000 })
+        .toHaveTextContent("true");
+    } finally {
+      await screen.unmount();
+    }
+  }
+);
+
+it(
+  "surfaces a createDeepAgent subagent interrupt live on useStream().interrupts",
+  { timeout: 30_000 },
+  async () => {
+    const screen = await render(NestedInterruptStream, {
+      apiUrl: serverUrl,
+      assistantId: "deep_agent_interrupt",
+      submitInput: deepAgentSubmitInput,
+    });
+
+    try {
+      await screen.getByTestId("submit").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 20_000 })
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("interrupt-prompt"))
+        .toHaveTextContent("Approve subagent tool action?");
+      await expect
+        .element(screen.getByTestId("interrupt-id"))
+        .not.toHaveTextContent("");
+
+      const namespaceText =
+        screen.getByTestId("interrupt-namespace").element().textContent ?? "[]";
+      const namespace = JSON.parse(namespaceText) as string[];
+      expect(namespace.length).toBeGreaterThan(0);
+
+      await screen.getByTestId("resume").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 20_000 })
+        .toHaveTextContent("0");
+      await expect
+        .element(screen.getByTestId("loading"), { timeout: 20_000 })
+        .toHaveTextContent("Not loading");
+    } finally {
+      await screen.unmount();
+    }
+  }
+);
+
+it(
+  "hydrates a nested StateGraph interrupt after remount",
+  { timeout: 30_000 },
+  async () => {
+    let capturedThreadId: string | undefined;
+
+    const seed = await render(NestedInterruptStream, {
+      apiUrl: serverUrl,
+      assistantId: "nested_interrupt_graph",
+      submitInput: nestedSubmitInput,
+      onThreadId: (id: string) => {
+        capturedThreadId = id;
+      },
+    });
+    try {
+      await seed.getByTestId("submit").click();
+      await expect
+        .element(seed.getByTestId("interrupt-count"), { timeout: 15_000 })
+        .toHaveTextContent("1");
+    } finally {
+      await seed.unmount();
+    }
+    expect(capturedThreadId).toMatch(/.+/);
+
+    const screen = await render(NestedInterruptStream, {
+      apiUrl: serverUrl,
+      assistantId: "nested_interrupt_graph",
+      threadId: capturedThreadId,
+      submitInput: nestedSubmitInput,
+    });
+    try {
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 15_000 })
+        .toHaveTextContent("1");
+
+      const namespaceText =
+        screen.getByTestId("interrupt-namespace").element().textContent ?? "[]";
+      const namespace = JSON.parse(namespaceText) as string[];
+      expect(namespace.length).toBeGreaterThan(0);
+
+      await screen.getByTestId("resume").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 15_000 })
+        .toHaveTextContent("0");
+      await expect
+        .element(screen.getByTestId("completed"), { timeout: 15_000 })
+        .toHaveTextContent("true");
+    } finally {
+      await screen.unmount();
+    }
+  }
+);

--- a/libs/sdk-vue/src/tests/components/NestedInterruptStream.tsx
+++ b/libs/sdk-vue/src/tests/components/NestedInterruptStream.tsx
@@ -1,0 +1,93 @@
+import { computed, defineComponent, type PropType } from "vue";
+
+import { useStream } from "../../index.js";
+
+interface NestedInterruptState {
+  request?: string;
+  decision?: Record<string, unknown> | null;
+  completed?: boolean;
+  messages?: unknown[];
+}
+
+/**
+ * HITL harness for nested / subagent interrupts.
+ *
+ * Exposes namespace and resumes via `respond({ interruptId })` without
+ * an explicit `namespace` so the controller lookup path is covered.
+ */
+export const NestedInterruptStream = defineComponent({
+  name: "NestedInterruptStream",
+  props: {
+    apiUrl: { type: String, required: true },
+    assistantId: { type: String, required: true },
+    threadId: { type: String, default: undefined },
+    onThreadId: {
+      type: Function as unknown as () => (threadId: string) => void,
+      default: undefined,
+    },
+    submitInput: {
+      type: Object as PropType<Record<string, unknown>>,
+      required: true,
+    },
+  },
+  setup(props) {
+    const stream = useStream<NestedInterruptState>({
+      assistantId: props.assistantId,
+      apiUrl: props.apiUrl,
+      threadId: props.threadId,
+      onThreadId: props.onThreadId,
+    });
+
+    const interruptPrompt = computed(() => {
+      const promptValue = stream.interrupt.value?.value;
+      if (
+        promptValue != null &&
+        typeof promptValue === "object" &&
+        "prompt" in (promptValue as object)
+      ) {
+        return String((promptValue as { prompt?: unknown }).prompt ?? "");
+      }
+      return "";
+    });
+
+    const namespaceJson = computed(() =>
+      JSON.stringify(stream.interrupt.value?.namespace ?? [])
+    );
+
+    return () => (
+      <div>
+        <div data-testid="interrupt-count">
+          {stream.interrupts.value.length}
+        </div>
+        <div data-testid="interrupt-prompt">{interruptPrompt.value}</div>
+        <div data-testid="interrupt-id">
+          {stream.interrupt.value?.id ?? ""}
+        </div>
+        <div data-testid="interrupt-namespace">{namespaceJson.value}</div>
+        <div data-testid="completed">
+          {stream.values.value?.completed ? "true" : "false"}
+        </div>
+        <div data-testid="loading">
+          {stream.isLoading.value ? "Loading..." : "Not loading"}
+        </div>
+        <button
+          data-testid="submit"
+          onClick={() => void stream.submit(props.submitInput)}
+        >
+          Submit
+        </button>
+        <button
+          data-testid="resume"
+          onClick={() => {
+            const id = stream.interrupt.value?.id;
+            if (id != null) {
+              void stream.respond({ approved: true }, { interruptId: id });
+            }
+          }}
+        >
+          Resume
+        </button>
+      </div>
+    );
+  },
+});

--- a/libs/sdk-vue/src/tests/fixtures/deep-agent-interrupt.ts
+++ b/libs/sdk-vue/src/tests/fixtures/deep-agent-interrupt.ts
@@ -1,0 +1,147 @@
+import {
+  AIMessage,
+  AIMessageChunk,
+  type BaseMessage,
+} from "@langchain/core/messages";
+import {
+  BaseChatModel,
+  type BaseChatModelParams,
+} from "@langchain/core/language_models/chat_models";
+import { ChatGenerationChunk, type ChatResult } from "@langchain/core/outputs";
+import { interrupt } from "@langchain/langgraph";
+import { createDeepAgent, type DeepAgent } from "deepagents";
+import { tool } from "langchain";
+import { z } from "zod/v4";
+
+/** Deterministic tool-calling model for Node-side fixtures only. */
+class FakeToolCallingModel extends BaseChatModel {
+  responses: BaseMessage[];
+  callCount = 0;
+
+  constructor(fields: { responses: BaseMessage[] } & BaseChatModelParams) {
+    super(fields);
+    this.responses = fields.responses;
+  }
+
+  _llmType() {
+    return "fake-tool-calling";
+  }
+
+  _combineLLMOutput() {
+    return [];
+  }
+
+  async _generate(): Promise<ChatResult> {
+    const baseMsg = this.responses[this.callCount % this.responses.length];
+    this.callCount += 1;
+    return {
+      generations: [
+        { text: (baseMsg.content as string) || "", message: baseMsg },
+      ],
+    };
+  }
+
+  async *_streamResponseChunks() {
+    const baseMsg = this.responses[this.callCount % this.responses.length];
+    const toolCalls = (baseMsg as AIMessage).tool_calls;
+    const chunkFields: Record<string, unknown> = {
+      content: (baseMsg.content as string) || "",
+    };
+    if (toolCalls?.length) {
+      chunkFields.tool_call_chunks = toolCalls.map(
+        (
+          tc: { name: string; args: Record<string, unknown>; id?: string },
+          index: number
+        ) => ({
+          name: tc.name,
+          args: JSON.stringify(tc.args),
+          id: tc.id,
+          index,
+          type: "tool_call_chunk" as const,
+        })
+      );
+    }
+    yield new ChatGenerationChunk({
+      message: new AIMessageChunk(chunkFields),
+      text: (baseMsg.content as string) || "",
+    });
+    this.callCount += 1;
+  }
+
+  bindTools() {
+    return this;
+  }
+}
+
+const requestApprovalTool = tool(
+  async () => {
+    const decision = interrupt({
+      prompt: "Approve subagent tool action?",
+    });
+    return JSON.stringify(decision ?? { approved: true });
+  },
+  {
+    name: "request_approval",
+    description: "Request human approval before proceeding.",
+    schema: z.object({}),
+  }
+);
+
+const orchestratorModel = new FakeToolCallingModel({
+  responses: [
+    new AIMessage({
+      id: "deep-interrupt-orchestrator",
+      content: "",
+      tool_calls: [
+        {
+          id: "task-approve-1",
+          name: "task",
+          args: {
+            description: "Request approval for the pending change",
+            subagent_type: "approver",
+          },
+          type: "tool_call" as const,
+        },
+      ],
+    }),
+    new AIMessage({
+      id: "deep-interrupt-final",
+      content: "Subagent approval completed.",
+    }),
+  ],
+});
+
+const approverModel = new FakeToolCallingModel({
+  responses: [
+    new AIMessage({
+      id: "approver-call",
+      content: "",
+      tool_calls: [
+        {
+          id: "approval-1",
+          name: "request_approval",
+          args: {},
+          type: "tool_call" as const,
+        },
+      ],
+    }),
+    new AIMessage({
+      id: "approver-done",
+      content: "Approval recorded.",
+    }),
+  ],
+});
+
+export const graph = createDeepAgent({
+  model: orchestratorModel,
+  subagents: [
+    {
+      name: "approver",
+      description: "Requests human approval before acting.",
+      systemPrompt: "You must request approval before proceeding.",
+      tools: [requestApprovalTool],
+      model: approverModel,
+    },
+  ],
+  systemPrompt: "Delegate approval work to the approver subagent.",
+}) as DeepAgent;

--- a/libs/sdk-vue/src/tests/fixtures/deep-agent-interrupt.ts
+++ b/libs/sdk-vue/src/tests/fixtures/deep-agent-interrupt.ts
@@ -1,76 +1,24 @@
-import {
-  AIMessage,
-  AIMessageChunk,
-  type BaseMessage,
-} from "@langchain/core/messages";
-import {
-  BaseChatModel,
-  type BaseChatModelParams,
-} from "@langchain/core/language_models/chat_models";
-import { ChatGenerationChunk, type ChatResult } from "@langchain/core/outputs";
+import { AIMessage } from "@langchain/core/messages";
 import { interrupt } from "@langchain/langgraph";
 import { createDeepAgent, type DeepAgent } from "deepagents";
-import { tool } from "langchain";
+import { fakeModel, tool } from "langchain";
 import { z } from "zod/v4";
 
-/** Deterministic tool-calling model for Node-side fixtures only. */
-class FakeToolCallingModel extends BaseChatModel {
-  responses: BaseMessage[];
-  callCount = 0;
-
-  constructor(fields: { responses: BaseMessage[] } & BaseChatModelParams) {
-    super(fields);
-    this.responses = fields.responses;
-  }
-
-  _llmType() {
-    return "fake-tool-calling";
-  }
-
-  _combineLLMOutput() {
-    return [];
-  }
-
-  async _generate(): Promise<ChatResult> {
-    const baseMsg = this.responses[this.callCount % this.responses.length];
-    this.callCount += 1;
-    return {
-      generations: [
-        { text: (baseMsg.content as string) || "", message: baseMsg },
-      ],
-    };
-  }
-
-  async *_streamResponseChunks() {
-    const baseMsg = this.responses[this.callCount % this.responses.length];
-    const toolCalls = (baseMsg as AIMessage).tool_calls;
-    const chunkFields: Record<string, unknown> = {
-      content: (baseMsg.content as string) || "",
-    };
-    if (toolCalls?.length) {
-      chunkFields.tool_call_chunks = toolCalls.map(
-        (
-          tc: { name: string; args: Record<string, unknown>; id?: string },
-          index: number
-        ) => ({
-          name: tc.name,
-          args: JSON.stringify(tc.args),
-          id: tc.id,
-          index,
-          type: "tool_call_chunk" as const,
-        })
-      );
-    }
-    yield new ChatGenerationChunk({
-      message: new AIMessageChunk(chunkFields),
-      text: (baseMsg.content as string) || "",
+/**
+ * {@link fakeModel} that replays responses in a loop so the shared
+ * mock-server graph survives multiple suite tests.
+ */
+function scriptedFakeModel(responses: AIMessage[], capacity = 512) {
+  let turn = 0;
+  let model = fakeModel();
+  for (let i = 0; i < capacity; i++) {
+    model = model.respond(() => {
+      const message = responses[turn % responses.length]!;
+      turn += 1;
+      return message;
     });
-    this.callCount += 1;
   }
-
-  bindTools() {
-    return this;
-  }
+  return model;
 }
 
 const requestApprovalTool = tool(
@@ -87,50 +35,46 @@ const requestApprovalTool = tool(
   }
 );
 
-const orchestratorModel = new FakeToolCallingModel({
-  responses: [
-    new AIMessage({
-      id: "deep-interrupt-orchestrator",
-      content: "",
-      tool_calls: [
-        {
-          id: "task-approve-1",
-          name: "task",
-          args: {
-            description: "Request approval for the pending change",
-            subagent_type: "approver",
-          },
-          type: "tool_call" as const,
+const orchestratorModel = scriptedFakeModel([
+  new AIMessage({
+    id: "deep-interrupt-orchestrator",
+    content: "",
+    tool_calls: [
+      {
+        id: "task-approve-1",
+        name: "task",
+        args: {
+          description: "Request approval for the pending change",
+          subagent_type: "approver",
         },
-      ],
-    }),
-    new AIMessage({
-      id: "deep-interrupt-final",
-      content: "Subagent approval completed.",
-    }),
-  ],
-});
+        type: "tool_call" as const,
+      },
+    ],
+  }),
+  new AIMessage({
+    id: "deep-interrupt-final",
+    content: "Subagent approval completed.",
+  }),
+]);
 
-const approverModel = new FakeToolCallingModel({
-  responses: [
-    new AIMessage({
-      id: "approver-call",
-      content: "",
-      tool_calls: [
-        {
-          id: "approval-1",
-          name: "request_approval",
-          args: {},
-          type: "tool_call" as const,
-        },
-      ],
-    }),
-    new AIMessage({
-      id: "approver-done",
-      content: "Approval recorded.",
-    }),
-  ],
-});
+const approverModel = scriptedFakeModel([
+  new AIMessage({
+    id: "approver-call",
+    content: "",
+    tool_calls: [
+      {
+        id: "approval-1",
+        name: "request_approval",
+        args: {},
+        type: "tool_call" as const,
+      },
+    ],
+  }),
+  new AIMessage({
+    id: "approver-done",
+    content: "Approval recorded.",
+  }),
+]);
 
 export const graph = createDeepAgent({
   model: orchestratorModel,

--- a/libs/sdk-vue/src/tests/fixtures/mock-server.ts
+++ b/libs/sdk-vue/src/tests/fixtures/mock-server.ts
@@ -46,6 +46,8 @@ import type { TestProject } from "vitest/node";
 
 import { getLocationTool } from "./browser-fixtures.js";
 import { graph as multiInterruptGraph } from "./multi-interrupt-graph.js";
+import { graph as nestedInterruptGraph } from "./nested-interrupt-graph.js";
+import { graph as deepAgentInterruptGraph } from "./deep-agent-interrupt.js";
 
 declare module "vitest" {
   export interface ProvidedContext {
@@ -676,6 +678,8 @@ const graphs: Record<string, AnyPregel> = {
   interruptAgent,
   interrupt_card_graph: interruptCardGraph,
   multi_interrupt_graph: multiInterruptGraph as unknown as AnyPregel,
+  nested_interrupt_graph: nestedInterruptGraph as unknown as AnyPregel,
+  deep_agent_interrupt: deepAgentInterruptGraph as unknown as AnyPregel,
   parentAgent,
   removeMessageAgent,
   errorAgent,

--- a/libs/sdk-vue/src/tests/fixtures/nested-interrupt-graph.ts
+++ b/libs/sdk-vue/src/tests/fixtures/nested-interrupt-graph.ts
@@ -1,0 +1,59 @@
+import {
+  Annotation,
+  END,
+  interrupt,
+  START,
+  StateGraph,
+} from "@langchain/langgraph";
+
+/**
+ * Parent → child → grandchild StateGraph where the innermost node
+ * calls `interrupt()`. Used to assert that nested
+ * `input.requested` events surface on `useStream().interrupts` live
+ * (not only after hydrate).
+ */
+const GraphState = Annotation.Root({
+  request: Annotation<string>(),
+  decision: Annotation<Record<string, unknown> | null>({
+    reducer: (_, next) => next,
+    default: () => null,
+  }),
+  completed: Annotation<boolean>({
+    reducer: (_, next) => next,
+    default: () => false,
+  }),
+});
+
+const reviewNode = (state: typeof GraphState.State) => {
+  const decision = interrupt({
+    prompt: "Approve nested subgraph action?",
+    request: state.request,
+  });
+
+  return {
+    decision:
+      decision != null && typeof decision === "object"
+        ? (decision as Record<string, unknown>)
+        : { value: decision },
+    completed: true,
+  };
+};
+
+const grandchild = new StateGraph(GraphState)
+  .addNode("review", reviewNode)
+  .addEdge(START, "review")
+  .addEdge("review", END)
+  .compile();
+
+const child = new StateGraph(GraphState)
+  .addNode("inner", grandchild, { subgraphs: [grandchild] })
+  .addEdge(START, "inner")
+  .addEdge("inner", END)
+  .compile();
+
+const workflow = new StateGraph(GraphState)
+  .addNode("child", child, { subgraphs: [child] })
+  .addEdge(START, "child")
+  .addEdge("child", END);
+
+export const graph = workflow.compile();

--- a/libs/sdk-vue/src/tests/stream.nested-interrupts.test.tsx
+++ b/libs/sdk-vue/src/tests/stream.nested-interrupts.test.tsx
@@ -1,0 +1,156 @@
+import { expect, it } from "vitest";
+import { render } from "vitest-browser-vue";
+
+import { NestedInterruptStream } from "./components/NestedInterruptStream.js";
+import { apiUrl } from "./test-utils.js";
+
+const nestedSubmitInput = { request: "ship nested change" };
+const deepAgentSubmitInput = {
+  messages: [{ role: "user", content: "Please get approval" }],
+};
+
+it(
+  "surfaces a nested StateGraph interrupt live on useStream().interrupts",
+  { timeout: 20_000 },
+  async () => {
+    const screen = await render(NestedInterruptStream, {
+      props: {
+        apiUrl,
+        assistantId: "nested_interrupt_graph",
+        submitInput: nestedSubmitInput,
+      },
+    });
+
+    try {
+      await screen.getByTestId("submit").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 15_000 })
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("interrupt-prompt"))
+        .toHaveTextContent("Approve nested subgraph action?");
+      await expect
+        .element(screen.getByTestId("interrupt-id"))
+        .not.toHaveTextContent("");
+
+      const namespaceText =
+        screen.getByTestId("interrupt-namespace").element().textContent ?? "[]";
+      const namespace = JSON.parse(namespaceText) as string[];
+      expect(namespace.length).toBeGreaterThan(0);
+
+      await screen.getByTestId("resume").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 15_000 })
+        .toHaveTextContent("0");
+      await expect
+        .element(screen.getByTestId("completed"), { timeout: 15_000 })
+        .toHaveTextContent("true");
+    } finally {
+      await screen.unmount();
+    }
+  }
+);
+
+it(
+  "surfaces a createDeepAgent subagent interrupt live on useStream().interrupts",
+  { timeout: 30_000 },
+  async () => {
+    const screen = await render(NestedInterruptStream, {
+      props: {
+        apiUrl,
+        assistantId: "deep_agent_interrupt",
+        submitInput: deepAgentSubmitInput,
+      },
+    });
+
+    try {
+      await screen.getByTestId("submit").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 20_000 })
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("interrupt-prompt"))
+        .toHaveTextContent("Approve subagent tool action?");
+      await expect
+        .element(screen.getByTestId("interrupt-id"))
+        .not.toHaveTextContent("");
+
+      const namespaceText =
+        screen.getByTestId("interrupt-namespace").element().textContent ?? "[]";
+      const namespace = JSON.parse(namespaceText) as string[];
+      expect(namespace.length).toBeGreaterThan(0);
+
+      await screen.getByTestId("resume").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 20_000 })
+        .toHaveTextContent("0");
+      await expect
+        .element(screen.getByTestId("loading"), { timeout: 20_000 })
+        .toHaveTextContent("Not loading");
+    } finally {
+      await screen.unmount();
+    }
+  }
+);
+
+it(
+  "hydrates a nested StateGraph interrupt after remount",
+  { timeout: 30_000 },
+  async () => {
+    let capturedThreadId: string | undefined;
+
+    const seed = await render(NestedInterruptStream, {
+      props: {
+        apiUrl,
+        assistantId: "nested_interrupt_graph",
+        submitInput: nestedSubmitInput,
+        onThreadId: (id: string) => {
+          capturedThreadId = id;
+        },
+      },
+    });
+    try {
+      await seed.getByTestId("submit").click();
+      await expect
+        .element(seed.getByTestId("interrupt-count"), { timeout: 15_000 })
+        .toHaveTextContent("1");
+    } finally {
+      await seed.unmount();
+    }
+    expect(capturedThreadId).toMatch(/.+/);
+
+    const screen = await render(NestedInterruptStream, {
+      props: {
+        apiUrl,
+        assistantId: "nested_interrupt_graph",
+        threadId: capturedThreadId,
+        submitInput: nestedSubmitInput,
+      },
+    });
+    try {
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 15_000 })
+        .toHaveTextContent("1");
+
+      const namespaceText =
+        screen.getByTestId("interrupt-namespace").element().textContent ?? "[]";
+      const namespace = JSON.parse(namespaceText) as string[];
+      expect(namespace.length).toBeGreaterThan(0);
+
+      await screen.getByTestId("resume").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 15_000 })
+        .toHaveTextContent("0");
+      await expect
+        .element(screen.getByTestId("completed"), { timeout: 15_000 })
+        .toHaveTextContent("true");
+    } finally {
+      await screen.unmount();
+    }
+  }
+);

--- a/libs/sdk/src/client/stream/types.ts
+++ b/libs/sdk/src/client/stream/types.ts
@@ -231,10 +231,10 @@ export interface ThreadModules {
  * Matches the in-process `InterruptPayload` type.
  *
  * {@link ThreadStream.interrupts} collects these entries in arrival order.
- * Use them (via {@link StreamController.getThread `getThread()`}) when
- * you need the protocol `namespace` tuple for
- * {@link StreamController.respond `respond()`} — for example subgraph
- * interrupts that are not mirrored on {@link RootSnapshot.interrupts}.
+ * The same pending interrupts (including nested namespaces) are also
+ * mirrored onto {@link RootSnapshot.interrupts} / framework
+ * `stream.interrupts` for UI rendering; `respond()` resolves `namespace`
+ * from either list when only `interruptId` is supplied.
  */
 export interface InterruptPayload<TPayload = unknown> {
   interruptId: string;

--- a/libs/sdk/src/schema.ts
+++ b/libs/sdk/src/schema.ts
@@ -172,6 +172,14 @@ export interface Interrupt<TValue = unknown> {
   value?: TValue;
 
   /**
+   * Protocol namespace tuple for resume targeting (`[]` at root).
+   * Populated for nested subgraph / subagent interrupts so
+   * `respond({ interruptId })` can resume without a separate
+   * `getThread()?.interrupts` lookup.
+   */
+  namespace?: string[];
+
+  /**
    * Will be deprecated in the future.
    * @deprecated Will be removed in the future.
    */

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -92,7 +92,8 @@ function inputRequestedEvent(
         args: { to: "qa@example.com" },
       },
     ],
-  }
+  },
+  namespace: string[] = []
 ): Event {
   return {
     type: "event",
@@ -100,7 +101,7 @@ function inputRequestedEvent(
     seq: 1,
     method: "input.requested",
     params: {
-      namespace: [],
+      namespace,
       timestamp: 0,
       data: {
         interrupt_id: interruptId,
@@ -635,6 +636,157 @@ describe("StreamController", () => {
       "active-2",
     ]);
     expect(snapshot.interrupt?.id).toBe("active-1");
+
+    await controller.dispose();
+  });
+
+  it("mirrors nested input.requested into rootStore.interrupts with namespace", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+
+    let onEvent: ((event: Event) => void) | undefined;
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        onEvent = listener;
+        return vi.fn();
+      }),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {}, next: ["agent"] })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, unknown>({
+      assistantId: "human-in-the-loop",
+      client: client as never,
+      threadId: "thread-nested",
+    });
+    await controller.hydrationPromise;
+    expect(onEvent).toBeDefined();
+
+    const nestedNs = ["tools:task-abc"];
+    onEvent?.(
+      inputRequestedEvent(
+        "nested-int-1",
+        { prompt: "Approve nested action?" },
+        nestedNs
+      )
+    );
+
+    const snapshot = controller.rootStore.getSnapshot();
+    expect(snapshot.interrupts).toHaveLength(1);
+    expect(snapshot.interrupt?.id).toBe("nested-int-1");
+    expect(snapshot.interrupt?.namespace).toEqual(nestedNs);
+    expect(snapshot.interrupt?.value).toEqual({
+      prompt: "Approve nested action?",
+    });
+
+    await controller.dispose();
+  });
+
+  it("hydrate seeds nested task interrupt namespaces from checkpoint_ns", async () => {
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({
+          values: {},
+          tasks: [
+            {
+              checkpoint: {
+                checkpoint_ns: "child:u1|inner:u2",
+              },
+              interrupts: [
+                { id: "nested-active", value: { prompt: "nested?" } },
+              ],
+            },
+            {
+              interrupts: [{ id: "root-active", value: { prompt: "root?" } }],
+            },
+          ],
+        })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, unknown>({
+      assistantId: "human-in-the-loop",
+      client: client as never,
+      threadId: "thread-hydrate-ns",
+    });
+    await controller.hydrationPromise;
+
+    const snapshot = controller.rootStore.getSnapshot();
+    expect(snapshot.interrupts.map((i) => i.id)).toEqual([
+      "nested-active",
+      "root-active",
+    ]);
+    expect(snapshot.interrupts[0]?.namespace).toEqual(["child:u1", "inner:u2"]);
+    expect(snapshot.interrupts[1]?.namespace).toEqual([]);
+
+    await controller.dispose();
+  });
+
+  it("respond() resolves nested namespace from thread.interrupts when only interruptId is passed", async () => {
+    const nestedNs = ["tools:call-xyz"];
+    const respondInput = vi.fn(async () => undefined);
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [
+        {
+          interruptId: "nested-int",
+          payload: { prompt: "Approve?" },
+          namespace: nestedNs,
+        },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({
+          values: {},
+          tasks: [
+            {
+              checkpoint: { checkpoint_ns: "tools:call-xyz" },
+              interrupts: [{ id: "nested-int", value: { prompt: "Approve?" } }],
+            },
+          ],
+        })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, { prompt: string }>({
+      assistantId: "interrupt_graph",
+      client: client as never,
+      threadId: "thread-nested-respond",
+    });
+    await controller.hydrationPromise;
+
+    await controller.respond(
+      { approved: true },
+      { interruptId: "nested-int" }
+    );
+    expect(respondInput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interrupt_id: "nested-int",
+        namespace: nestedNs,
+        response: { approved: true },
+      })
+    );
 
     await controller.dispose();
   });

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -674,9 +674,16 @@ export class StreamController<
         const activeIds = new Set<string>();
         for (const task of state.tasks) {
           if (!Array.isArray(task?.interrupts)) continue;
+          const checkpointNs = (
+            task as { checkpoint?: { checkpoint_ns?: unknown } | null }
+          )?.checkpoint?.checkpoint_ns;
+          const namespace =
+            typeof checkpointNs === "string" && checkpointNs.length > 0
+              ? checkpointNs.split("|").filter((segment) => segment.length > 0)
+              : [...ROOT_NAMESPACE];
           for (const interrupt of task.interrupts) {
             const typed = interrupt as
-              | { id?: string; value?: unknown }
+              | { id?: string; value?: unknown; namespace?: string[] }
               | null
               | undefined;
             const id = typed?.id;
@@ -686,6 +693,9 @@ export class StreamController<
               normalizeInterruptForClient({
                 id,
                 value: typed?.value as InterruptType,
+                namespace: Array.isArray(typed?.namespace)
+                  ? [...typed.namespace]
+                  : namespace,
               })
             );
           }
@@ -1210,14 +1220,15 @@ export class StreamController<
    * oldest and picks the first entry whose `interruptId` has not already
    * been resolved by a prior `respond()` call. That entry may be at the
    * root (`namespace: []`) or inside a subgraph (non-empty `namespace`).
-   * This is **not** the same as {@link RootSnapshot.interrupts
-   * `rootStore.interrupts[0]`} / framework `stream.interrupt`, which only
-   * mirrors root-namespace interrupts for UI convenience.
+   * {@link RootSnapshot.interrupts `rootStore.interrupts`} /
+   * framework `stream.interrupts` mirrors the same pending interrupts
+   * (including nested namespaces) for UI rendering.
    *
    * Omitting `interruptId` is fine when exactly one interrupt is pending.
    * When several can be active (parallel subagents, fan-out, nested
-   * graphs), pass an explicit `interruptId` (and `namespace` for subgraph
-   * interrupts) so you resume the interrupt the user acted on.
+   * graphs), pass an explicit `interruptId` so you resume the interrupt
+   * the user acted on. `namespace` is resolved automatically from
+   * `thread.interrupts` / `stream.interrupts` when omitted.
    *
    * To resume several interrupts pending at the same checkpoint in one
    * command, use {@link respondAll} — sequential single `respond()` calls
@@ -1225,9 +1236,8 @@ export class StreamController<
    * others with no interrupted run to respond to.
    *
    * The server validates `namespace` against the pending interrupt. Root
-   * interrupts use `namespace: []` (the default when `namespace` is
-   * omitted). Subgraph interrupts require the exact tuple from
-   * `getThread()?.interrupts` — see the example below.
+   * interrupts use `namespace: []`. Subgraph interrupts carry the exact
+   * tuple on each {@link Interrupt} / {@link InterruptPayload} entry.
    *
    * @param response - Payload sent back to the interrupted namespace.
    * @param options - Optional target (`interruptId` / `namespace`) and
@@ -1248,27 +1258,16 @@ export class StreamController<
    * );
    * ```
    *
-   * @example Multiple root interrupts — target by id
+   * @example Multiple / nested interrupts — target by id
    * ```tsx
    * for (const intr of stream.interrupts) {
    *   await stream.respond(decide(intr.value), { interruptId: intr.id! });
    * }
    * ```
    *
-   * @example Subgraph interrupt — read `namespace` from the thread stream
-   * ```tsx
-   * const thread = stream.getThread();
-   * for (const entry of thread?.interrupts ?? []) {
-   *   await stream.respond(buildResponse(entry.payload), {
-   *     interruptId: entry.interruptId,
-   *     namespace: entry.namespace,
-   *   });
-   * }
-   * ```
-   *
-   * Each {@link InterruptPayload} on `thread.interrupts` mirrors an
-   * `input.requested` event: `{ interruptId, payload, namespace }`.
-   * Nested interrupts may appear here but not on `stream.interrupts`.
+   * Each {@link InterruptPayload} on `thread.interrupts` and each
+   * {@link Interrupt} on `stream.interrupts` mirrors an
+   * `input.requested` event with its protocol `namespace`.
    */
   async respond(
     response: unknown,
@@ -1282,7 +1281,10 @@ export class StreamController<
       options?.interruptId != null
         ? {
             interruptId: options.interruptId,
-            namespace: options.namespace ?? [...ROOT_NAMESPACE],
+            namespace: this.#resolveNamespaceForInterruptId(
+              options.interruptId,
+              options.namespace
+            ),
           }
         : this.#resolveInterruptForResume();
     if (resolved == null) {
@@ -1880,16 +1882,14 @@ export class StreamController<
     this.#lifecycleLoading.handle(event);
 
     /**
-     * Nested `input.requested` events (HITL inside a subagent /
-     * subgraph) are not observable via the narrow content pump. The
-     * `ThreadStream` itself already records them into
-     * `thread.interrupts`, which `#latestUnresolvedInterrupt()`
-     * consults — so HITL respond() works for any depth. Root-level
-     * interrupts are also mirrored into `rootStore.interrupts` here so
-     * UI state does not depend on the narrower content pump being the
-     * first consumer to see the event.
+     * `input.requested` events (including HITL inside a subagent /
+     * subgraph) are not always observable via the narrow content pump.
+     * Mirror every namespace into `rootStore.interrupts` here so UI
+     * state does not depend on the content pump being the first
+     * consumer. `ThreadStream.interrupts` is updated in parallel for
+     * resume targeting.
      */
-    this.#recordRootInterrupt(event);
+    this.#recordInterrupt(event);
   }
 
   /**
@@ -2041,7 +2041,7 @@ export class StreamController<
     }
 
     if (event.method === "input.requested") {
-      this.#recordRootInterrupt(event);
+      this.#recordInterrupt(event);
       return;
     }
 
@@ -2242,14 +2242,13 @@ export class StreamController<
   }
 
   /**
-   * Mirror root protocol interrupts into the root snapshot.
+   * Mirror protocol interrupts (any namespace) into the root snapshot.
    *
    * This can be called from both the wildcard lifecycle/input watcher and the
    * root content pump. Store-level dedup keeps the user-facing list stable.
    */
-  #recordRootInterrupt(event: Event): void {
+  #recordInterrupt(event: Event): void {
     if (event.method !== "input.requested") return;
-    if (!isRootNamespace(event.params.namespace)) return;
     const data = event.params.data as {
       interrupt_id?: string;
       payload?: unknown;
@@ -2274,15 +2273,42 @@ export class StreamController<
     ) {
       return;
     }
+    const namespace = Array.isArray(event.params.namespace)
+      ? [...event.params.namespace]
+      : [...ROOT_NAMESPACE];
     const interrupt: Interrupt<InterruptType> = normalizeInterruptForClient({
       id: interruptId,
       value: data.payload as InterruptType,
+      namespace,
     });
     this.rootStore.setState((s) => {
       if (s.interrupts.some((entry) => entry.id === interruptId)) return s;
       const interrupts = [...s.interrupts, interrupt];
       return { ...s, interrupts, interrupt: interrupts[0] };
     });
+  }
+
+  /**
+   * Resolve the protocol namespace for a targeted resume.
+   *
+   * Prefer an explicit caller-supplied namespace, then the matching
+   * {@link ThreadStream.interrupts} entry, then the UI mirror on
+   * `rootStore.interrupts`, finally root (`[]`).
+   */
+  #resolveNamespaceForInterruptId(
+    interruptId: string,
+    explicitNamespace?: string[]
+  ): string[] {
+    if (explicitNamespace != null) return [...explicitNamespace];
+    const fromThread = this.#thread?.interrupts.find(
+      (entry) => entry.interruptId === interruptId
+    )?.namespace;
+    if (fromThread != null) return [...fromThread];
+    const fromRoot = this.rootStore
+      .getSnapshot()
+      .interrupts.find((entry) => entry.id === interruptId)?.namespace;
+    if (fromRoot != null) return [...fromRoot];
+    return [...ROOT_NAMESPACE];
   }
 
   /**

--- a/libs/sdk/src/stream/types.ts
+++ b/libs/sdk/src/stream/types.ts
@@ -132,9 +132,9 @@ export interface StreamRespondOptions<
    */
   interruptId?: string;
   /**
-   * Namespace of the targeted interrupt. Root interrupts use `[]` (the
-   * default when omitted). Subgraph interrupts require the exact tuple
-   * from `getThread()?.interrupts`.
+   * Namespace of the targeted interrupt. Root interrupts use `[]`.
+   * When omitted, resolved from `thread.interrupts` /
+   * `stream.interrupts` for the given `interruptId`.
    */
   namespace?: string[];
 }


### PR DESCRIPTION
Nested `interrupt()` calls (subgraphs / createDeepAgent subagents) never showed up on `useStream().interrupts` while the run was live — `#recordRootInterrupt` early-returned on non-root namespaces — but hydrate seeded them from `state.tasks`, so the same interrupt appeared after a reload. Mirror every `input.requested` onto `rootStore.interrupts` with `Interrupt.namespace`, and look that namespace up in `respond({ interruptId })` when it isn't passed explicitly.
