### PR TITLE
fix(sdk): clear messages on hydrate(null) with a pending interrupt

### DIFF
--- a/.changeset/fix-hydrate-null-interrupted-messages.md
+++ b/.changeset/fix-hydrate-null-interrupted-messages.md
@@ -1,0 +1,8 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): clear messages on hydrate(null) with a pending interrupt
+
+Teardown awaited the paused root pump, so threadId went null while
+the old conversation stayed on screen. Reset the snapshot first.

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -1556,6 +1556,117 @@ describe("StreamController", () => {
     await controller.dispose();
   });
 
+  it("hydrate(null) ignores buffered root events drained after subscription close", async () => {
+    // Regression for open-swe on #2691: SubscriptionHandle.close() leaves
+    // queued events intact and the iterator drains them before observing
+    // closed. An interrupted pump parked on waitForResume() therefore
+    // still dispatches those events through #onRootEvent after hydrate()
+    // has already cleared rootStore — unless the pump generation guard
+    // drops them.
+    let paused = true;
+    let closed = false;
+    const queue: Event[] = [];
+    let resumeResolve: (() => void) | undefined;
+    const hungSubscription = {
+      get isPaused() {
+        return paused;
+      },
+      waitForResume: () => {
+        if (!paused) return Promise.resolve();
+        return new Promise<void>((resolve) => {
+          resumeResolve = resolve;
+        });
+      },
+      unsubscribe: vi.fn(async () => undefined),
+      close: vi.fn(() => {
+        closed = true;
+        paused = false;
+        resumeResolve?.();
+        resumeResolve = undefined;
+      }),
+      buffer(event: Event) {
+        queue.push(event);
+      },
+      [Symbol.asyncIterator]() {
+        return {
+          next: async (): Promise<IteratorResult<Event>> => {
+            // Mirror SubscriptionHandle: drain the queue even after close.
+            if (queue.length > 0) {
+              return { done: false, value: queue.shift()! };
+            }
+            if (closed || paused) {
+              return { done: true, value: undefined };
+            }
+            return { done: true, value: undefined };
+          },
+        };
+      },
+    };
+    const thread = {
+      subscribe: vi.fn(async () => hungSubscription),
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({
+          values: {
+            messages: [
+              { type: "human", content: "old thread message", id: "h-1" },
+            ],
+          },
+          next: [],
+          tasks: [
+            {
+              interrupts: [
+                { id: "int-1", value: { question: "approve?" } },
+              ],
+            },
+          ],
+        })),
+        getHistory: vi.fn(async () => []),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, unknown>({
+      assistantId: "human-in-the-loop",
+      client: client as never,
+      threadId: "thread-interrupted",
+    });
+    await controller.hydrationPromise;
+    await waitForExpectation(() => {
+      expect(thread.subscribe).toHaveBeenCalled();
+    });
+    // Let the root pump park on waitForResume().
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(controller.rootStore.getSnapshot().messages.map((m) => m.id)).toEqual(
+      ["h-1"]
+    );
+
+    // Events buffered while paused — close() will drain these into the
+    // pump after hydrate() has already reset the snapshot.
+    hungSubscription.buffer(
+      valuesEvent(
+        [{ type: "human", content: "stale buffered message", id: "h-stale" }],
+        99
+      )
+    );
+
+    await controller.hydrate(null);
+
+    const snapshot = controller.rootStore.getSnapshot();
+    expect(snapshot.threadId).toBeNull();
+    expect(snapshot.messages).toHaveLength(0);
+    expect(snapshot.interrupts).toHaveLength(0);
+    expect(hungSubscription.close).toHaveBeenCalled();
+
+    await controller.dispose();
+  });
+
   it("hydrate(null) clears subgraph discovery from the previous thread", async () => {
     let onEvent: ((event: Event) => void) | undefined;
     const thread = {

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -1467,6 +1467,95 @@ describe("StreamController", () => {
     await controller.dispose();
   });
 
+  it("hydrate(null) clears messages even when teardown is blocked on a pending interrupt", async () => {
+    // Regression: useStream reuses the controller and fire-and-forgets
+    // hydrate(null) when threadId goes undefined. If the previous thread
+    // is paused at an interrupt, the root pump is parked on
+    // waitForResume() and #teardownThread() awaits that pump. The UI
+    // snapshot must reset independently of that await — otherwise
+    // threadId becomes null while messages keep the old conversation.
+    let resumeTeardown!: () => void;
+    const hungSubscription = {
+      isPaused: true,
+      waitForResume: () =>
+        new Promise<void>((resolve) => {
+          resumeTeardown = resolve;
+        }),
+      unsubscribe: vi.fn(async () => undefined),
+      close: vi.fn(),
+      [Symbol.asyncIterator]() {
+        return {
+          next: async (): Promise<IteratorResult<Event>> => ({
+            done: true,
+            value: undefined,
+          }),
+        };
+      },
+    };
+    const thread = {
+      subscribe: vi.fn(async () => hungSubscription),
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({
+          values: {
+            messages: [
+              { type: "human", content: "old thread message", id: "h-1" },
+            ],
+          },
+          next: [],
+          tasks: [
+            {
+              interrupts: [
+                { id: "int-1", value: { question: "approve?" } },
+              ],
+            },
+          ],
+        })),
+        getHistory: vi.fn(async () => []),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, unknown>({
+      assistantId: "human-in-the-loop",
+      client: client as never,
+      threadId: "thread-interrupted",
+    });
+    await controller.hydrationPromise;
+    await waitForExpectation(() => {
+      expect(thread.subscribe).toHaveBeenCalled();
+    });
+    // Let the root pump park on waitForResume().
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const seeded = controller.rootStore.getSnapshot();
+    expect(seeded.messages.map((message) => message.id)).toEqual(["h-1"]);
+    expect(seeded.interrupts.map((interrupt) => interrupt.id)).toEqual([
+      "int-1",
+    ]);
+
+    // Same as useStream: do not await hydrate().
+    void controller.hydrate(null);
+
+    await waitForExpectation(() => {
+      const snapshot = controller.rootStore.getSnapshot();
+      expect(snapshot.threadId).toBeNull();
+      expect(snapshot.messages).toHaveLength(0);
+      expect(snapshot.interrupts).toHaveLength(0);
+      expect(snapshot.interrupt).toBeUndefined();
+      expect(snapshot.isLoading).toBe(false);
+      expect(snapshot.isThreadLoading).toBe(false);
+    });
+
+    resumeTeardown?.();
+    await controller.dispose();
+  });
+
   it("hydrate(null) clears subgraph discovery from the previous thread", async () => {
     let onEvent: ((event: Event) => void) | undefined;
     const thread = {

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -1878,10 +1878,7 @@ export class StreamController<
          */
         while (!this.#disposed && pumpGeneration === this.#rootPumpGeneration) {
           for await (const event of subscription) {
-            if (
-              this.#disposed ||
-              pumpGeneration !== this.#rootPumpGeneration
-            ) {
+            if (this.#disposed || pumpGeneration !== this.#rootPumpGeneration) {
               break;
             }
             /**

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -529,13 +529,16 @@ export class StreamController<
        * Suspense boundary remounted against the new id suspends again.
        */
       this.#resetHydrationPromise();
-      await this.#teardownThread();
       /**
-       * Reset UI-facing snapshot so stale messages/values/tool-calls
-       * from the previous thread don't bleed into the new one. The
-       * new thread's state (if any) is then populated below via
-       * `#applyValues`.
+       * Kick teardown so the synchronous abort (unbind, drop onEvent,
+       * close the root subscription, reset assemblers) runs before we
+       * touch the snapshot. Then reset immediately so the UI does not
+       * wait on pump/close. An interrupted thread parks the root pump
+       * on `waitForResume()`; awaiting teardown *before* this reset
+       * left `threadId` null while `messages` still showed the previous
+       * conversation (`useStream` fire-and-forgets `hydrate()`).
        */
+      const teardown = this.#teardownThread();
       this.rootStore.setState(() => ({
         ...this.#createInitialSnapshot(),
         threadId: this.#currentThreadId,
@@ -548,6 +551,7 @@ export class StreamController<
       this.queueStore.setState(
         () => EMPTY_QUEUE as SubmissionQueueSnapshot<StateType>
       );
+      await teardown;
     }
 
     if (this.#currentThreadId == null) {
@@ -1697,25 +1701,22 @@ export class StreamController<
      */
     this.#rootEventListeners.delete(this.#lifecycleLoading.listener);
     this.#rootEventListeners.delete(this.#runLifecycleListener);
-    try {
-      await this.#rootSubscription?.unsubscribe();
-    } catch {
-      /* already closed */
-    }
+    /**
+     * Close first so a pump parked on `waitForResume()` (interrupted
+     * run) unparks even if the unsubscribe RPC is slow. `close()` is
+     * idempotent; `unsubscribe()` is then a no-op once closed.
+     */
+    const subscription = this.#rootSubscription;
     this.#rootSubscription = undefined;
+    subscription?.close();
     this.#rootPumpReady = undefined;
     // Reset so a swap to a new thread doesn't carry over a stale
     // deferred flag — `#ensureThread` will set it again if the new
     // thread is self-created.
     this.#rootPumpDeferred = false;
-    try {
-      await this.#rootPump;
-    } catch {
-      /* ignore */
-    }
-    this.#rootPump = undefined;
 
-    // Reset per-thread assembly state.
+    // Reset per-thread assembly state before any awaits so hydrate()
+    // can clear the UI snapshot without waiting on pump/close.
     this.#rootMessages.reset();
     this.#rootToolAssembler = new ToolCallAssembler();
     this.#lifecycleLoading.reset();
@@ -1731,6 +1732,18 @@ export class StreamController<
     this.queueStore.setState(
       () => EMPTY_QUEUE as SubmissionQueueSnapshot<StateType>
     );
+
+    try {
+      await subscription?.unsubscribe();
+    } catch {
+      /* already closed */
+    }
+    try {
+      await this.#rootPump;
+    } catch {
+      /* ignore */
+    }
+    this.#rootPump = undefined;
 
     if (thread != null) {
       try {

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -263,6 +263,14 @@ export class StreamController<
    */
   #submitGeneration = 0;
   /**
+   * Monotonic counter bumped at the start of each `#teardownThread`.
+   * The root pump captures the generation when it starts and drops
+   * any event whose generation no longer matches — including queued
+   * events that `SubscriptionHandle.close()` still drains after the
+   * snapshot has already been cleared by `hydrate()`.
+   */
+  #rootPumpGeneration = 0;
+  /**
    * Thread ids this controller minted client-side on first `submit()`.
    * `hydrate()` skips `threads.getState()` for these — we know there
    * is nothing checkpointed yet. Cleared once dispatch commits the
@@ -1689,6 +1697,14 @@ export class StreamController<
    * Close the current thread stream and reset per-thread assembly state.
    */
   async #teardownThread(): Promise<void> {
+    /**
+     * Invalidate the in-flight root pump before `close()` unparks it.
+     * `SubscriptionHandle.close()` leaves queued events intact and the
+     * iterator drains them before observing `closed`, so without this
+     * bump a parked interrupted pump would still dispatch stale
+     * `values` / `messages` into a snapshot `hydrate()` already cleared.
+     */
+    this.#rootPumpGeneration += 1;
     const thread = this.#thread;
     this.#thread = undefined;
     this.registry.bind(undefined);
@@ -1772,6 +1788,7 @@ export class StreamController<
    */
   #startRootPump(thread: ThreadStream): void {
     if (this.#rootPump != null) return;
+    const pumpGeneration = this.#rootPumpGeneration;
     let resolveReady: (() => void) | undefined;
     this.#rootPumpReady = new Promise<void>((resolve) => {
       resolveReady = resolve;
@@ -1836,6 +1853,16 @@ export class StreamController<
           });
         }
         const subscription = await subscriptionPromise;
+        if (pumpGeneration !== this.#rootPumpGeneration) {
+          resolveReady?.();
+          resolveReady = undefined;
+          try {
+            subscription.close();
+          } catch {
+            /* ignore */
+          }
+          return;
+        }
         resolveReady?.();
         resolveReady = undefined;
         this.#rootSubscription = subscription;
@@ -1849,9 +1876,12 @@ export class StreamController<
          * for every resumed iteration until the subscription is
          * permanently closed or the controller is disposed.
          */
-        while (!this.#disposed) {
+        while (!this.#disposed && pumpGeneration === this.#rootPumpGeneration) {
           for await (const event of subscription) {
-            if (this.#disposed) {
+            if (
+              this.#disposed ||
+              pumpGeneration !== this.#rootPumpGeneration
+            ) {
               break;
             }
             /**
@@ -1892,7 +1922,9 @@ export class StreamController<
                */
             }
           }
-          if (this.#disposed) break;
+          if (this.#disposed || pumpGeneration !== this.#rootPumpGeneration) {
+            break;
+          }
           if (!subscription.isPaused) {
             break;
           }


### PR DESCRIPTION
## Summary

Teardown awaited the paused root pump, so threadId went null while the old conversation stayed on screen. Reset the snapshot first.

- Starting a new chat (`threadId` → undefined) on a reused `useStream` left the previous thread's messages on screen when that thread was sitting on a pending interrupt. The snapshot now clears before teardown finishes waiting on the paused pump.
