### PR TITLE
fix(checkpoint): allow reviving non-core classes from checkpoints

### DIFF
--- a/.changeset/checkpoint-serde-load-options.md
+++ b/.changeset/checkpoint-serde-load-options.md
@@ -1,0 +1,13 @@
+---
+"@langchain/langgraph-checkpoint": patch
+---
+
+fix(checkpoint): allow reviving non-core classes from checkpoints
+
+`JsonPlusSerializer` called `load()` from `@langchain/core/load` with no options, so only the `langchain_core` namespace could be resolved. Reading back a checkpoint containing any object from another package (for example `ChatOpenAI`, whose namespace is `langchain`) threw `Invalid namespace`. The serializer now accepts `LoadOptions` and forwards them to `load()`, and is exported from the package entrypoint so applications can opt those classes in:
+
+```ts
+new MemorySaver(new JsonPlusSerializer({ importMap: { ... } }))
+```
+
+Defaults are unchanged — with no options the serializer resolves exactly what it did before.

--- a/libs/checkpoint/src/index.ts
+++ b/libs/checkpoint/src/index.ts
@@ -3,6 +3,7 @@ export * from "./base.js";
 export * from "./id.js";
 export * from "./types.js";
 export * from "./serde/base.js";
+export * from "./serde/jsonplus.js";
 export * from "./serde/types.js";
 export * from "./store/index.js";
 export * from "./cache/index.js";

--- a/libs/checkpoint/src/serde/jsonplus.ts
+++ b/libs/checkpoint/src/serde/jsonplus.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable no-instanceof/no-instanceof */
-import { load } from "@langchain/core/load";
+import { load, type LoadOptions } from "@langchain/core/load";
 import { SerializerProtocol } from "./base.js";
 import { stringify } from "./utils/fast-safe-stringify/index.js";
 import { DeltaSnapshot } from "./types.js";
@@ -22,17 +22,17 @@ function isLangChainSerializedObject(value: Record<string, unknown>) {
  * We therefore must start from the most nested elements in the input and
  * deserialize upwards rather than top-down.
  */
-async function _reviver(value: any): Promise<any> {
+async function _reviver(value: any, options?: LoadOptions): Promise<any> {
   if (value && typeof value === "object") {
     if (Array.isArray(value)) {
       const revivedArray = await Promise.all(
-        value.map((item) => _reviver(item))
+        value.map((item) => _reviver(item, options))
       );
       return revivedArray;
     } else {
       const revivedObj: any = {};
       for (const [k, v] of Object.entries(value)) {
-        revivedObj[k] = await _reviver(v);
+        revivedObj[k] = await _reviver(v, options);
       }
 
       if (revivedObj.lc === 2 && revivedObj.type === "undefined") {
@@ -79,7 +79,7 @@ async function _reviver(value: any): Promise<any> {
           return revivedObj;
         }
       } else if (isLangChainSerializedObject(revivedObj)) {
-        return load(JSON.stringify(revivedObj));
+        return load(JSON.stringify(revivedObj), options);
       }
 
       return revivedObj;
@@ -142,7 +142,52 @@ function _default(obj: any): any {
   }
 }
 
+/**
+ * Default serializer used by every checkpointer and cache.
+ *
+ * Deserialization of LangChain objects is delegated to `load()` from
+ * `@langchain/core/load`, which resolves classes from a namespace path rather
+ * than importing arbitrary modules. Only the `langchain_core` namespace
+ * resolves automatically — classes from any other package (for example
+ * `ChatOpenAI`, whose namespace is `langchain`) are unreachable unless the
+ * application explicitly opts them in, since core has no way to know which
+ * packages are installed.
+ *
+ * Pass {@link LoadOptions} here to opt those classes in, then hand the
+ * serializer to any checkpointer:
+ *
+ * @example
+ * ```typescript
+ * import { MemorySaver, JsonPlusSerializer } from "@langchain/langgraph-checkpoint";
+ * import * as chatModels from "@langchain/openai";
+ *
+ * const checkpointer = new MemorySaver(
+ *   new JsonPlusSerializer({
+ *     importMap: { chat_models__openai: chatModels },
+ *     // Provider classes serialize their credentials as secret references,
+ *     // so reviving them also needs the secrets resolved.
+ *     secretsMap: { OPENAI_API_KEY: process.env.OPENAI_API_KEY! },
+ *   })
+ * );
+ * ```
+ *
+ * @remarks
+ * **Security:** `importMap` / `optionalImportsMap` widen the set of classes a
+ * checkpoint payload can instantiate, and constructors run during
+ * deserialization. Only pass modules you trust, and never build these maps
+ * from user input. See {@link LoadOptions} for full guidance.
+ */
 export class JsonPlusSerializer implements SerializerProtocol {
+  /**
+   * Options forwarded to `load()` when reviving LangChain objects.
+   * When omitted, only `langchain_core` classes can be revived.
+   */
+  protected loadOptions?: LoadOptions;
+
+  constructor(loadOptions?: LoadOptions) {
+    this.loadOptions = loadOptions;
+  }
+
   protected _dumps(obj: any): Uint8Array {
     const encoder = new TextEncoder();
     return encoder.encode(
@@ -162,7 +207,7 @@ export class JsonPlusSerializer implements SerializerProtocol {
 
   protected async _loads(data: string): Promise<any> {
     const parsed = JSON.parse(data);
-    return _reviver(parsed);
+    return _reviver(parsed, this.loadOptions);
   }
 
   async loadsTyped(type: string, data: Uint8Array | string): Promise<any> {

--- a/libs/checkpoint/src/serde/tests/jsonplus.test.ts
+++ b/libs/checkpoint/src/serde/tests/jsonplus.test.ts
@@ -1,7 +1,10 @@
-import { it, expect } from "vitest";
+import { describe, it, expect } from "vitest";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
+import { Serializable } from "@langchain/core/load/serializable";
 import { uuid6 } from "../../id.js";
 import { JsonPlusSerializer } from "../jsonplus.js";
+import { emptyCheckpoint } from "../../base.js";
+import { MemorySaver } from "../../memory.js";
 
 const messageWithToolCall = new AIMessage({
   content: "",
@@ -156,6 +159,132 @@ it("Should serialize a Send without a timeout unchanged", async () => {
   const [type, serialized] = await serde.dumpsTyped(packet);
   const loaded = await serde.loadsTyped(type, serialized);
   expect(loaded).toEqual({ node: "worker", args: { x: 1 } });
+});
+
+/**
+ * Stands in for a class that lives outside `@langchain/core` — e.g.
+ * `ChatOpenAI`, whose namespace is `langchain`, not `langchain_core`.
+ * Declared here so the test does not depend on a provider package.
+ */
+class FakeChatModel extends Serializable {
+  lc_namespace = ["langchain", "chat_models", "fake"];
+
+  lc_serializable = true;
+
+  modelName: string;
+
+  constructor(fields: { modelName: string }) {
+    super(fields);
+    this.modelName = fields.modelName;
+  }
+}
+
+/** A class carrying a secret, mirroring how providers serialize credentials. */
+class FakeChatModelWithSecret extends Serializable {
+  lc_namespace = ["langchain", "chat_models", "fake"];
+
+  lc_serializable = true;
+
+  get lc_secrets(): { [key: string]: string } {
+    return { apiKey: "FAKE_API_KEY" };
+  }
+
+  apiKey: string;
+
+  constructor(fields: { apiKey: string }) {
+    super(fields);
+    this.apiKey = fields.apiKey;
+  }
+}
+
+const fakeChatModelsModule = { FakeChatModel, FakeChatModelWithSecret };
+
+describe("Non-core LangChain classes", () => {
+  it("Should throw without an explicit opt-in", async () => {
+    const serde = new JsonPlusSerializer();
+    const [type, serialized] = await serde.dumpsTyped({
+      model: new FakeChatModel({ modelName: "gpt-4o" }),
+    });
+    await expect(serde.loadsTyped(type, serialized)).rejects.toThrow(
+      /Invalid namespace/
+    );
+  });
+
+  it("Should revive a class provided via importMap", async () => {
+    const serde = new JsonPlusSerializer({
+      importMap: { chat_models__fake: fakeChatModelsModule },
+    });
+    const [type, serialized] = await serde.dumpsTyped({
+      model: new FakeChatModel({ modelName: "gpt-4o" }),
+    });
+    const loaded = await serde.loadsTyped(type, serialized);
+    expect(loaded.model).toBeInstanceOf(FakeChatModel);
+    expect(loaded.model.modelName).toBe("gpt-4o");
+  });
+
+  it("Should revive classes nested in arrays, maps and sets", async () => {
+    const serde = new JsonPlusSerializer({
+      importMap: { chat_models__fake: fakeChatModelsModule },
+    });
+    const value = {
+      list: [new FakeChatModel({ modelName: "a" })],
+      map: new Map([["key", new FakeChatModel({ modelName: "b" })]]),
+      deep: { nested: { model: new FakeChatModel({ modelName: "c" }) } },
+    };
+    const [type, serialized] = await serde.dumpsTyped(value);
+    const loaded = await serde.loadsTyped(type, serialized);
+    expect(loaded.list[0]).toBeInstanceOf(FakeChatModel);
+    expect(loaded.map.get("key")).toBeInstanceOf(FakeChatModel);
+    expect(loaded.deep.nested.model).toBeInstanceOf(FakeChatModel);
+    expect(loaded.deep.nested.model.modelName).toBe("c");
+  });
+
+  it("Should resolve secrets via secretsMap", async () => {
+    const serde = new JsonPlusSerializer({
+      importMap: { chat_models__fake: fakeChatModelsModule },
+      secretsMap: { FAKE_API_KEY: "sk-test" },
+    });
+    const [type, serialized] = await serde.dumpsTyped({
+      model: new FakeChatModelWithSecret({ apiKey: "sk-test" }),
+    });
+    expect(new TextDecoder().decode(serialized)).not.toContain("sk-test");
+    const loaded = await serde.loadsTyped(type, serialized);
+    expect(loaded.model).toBeInstanceOf(FakeChatModelWithSecret);
+    expect(loaded.model.apiKey).toBe("sk-test");
+  });
+
+  it("Should still revive langchain_core classes without any options", async () => {
+    const serde = new JsonPlusSerializer();
+    const [type, serialized] = await serde.dumpsTyped({
+      message: new AIMessage("hello"),
+    });
+    const loaded = await serde.loadsTyped(type, serialized);
+    expect(loaded.message).toBeInstanceOf(AIMessage);
+  });
+
+  it("Should round-trip through a checkpointer given a configured serde", async () => {
+    const checkpointer = new MemorySaver(
+      new JsonPlusSerializer({
+        importMap: { chat_models__fake: fakeChatModelsModule },
+      })
+    );
+    const config = { configurable: { thread_id: "1" } };
+    const checkpoint = {
+      ...emptyCheckpoint(),
+      channel_values: { model: new FakeChatModel({ modelName: "gpt-4o" }) },
+    };
+
+    const nextConfig = await checkpointer.put(config, checkpoint, {
+      source: "update",
+      step: 1,
+      parents: {},
+    });
+    const tuple = await checkpointer.getTuple(nextConfig);
+
+    expect(tuple?.checkpoint.channel_values.model).toBeInstanceOf(
+      FakeChatModel
+    );
+  });
 });
 
 it("Should replace circular JSON inputs", async () => {


### PR DESCRIPTION
Fixes #777

## Problem

`JsonPlusSerializer` is the default serializer for every checkpointer and cache. When reviving a checkpoint, `_reviver` called `load()` from `@langchain/core/load` with **no options**:

```ts
return load(JSON.stringify(revivedObj));
```

`load()` only resolves classes automatically for the `langchain_core` namespace, via core's own static import map. Classes from any other namespace require the caller to supply an `importMap` / `optionalImportsMap` — core has no way to know which packages the *application* has installed.

Because the serializer never passed those options, writing a graph state containing any non-core LangChain object (e.g. `ChatOpenAI`, namespace `langchain`, or `ChatMessage` as reported in the issue thread) and reading it back threw:

```
Invalid namespace: $ -> ...
```

`BaseCheckpointSaver` constructs `new JsonPlusSerializer()` with zero configuration, and the class was never exported from the package entrypoint — so there was no way for an application to work around this from the outside.

## Fix

- `JsonPlusSerializer`'s constructor now accepts an optional `LoadOptions`, threaded through `_reviver` into the `load()` call.
- Exported `JsonPlusSerializer` from the package entrypoint so applications can actually construct one. Every saver already accepts `serde?`, so no other API change was needed.

```ts
import { MemorySaver, JsonPlusSerializer } from "@langchain/langgraph-checkpoint";
import * as chatModels from "@langchain/openai";

const checkpointer = new MemorySaver(
  new JsonPlusSerializer({
    importMap: { chat_models__openai: chatModels },
    secretsMap: { OPENAI_API_KEY: process.env.OPENAI_API_KEY! },
  })
);
```

## Design note

This deliberately keeps resolution **opt-in by explicit configuration** rather than broadening the default allowlist. That matches the maintainer stance in #2346 / #2337, where widening what `load()` can reach by default was rejected — anything outside `langchain_core` should require "explicit configuration beyond the generic serde system."

The added JSDoc calls out the security tradeoff directly: `importMap` widens the set of classes a checkpoint payload can instantiate and constructors run during deserialization, so these maps must never be built from user input.

## Backward compatibility

Fully backward compatible. The constructor argument is optional, and with no options the serializer resolves exactly what it resolved before — the `load()` call receives `undefined`, which is what it received previously.

## Testing

Added coverage in `libs/checkpoint/src/serde/tests/jsonplus.test.ts` for reviving a non-core class via `importMap`, the nested/array reviver paths, and the unchanged default behaviour.

- `libs/checkpoint`: 103/103 tests pass
- Build clean, including `attw` and `publint`
- `oxlint`, `oxfmt --check`, and `dpdm` circular-dependency check all clean
