### PR TITLE
fix(sdk): resolve respond() namespace from interrupt id

### DIFF
--- a/.changeset/fix-respond-resolve-interrupt-namespace.md
+++ b/.changeset/fix-respond-resolve-interrupt-namespace.md
@@ -1,0 +1,12 @@
+---
+"@langchain/langgraph-sdk": patch
+"@langchain/react": patch
+"@langchain/angular": patch
+"@langchain/vue": patch
+"@langchain/svelte": patch
+---
+
+fix(sdk): resolve respond() namespace from interrupt id
+
+When callers pass `{ interruptId }` without `namespace`, look the
+namespace up on `thread.interrupts` instead of defaulting to root.

--- a/libs/sdk-angular/docs/interrupts.md
+++ b/libs/sdk-angular/docs/interrupts.md
@@ -54,9 +54,9 @@ export class ChatComponent {
 
 ## Responding to a specific interrupt
 
-When multiple interrupts are pending, pass `{ interruptId, namespace? }`.
-Root interrupts can omit `namespace` (defaults to `[]`). Subgraph
-interrupts need the exact tuple from `getThread()?.interrupts`:
+When multiple interrupts are pending, pass `{ interruptId }`. When
+`namespace` is omitted, it is resolved from `getThread()?.interrupts` by
+that id (falling back to root `[]` only if the id is unknown):
 
 ```typescript
 for (const intr of stream.interrupts()) {
@@ -67,7 +67,6 @@ const thread = stream.getThread();
 for (const entry of thread?.interrupts ?? []) {
   await stream.respond(buildResponse(entry.payload), {
     interruptId: entry.interruptId,
-    namespace: entry.namespace,
   });
 }
 ```

--- a/libs/sdk-angular/src/use-stream.ts
+++ b/libs/sdk-angular/src/use-stream.ts
@@ -262,12 +262,9 @@ export interface UseStreamReturn<
    * `respond()` call. That may be a root or subgraph interrupt and is
    * **not** necessarily {@link interrupt} (`interrupts()[0]`, root-only).
    * Safe when exactly one interrupt is pending; otherwise pass an explicit
-   * `options.interruptId` (and `options.namespace` for subgraph
-   * interrupts).
-   *
-   * The server validates `namespace` against the pending interrupt. Root
-   * interrupts use `namespace: []` (default when omitted). For subgraph
-   * interrupts, copy `namespace` from `getThread()?.interrupts`.
+   * `options.interruptId`. When `options.namespace` is omitted, it is
+   * resolved from `getThread()?.interrupts` by that id (falling back to
+   * root `[]` only if the id is unknown).
    *
    * Pass `options.update` (and/or `options.goto`) to apply a state update
    * (and/or directed jump) in the **same superstep** as the resume — mapped
@@ -311,12 +308,11 @@ export interface UseStreamReturn<
    *
    * @example
    * ```ts
-   * // Subgraph interrupt — namespace from `getThread()`
+   * // Nested interrupt — namespace resolved from the id
    * const thread = stream.getThread();
    * for (const entry of thread?.interrupts ?? []) {
    *   await stream.respond(buildResponse(entry.payload), {
    *     interruptId: entry.interruptId,
-   *     namespace: entry.namespace,
    *   });
    * }
    * ```

--- a/libs/sdk-react/docs/interrupts.md
+++ b/libs/sdk-react/docs/interrupts.md
@@ -65,7 +65,7 @@ That list includes root **and** subgraph interrupts. It is **not** the same as `
 | Surface | What it contains | Use for |
 | ------- | ---------------- | ------- |
 | `stream.interrupts` | Root-namespace interrupts (`{ id, value }`) | Rendering root HITL UI |
-| `stream.getThread()?.interrupts` | All protocol interrupts (`{ interruptId, payload, namespace }`) | Targeting + namespace for `respond()` |
+| `stream.getThread()?.interrupts` | All protocol interrupts (`{ interruptId, payload, namespace }`) | Targeting nested / all interrupts |
 
 When several root interrupts are pending, target by id:
 
@@ -82,13 +82,13 @@ stream.interrupts.map((intr) => (
 ));
 ```
 
-Root interrupts use `namespace: []`. You can omit `namespace` in the target — it defaults to the root tuple.
+When `namespace` is omitted, `respond()` looks it up from `getThread()?.interrupts` by `interruptId` (falling back to root `[]` only if the id is unknown). An explicit `namespace` overrides the lookup.
 
 ## Subgraph interrupts and namespace
 
 Interrupts raised inside a subagent or nested graph carry a **non-empty** protocol `namespace` tuple (for example `["task:research"]`). The server validates that tuple when you resume.
 
-Those entries appear on `stream.getThread()?.interrupts` but may **not** appear on `stream.interrupts`. Read `namespace` from the thread stream entry — do not guess it from UI state:
+Those entries appear on `stream.getThread()?.interrupts` but may **not** appear on `stream.interrupts`. Passing `{ interruptId }` is enough — the SDK resolves `namespace` from the thread stream:
 
 ```tsx
 const thread = stream.getThread();
@@ -105,7 +105,6 @@ return (
           onClick={() =>
             void stream.respond(buildResponse(entry.payload), {
               interruptId: entry.interruptId,
-              namespace: entry.namespace,
             })
           }
         >
@@ -117,7 +116,7 @@ return (
 );
 ```
 
-Each entry mirrors an `input.requested` event: `{ interruptId, payload, namespace }`. Pass both `interruptId` and `namespace` for subgraph interrupts; omitting `namespace` assumes root (`[]`) and the server will reject the resume if the pending interrupt lives in a subgraph.
+Each entry mirrors an `input.requested` event: `{ interruptId, payload, namespace }`.
 
 ## `respond(response, options?)`
 
@@ -140,8 +139,8 @@ stream.respond(
 | `options.interruptId` | Behavior |
 | --------------------- | -------- |
 | Omitted | Newest unresolved entry in `getThread()?.interrupts`. Safe when one interrupt is pending. |
-| `interruptId` set | Resume that id at root (`namespace: []`). |
-| `interruptId` + `namespace` | Resume that id in the given subgraph namespace. Required when the interrupt is not at root. |
+| `interruptId` set | Resume that id; `namespace` resolved from `getThread()?.interrupts` (root `[]` if unknown). |
+| `interruptId` + `namespace` | Resume that id in the given namespace (overrides the lookup). |
 
 `options.config` / `options.metadata` are folded into the run that services the resume — the same `config` / `metadata` you'd pass to `submit()`. Use them to carry model/user config or run metadata (e.g. trigger source) onto a HITL resume.
 

--- a/libs/sdk-react/docs/use-stream.md
+++ b/libs/sdk-react/docs/use-stream.md
@@ -128,9 +128,7 @@ Pass `{ cancel: false }` to disconnect without cancelling server-side execution,
 
 ### `respond(response, options?)`
 
-Resume a single pending interrupt. When `options.interruptId` is omitted, `respond()` walks `stream.getThread()?.interrupts` from newest to oldest and resumes the first entry not yet resolved by a prior `respond()` call. That may be a root or subgraph interrupt — it is **not** necessarily `stream.interrupt` (`stream.interrupts[0]`, root-only). Safe when exactly one interrupt is pending; otherwise pass `options.interruptId` (and `options.namespace` for subgraph interrupts).
-
-The server validates `namespace` against the pending interrupt. Root interrupts use `namespace: []` (default when omitted). For subgraph interrupts, copy `namespace` from `getThread()?.interrupts` — see [Interrupts](./interrupts.md#subgraph-interrupts-and-namespace).
+Resume a single pending interrupt. When `options.interruptId` is omitted, `respond()` walks `stream.getThread()?.interrupts` from newest to oldest and resumes the first entry not yet resolved by a prior `respond()` call. That may be a root or subgraph interrupt — it is **not** necessarily `stream.interrupt` (`stream.interrupts[0]`, root-only). Safe when exactly one interrupt is pending; otherwise pass `options.interruptId`. When `options.namespace` is omitted, it is resolved from `getThread()?.interrupts` by that id (falling back to root `[]` only if the id is unknown) — see [Interrupts](./interrupts.md#subgraph-interrupts-and-namespace).
 
 Pass `options.config` / `options.metadata` to fold run-level config (model, user context, …) and metadata (trigger source, test flags, …) into the resumed run, mirroring `submit()`.
 
@@ -138,17 +136,8 @@ Pass `options.config` / `options.metadata` to fold run-level config (model, user
 // Single pending interrupt — omit target:
 await stream.respond({ approved: true });
 
-// Multiple root interrupts — target by id:
+// Multiple / nested interrupts — target by id (namespace resolved):
 await stream.respond({ approved: true }, { interruptId: myInterrupt.id! });
-
-// Subgraph interrupt — namespace from getThread():
-const entry = stream.getThread()?.interrupts.find(
-  (e) => e.interruptId === myInterruptId,
-);
-await stream.respond(
-  { approved: true },
-  { interruptId: entry!.interruptId, namespace: entry!.namespace },
-);
 
 // Carry run config + metadata onto the resume:
 await stream.respond({ approved: true }, {

--- a/libs/sdk-react/src/use-stream.ts
+++ b/libs/sdk-react/src/use-stream.ts
@@ -243,12 +243,9 @@ export interface UseStreamReturn<
    * `respond()` call. That may be a root or subgraph interrupt and is
    * **not** necessarily {@link interrupt} (`interrupts[0]`, root-only).
    * Safe when exactly one interrupt is pending; otherwise pass an explicit
-   * `options.interruptId` (and `options.namespace` for subgraph
-   * interrupts).
-   *
-   * The server validates `namespace` against the pending interrupt. Root
-   * interrupts use `namespace: []` (default when omitted). For subgraph
-   * interrupts, copy `namespace` from `getThread()?.interrupts`.
+   * `options.interruptId`. When `options.namespace` is omitted, it is
+   * resolved from `getThread()?.interrupts` by that id (falling back to
+   * root `[]` only if the id is unknown).
    *
    * Pass `options.config` / `options.metadata` to fold run-level config
    * (model, user context, …) and metadata (trigger source, test flags,
@@ -310,7 +307,7 @@ export interface UseStreamReturn<
    *
    * @example
    * ```tsx
-   * // Subgraph interrupt — namespace from `getThread()`
+   * // Nested interrupt — namespace resolved from the id
    * const thread = stream.getThread();
    * thread?.interrupts.map((entry) => (
    *   <button
@@ -318,7 +315,6 @@ export interface UseStreamReturn<
    *     onClick={() =>
    *       void stream.respond(buildResponse(entry.payload), {
    *         interruptId: entry.interruptId,
-   *         namespace: entry.namespace,
    *       })
    *     }
    *   />

--- a/libs/sdk-svelte/docs/interrupts.md
+++ b/libs/sdk-svelte/docs/interrupts.md
@@ -22,7 +22,7 @@ When a graph pauses on an interrupt, `stream.interrupt` (and the full list in `s
 
 ### Targeting a specific interrupt
 
-When multiple concurrent interrupts are in flight (subagents, fan-out, nested graphs), pass `{ interruptId, namespace? }`. Root interrupts can omit `namespace` (defaults to `[]`). Subgraph interrupts need the exact tuple from `getThread()?.interrupts`:
+When multiple concurrent interrupts are in flight (subagents, fan-out, nested graphs), pass `{ interruptId }`. When `namespace` is omitted, it is resolved from `getThread()?.interrupts` by that id (falling back to root `[]` only if the id is unknown):
 
 ```ts
 await stream.respond(
@@ -34,7 +34,6 @@ const thread = stream.getThread();
 for (const entry of thread?.interrupts ?? []) {
   await stream.respond(buildResponse(entry.payload), {
     interruptId: entry.interruptId,
-    namespace: entry.namespace,
   });
 }
 ```

--- a/libs/sdk-svelte/src/use-stream.svelte.ts
+++ b/libs/sdk-svelte/src/use-stream.svelte.ts
@@ -263,12 +263,9 @@ export interface UseStreamReturn<
    * `respond()` call. That may be a root or subgraph interrupt and is
    * **not** necessarily {@link interrupt} (`interrupts[0]`, root-only).
    * Safe when exactly one interrupt is pending; otherwise pass an explicit
-   * `options.interruptId` (and `options.namespace` for subgraph
-   * interrupts).
-   *
-   * The server validates `namespace` against the pending interrupt. Root
-   * interrupts use `namespace: []` (default when omitted). For subgraph
-   * interrupts, copy `namespace` from `getThread()?.interrupts`.
+   * `options.interruptId`. When `options.namespace` is omitted, it is
+   * resolved from `getThread()?.interrupts` by that id (falling back to
+   * root `[]` only if the id is unknown).
    *
    * Pass `options.update` (and/or `options.goto`) to apply a state update
    * (and/or directed jump) in the **same superstep** as the resume — mapped
@@ -314,12 +311,11 @@ export interface UseStreamReturn<
    *
    * @example
    * ```ts
-   * // Subgraph interrupt — namespace from `getThread()`
+   * // Nested interrupt — namespace resolved from the id
    * const thread = stream.getThread();
    * for (const entry of thread?.interrupts ?? []) {
    *   await stream.respond(buildResponse(entry.payload), {
    *     interruptId: entry.interruptId,
-   *     namespace: entry.namespace,
    *   });
    * }
    * ```

--- a/libs/sdk-vue/docs/interrupts.md
+++ b/libs/sdk-vue/docs/interrupts.md
@@ -195,7 +195,7 @@ When `options.interruptId` is omitted, `respond()` walks `stream.getThread()?.in
 | Surface | What it contains | Use for |
 | ------- | ---------------- | ------- |
 | `stream.interrupts` | Root-namespace interrupts (`{ id, value }`) | Rendering root HITL UI |
-| `stream.getThread()?.interrupts` | All protocol interrupts (`{ interruptId, payload, namespace }`) | Targeting + namespace for `respond()` |
+| `stream.getThread()?.interrupts` | All protocol interrupts (`{ interruptId, payload, namespace }`) | Targeting nested / all interrupts |
 
 ```ts
 for (const intr of stream.interrupts.value) {
@@ -205,28 +205,27 @@ for (const intr of stream.interrupts.value) {
 
 ## Subgraph interrupts and namespace
 
-Subgraph interrupts carry a non-empty protocol `namespace` tuple (for example `["task:research"]`). The server validates it on resume. Read it from `getThread()?.interrupts` — nested entries may not appear on `stream.interrupts`:
+Subgraph interrupts carry a non-empty protocol `namespace` tuple (for example `["task:research"]`). The server validates it on resume. Nested entries may not appear on `stream.interrupts`, but passing `{ interruptId }` is enough — the SDK resolves `namespace` from `getThread()?.interrupts`:
 
 ```ts
 const thread = stream.getThread();
 for (const entry of thread?.interrupts ?? []) {
   await stream.respond(buildResponse(entry.payload), {
     interruptId: entry.interruptId,
-    namespace: entry.namespace,
   });
 }
 ```
 
 ## `respond(response, options?)`
 
-When multiple interrupts are active (subagents, fan-out, nested graphs), pass `options.interruptId` (and `options.namespace` for subgraph interrupts):
+When multiple interrupts are active (subagents, fan-out, nested graphs), pass `options.interruptId`. When `options.namespace` is omitted, it is resolved from `getThread()?.interrupts` by that id:
 
 ```ts
 await stream.respond({ approved: true });
 
 await stream.respond(
   { approved: true },
-  { interruptId: myInterrupt.id!, namespace: entry.namespace },
+  { interruptId: myInterrupt.id! },
 );
 ```
 

--- a/libs/sdk-vue/src/use-stream.ts
+++ b/libs/sdk-vue/src/use-stream.ts
@@ -270,12 +270,9 @@ export interface UseStreamReturn<
    * `respond()` call. That may be a root or subgraph interrupt and is
    * **not** necessarily {@link interrupt} (`interrupts[0]`, root-only).
    * Safe when exactly one interrupt is pending; otherwise pass an explicit
-   * `options.interruptId` (and `options.namespace` for subgraph
-   * interrupts).
-   *
-   * The server validates `namespace` against the pending interrupt. Root
-   * interrupts use `namespace: []` (default when omitted). For subgraph
-   * interrupts, copy `namespace` from `getThread()?.interrupts`.
+   * `options.interruptId`. When `options.namespace` is omitted, it is
+   * resolved from `getThread()?.interrupts` by that id (falling back to
+   * root `[]` only if the id is unknown).
    *
    * Pass `options.update` (and/or `options.goto`) to apply a state update
    * (and/or directed jump) in the **same superstep** as the resume — mapped
@@ -319,12 +316,11 @@ export interface UseStreamReturn<
    *
    * @example
    * ```tsx
-   * // Subgraph interrupt — namespace from `getThread()`
+   * // Nested interrupt — namespace resolved from the id
    * const thread = stream.getThread();
    * for (const entry of thread?.interrupts ?? []) {
    *   await stream.respond(buildResponse(entry.payload), {
    *     interruptId: entry.interruptId,
-   *     namespace: entry.namespace,
    *   });
    * }
    * ```

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -1813,6 +1813,142 @@ describe("StreamController", () => {
     await controller.dispose();
   });
 
+  it("respond() resolves namespace from thread.interrupts when only interruptId is provided", async () => {
+    const respondInput = vi.fn(async () => undefined);
+    const nestedNamespace = ["subgraph:child", "tools:tc-1"];
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [
+        {
+          interruptId: "int-nested",
+          payload: { prompt: "Approve nested?" },
+          namespace: nestedNamespace,
+        },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {}, next: ["agent"] })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, { prompt: string }>({
+      assistantId: "interrupt_graph",
+      client: client as never,
+      threadId: "thread-1",
+    });
+    await controller.hydrationPromise;
+
+    await controller.respond(
+      { approved: true },
+      { interruptId: "int-nested" }
+    );
+    expect(respondInput).toHaveBeenCalledWith({
+      namespace: nestedNamespace,
+      interrupt_id: "int-nested",
+      response: { approved: true },
+      config: undefined,
+      metadata: undefined,
+    });
+
+    await controller.dispose();
+  });
+
+  it("respond() keeps an explicit namespace over the thread.interrupts lookup", async () => {
+    const respondInput = vi.fn(async () => undefined);
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [
+        {
+          interruptId: "int-nested",
+          payload: { prompt: "Approve nested?" },
+          namespace: ["subgraph:child"],
+        },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {}, next: ["agent"] })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, { prompt: string }>({
+      assistantId: "interrupt_graph",
+      client: client as never,
+      threadId: "thread-1",
+    });
+    await controller.hydrationPromise;
+
+    await controller.respond(
+      { approved: true },
+      { interruptId: "int-nested", namespace: ["custom:override"] }
+    );
+    expect(respondInput).toHaveBeenCalledWith({
+      namespace: ["custom:override"],
+      interrupt_id: "int-nested",
+      response: { approved: true },
+      config: undefined,
+      metadata: undefined,
+    });
+
+    await controller.dispose();
+  });
+
+  it("respond() falls back to root namespace when interruptId is unknown", async () => {
+    const respondInput = vi.fn(async () => undefined);
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [
+        {
+          interruptId: "int-other",
+          payload: { prompt: "Other?" },
+          namespace: ["subgraph:child"],
+        },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {}, next: ["agent"] })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, { prompt: string }>({
+      assistantId: "interrupt_graph",
+      client: client as never,
+      threadId: "thread-1",
+    });
+    await controller.hydrationPromise;
+
+    await controller.respond(
+      { approved: true },
+      { interruptId: "int-missing" }
+    );
+    expect(respondInput).toHaveBeenCalledWith({
+      namespace: [],
+      interrupt_id: "int-missing",
+      response: { approved: true },
+      config: undefined,
+      metadata: undefined,
+    });
+
+    await controller.dispose();
+  });
+
   it("respondAll() resumes several interrupts at once with distinct payloads", async () => {
     let onEvent: ((event: Event) => void) | undefined;
     const respondInput = vi.fn(async () => undefined);

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -1439,12 +1439,10 @@ export class StreamController<
       throw new Error("respondAll() requires at least one response.");
     }
     const thread = this.#thread;
-    const pending = thread.interrupts;
     const responses = entries.map(([interruptId, response]) => ({
       interrupt_id: interruptId,
       response: normalizeHitlResponseForServer(response),
-      namespace: pending.find((entry) => entry.interruptId === interruptId)
-        ?.namespace ?? [...ROOT_NAMESPACE],
+      namespace: this.#resolveNamespaceForInterruptId(interruptId),
     }));
     // Apply the run-level `update` optimistically (see `respond()` for the
     // rationale): the batched resume's pushed messages paint immediately and


### PR DESCRIPTION
`respond(response, { interruptId })` was sending resumes with the root namespace whenever `namespace` was omitted. For subgraph interrupts that mis-targets the resume even though the id already uniquely identifies the pending interrupt on the thread.
Look the namespace up from `thread.interrupts` by id (same as `respondAll` / the no-arg path). An explicit `namespace` still overrides; unknown ids still fall back to root.
