### PR TITLE
fix(sdk): deliver input channel events on the root-bus fast path

### DIFF
--- a/.changeset/fix-channel-projection-input-fast-path.md
+++ b/.changeset/fix-channel-projection-input-fast-path.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): deliver input channel events on the root-bus fast path
+
+`channelProjection` with `replay: false` (the `useChannelEffect` default) compared `event.method` to channel names, so `input.requested` never matched `"input"`. Match via `inferChannel` instead, same as the slow path.

--- a/libs/sdk/src/client/stream/subscription.ts
+++ b/libs/sdk/src/client/stream/subscription.ts
@@ -82,7 +82,6 @@ export function inferChannel(event: Event): Channel | undefined {
     }
     case "lifecycle":
       return "lifecycle";
-    case "input":
     case "input.requested":
       return "input";
     case "tasks":

--- a/libs/sdk/src/client/stream/subscription.ts
+++ b/libs/sdk/src/client/stream/subscription.ts
@@ -82,6 +82,7 @@ export function inferChannel(event: Event): Channel | undefined {
     }
     case "lifecycle":
       return "lifecycle";
+    case "input":
     case "input.requested":
       return "input";
     case "tasks":

--- a/libs/sdk/src/stream/projections/channel.test.ts
+++ b/libs/sdk/src/stream/projections/channel.test.ts
@@ -116,4 +116,69 @@ describe("channelProjection", () => {
     expect(rootBus.subscribe).toHaveBeenCalledTimes(1);
     expect(thread.subscribe).not.toHaveBeenCalled();
   });
+
+  it("delivers input.requested on the root-bus fast path", () => {
+    // `useChannelEffect` defaults to replay: false, which takes this path.
+    // Events use method "input.requested", not "input" — matching must go
+    // through inferChannel, not a raw method===channel compare.
+    const rootBus = makeRootBus(["input"]);
+    const projection = channelProjection(["input"], [], { replay: false });
+    const store = new StreamStore(projection.initial);
+    const thread = {
+      subscribe: vi.fn(),
+    } as unknown as ThreadStream;
+    const requested = {
+      type: "event",
+      method: "input.requested",
+      params: {
+        namespace: [],
+        timestamp: 0,
+        data: { interrupt_id: "i1", value: { question: "approve?" } },
+      },
+    } as unknown as Event;
+
+    projection.open({ thread, store, rootBus: rootBus as RootEventBus });
+    rootBus.emit(requested);
+
+    expect(store.getSnapshot()).toEqual([requested]);
+    expect(thread.subscribe).not.toHaveBeenCalled();
+  });
+
+  it("delivers named custom events on the root-bus fast path", () => {
+    // Force the fast path by advertising the requested channel; the
+    // matcher still has to resolve method "custom" + data.name → channel.
+    const rootBus = makeRootBus(["custom:a2a"] as Channel[]);
+    const projection = channelProjection(["custom:a2a"], [], {
+      replay: false,
+    });
+    const store = new StreamStore(projection.initial);
+    const thread = {
+      subscribe: vi.fn(),
+    } as unknown as ThreadStream;
+    const a2a = {
+      type: "event",
+      method: "custom",
+      params: {
+        namespace: [],
+        timestamp: 0,
+        data: { name: "a2a", payload: { status: "working" } },
+      },
+    } as unknown as Event;
+    const other = {
+      type: "event",
+      method: "custom",
+      params: {
+        namespace: [],
+        timestamp: 0,
+        data: { name: "other", payload: {} },
+      },
+    } as unknown as Event;
+
+    projection.open({ thread, store, rootBus: rootBus as RootEventBus });
+    rootBus.emit(a2a);
+    rootBus.emit(other);
+
+    expect(store.getSnapshot()).toEqual([a2a]);
+    expect(thread.subscribe).not.toHaveBeenCalled();
+  });
 });

--- a/libs/sdk/src/stream/projections/channel.ts
+++ b/libs/sdk/src/stream/projections/channel.ts
@@ -11,6 +11,7 @@
  * for inspection, custom reducers, or niche use-cases.
  */
 import type { Channel, Event } from "@langchain/protocol";
+import { inferChannel } from "../../client/stream/subscription.js";
 import type { ProjectionSpec, ProjectionRuntime } from "../types.js";
 import { isRootNamespace, namespaceKey } from "../namespace.js";
 import { openProjectionSubscription } from "./runtime.js";
@@ -61,27 +62,18 @@ export function channelProjection(
 
       if (covered) {
         const requestedSet = new Set(chs as Channel[]);
-        // Pre-compute `custom:<name>` sub-filters so incoming events
-        // can be matched in O(1). The server delivers named custom
-        // events as `{ method: "custom", params: { data: { name } } }`,
-        // so matching purely on `event.method` would miss them — we
-        // need to peek at `data.name` when the caller asked for a
-        // specific `custom:<name>` channel.
-        const namedCustom = new Set<string>();
-        for (const channel of chs) {
-          if (channel.startsWith("custom:")) {
-            namedCustom.add(channel.slice("custom:".length));
-          }
-        }
+        // Classify via `inferChannel` so namespaced methods (e.g.
+        // `input.requested` → `input`) and named custom events
+        // (`custom` + `data.name` → `custom:<name>`) match the same
+        // way as the slow path's `matchesSubscription`. Comparing
+        // `event.method` to channel names would silently drop `input`.
         const matches = (event: Event): boolean => {
-          if (requestedSet.has(event.method as Channel)) return true;
-          if (event.method !== "custom" || namedCustom.size === 0) {
-            return false;
-          }
-          const data = (event.params as Record<string, unknown>).data as
-            | { name?: unknown }
-            | undefined;
-          return typeof data?.name === "string" && namedCustom.has(data.name);
+          const channel = inferChannel(event);
+          if (channel === undefined) return false;
+          return (
+            requestedSet.has(channel) ||
+            (channel.startsWith("custom:") && requestedSet.has("custom"))
+          );
         };
         const push = (event: Event): void => {
           if (!matches(event)) return;


### PR DESCRIPTION
`channelProjection` with `replay: false` (the `useChannelEffect` default) matched root-bus events by comparing `event.method` to channel names. That works for `values` / `messages` / etc., but input events are `input.requested`, so subscribers to `["input"]` got nothing and no error.

The fast path now classifies with `inferChannel`, same as the slow subscription path.

## Test plan
- [x] `pnpm exec vitest run src/stream/projections/channel.test.ts src/client/stream/subscription.test.ts src/stream/projections/channel-effect.test.ts` (from `libs/sdk`)
- [x] Changeset added for affected package(s)
- [ ] `useChannelEffect(stream, ["input"], { onEvent })` on a graph that `interrupt()`s — callback fires without needing `replay: true`