### PR TITLE
fix(sdk): defer stream join until lazy thread create commits

### DIFF
--- a/.changeset/fix-lazy-thread-stream-join-race.md
+++ b/.changeset/fix-lazy-thread-stream-join-race.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): defer stream join until lazy thread create commits
+
+Hydrating an externally-minted thread id that 404s still opened `/stream/events` before `POST /commands` created the row. On langgraph_api's in-mem runtime that join is accepted but dead, so the first run delivered nothing until idle reconnect. Treat missing threads like client-minted ones and start the root pump only after dispatch succeeds.

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -925,6 +925,96 @@ describe("StreamController", () => {
     await controller.dispose();
   });
 
+  it("does NOT open SSE pumps on hydrate when the thread is missing (404)", async () => {
+    // Externally-minted ids (URL / localStorage) 404 on getState until
+    // the first submit's run.start creates the row. Opening
+    // /stream/events before that create races the in-mem runtime and
+    // strands the first run until idle reconnect.
+    const startLifecycleWatcher = vi.fn(() => undefined);
+    const subscribe = vi.fn(async () => makeNeverEndingSubscription());
+    const stream = vi.fn(() => {
+      throw new Error("threads.stream must not run for a missing thread");
+    });
+    const notFound = Object.assign(new Error("Thread not found"), {
+      status: 404,
+    });
+    const client = {
+      threads: {
+        getState: vi.fn(async () => {
+          throw notFound;
+        }),
+        stream,
+      },
+    };
+
+    const controller = new StreamController<State, unknown>({
+      assistantId: "deep-agent",
+      client: client as never,
+      threadId: "thread-not-yet-created",
+    });
+    await controller.hydrationPromise;
+
+    expect(stream).not.toHaveBeenCalled();
+    expect(subscribe).not.toHaveBeenCalled();
+    expect(startLifecycleWatcher).not.toHaveBeenCalled();
+    expect(controller.rootStore.getSnapshot().error).toBeUndefined();
+    await controller.dispose();
+  });
+
+  it("brings up the content pump only after submitRun for a missing thread", async () => {
+    const subscribe = vi.fn(async () => makeNeverEndingSubscription());
+    const startLifecycleWatcher = vi.fn(() => undefined);
+    let resolveSubmit!: (value: { run_id: string }) => void;
+    const submitRun = vi.fn(
+      () =>
+        new Promise<{ run_id: string }>((resolve) => {
+          resolveSubmit = resolve;
+        })
+    );
+    const thread = {
+      subscribe,
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      submitRun,
+      startLifecycleWatcher,
+    } as unknown as ThreadStream;
+    const notFound = Object.assign(new Error("Thread not found"), {
+      status: 404,
+    });
+    const client = {
+      threads: {
+        getState: vi.fn(async () => {
+          throw notFound;
+        }),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State>({
+      assistantId: "deep-agent",
+      client: client as never,
+      threadId: "thread-not-yet-created",
+    });
+    await controller.hydrationPromise;
+    expect(client.threads.stream).not.toHaveBeenCalled();
+    expect(subscribe).not.toHaveBeenCalled();
+
+    void controller.submit({ messages: [] });
+
+    await waitForExpectation(() => {
+      expect(submitRun).toHaveBeenCalled();
+    });
+    // Still deferred until the command response commits the thread.
+    expect(subscribe).not.toHaveBeenCalled();
+
+    resolveSubmit({ run_id: "run-1" });
+    await waitForExpectation(() => {
+      expect(subscribe).toHaveBeenCalled();
+    });
+    await controller.dispose();
+  });
+
   it("brings up the content pump on first submit() for an idle thread", async () => {
     const subscribe = vi.fn(async () => makeNeverEndingSubscription());
     const startLifecycleWatcher = vi.fn(() => undefined);

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -1015,6 +1015,53 @@ describe("StreamController", () => {
     await controller.dispose();
   });
 
+  it("revalidates a prior hydrate-404 so an externally created thread is observed", async () => {
+    // open-swe: a 404 must not permanently skip getState via the
+    // self-created early return — another client may create the id.
+    const subscribe = vi.fn(async () => makeNeverEndingSubscription());
+    const startLifecycleWatcher = vi.fn(() => undefined);
+    const thread = {
+      subscribe,
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      startLifecycleWatcher,
+    } as unknown as ThreadStream;
+    const notFound = Object.assign(new Error("Thread not found"), {
+      status: 404,
+    });
+    let exists = false;
+    const getState = vi.fn(async () => {
+      if (!exists) throw notFound;
+      return { values: { messages: [] }, next: ["agent"], tasks: [] };
+    });
+    const client = {
+      threads: {
+        getState,
+        getHistory: vi.fn(async () => []),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, unknown>({
+      assistantId: "deep-agent",
+      client: client as never,
+      threadId: "thread-shared",
+    });
+    await controller.hydrationPromise;
+    expect(client.threads.stream).not.toHaveBeenCalled();
+    expect(getState).toHaveBeenCalledTimes(1);
+
+    exists = true;
+    await controller.hydrate("thread-shared");
+
+    expect(getState).toHaveBeenCalledTimes(2);
+    expect(client.threads.stream).toHaveBeenCalledOnce();
+    expect(subscribe).toHaveBeenCalledOnce();
+    expect(startLifecycleWatcher).toHaveBeenCalledOnce();
+    await controller.dispose();
+  });
+
   it("brings up the content pump on first submit() for an idle thread", async () => {
     const subscribe = vi.fn(async () => makeNeverEndingSubscription());
     const startLifecycleWatcher = vi.fn(() => undefined);

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -263,17 +263,22 @@ export class StreamController<
    */
   #submitGeneration = 0;
   /**
-   * Thread ids that are not known to exist server-side yet — either
-   * minted client-side on first `submit()`, or supplied by the caller
-   * and confirmed missing via a `threads.getState()` 404 during
-   * hydrate. Keeping them here lets `hydrate()` skip the getState
-   * round-trip on re-entry, and lets `submit()` defer the root SSE
-   * pump until `run.start` / `commands` commits the thread. Opening
-   * `/threads/{id}/stream/events` before that create leaves a dead
-   * subscription on langgraph_api's in-mem runtime (0 bytes until the
-   * idle reconnect replays the run).
+   * Thread ids this controller minted client-side on first `submit()`.
+   * `hydrate()` skips `threads.getState()` for these — we know there
+   * is nothing checkpointed yet. Cleared once dispatch commits the
+   * thread server-side.
    */
   readonly #selfCreatedThreadIds = new Set<string>();
+  /**
+   * Caller-supplied thread ids that 404'd on hydrate. Unlike
+   * {@link #selfCreatedThreadIds}, these are revalidated on every
+   * hydrate: another client may create the same id between visits.
+   * While marked missing, `submit()` still defers the root SSE pump
+   * until `run.start` / `commands` commits the row — joining
+   * `/stream/events` beforehand leaves a dead subscription on
+   * langgraph_api's in-mem runtime.
+   */
+  readonly #missingThreadIds = new Set<string>();
   /**
    * In-flight per-subagent namespace resolutions, keyed by tool-call
    * id. De-dupes concurrent {@link resolveSubagentNamespace} calls so
@@ -386,7 +391,8 @@ export class StreamController<
         this.#selfCreatedThreadIds.add(threadId);
       },
       isSelfCreatedThreadId: (threadId) =>
-        this.#selfCreatedThreadIds.has(threadId),
+        this.#selfCreatedThreadIds.has(threadId) ||
+        this.#missingThreadIds.has(threadId),
       hydrate: (threadId) => this.hydrate(threadId),
       ensureThread: (threadId, deferRootPump) =>
         this.#ensureThread(threadId, deferRootPump),
@@ -394,6 +400,7 @@ export class StreamController<
       abandonDeferredRootPump: () => this.#abandonDeferredRootPump(),
       forgetSelfCreatedThreadId: (threadId) => {
         this.#selfCreatedThreadIds.delete(threadId);
+        this.#missingThreadIds.delete(threadId);
       },
       waitForRootPumpReady: () => this.#rootPumpReady,
       awaitNextTerminal: (signal) => this.#awaitNextTerminal(signal),
@@ -588,6 +595,9 @@ export class StreamController<
       if (this.#disposed || this.#currentThreadId !== hydratedThreadId) return;
       threadExists = state != null;
       threadActive = isThreadStateActive(state);
+      // A prior hydrate-404 may have marked this id missing; clear it
+      // now that the server row exists (e.g. another client created it).
+      this.#missingThreadIds.delete(hydratedThreadId);
       if (state?.values != null) {
         /**
          * `threads.getState()` returns the legacy `ThreadState` shape
@@ -750,10 +760,12 @@ export class StreamController<
      * subscription never attaches to the live channel — the first run
      * then delivers 0 bytes until idle reconnect. Park the pump until
      * `submit()`'s `run.start` creates the row (see
-     * {@link #startDeferredRootPump}), matching the self-created path.
+     * {@link #startDeferredRootPump}). Tracked in `#missingThreadIds`
+     * (not `#selfCreatedThreadIds`) so a later hydrate revalidates —
+     * another client may create the same id between visits.
      */
     if (threadMissing) {
-      this.#selfCreatedThreadIds.add(hydratedThreadId);
+      this.#missingThreadIds.add(hydratedThreadId);
       return;
     }
 
@@ -946,7 +958,8 @@ export class StreamController<
       threadId == null ||
       params.namespace.length === 0 ||
       !this.#rootPumpDeferred ||
-      this.#selfCreatedThreadIds.has(threadId)
+      this.#selfCreatedThreadIds.has(threadId) ||
+      this.#missingThreadIds.has(threadId)
     ) {
       return false;
     }

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -263,10 +263,15 @@ export class StreamController<
    */
   #submitGeneration = 0;
   /**
-   * Thread ids we minted client-side on first `submit()`. Keeping them
-   * here lets `hydrate()` skip the `threads.getState()` round-trip —
-   * we know there is nothing checkpointed server-side yet (and the
-   * request would 404 and surface a spurious error to the UI).
+   * Thread ids that are not known to exist server-side yet — either
+   * minted client-side on first `submit()`, or supplied by the caller
+   * and confirmed missing via a `threads.getState()` 404 during
+   * hydrate. Keeping them here lets `hydrate()` skip the getState
+   * round-trip on re-entry, and lets `submit()` defer the root SSE
+   * pump until `run.start` / `commands` commits the thread. Opening
+   * `/threads/{id}/stream/events` before that create leaves a dead
+   * subscription on langgraph_api's in-mem runtime (0 bytes until the
+   * idle reconnect replays the run).
    */
   readonly #selfCreatedThreadIds = new Set<string>();
   /**
@@ -380,6 +385,8 @@ export class StreamController<
       rememberSelfCreatedThreadId: (threadId) => {
         this.#selfCreatedThreadIds.add(threadId);
       },
+      isSelfCreatedThreadId: (threadId) =>
+        this.#selfCreatedThreadIds.has(threadId),
       hydrate: (threadId) => this.hydrate(threadId),
       ensureThread: (threadId, deferRootPump) =>
         this.#ensureThread(threadId, deferRootPump),
@@ -560,6 +567,12 @@ export class StreamController<
     const hydratedThreadId = this.#currentThreadId;
     let hydrationError: unknown;
     let threadExists = false;
+    // True only when getState 404s — the id is bound in the client but
+    // the server row doesn't exist yet. A null state payload is
+    // different (thread may exist with nothing to seed) and still
+    // opens the pump below. Distinct from `hydrationError` so a
+    // transport failure still takes the eager pump path.
+    let threadMissing = false;
     // Default active so a getState error / non-404 failure never
     // silently disables streaming — the pumps open eagerly as before.
     // Flipped to the real signal once we have the state in hand.
@@ -716,6 +729,11 @@ export class StreamController<
       if (status !== 404) {
         hydrationError = error;
         this.rootStore.setState((s) => ({ ...s, error }));
+      } else {
+        // Caller supplied a brand-new / externally-minted thread id.
+        // There is no server row yet — same lifecycle as a client-
+        // minted id on first `submit()`.
+        threadMissing = true;
       }
     } finally {
       this.rootStore.setState((s) => ({ ...s, isThreadLoading: false }));
@@ -724,6 +742,19 @@ export class StreamController<
       } else {
         this.#resolveHydration();
       }
+    }
+
+    /**
+     * Missing threads must not open `/stream/events`. The in-mem
+     * runtime accepts the join against a not-yet-created id but the
+     * subscription never attaches to the live channel — the first run
+     * then delivers 0 bytes until idle reconnect. Park the pump until
+     * `submit()`'s `run.start` creates the row (see
+     * {@link #startDeferredRootPump}), matching the self-created path.
+     */
+    if (threadMissing) {
+      this.#selfCreatedThreadIds.add(hydratedThreadId);
+      return;
     }
 
     /**
@@ -1624,16 +1655,11 @@ export class StreamController<
    * Without this, the controller would be wedged in a state where:
    *   - `#thread` is wired but no content pump is open
    *   - `#rootPumpDeferred` stays `true`
-   *   - `selfCreatedThreadIds` still holds the id
    *
-   * A retry submit on the same controller would see
-   * `wasSelfCreated=false` (because `currentThreadId` is no longer
-   * null), `#ensureThread(id, false)` would early-return because
-   * `#thread != null`, and the pump would never start. The thread
-   * would have an id committed to the URL but no live subscription.
-   *
-   * Tearing down `#thread` so the next submit re-runs `#ensureThread`
-   * from scratch is the simplest recovery — the failed dispatch
+   * A retry submit must re-run `#ensureThread` from scratch (with
+   * `deferRootPump` still true — the id stays in
+   * `#selfCreatedThreadIds` until a successful dispatch). Tearing
+   * down `#thread` is the simplest recovery; the failed dispatch
    * means there was nothing to subscribe to anyway.
    */
   #abandonDeferredRootPump(): void {

--- a/libs/sdk/src/stream/submit-coordinator.test.ts
+++ b/libs/sdk/src/stream/submit-coordinator.test.ts
@@ -58,6 +58,8 @@ interface Harness {
   onRunCompleted: ReturnType<typeof vi.fn>;
   onRunEnd: ReturnType<typeof vi.fn>;
   rememberSelfCreatedThreadId: ReturnType<typeof vi.fn>;
+  isSelfCreatedThreadId: ReturnType<typeof vi.fn>;
+  selfCreatedThreadIds: Set<string>;
   setCurrentThreadId: ReturnType<typeof vi.fn>;
   threadIds: string[];
   setThreadId: (id: string | null) => void;
@@ -158,8 +160,16 @@ function makeHarness(
   const setCurrentThreadId = vi.fn((id: string | null) => {
     currentThreadId = id;
   });
-  const rememberSelfCreatedThreadId = vi.fn(() => undefined);
-  const forgetSelfCreatedThreadId = vi.fn(() => undefined);
+  const selfCreatedThreadIds = new Set<string>();
+  const rememberSelfCreatedThreadId = vi.fn((threadId: string) => {
+    selfCreatedThreadIds.add(threadId);
+  });
+  const isSelfCreatedThreadId = vi.fn((threadId: string) =>
+    selfCreatedThreadIds.has(threadId)
+  );
+  const forgetSelfCreatedThreadId = vi.fn((threadId: string) => {
+    selfCreatedThreadIds.delete(threadId);
+  });
   const onRunStart = vi.fn(() => undefined);
   const onRunCreated = vi.fn(() => undefined);
   const onRunCompleted = vi.fn(
@@ -186,6 +196,7 @@ function makeHarness(
     getCurrentThreadId: () => currentThreadId,
     setCurrentThreadId,
     rememberSelfCreatedThreadId,
+    isSelfCreatedThreadId,
     forgetSelfCreatedThreadId,
     hydrate,
     ensureThread,
@@ -241,6 +252,8 @@ function makeHarness(
     onRunCompleted,
     onRunEnd,
     rememberSelfCreatedThreadId,
+    isSelfCreatedThreadId,
+    selfCreatedThreadIds,
     setCurrentThreadId,
     threadIds: [],
     setThreadId: (id) => {
@@ -843,7 +856,9 @@ describe("SubmitCoordinator", () => {
 
       expect(h.rootStore.getSnapshot().error).toBe(err);
       expect(h.abandonDeferredRootPump).toHaveBeenCalledOnce();
-      expect(h.forgetSelfCreatedThreadId).toHaveBeenCalledOnce();
+      // Keep the self-created mark so a retry still defers the pump —
+      // the server row was never created.
+      expect(h.forgetSelfCreatedThreadId).not.toHaveBeenCalled();
       expect(h.startDeferredRootPump).not.toHaveBeenCalled();
     });
 
@@ -859,6 +874,29 @@ describe("SubmitCoordinator", () => {
 
       expect(h.rootStore.getSnapshot().error).toBe(err);
       expect(h.abandonDeferredRootPump).not.toHaveBeenCalled();
+    });
+
+    it("defers the root pump for an externally-minted id pending server create", async () => {
+      const h = makeHarness({ threadId: "thread-minted-externally" });
+      h.selfCreatedThreadIds.add("thread-minted-externally");
+
+      const submitPromise = h.coordinator.submit({ count: 1 });
+      await h.terminalRegistered();
+
+      const lastEnsureCall = h.ensureThread.mock.calls.at(-1);
+      expect(lastEnsureCall).toBeDefined();
+      expect(lastEnsureCall![1]).toBe(true);
+
+      h.resolveSubmit();
+      await vi.runAllTimersAsync();
+      expect(h.startDeferredRootPump).toHaveBeenCalledOnce();
+      expect(h.forgetSelfCreatedThreadId).toHaveBeenCalledWith(
+        "thread-minted-externally"
+      );
+
+      h.resolveTerminal({ event: "completed" });
+      await vi.runAllTimersAsync();
+      await submitPromise;
     });
   });
 });

--- a/libs/sdk/src/stream/submit-coordinator.ts
+++ b/libs/sdk/src/stream/submit-coordinator.ts
@@ -154,6 +154,8 @@ export class SubmitCoordinator<
   readonly #setCurrentThreadId: (threadId: string | null) => void;
   /** Records a thread id we created client-side so hydrate can skip a 404 round-trip. */
   readonly #rememberSelfCreatedThreadId: (threadId: string) => void;
+  /** True when the id is pending server-side create (minted or hydrate 404). */
+  readonly #isSelfCreatedThreadId: (threadId: string) => boolean;
   /** Drops a thread id from the self-created set once it's committed server-side. */
   readonly #forgetSelfCreatedThreadId: (threadId: string) => void;
   /** Triggers a hydrate on the controller (used by `options.threadId` rebinds). */
@@ -223,6 +225,7 @@ export class SubmitCoordinator<
     getCurrentThreadId: () => string | null;
     setCurrentThreadId: (threadId: string | null) => void;
     rememberSelfCreatedThreadId: (threadId: string) => void;
+    isSelfCreatedThreadId: (threadId: string) => boolean;
     forgetSelfCreatedThreadId: (threadId: string) => void;
     hydrate: (threadId?: string | null) => Promise<void>;
     ensureThread: (threadId: string, deferRootPump?: boolean) => ThreadStream;
@@ -251,6 +254,7 @@ export class SubmitCoordinator<
     this.#getCurrentThreadId = params.getCurrentThreadId;
     this.#setCurrentThreadId = params.setCurrentThreadId;
     this.#rememberSelfCreatedThreadId = params.rememberSelfCreatedThreadId;
+    this.#isSelfCreatedThreadId = params.isSelfCreatedThreadId;
     this.#forgetSelfCreatedThreadId = params.forgetSelfCreatedThreadId;
     this.#hydrate = params.hydrate;
     this.#ensureThread = params.ensureThread;
@@ -326,14 +330,18 @@ export class SubmitCoordinator<
 
     const currentThreadId = this.#getCurrentThreadId();
     if (currentThreadId == null) return;
-    // For client-self-created threads we defer the persistent root SSE
-    // pump until after `submitRun` / `respondInput` commits the thread
-    // server-side. Opening the pump's `subscription.subscribe` against
-    // a not-yet-existent thread row produces a `404: Thread not found`
-    // protocol error that strands lifecycle / messages events for the
-    // first run. The deferred path starts the pump after dispatch
-    // returns (see `#startDeferredRootPump` calls below).
-    const thread = this.#ensureThread(currentThreadId, wasSelfCreated);
+    // For threads that don't exist server-side yet (just minted here,
+    // or an externally-minted id that hydrate marked missing via 404)
+    // we defer the persistent root SSE pump until after `submitRun` /
+    // `respondInput` commits the thread. Opening the pump's
+    // `subscription.subscribe` against a not-yet-existent thread row
+    // either 404s or — on langgraph_api's in-mem runtime — joins a
+    // dead subscription that delivers 0 bytes until idle reconnect.
+    // The deferred path starts the pump after dispatch returns (see
+    // `#startDeferredRootPump` calls below).
+    const pendingServerCreate =
+      wasSelfCreated || this.#isSelfCreatedThreadId(currentThreadId);
+    const thread = this.#ensureThread(currentThreadId, pendingServerCreate);
     const activeThreadId = currentThreadId;
 
     const strategy = options?.multitaskStrategy ?? "rollback";
@@ -467,14 +475,14 @@ export class SubmitCoordinator<
         () => {
           // Dispatch failed. Without abandoning, `#rootPumpDeferred`
           // stays armed and `selfCreatedThreadIds` still holds this
-          // id — a retry submit would see `wasSelfCreated=false`
-          // (currentThreadId is no longer null), `#ensureThread`
-          // would early-return because `#thread != null`, and the
-          // root pump would never start. Tear down so the next
-          // submit re-runs `#ensureThread` from scratch.
-          if (wasSelfCreated) {
+          // id — a retry submit would see `pendingServerCreate=true`
+          // again but `#ensureThread` would early-return because
+          // `#thread != null`, and the root pump would never start.
+          // Tear down so the next submit re-runs `#ensureThread`
+          // from scratch. Keep the self-created mark so the retry
+          // still defers the pump (the server row was never created).
+          if (pendingServerCreate) {
             this.#abandonDeferredRootPump();
-            this.#forgetSelfCreatedThreadId(activeThreadId);
           }
         }
       );


### PR DESCRIPTION
Hydrating an externally-minted thread id that 404s still opened `/stream/events` before `POST /commands` created the row. On langgraph_api's in-mem runtime that join is accepted but dead, so the first run delivered nothing until idle reconnect. Treat missing threads like client-minted ones and start the root pump only after dispatch succeeds.
