### PR TITLE
feat(sdk): seek SSE replay with durable since_event_id

### DIFF
--- a/.changeset/durable-since-event-id.md
+++ b/.changeset/durable-since-event-id.md
@@ -1,0 +1,12 @@
+---
+"@langchain/langgraph-sdk": patch
+"@langchain/langgraph-api": patch
+"@langchain/langgraph-cli": patch
+"@langchain/langgraph-ui": patch
+---
+
+feat(sdk): seek SSE replay with durable since_event_id
+
+Honor `since_event_id` on event-stream opens so reconnects skip history
+the client already has. Session `since` stays for same-connection seq
+resume. JS Agent Server filters sinks the same way.

--- a/.changeset/sdk-run-boundary-gate.md
+++ b/.changeset/sdk-run-boundary-gate.md
@@ -1,0 +1,12 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): ignore prior-run protocol replay after hydrate submit
+
+New SSE subscriptions replay the thread tape from seq=0. Without a
+run-scoped filter, an older run's `lifecycle: completed` can settle the
+first submit and replayed `values` can rewind UI state. Gate root
+lifecycle/values/pause on durable `run_id` (envelope or synth fallback).
+
+Closes #2609

--- a/libs/langgraph-api/src/api/protocol.mts
+++ b/libs/langgraph-api/src/api/protocol.mts
@@ -19,6 +19,8 @@ const EventsFilterSchema = z
     namespaces: z.array(z.array(z.string())).optional(),
     depth: z.number().int().nonnegative().optional(),
     since: z.number().int().nonnegative().optional(),
+    since_event_id: z.string().min(1).optional(),
+    sinceEventId: z.string().min(1).optional(),
   })
   .strict();
 
@@ -166,11 +168,13 @@ export default function createProtocolApi(
 
       const body = c.req.valid("json");
       const sinkId = uuid7();
+      const sinceEventId = body.since_event_id ?? body.sinceEventId;
       const filter: EventSinkFilter = {
         channels: new Set(body.channels),
         namespaces: body.namespaces,
         depth: body.depth,
         since: body.since,
+        ...(sinceEventId != null ? { sinceEventId } : {}),
       };
 
       return streamSSE(c, async (stream) => {

--- a/libs/langgraph-api/src/experimental/embed/protocol.mts
+++ b/libs/langgraph-api/src/experimental/embed/protocol.mts
@@ -39,6 +39,8 @@ const EventsFilterSchema = z
     namespaces: z.array(z.array(z.string())).optional(),
     depth: z.number().int().nonnegative().optional(),
     since: z.number().int().nonnegative().optional(),
+    since_event_id: z.string().min(1).optional(),
+    sinceEventId: z.string().min(1).optional(),
   })
   .strict();
 
@@ -500,11 +502,13 @@ export function registerProtocolRoutes(
 
       const body = c.req.valid("json");
       const sinkId = uuidv7();
+      const sinceEventId = body.since_event_id ?? body.sinceEventId;
       const filter: EventSinkFilter = {
         channels: new Set(body.channels),
         namespaces: body.namespaces,
         depth: body.depth,
         since: body.since,
+        ...(sinceEventId != null ? { sinceEventId } : {}),
       };
 
       return streamSSE(c, async (stream) => {

--- a/libs/langgraph-api/src/protocol/service.mts
+++ b/libs/langgraph-api/src/protocol/service.mts
@@ -844,7 +844,16 @@ export function matchesSinkFilter(
   filter: EventSinkFilter,
   event: ProtocolEvent
 ): boolean {
-  if (filter.since != null && (event.seq ?? 0) <= filter.since) return false;
+  // Durable `sinceEventId` seeks across reconnects. Session `since` remains
+  // for same-connection ring-buffer resume only.
+  if (filter.sinceEventId != null) {
+    const eventId = event.event_id;
+    if (typeof eventId !== "string" || !(eventId > filter.sinceEventId)) {
+      return false;
+    }
+  } else if (filter.since != null && (event.seq ?? 0) <= filter.since) {
+    return false;
+  }
 
   // `inferChannel` resolves named custom channels to `custom:<name>`; a bare
   // `custom` filter still matches via the prefix check below.

--- a/libs/langgraph-api/src/protocol/types.mts
+++ b/libs/langgraph-api/src/protocol/types.mts
@@ -149,6 +149,8 @@ export type EventSinkFilter = {
   namespaces?: string[][];
   depth?: number;
   since?: number;
+  /** Durable cursor: deliver events with `event_id` strictly after this. */
+  sinceEventId?: string;
 };
 
 /**

--- a/libs/langgraph-api/tests/protocol-sink-filter.test.mts
+++ b/libs/langgraph-api/tests/protocol-sink-filter.test.mts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { matchesSinkFilter } from "../src/protocol/service.mjs";
+import type {
+  EventSinkFilter,
+  ProtocolEvent,
+} from "../src/protocol/types.mjs";
+
+const valuesEvent = (opts: {
+  event_id: string;
+  seq: number;
+}): ProtocolEvent =>
+  ({
+    type: "event",
+    method: "values",
+    event_id: opts.event_id,
+    seq: opts.seq,
+    params: {
+      namespace: [],
+      timestamp: 1,
+      data: { messages: [] },
+    },
+  }) as ProtocolEvent;
+
+describe("matchesSinkFilter sinceEventId", () => {
+  const baseFilter: EventSinkFilter = {
+    channels: new Set(["values"]),
+  };
+
+  it("skips envelopes at or before the durable cursor", () => {
+    // Redis ms-seq ids share a fixed-width millisecond prefix, so
+    // lexicographic `>` matches stream order (same as in-mem restore).
+    const filter: EventSinkFilter = {
+      ...baseFilter,
+      sinceEventId: "1710000000010-0",
+    };
+    expect(
+      matchesSinkFilter(
+        filter,
+        valuesEvent({ event_id: "1710000000010-0", seq: 1 })
+      )
+    ).toBe(false);
+    expect(
+      matchesSinkFilter(
+        filter,
+        valuesEvent({ event_id: "1710000000009-1", seq: 2 })
+      )
+    ).toBe(false);
+    expect(
+      matchesSinkFilter(
+        filter,
+        valuesEvent({ event_id: "1710000000010-0.1", seq: 3 })
+      )
+    ).toBe(true);
+    expect(
+      matchesSinkFilter(
+        filter,
+        valuesEvent({ event_id: "1710000000011-0", seq: 4 })
+      )
+    ).toBe(true);
+  });
+
+  it("prefers sinceEventId over session since", () => {
+    const filter: EventSinkFilter = {
+      ...baseFilter,
+      since: 100,
+      sinceEventId: "a",
+    };
+    expect(
+      matchesSinkFilter(filter, valuesEvent({ event_id: "b", seq: 1 }))
+    ).toBe(true);
+  });
+});

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -19,7 +19,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@langchain/protocol": "^0.0.19",
+    "@langchain/protocol": "^0.0.18",
     "@types/json-schema": "^7.0.15",
     "p-queue": "^9.0.1",
     "p-retry": "^7.1.1"

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -19,7 +19,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@langchain/protocol": "^0.0.18",
+    "@langchain/protocol": "^0.0.19",
     "@types/json-schema": "^7.0.15",
     "p-queue": "^9.0.1",
     "p-retry": "^7.1.1"

--- a/libs/sdk/src/client/stream/index.ts
+++ b/libs/sdk/src/client/stream/index.ts
@@ -60,6 +60,7 @@ import type { EventStreamHandle, TransportAdapter } from "./transport.js";
 import { ProtocolError } from "./error.js";
 import { NAMESPACE_SEPARATOR } from "../../stream/constants.js";
 import { isHeadlessToolInterrupt } from "../../headless-tools.js";
+import { extractEventRunId } from "../../stream/run-boundary-gate.js";
 
 type PendingCommand = {
   resolve: (response: CommandResponse) => void;
@@ -579,11 +580,24 @@ export class ThreadStream<
   // `subscribe`/`unsubscribe` changes the channel union.
   #sharedStream: EventStreamHandle | null = null;
   #sharedStreamFilter: SubscribeParams | null = null;
+  /**
+   * Last durable `event_id` observed on the content pump (not the
+   * lifecycle watcher). Used as `since_event_id` when reopening the
+   * shared SSE without pending subscribers that need a full replay.
+   */
+  #sharedStreamLastEventId?: string;
   #rotationState: "idle" | "scheduled" | "rotating" = "idle";
   /** Pending `subscribe()` promises waiting for a covering rotation. */
   readonly #pendingSubResolves: PendingSubResolve[] = [];
   #terminalPauseTimer: ReturnType<typeof setTimeout> | undefined;
   #terminalPauseSeq: number | null | undefined;
+  /**
+   * Run id from the latest `run.start` ack. While awaiting that ack
+   * after {@link #prepareForNextRun}, terminal pauses are suppressed so
+   * replayed older-run terminals cannot thrash subscriptions.
+   */
+  #activeRunId: string | undefined;
+  #awaitingRunId = false;
 
   #lifecycleSubId: string | null = null;
   #lifecycleStartPromise?: Promise<void>;
@@ -698,7 +712,7 @@ export class ThreadStream<
         // the in-flight `run.start` send completes. Sites that open
         // SSE/WS resources await this gate; everything else (event
         // dispatch, projection bookkeeping) runs without delay.
-        return await this.#withRunStartGate(() => {
+        return await this.#withRunStartGate(async () => {
           this.#ensureLifecycleTracking();
           // Eagerly start the values projection so `thread.output` /
           // `thread.values` resolve with the final state regardless of
@@ -712,10 +726,12 @@ export class ThreadStream<
           // replay any custom events that were emitted before the
           // subscription landed. This keeps the zero-extensions hot path
           // free of an unused `custom` subscription per run.
-          return this.#send("run.start", {
+          const result = await this.#send("run.start", {
             ...foldForkFromIntoConfig(params),
             assistant_id: this.assistantId,
           });
+          this.#bindActiveRunId(result.run_id);
+          return result;
         });
       },
     };
@@ -733,6 +749,7 @@ export class ThreadStream<
         // across resumes regardless of access order.
         void this.values;
         await this.#send("input.respond", params);
+        this.#awaitingRunId = false;
       },
       inject: async (params) => {
         await this.#send(
@@ -869,6 +886,8 @@ export class ThreadStream<
    */
   #prepareForNextRun(respondedInterruptId?: string | readonly string[]): void {
     this.interrupted = false;
+    this.#awaitingRunId = true;
+    this.#activeRunId = undefined;
     if (respondedInterruptId != null) {
       const respondedIds = new Set(
         Array.isArray(respondedInterruptId)
@@ -893,6 +912,30 @@ export class ThreadStream<
         subscription.resume();
       }
     }
+  }
+
+  #bindActiveRunId(runId: unknown): void {
+    if (typeof runId === "string" && runId.length > 0) {
+      this.#activeRunId = runId;
+    }
+    this.#awaitingRunId = false;
+  }
+
+  /**
+   * Skip terminal pauses for other runs' replayed lifecycle events.
+   * While `run.start` has not ack'd, suppress all pauses.
+   */
+  #shouldPauseForTerminal(message: Event): boolean {
+    if (this.#awaitingRunId) return false;
+    const eventRunId = extractEventRunId(message);
+    if (
+      this.#activeRunId != null &&
+      eventRunId != null &&
+      eventRunId !== this.#activeRunId
+    ) {
+      return false;
+    }
+    return true;
   }
 
   // ---------- Lazy getters mirroring in-process GraphRunStream ----------
@@ -1363,12 +1406,14 @@ export class ThreadStream<
     // its downstream `useToolCalls` / `useMessages` subscriptions
     // don't race the run), but its server-side SSE/WS open is staged
     // behind `#runStartReady` to avoid a `404: Thread not found`.
-    return await this.#withRunStartGate(() => {
+    return await this.#withRunStartGate(async () => {
       this.#startLifecycleWatcher();
-      return this.#send("run.start", {
+      const result = await this.#send("run.start", {
         ...(foldForkFromIntoConfig(params) as Record<string, unknown>),
         assistant_id: this.assistantId,
       });
+      this.#bindActiveRunId(result.run_id);
+      return result;
     });
   }
 
@@ -1389,6 +1434,9 @@ export class ThreadStream<
     this.#prepareForNextRun(respondedIds);
     this.#startLifecycleWatcher();
     await this.#send("input.respond", params);
+    // input.respond does not return a run_id; allow pauses again and
+    // correlate via envelope run_id when present (legacy: unfiltered).
+    this.#awaitingRunId = false;
   }
 
   /**
@@ -1869,6 +1917,29 @@ export class ThreadStream<
   }
 
   /**
+   * Build the filter passed to {@link TransportAdapter.openEventStream}.
+   *
+   * When there are no pending subscribers waiting on a full tape replay,
+   * attach the content pump's durable cursor so the server can seek
+   * instead of dumping history the client already has.
+   */
+  #openEventStreamParams(desired: SubscribeParams): SubscribeParams {
+    const sinceEventId = this.#sharedStreamLastEventId;
+    if (sinceEventId == null) return desired;
+    // Late subscribers that widen/reopen an already-live union need a
+    // full tape replay. A brand-new open (deferred pump / reopen after
+    // the shared handle was torn down) can seek: events after the
+    // cursor still flow, and older history is already on the client.
+    if (this.#sharedStream != null && this.#pendingSubResolves.length > 0) {
+      return desired;
+    }
+    return {
+      ...desired,
+      since_event_id: sinceEventId,
+    } as SubscribeParams;
+  }
+
+  /**
    * Schedule a stream reconciliation for the next microtask.
    *
    * Coalesces multiple subscribe/unsubscribe calls in the same tick
@@ -1958,7 +2029,9 @@ export class ThreadStream<
     this.#rotationState = "rotating";
     let newHandle: EventStreamHandle;
     try {
-      newHandle = this.#transportAdapter.openEventStream!(desired);
+      newHandle = this.#transportAdapter.openEventStream!(
+        this.#openEventStreamParams(desired)
+      );
     } catch (err) {
       this.#rotationState = "idle";
       this.#rejectUncoveredPending(err);
@@ -2295,6 +2368,7 @@ export class ThreadStream<
       }
       if (message.event_id) {
         this.ordering.lastEventId = message.event_id;
+        this.#sharedStreamLastEventId = message.event_id;
       }
 
       // Two flavors of dedup live here:
@@ -2392,6 +2466,9 @@ export class ThreadStream<
           this.#headlessInterruptsAwaitingTerminal.size > 0;
         if (shouldSkipPause) {
           this.#headlessInterruptsAwaitingTerminal.clear();
+          return;
+        }
+        if (!this.#shouldPauseForTerminal(message)) {
           return;
         }
         // A single shared stream delivers every subscription's events,

--- a/libs/sdk/src/client/stream/transport.ts
+++ b/libs/sdk/src/client/stream/transport.ts
@@ -77,7 +77,8 @@ export interface TransportAdapter {
    * whose filter matches. The SDK's shared-stream rotation relies on
    * this: when a subscription's filter widens the union, the SDK opens
    * a fresh stream and expects to receive the run's full history from
-   * `seq=0` (deduplication is handled client-side via `event_id`). The
+   * `seq=0` (deduplication is handled client-side via `event_id`), unless
+   * the caller passes durable `since_event_id` to seek the tape. The
    * SDK also defers the open until after `run.start` has committed the
    * thread server-side to avoid a `404: Thread not found`, which means
    * events emitted during that window MUST be delivered to the late

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -415,6 +415,8 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
     expect(streamBodies).toHaveLength(2);
     expect(streamBodies[0]).not.toHaveProperty("since");
     expect(streamBodies[1]).not.toHaveProperty("since");
+    expect(streamBodies[0]).not.toHaveProperty("since_event_id");
+    expect(streamBodies[1]).toMatchObject({ since_event_id: "e1" });
 
     await transport.close();
   });
@@ -496,8 +498,93 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
     expect(streamBodies).toHaveLength(2);
     expect(streamBodies[0]).toMatchObject({ since: 5 });
     expect(streamBodies[1]).not.toHaveProperty("since");
+    expect(streamBodies[1]).toMatchObject({ since_event_id: "e6" });
     expect(received.map((m) => m.event_id)).toEqual(
       expect.arrayContaining(["e6", "e1"])
+    );
+
+    await transport.close();
+  });
+
+  it("sends caller since_event_id on the initial open and reconnect", async () => {
+    let streamOpens = 0;
+    const encoder = new TextEncoder();
+    const fetchImpl = vi.fn((input: URL | RequestInfo) => {
+      if (!String(input).includes("/stream/events")) {
+        return Promise.resolve(protocolSuccessResponse());
+      }
+      streamOpens += 1;
+      if (streamOpens === 1) {
+        return Promise.resolve(
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(
+                  encoder.encode(
+                    'event: values\ndata: {"type":"event","method":"values","seq":1,"event_id":"e10"}\n\n'
+                  )
+                );
+                setTimeout(() => {
+                  controller.error(
+                    new TypeError("net::ERR_QUIC_PROTOCOL_ERROR")
+                  );
+                }, 10);
+              },
+            }),
+            {
+              status: 200,
+              headers: { "content-type": "text/event-stream" },
+            }
+          )
+        );
+      }
+      return Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  'event: values\ndata: {"type":"event","method":"values","seq":2,"event_id":"e11"}\n\n'
+                )
+              );
+              controller.close();
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          }
+        )
+      );
+    }) as MockFetch;
+
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: THREAD_ID,
+      fetch: fetchImpl,
+      maxReconnectAttempts: 3,
+      reconnectDelayMs: () => 0,
+      idleReconnect: 0,
+    });
+
+    const handle = transport.openEventStream({
+      channels: ["values"],
+      since_event_id: "e9",
+    } as SubscribeParams & { since_event_id: string });
+    await handle.ready;
+
+    const received: Array<{ event_id?: string }> = [];
+    for await (const message of handle.events) {
+      received.push(message as { event_id?: string });
+      if (received.some((m) => m.event_id === "e11")) break;
+    }
+
+    const streamBodies = streamEventBodies(fetchImpl);
+    expect(streamBodies).toHaveLength(2);
+    expect(streamBodies[0]).toMatchObject({ since_event_id: "e9" });
+    expect(streamBodies[1]).toMatchObject({ since_event_id: "e10" });
+    expect(received.map((m) => m.event_id)).toEqual(
+      expect.arrayContaining(["e10", "e11"])
     );
 
     await transport.close();

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -256,14 +256,29 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
     // once. Do not advance it from observed `seq` values — those are
     // connection-local, and carrying them onto a post-connect reconnect
     // POST filters out the full Redis replay (heartbeats only). Pre-ready
-    // retries still send the caller cursor; only after a successful open
-    // do reconnects omit `since` and rely on durable `event_id` dedup.
+    // retries still send the caller cursor; after a successful open,
+    // reconnects omit `since` and send durable `since_event_id` instead.
     const initialSince =
       typeof (params as SubscribeParams & { since?: unknown }).since ===
       "number"
         ? (params as SubscribeParams & { since: number }).since
         : undefined;
 
+    const initialSinceEventId = (() => {
+      const raw = (
+        params as SubscribeParams & {
+          since_event_id?: unknown;
+          sinceEventId?: unknown;
+        }
+      ).since_event_id;
+      if (typeof raw === "string" && raw.length > 0) return raw;
+      const camel = (
+        params as SubscribeParams & { sinceEventId?: unknown }
+      ).sinceEventId;
+      return typeof camel === "string" && camel.length > 0 ? camel : undefined;
+    })();
+
+    let lastDurableEventId = initialSinceEventId;
     let readySettled = false;
 
     const startStream = async () => {
@@ -271,6 +286,12 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
 
       while (!ac.signal.aborted && !this.closed) {
         try {
+          const sinceEventId =
+            readySettled && lastDurableEventId != null
+              ? lastDurableEventId
+              : !readySettled
+                ? initialSinceEventId
+                : undefined;
           const response = await this.request(
             streamUrl,
             {
@@ -285,6 +306,9 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
                 ...(params.depth != null ? { depth: params.depth } : {}),
                 ...(!readySettled && initialSince != null
                   ? { since: initialSince }
+                  : {}),
+                ...(sinceEventId != null
+                  ? { since_event_id: sinceEventId }
                   : {}),
               }),
               signal: ac.signal,
@@ -327,7 +351,15 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
               break;
             }
             if (isRecord(event.data)) {
-              streamQueue.push(event.data as Message);
+              const message = event.data as Message;
+              if (
+                message.type === "event" &&
+                typeof message.event_id === "string" &&
+                message.event_id.length > 0
+              ) {
+                lastDurableEventId = message.event_id;
+              }
+              streamQueue.push(message);
             }
           }
           streamQueue.close();

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -272,9 +272,8 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
         }
       ).since_event_id;
       if (typeof raw === "string" && raw.length > 0) return raw;
-      const camel = (
-        params as SubscribeParams & { sinceEventId?: unknown }
-      ).sinceEventId;
+      const camel = (params as SubscribeParams & { sinceEventId?: unknown })
+        .sinceEventId;
       return typeof camel === "string" && camel.length > 0 ? camel : undefined;
     })();
 

--- a/libs/sdk/src/client/stream/transport/types.ts
+++ b/libs/sdk/src/client/stream/transport/types.ts
@@ -59,6 +59,8 @@ export interface ProtocolSseTransportOptions {
    * that hard-kills the serving pod). On idle the underlying read is aborted,
    * which the reconnect loop treats like any other disconnect and re-opens
    * the SSE without carrying a connection-local `since` (`seq` resets).
+   * After the first successful open, reconnects send durable
+   * `since_event_id` from the last observed `event_id` instead.
    *
    * - `"auto"` (`DEFAULT_IDLE_RECONNECT` from `utils/stream`): arm only once
    *   the server's SSE keep-alive heartbeats (LangGraph Platform:

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -8,6 +8,7 @@ import type { ThreadStream } from "../client/stream/index.js";
 
 interface State {
   messages?: unknown[];
+  title?: string;
 }
 
 function makeNeverEndingSubscription() {
@@ -111,17 +112,23 @@ function inputRequestedEvent(
   } as Event;
 }
 
-function valuesEvent(messages: unknown[], seq: number): Event {
+function valuesEvent(
+  messages: unknown[],
+  seq: number,
+  opts: { run_id?: string; title?: string; event_id?: string } = {}
+): Event {
   return {
     type: "event",
-    event_id: `values-${seq}`,
+    event_id: opts.event_id ?? `values-${seq}`,
     seq,
+    ...(opts.run_id != null ? { run_id: opts.run_id } : {}),
     method: "values",
     params: {
       namespace: [],
       timestamp: 0,
       data: {
         messages,
+        ...(opts.title != null ? { title: opts.title } : {}),
       },
     },
   } as Event;
@@ -141,11 +148,16 @@ function checkpointsEvent(step: number, seq: number, id = `cp-${step}`): Event {
   } as unknown as Event;
 }
 
-function lifecycleEvent(event: string, seq: number): Event {
+function lifecycleEvent(
+  event: string,
+  seq: number,
+  opts: { run_id?: string; event_id?: string } = {}
+): Event {
   return {
     type: "event",
-    event_id: `lifecycle-${event}-${seq}`,
+    event_id: opts.event_id ?? `lifecycle-${event}-${seq}`,
     seq,
+    ...(opts.run_id != null ? { run_id: opts.run_id } : {}),
     method: "lifecycle",
     params: {
       namespace: [],
@@ -1318,6 +1330,138 @@ describe("StreamController", () => {
       "ai-1",
     ]);
     expect((messages[1] as { text?: string }).text).toBe("All done.");
+
+    await controller.dispose();
+  });
+
+  it("ignores prior-run lifecycle/values replay after idle hydrate submit (#2609)", async () => {
+    // Hydrate an idle thread, submit a new run, then replay the finished
+    // prior run's root lifecycle + values before any current-run event.
+    // The prior terminal must not settle submit / clear isLoading, and
+    // prior values must not rewind hydrated non-message state.
+    const rootSubscription = makePushableSubscription();
+    const submitRun = vi.fn(async () => ({ run_id: "run-current" }));
+    const thread = {
+      subscribe: vi.fn(async () => rootSubscription),
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      submitRun,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const seededMessages = [
+      { type: "human", content: "old", id: "old-user" },
+      { type: "ai", id: "old-ai", content: "old answer" },
+    ];
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({
+          values: { messages: seededMessages, title: "Current title" },
+          next: [],
+          tasks: [],
+          checkpoint: { checkpoint_id: "cp-latest" },
+          metadata: { step: 9 },
+        })),
+        getHistory: vi.fn(async () => []),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State>({
+      assistantId: "deep-agent",
+      client: client as never,
+      threadId: "thread-idle",
+    });
+    await controller.hydrationPromise;
+    await waitForExpectation(() => {
+      expect(controller.rootStore.getSnapshot().values).toMatchObject({
+        title: "Current title",
+      });
+    });
+
+    const submitPromise = controller.submit({
+      messages: [{ type: "human", content: "new", id: "new-user" }],
+    });
+    await waitForExpectation(() => {
+      expect(thread.submitRun).toHaveBeenCalled();
+      expect(thread.subscribe).toHaveBeenCalled();
+    });
+    await rootSubscription.started;
+
+    // Prior-run replay (would previously settle submit + rewind title).
+    rootSubscription.push(
+      lifecycleEvent("running", 1, {
+        run_id: "run-old",
+        event_id: "synth:run-old:lc||running",
+      })
+    );
+    rootSubscription.push(
+      valuesEvent([{ type: "human", content: "old", id: "old-user" }], 2, {
+        run_id: "run-old",
+        title: "Initial title",
+        event_id: "synth:run-old:values|2",
+      })
+    );
+    rootSubscription.push(
+      lifecycleEvent("completed", 3, {
+        run_id: "run-old",
+        event_id: "synth:run-old:lc||completed",
+      })
+    );
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(controller.rootStore.getSnapshot().isLoading).toBe(true);
+    expect(controller.rootStore.getSnapshot().values).toMatchObject({
+      title: "Current title",
+    });
+    expect(
+      controller.rootStore.getSnapshot().messages.map((m) => (m as { id?: string }).id)
+    ).toEqual(expect.arrayContaining(["old-user", "old-ai", "new-user"]));
+
+    let submitSettled = false;
+    void submitPromise.then(() => {
+      submitSettled = true;
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(submitSettled).toBe(false);
+
+    // Current-run events — only these may settle submit / update title.
+    rootSubscription.push(
+      lifecycleEvent("running", 4, {
+        run_id: "run-current",
+        event_id: "synth:run-current:lc||running",
+      })
+    );
+    rootSubscription.push(
+      valuesEvent(
+        [
+          ...seededMessages,
+          { type: "human", content: "new", id: "new-user" },
+          { type: "ai", id: "new-ai", content: "new answer" },
+        ],
+        5,
+        {
+          run_id: "run-current",
+          title: "Updated title",
+          event_id: "synth:run-current:values|5",
+        }
+      )
+    );
+    rootSubscription.push(
+      lifecycleEvent("completed", 6, {
+        run_id: "run-current",
+        event_id: "synth:run-current:lc||completed",
+      })
+    );
+
+    await submitPromise;
+    await waitForExpectation(() => {
+      expect(controller.rootStore.getSnapshot().isLoading).toBe(false);
+    });
+    expect(controller.rootStore.getSnapshot().values).toMatchObject({
+      title: "Updated title",
+    });
 
     await controller.dispose();
   });

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -69,6 +69,10 @@ import {
   type MessageMetadataMap,
 } from "./message-metadata-tracker.js";
 import { LifecycleLoadingTracker } from "./lifecycle-loading-tracker.js";
+import {
+  RunBoundaryGate,
+  type RunBoundFlush,
+} from "./run-boundary-gate.js";
 import { RootMessageProjection } from "./root-message-projection.js";
 import {
   prepareOptimisticInput,
@@ -304,6 +308,12 @@ export class StreamController<
   readonly #rootBus: RootEventBus;
   #activeRunId: string | undefined;
   #localRunDepth = 0;
+  readonly #runBoundary = new RunBoundaryGate();
+  /**
+   * Submit waiters register here so buffered terminals/values flushed
+   * at {@link #notifyCreated} can settle the fast-ack race.
+   */
+  readonly #boundFlushListeners = new Set<(flush: RunBoundFlush) => void>();
   /**
    * `true` once a root `values` event has been applied for the current
    * optimistic run. Reset to `false` in {@link #beginOptimistic} and
@@ -373,6 +383,7 @@ export class StreamController<
     this.#lifecycleLoading = new LifecycleLoadingTracker({
       store: this.rootStore,
       isDisposed: () => this.#disposed,
+      acceptLifecycle: (event) => this.#runBoundary.acceptLifecycle(event),
     });
     this.messageMetadataStore = this.#messageMetadata.store;
     this.queueStore = new StreamStore<SubmissionQueueSnapshot<StateType>>(
@@ -406,7 +417,7 @@ export class StreamController<
       awaitNextTerminal: (signal) => this.#awaitNextTerminal(signal),
       awaitResumedRunTerminal: (signal) =>
         this.#awaitResumedRunTerminal(signal),
-      onSubmitStart: () => {
+      onSubmitStart: (kind) => {
         // Clear the hydrate-window allowlist so genuinely-new live
         // interrupts on the just-started run (submit *or* respond /
         // respondAll via dispatchResume) aren't filtered. Bump the
@@ -414,6 +425,11 @@ export class StreamController<
         // write on return (see #hydratedActiveInterruptIds).
         this.#hydratedActiveInterruptIds = null;
         this.#submitGeneration += 1;
+        if (kind === "resume") {
+          this.#runBoundary.onResumeStart();
+        } else {
+          this.#runBoundary.onSubmitStart();
+        }
       },
       onRunStart: () => this.#markLocalRunStart(),
       onRunCreated: (runId) => this.#notifyCreated(runId),
@@ -598,6 +614,17 @@ export class StreamController<
       // A prior hydrate-404 may have marked this id missing; clear it
       // now that the server row exists (e.g. another client created it).
       this.#missingThreadIds.delete(hydratedThreadId);
+      // Bind the run-boundary gate to the in-flight run when possible so
+      // SSE replay of older runs is dropped without a local submit.
+      if (threadActive) {
+        const metaRunId = (
+          state?.metadata as { run_id?: unknown } | undefined
+        )?.run_id;
+        if (typeof metaRunId === "string" && metaRunId.length > 0) {
+          this.#runBoundary.onRunBound(metaRunId);
+          this.#activeRunId = metaRunId;
+        }
+      }
       if (state?.values != null) {
         /**
          * `threads.getState()` returns the legacy `ThreadState` shape
@@ -1194,7 +1221,31 @@ export class StreamController<
   }
 
   #notifyCreated(runId: string): void {
+    const alreadyBound = this.#activeRunId === runId;
     this.#activeRunId = runId;
+    const flush = this.#runBoundary.onRunBound(runId);
+    // Re-apply values that arrived before run.start resolved, then
+    // notify submit waiters of matching buffered terminals.
+    for (const valuesEvent of flush.values) {
+      if (valuesEvent.method !== "values") continue;
+      const data = (valuesEvent as ValuesEvent).params.data;
+      this.#applyValues(data);
+    }
+    if (flush.terminals.length > 0 || flush.values.length > 0) {
+      for (const listener of this.#boundFlushListeners) {
+        try {
+          listener(flush);
+        } catch {
+          /* waiter errors must not crash the stream */
+        }
+      }
+      // Loading tracker skipped these during expecting mode — drive it
+      // now that the gate accepts the bound run's lifecycle.
+      for (const terminal of flush.terminals) {
+        this.#lifecycleLoading.handle(terminal);
+      }
+    }
+    if (alreadyBound) return;
     try {
       this.#options.onCreated?.({ runId });
     } catch {
@@ -1209,6 +1260,7 @@ export class StreamController<
     if (runId != null && runId === this.#activeRunId) {
       this.#activeRunId = undefined;
     }
+    this.#runBoundary.onRunSettled();
     setTimeout(() => {
       if (this.#disposed) return;
       try {
@@ -1225,6 +1277,7 @@ export class StreamController<
     if (this.#localRunDepth > 0) return;
     if (event.method !== "lifecycle") return;
     if (!isRootNamespace(event.params.namespace)) return;
+    if (!this.#runBoundary.acceptLifecycle(event)) return;
     if (!this.rootStore.getSnapshot().isLoading) return;
     const lifecycle = (event as LifecycleEvent).params.data as {
       event?: string;
@@ -1719,6 +1772,8 @@ export class StreamController<
     this.#rootMessages.reset();
     this.#rootToolAssembler = new ToolCallAssembler();
     this.#lifecycleLoading.reset();
+    this.#runBoundary.reset();
+    this.#boundFlushListeners.clear();
     this.#subagents.reset();
     this.#subgraphs.reset();
     this.#scopedHistorySeeds.clear();
@@ -2073,6 +2128,9 @@ export class StreamController<
       const bufferedCheckpoint = this.#messageMetadata.consumeCheckpoint(
         event.params.namespace
       );
+      if (!this.#runBoundary.acceptValues(event)) {
+        return;
+      }
       this.#applyValues(valuesEvent.params.data, bufferedCheckpoint);
       return;
     }
@@ -2423,22 +2481,28 @@ export class StreamController<
     return new Promise((resolve) => {
       let settled = false;
       let sawRunning = false;
-      function finish(result: {
+      let unsubscribeRoot: (() => void) | undefined;
+      let unsubscribeThread: (() => void) | undefined;
+      const finish = (result: {
         event: "completed" | "failed" | "interrupted" | "aborted";
         error?: string;
-      }) {
+      }) => {
         if (settled) return;
         settled = true;
+        this.#boundFlushListeners.delete(onFlush);
         unsubscribeRoot?.();
         unsubscribeThread?.();
         signal.removeEventListener("abort", finishAborted);
         resolve(result);
-      }
+      };
       const finishAborted = () => finish({ event: "aborted" });
-      const onEvent = (event: Event) => {
+      const handleLifecycle = (event: Event, alreadyAccepted: boolean) => {
         if (settled) return;
         if (event.method !== "lifecycle") return;
         if (!isRootNamespace(event.params.namespace)) return;
+        if (!alreadyAccepted && !this.#runBoundary.acceptLifecycle(event)) {
+          return;
+        }
         const lifecycle = (event as LifecycleEvent).params.data as {
           event?: string;
           error?: string;
@@ -2461,8 +2525,16 @@ export class StreamController<
           setTimeout(() => finish({ event: "interrupted" }), 0);
         }
       };
-      const unsubscribeRoot = this.#rootBus.subscribe(onEvent);
-      const unsubscribeThread = this.#thread?.onEvent(onEvent);
+      const onEvent = (event: Event) => handleLifecycle(event, false);
+      const onFlush = (flush: RunBoundFlush) => {
+        for (const terminal of flush.terminals) {
+          // Gate already accepted these on bind; don't re-filter.
+          handleLifecycle(terminal, true);
+        }
+      };
+      this.#boundFlushListeners.add(onFlush);
+      unsubscribeRoot = this.#rootBus.subscribe(onEvent);
+      unsubscribeThread = this.#thread?.onEvent(onEvent);
       if (signal.aborted) {
         finishAborted();
       } else {

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -69,10 +69,7 @@ import {
   type MessageMetadataMap,
 } from "./message-metadata-tracker.js";
 import { LifecycleLoadingTracker } from "./lifecycle-loading-tracker.js";
-import {
-  RunBoundaryGate,
-  type RunBoundFlush,
-} from "./run-boundary-gate.js";
+import { RunBoundaryGate, type RunBoundFlush } from "./run-boundary-gate.js";
 import { RootMessageProjection } from "./root-message-projection.js";
 import {
   prepareOptimisticInput,
@@ -617,9 +614,8 @@ export class StreamController<
       // Bind the run-boundary gate to the in-flight run when possible so
       // SSE replay of older runs is dropped without a local submit.
       if (threadActive) {
-        const metaRunId = (
-          state?.metadata as { run_id?: unknown } | undefined
-        )?.run_id;
+        const metaRunId = (state?.metadata as { run_id?: unknown } | undefined)
+          ?.run_id;
         if (typeof metaRunId === "string" && metaRunId.length > 0) {
           this.#runBoundary.onRunBound(metaRunId);
           this.#activeRunId = metaRunId;
@@ -2481,8 +2477,7 @@ export class StreamController<
     return new Promise((resolve) => {
       let settled = false;
       let sawRunning = false;
-      let unsubscribeRoot: (() => void) | undefined;
-      let unsubscribeThread: (() => void) | undefined;
+      const unsubscribes: Array<() => void> = [];
       const finish = (result: {
         event: "completed" | "failed" | "interrupted" | "aborted";
         error?: string;
@@ -2490,8 +2485,7 @@ export class StreamController<
         if (settled) return;
         settled = true;
         this.#boundFlushListeners.delete(onFlush);
-        unsubscribeRoot?.();
-        unsubscribeThread?.();
+        for (const unsubscribe of unsubscribes) unsubscribe();
         signal.removeEventListener("abort", finishAborted);
         resolve(result);
       };
@@ -2533,8 +2527,9 @@ export class StreamController<
         }
       };
       this.#boundFlushListeners.add(onFlush);
-      unsubscribeRoot = this.#rootBus.subscribe(onEvent);
-      unsubscribeThread = this.#thread?.onEvent(onEvent);
+      unsubscribes.push(this.#rootBus.subscribe(onEvent));
+      const unsubscribeThread = this.#thread?.onEvent(onEvent);
+      if (unsubscribeThread != null) unsubscribes.push(unsubscribeThread);
       if (signal.aborted) {
         finishAborted();
       } else {

--- a/libs/sdk/src/stream/lifecycle-loading-tracker.ts
+++ b/libs/sdk/src/stream/lifecycle-loading-tracker.ts
@@ -66,6 +66,12 @@ export class LifecycleLoadingTracker<T extends LoadingSnapshot> {
   readonly #isDisposed: () => boolean;
 
   /**
+   * Optional run-boundary filter. When provided, root lifecycle events
+   * rejected by the gate (replay from other runs) are ignored.
+   */
+  readonly #acceptLifecycle: ((event: Event) => boolean) | undefined;
+
+  /**
    * Highest sequence number of a terminal lifecycle we've observed.
    * `running` events at or below this seq are stale replays and
    * are dropped to avoid flipping the loading flag back on after the
@@ -76,10 +82,16 @@ export class LifecycleLoadingTracker<T extends LoadingSnapshot> {
   /**
    * @param params.store      - Store whose `isLoading` slot we drive.
    * @param params.isDisposed - Disposal probe consulted from deferred callbacks.
+   * @param params.acceptLifecycle - Optional run-boundary accept predicate.
    */
-  constructor(params: { store: StreamStore<T>; isDisposed: () => boolean }) {
+  constructor(params: {
+    store: StreamStore<T>;
+    isDisposed: () => boolean;
+    acceptLifecycle?: (event: Event) => boolean;
+  }) {
     this.#store = params.store;
     this.#isDisposed = params.isDisposed;
+    this.#acceptLifecycle = params.acceptLifecycle;
   }
 
   /**
@@ -112,6 +124,9 @@ export class LifecycleLoadingTracker<T extends LoadingSnapshot> {
   handle(event: Event): void {
     if (event.method !== "lifecycle") return;
     if (!isRootNamespace(event.params.namespace)) return;
+    if (this.#acceptLifecycle != null && !this.#acceptLifecycle(event)) {
+      return;
+    }
     const lifecycle = (event as LifecycleEvent).params.data as {
       event?: string;
     };

--- a/libs/sdk/src/stream/run-boundary-gate.test.ts
+++ b/libs/sdk/src/stream/run-boundary-gate.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import type { Event, LifecycleEvent, ValuesEvent } from "@langchain/protocol";
+
+import {
+  extractEventRunId,
+  RunBoundaryGate,
+} from "./run-boundary-gate.js";
+
+function lifecycleEvent(
+  status: string,
+  opts: { run_id?: string; event_id?: string; seq?: number } = {}
+): Event {
+  return {
+    type: "event",
+    method: "lifecycle",
+    seq: opts.seq ?? 1,
+    ...(opts.run_id != null ? { run_id: opts.run_id } : {}),
+    ...(opts.event_id != null ? { event_id: opts.event_id } : {}),
+    params: {
+      namespace: [],
+      timestamp: 0,
+      data: { event: status },
+    },
+  } as LifecycleEvent & Event;
+}
+
+function valuesEvent(
+  opts: { run_id?: string; event_id?: string; title?: string } = {}
+): Event {
+  return {
+    type: "event",
+    method: "values",
+    seq: 1,
+    ...(opts.run_id != null ? { run_id: opts.run_id } : {}),
+    ...(opts.event_id != null ? { event_id: opts.event_id } : {}),
+    params: {
+      namespace: [],
+      timestamp: 0,
+      data: { title: opts.title ?? "x", messages: [] },
+    },
+  } as ValuesEvent & Event;
+}
+
+describe("extractEventRunId", () => {
+  it("prefers envelope run_id", () => {
+    expect(
+      extractEventRunId({
+        run_id: "run-a",
+        event_id: "synth:run-b:lc||completed",
+      })
+    ).toBe("run-a");
+  });
+
+  it("falls back to synth event_id prefix", () => {
+    expect(
+      extractEventRunId({ event_id: "synth:run-old:lc||completed" })
+    ).toBe("run-old");
+  });
+
+  it("returns undefined for opaque event ids", () => {
+    expect(extractEventRunId({ event_id: "1-2" })).toBeUndefined();
+  });
+});
+
+describe("RunBoundaryGate", () => {
+  it("accepts everything while idle", () => {
+    const gate = new RunBoundaryGate();
+    expect(gate.acceptLifecycle(lifecycleEvent("completed", { run_id: "x" }))).toBe(
+      true
+    );
+    expect(gate.acceptValues(valuesEvent({ run_id: "x" }))).toBe(true);
+  });
+
+  it("buffers matching terminals until bind and rejects other runs", () => {
+    const gate = new RunBoundaryGate();
+    gate.onSubmitStart();
+    expect(
+      gate.acceptLifecycle(
+        lifecycleEvent("completed", {
+          run_id: "run-old",
+          event_id: "e-old",
+        })
+      )
+    ).toBe(false);
+    expect(
+      gate.acceptLifecycle(
+        lifecycleEvent("completed", {
+          run_id: "run-current",
+          event_id: "e-cur",
+        })
+      )
+    ).toBe(false);
+
+    const flush = gate.onRunBound("run-current");
+    expect(flush.terminals.map((e) => e.event_id)).toEqual(["e-cur"]);
+    expect(
+      gate.acceptLifecycle(
+        lifecycleEvent("completed", { run_id: "run-old", event_id: "e2" })
+      )
+    ).toBe(false);
+    expect(
+      gate.acceptLifecycle(
+        lifecycleEvent("completed", {
+          run_id: "run-current",
+          event_id: "e3",
+        })
+      )
+    ).toBe(true);
+  });
+
+  it("rejects values from other runs after bind", () => {
+    const gate = new RunBoundaryGate();
+    gate.onSubmitStart();
+    gate.onRunBound("run-current");
+    expect(gate.acceptValues(valuesEvent({ run_id: "run-old" }))).toBe(false);
+    expect(gate.acceptValues(valuesEvent({ run_id: "run-current" }))).toBe(
+      true
+    );
+  });
+
+  it("legacy path requires running after bind before terminals", () => {
+    const gate = new RunBoundaryGate();
+    gate.onSubmitStart();
+    gate.onRunBound("run-current");
+    expect(gate.acceptLifecycle(lifecycleEvent("completed"))).toBe(false);
+    expect(gate.acceptLifecycle(lifecycleEvent("running"))).toBe(true);
+    expect(gate.acceptLifecycle(lifecycleEvent("completed"))).toBe(true);
+  });
+
+  it("resume mode ignores interrupted until running but accepts failed", () => {
+    const gate = new RunBoundaryGate();
+    gate.onResumeStart();
+    expect(gate.acceptLifecycle(lifecycleEvent("interrupted"))).toBe(false);
+    expect(gate.acceptLifecycle(lifecycleEvent("failed"))).toBe(true);
+    expect(gate.acceptLifecycle(lifecycleEvent("running"))).toBe(true);
+    expect(gate.acceptLifecycle(lifecycleEvent("interrupted"))).toBe(true);
+  });
+
+  it("uses synth event_id when envelope run_id is absent", () => {
+    const gate = new RunBoundaryGate();
+    gate.onSubmitStart();
+    gate.onRunBound("run-current");
+    expect(
+      gate.acceptLifecycle(
+        lifecycleEvent("completed", {
+          event_id: "synth:run-old:lc||completed",
+        })
+      )
+    ).toBe(false);
+    expect(
+      gate.acceptLifecycle(
+        lifecycleEvent("completed", {
+          event_id: "synth:run-current:lc||completed",
+        })
+      )
+    ).toBe(true);
+  });
+});

--- a/libs/sdk/src/stream/run-boundary-gate.test.ts
+++ b/libs/sdk/src/stream/run-boundary-gate.test.ts
@@ -127,6 +127,29 @@ describe("RunBoundaryGate", () => {
     expect(gate.acceptLifecycle(lifecycleEvent("completed"))).toBe(true);
   });
 
+  it("buffers legacy terminals during expect and flushes them on bind", () => {
+    const gate = new RunBoundaryGate();
+    gate.onSubmitStart();
+    expect(
+      gate.acceptLifecycle(
+        lifecycleEvent("running", { event_id: "1" })
+      )
+    ).toBe(false);
+    expect(
+      gate.acceptLifecycle(
+        lifecycleEvent("completed", { event_id: "2" })
+      )
+    ).toBe(false);
+
+    const flush = gate.onRunBound("run-current");
+    expect(flush.terminals.map((e) => e.event_id)).toEqual(["2"]);
+    // Running during expect arms the legacy flag so later bare terminals
+    // are accepted without waiting for another running.
+    expect(gate.acceptLifecycle(lifecycleEvent("completed", { event_id: "3" }))).toBe(
+      true
+    );
+  });
+
   it("resume mode ignores interrupted until running but accepts failed", () => {
     const gate = new RunBoundaryGate();
     gate.onResumeStart();

--- a/libs/sdk/src/stream/run-boundary-gate.ts
+++ b/libs/sdk/src/stream/run-boundary-gate.ts
@@ -1,0 +1,244 @@
+/**
+ * Run-scoped filter for protocol v2 replay.
+ *
+ * New SSE subscriptions replay the thread tape from `seq=0`. Connection-
+ * local `seq` cannot tell "old run" from "current run". This gate uses
+ * durable `run_id` (envelope field, with a `synth:<run_id>:…` fallback)
+ * so submit settle, loading, and values application ignore pre-boundary
+ * replay from older runs.
+ *
+ * Modes:
+ * - `idle` — no local submit / bound run; accept everything (legacy).
+ * - `expecting` — submit started, `run.start` not yet resolved; buffer
+ *   terminals/values that carry a run id for flush on bind.
+ * - `bound` — expected run id known; accept only matching events (or,
+ *   on old servers without run id, events after a post-bind `running`).
+ */
+import type { Event, LifecycleEvent } from "@langchain/protocol";
+
+const TERMINAL_EVENTS = new Set(["completed", "failed", "interrupted"]);
+
+export type RunBoundaryMode = "idle" | "expecting" | "bound";
+
+export interface RunBoundFlush {
+  readonly terminals: Event[];
+  readonly values: Event[];
+}
+
+/**
+ * Read durable run identity from a protocol event.
+ *
+ * Prefers the envelope `run_id` field. Falls back to parsing
+ * `synth:<run_id>:…` event ids minted by Agent Server for synthetic
+ * lifecycle frames — not a public contract, only a compatibility path
+ * until all servers stamp the envelope field.
+ */
+export function extractEventRunId(event: {
+  run_id?: unknown;
+  event_id?: unknown;
+}): string | undefined {
+  if (typeof event.run_id === "string" && event.run_id.length > 0) {
+    return event.run_id;
+  }
+  if (typeof event.event_id === "string") {
+    const match = /^synth:([^:]+):/.exec(event.event_id);
+    if (match?.[1]) return match[1];
+  }
+  return undefined;
+}
+
+function lifecycleStatus(event: Event): string | undefined {
+  if (event.method !== "lifecycle") return undefined;
+  const data = (event as LifecycleEvent).params.data as { event?: string };
+  return typeof data?.event === "string" ? data.event : undefined;
+}
+
+export class RunBoundaryGate {
+  #mode: RunBoundaryMode = "idle";
+  #expectedRunId: string | undefined;
+  /**
+   * When bound without a concrete run id (HITL resume via `input.respond`,
+   * which does not return `run_id`), require a root `running` before
+   * terminals/values count — same idea as `#awaitResumedRunTerminal`.
+   */
+  #legacyRequireRunning = false;
+  #sawRunningForExpected = false;
+  #bufferedTerminals: Event[] = [];
+  #bufferedValues: Event[] = [];
+
+  get mode(): RunBoundaryMode {
+    return this.#mode;
+  }
+
+  get expectedRunId(): string | undefined {
+    return this.#expectedRunId;
+  }
+
+  /**
+   * Enter expecting mode at the start of a local submit.
+   * Until {@link onRunBound}, root terminals and values are not applied.
+   */
+  onSubmitStart(): void {
+    this.#mode = "expecting";
+    this.#expectedRunId = undefined;
+    this.#legacyRequireRunning = false;
+    this.#sawRunningForExpected = false;
+    this.#bufferedTerminals = [];
+    this.#bufferedValues = [];
+  }
+
+  /**
+   * Enter a run-id-less boundary for `input.respond` resumes.
+   * `input.respond` does not return a run id, so we accept events after
+   * the next root `running` (and ignore pre-running terminals).
+   */
+  onResumeStart(): void {
+    this.#mode = "bound";
+    this.#expectedRunId = undefined;
+    this.#legacyRequireRunning = true;
+    this.#sawRunningForExpected = false;
+    this.#bufferedTerminals = [];
+    this.#bufferedValues = [];
+  }
+
+  /**
+   * Bind to the run accepted by `run.start` (or hydrate of an active run).
+   *
+   * @returns Buffered root events whose run id matches, for waiters /
+   *   projection to apply (fast path before command ack).
+   */
+  onRunBound(runId: string): RunBoundFlush {
+    if (this.#mode === "bound" && this.#expectedRunId === runId) {
+      // Idempotent re-bind (submit coordinator may notify twice).
+      return { terminals: [], values: [] };
+    }
+    this.#expectedRunId = runId;
+    this.#mode = "bound";
+    this.#legacyRequireRunning = false;
+    const terminals = this.#bufferedTerminals.filter(
+      (event) => extractEventRunId(event) === runId
+    );
+    const values = this.#bufferedValues.filter(
+      (event) => extractEventRunId(event) === runId
+    );
+    this.#bufferedTerminals = [];
+    this.#bufferedValues = [];
+    return { terminals, values };
+  }
+
+  /** Clear on thread teardown. */
+  reset(): void {
+    this.#mode = "idle";
+    this.#expectedRunId = undefined;
+    this.#legacyRequireRunning = false;
+    this.#sawRunningForExpected = false;
+    this.#bufferedTerminals = [];
+    this.#bufferedValues = [];
+  }
+
+  /**
+   * Clear after the bound local run settles so later replay / re-attach
+   * falls back to idle acceptance until the next submit.
+   */
+  onRunSettled(): void {
+    this.reset();
+  }
+
+  /**
+   * Whether a root lifecycle event should drive loading / submit settle.
+   */
+  acceptLifecycle(event: Event): boolean {
+    if (this.#mode === "idle") return true;
+
+    const status = lifecycleStatus(event);
+    if (status == null) return true;
+
+    const runId = extractEventRunId(event);
+
+    if (this.#mode === "expecting") {
+      if (TERMINAL_EVENTS.has(status) && runId != null) {
+        this.#bufferUnique(this.#bufferedTerminals, event);
+      }
+      // Drop `running` from unknown runs until bound — loading must not
+      // flicker on replayed prior-run lifecycle.
+      return false;
+    }
+
+    // bound
+    if (this.#expectedRunId != null) {
+      if (runId != null) {
+        if (runId !== this.#expectedRunId) return false;
+        if (status === "running") this.#sawRunningForExpected = true;
+        return true;
+      }
+      // Legacy servers: no envelope / synth run id — require a `running`
+      // after bind before terminals count.
+      if (status === "running") {
+        this.#sawRunningForExpected = true;
+        return true;
+      }
+      if (TERMINAL_EVENTS.has(status)) {
+        return this.#sawRunningForExpected;
+      }
+      return true;
+    }
+
+    // Resume without run id (`onResumeStart`): mirror
+    // `#awaitResumedRunTerminal` — only `interrupted` waits for a
+    // post-resume `running`; `completed` / `failed` settle immediately.
+    if (this.#legacyRequireRunning) {
+      if (status === "running") {
+        this.#sawRunningForExpected = true;
+        return true;
+      }
+      if (status === "interrupted") {
+        return this.#sawRunningForExpected;
+      }
+      return true;
+    }
+
+    return true;
+  }
+
+  /**
+   * Whether a root `values` snapshot should update projected state.
+   * Hydrated `getState()` remains authoritative until the current run
+   * produces snapshots.
+   */
+  acceptValues(event: Event): boolean {
+    if (this.#mode === "idle") return true;
+
+    const runId = extractEventRunId(event);
+
+    if (this.#mode === "expecting") {
+      if (runId != null) {
+        this.#bufferUnique(this.#bufferedValues, event);
+      }
+      return false;
+    }
+
+    if (this.#expectedRunId != null) {
+      if (runId != null) {
+        return runId === this.#expectedRunId;
+      }
+      return this.#sawRunningForExpected;
+    }
+
+    if (this.#legacyRequireRunning) {
+      return this.#sawRunningForExpected;
+    }
+
+    return true;
+  }
+
+  #bufferUnique(buffer: Event[], event: Event): void {
+    const eventId = event.event_id;
+    if (
+      typeof eventId === "string" &&
+      buffer.some((entry) => entry.event_id === eventId)
+    ) {
+      return;
+    }
+    buffer.push(event);
+  }
+}

--- a/libs/sdk/src/stream/run-boundary-gate.ts
+++ b/libs/sdk/src/stream/run-boundary-gate.ts
@@ -115,12 +115,15 @@ export class RunBoundaryGate {
     this.#expectedRunId = runId;
     this.#mode = "bound";
     this.#legacyRequireRunning = false;
-    const terminals = this.#bufferedTerminals.filter(
-      (event) => extractEventRunId(event) === runId
-    );
-    const values = this.#bufferedValues.filter(
-      (event) => extractEventRunId(event) === runId
-    );
+    const terminals = this.#bufferedTerminals.filter((event) => {
+      const eventRunId = extractEventRunId(event);
+      // Keep matching run ids, and legacy envelopes with no run id.
+      return eventRunId == null || eventRunId === runId;
+    });
+    const values = this.#bufferedValues.filter((event) => {
+      const eventRunId = extractEventRunId(event);
+      return eventRunId == null || eventRunId === runId;
+    });
     this.#bufferedTerminals = [];
     this.#bufferedValues = [];
     return { terminals, values };
@@ -156,11 +159,19 @@ export class RunBoundaryGate {
     const runId = extractEventRunId(event);
 
     if (this.#mode === "expecting") {
-      if (TERMINAL_EVENTS.has(status) && runId != null) {
+      // Buffer terminals for flush on bind. Include legacy envelopes with
+      // no run id — otherwise a fast completed before `run.start` resolves
+      // is dropped and submit waiters hang (embed tests before API stamp).
+      if (TERMINAL_EVENTS.has(status)) {
         this.#bufferUnique(this.#bufferedTerminals, event);
       }
-      // Drop `running` from unknown runs until bound — loading must not
-      // flicker on replayed prior-run lifecycle.
+      if (status === "running" && runId == null) {
+        // Legacy servers emit `running` without run id during the
+        // expect window; remember it so post-bind terminals can settle.
+        this.#sawRunningForExpected = true;
+      }
+      // Drop live apply until bound — loading must not flicker on
+      // replayed prior-run lifecycle.
       return false;
     }
 
@@ -172,7 +183,7 @@ export class RunBoundaryGate {
         return true;
       }
       // Legacy servers: no envelope / synth run id — require a `running`
-      // after bind before terminals count.
+      // after bind (or during expect) before terminals count.
       if (status === "running") {
         this.#sawRunningForExpected = true;
         return true;

--- a/libs/sdk/src/stream/submit-coordinator.ts
+++ b/libs/sdk/src/stream/submit-coordinator.ts
@@ -180,8 +180,12 @@ export class SubmitCoordinator<
   readonly #awaitResumedRunTerminal: (
     signal: AbortSignal
   ) => Promise<TerminalResult>;
-  /** Called once at the start of every {@link submit} invocation. */
-  readonly #onSubmitStart: () => void;
+  /**
+   * Called once at the start of every {@link submit} / {@link dispatchResume}.
+   * `kind` selects the run-boundary gate mode (`submit` waits for run id;
+   * `resume` uses the running-before-terminal legacy boundary).
+   */
+  readonly #onSubmitStart: (kind: "submit" | "resume") => void;
   /** Marks that a local run dispatch is now active. */
   readonly #onRunStart: () => void;
   /** Records a server-accepted local run id and fires `onCreated`. */
@@ -234,7 +238,7 @@ export class SubmitCoordinator<
     waitForRootPumpReady: () => Promise<void> | undefined;
     awaitNextTerminal: (signal: AbortSignal) => Promise<TerminalResult>;
     awaitResumedRunTerminal: (signal: AbortSignal) => Promise<TerminalResult>;
-    onSubmitStart?: () => void;
+    onSubmitStart?: (kind: "submit" | "resume") => void;
     onRunStart?: () => void;
     onRunCreated?: (runId: string) => void;
     onRunCompleted?: (reason: RunExecutionReason, runId?: string) => void;
@@ -301,7 +305,7 @@ export class SubmitCoordinator<
     options?: StreamSubmitOptions<StateType, ConfigurableType>
   ): Promise<void> {
     if (this.#getDisposed()) return;
-    this.#onSubmitStart();
+    this.#onSubmitStart("submit");
 
     // Per-submit thread override: rebind first so the rest of the
     // submit operates against the new thread.
@@ -467,8 +471,23 @@ export class SubmitCoordinator<
       // Fire-and-forget: we don't want to gate Promise.race on this,
       // and `commandPromise.catch` is already handled below. A
       // dispatch failure means there's no thread to pump anyway.
+      const notifyCreated = (result: { run_id?: unknown }) => {
+        if (typeof result.run_id !== "string") return;
+        if (createdRunId === result.run_id) return;
+        createdRunId = result.run_id;
+        // Bind the run-boundary gate *before* opening the deferred
+        // pump so seq=0 replay cannot settle submit / rewind values
+        // under an unbound gate.
+        this.#onRunCreated(createdRunId);
+        if (pendingCompletionReason != null) {
+          notifyCompletion(pendingCompletionReason);
+        }
+      };
+      // Bind run id then start the deferred pump on the same resolution
+      // path — ordering matters for the idle-thread replay gate.
       void commandPromise.then(
-        () => {
+        (result) => {
+          notifyCreated(result);
           this.#startDeferredRootPump();
           this.#forgetSelfCreatedThreadId(activeThreadId);
         },
@@ -486,14 +505,6 @@ export class SubmitCoordinator<
           }
         }
       );
-      const notifyCreated = (result: { run_id?: unknown }) => {
-        if (typeof result.run_id !== "string") return;
-        createdRunId = result.run_id;
-        this.#onRunCreated(createdRunId);
-        if (pendingCompletionReason != null) {
-          notifyCompletion(pendingCompletionReason);
-        }
-      };
       const first = await Promise.race([
         terminalPromise.then((value) => ({
           type: "terminal" as const,
@@ -506,14 +517,15 @@ export class SubmitCoordinator<
       ]);
       if (first.type === "error") throw first.error;
       if (first.type === "command") {
+        // Created + pump already handled by commandPromise.then above;
+        // notifyCreated is idempotent if that listener already ran.
         notifyCreated(first.result);
       } else {
-        // Terminal landed first (very fast runs). Wait for the
-        // dispatch response in the background so onCreated fires
-        // and dispatch errors still surface.
+        // Terminal landed first (very fast runs). Created/pump remain
+        // owned by commandPromise.then; only surface dispatch errors.
         terminal = first.value;
         terminalSettled = true;
-        void commandPromise.then(notifyCreated).catch((error) => {
+        void commandPromise.catch((error) => {
           if (!terminalSettled) reportError(error);
         });
       }
@@ -608,7 +620,8 @@ export class SubmitCoordinator<
     // *new* interrupt id. Without this, the hydrate-window allowlist
     // still contains only the interrupt being answered and
     // `#recordRootInterrupt` drops the follow-on `input.requested`.
-    this.#onSubmitStart();
+    // Use resume gate mode — `input.respond` does not return a run id.
+    this.#onSubmitStart("resume");
 
     // Rollback any run still tracked as active (mirrors submit()), then
     // claim the in-flight slot so stop()/dispose()/a concurrent submit


### PR DESCRIPTION
SSE reconnects were opening without a durable cursor, so the server dumped the full thread tape every time. Track the last `event_id` and send `since_event_id` on reconnect / safe reopen; JS Agent Server skips envelopes at or before that cursor. Session `since` is unchanged for same-connection seq resume.

Depends on [`@langchain/protocol` with `EventStreamRequest.sinceEventId`](https://github.com/langchain-ai/agent-protocol/pull/94).