### PR TITLE
fix(sdk): adopt server metadata on same-id optimistic message echo

### DIFF
--- a/.changeset/fix-optimistic-human-values-metadata.md
+++ b/.changeset/fix-optimistic-human-values-metadata.md
@@ -1,0 +1,12 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): adopt server metadata on same-id optimistic message echo
+
+When a `values` snapshot echoes an optimistic human with the same
+content plus committed `additional_kwargs` (e.g. attachment paths),
+`stream.messages` now takes the server copy instead of keeping the
+plain optimistic message until hydration. In-flight AI token
+streaming is unchanged: streamed content still wins when it has
+moved past the snapshot.

--- a/.changeset/fix-optimistic-human-values-metadata.md
+++ b/.changeset/fix-optimistic-human-values-metadata.md
@@ -7,6 +7,7 @@ fix(sdk): adopt server metadata on same-id optimistic message echo
 When a `values` snapshot echoes an optimistic human with the same
 content plus committed `additional_kwargs` (e.g. attachment paths),
 `stream.messages` now takes the server copy instead of keeping the
-plain optimistic message until hydration. In-flight AI token
-streaming is unchanged: streamed content still wins when it has
-moved past the snapshot.
+plain optimistic message until hydration. Preferring is asymmetric:
+lagging or poorer values snapshots do not strip richer current
+metadata. In-flight AI token streaming is unchanged: streamed content
+still wins when it has moved past the snapshot.

--- a/libs/sdk/src/stream/message-reconciliation.test.ts
+++ b/libs/sdk/src/stream/message-reconciliation.test.ts
@@ -115,6 +115,63 @@ describe("reconcileMessagesFromValues", () => {
     ).toEqual([{ filename: "notes.pdf", path: "uploads/notes.pdf" }]);
   });
 
+  it("keeps richer current metadata when a lagging values snapshot omits it", () => {
+    const seeded = new HumanMessage({
+      id: "human-1",
+      content: "see attached",
+      additional_kwargs: {
+        attachments: [{ filename: "notes.pdf", path: "uploads/notes.pdf" }],
+      },
+    });
+    const lagging = new HumanMessage({
+      id: "human-1",
+      content: "see attached",
+    });
+
+    const result = reconcileMessagesFromValues({
+      valueMessages: [lagging],
+      currentMessages: [seeded],
+      currentIndexById: buildMessageIndex([seeded]),
+      previousValueMessageIds: new Set(["human-1"]),
+      preferValuesMessage: shouldPreferValuesMessage,
+      addOnly: true,
+    });
+
+    expect(result.messages).toEqual([seeded]);
+    expect(
+      (result.messages[0] as HumanMessage).additional_kwargs.attachments
+    ).toEqual([{ filename: "notes.pdf", path: "uploads/notes.pdf" }]);
+  });
+
+  it("keeps streamed usage_metadata when the values snapshot omits it", () => {
+    const streamed = new AIMessage({
+      id: "assistant-1",
+      content: "done",
+      usage_metadata: {
+        input_tokens: 10,
+        output_tokens: 5,
+        total_tokens: 15,
+      },
+    });
+    const values = new AIMessage({
+      id: "assistant-1",
+      content: "done",
+    });
+
+    const result = reconcileMessagesFromValues({
+      valueMessages: [values],
+      currentMessages: [streamed],
+      currentIndexById: buildMessageIndex([streamed]),
+      previousValueMessageIds: new Set(),
+      preferValuesMessage: shouldPreferValuesMessage,
+    });
+
+    expect(result.messages).toEqual([streamed]);
+    expect(
+      (result.messages[0] as AIMessage).usage_metadata?.total_tokens
+    ).toBe(15);
+  });
+
   it("can prefer values messages when they contain finalized tool calls", () => {
     const streamed = new AIMessage({
       id: "assistant-1",

--- a/libs/sdk/src/stream/message-reconciliation.test.ts
+++ b/libs/sdk/src/stream/message-reconciliation.test.ts
@@ -4,6 +4,7 @@ import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import {
   buildMessageIndex,
   reconcileMessagesFromValues,
+  shouldPreferValuesMessage,
   shouldPreferValuesMessageForToolCalls,
 } from "./message-reconciliation.js";
 
@@ -87,6 +88,33 @@ describe("reconcileMessagesFromValues", () => {
     expect(result.valueMessageIds).toEqual(new Set());
   });
 
+  it("prefers the values human when it carries additional_kwargs the optimistic copy lacks", () => {
+    const optimistic = new HumanMessage({
+      id: "human-1",
+      content: "see attached",
+    });
+    const echoed = new HumanMessage({
+      id: "human-1",
+      content: "see attached",
+      additional_kwargs: {
+        attachments: [{ filename: "notes.pdf", path: "uploads/notes.pdf" }],
+      },
+    });
+
+    const result = reconcileMessagesFromValues({
+      valueMessages: [echoed],
+      currentMessages: [optimistic],
+      currentIndexById: buildMessageIndex([optimistic]),
+      previousValueMessageIds: new Set(),
+      preferValuesMessage: shouldPreferValuesMessage,
+    });
+
+    expect(result.messages).toEqual([echoed]);
+    expect(
+      (result.messages[0] as HumanMessage).additional_kwargs.attachments
+    ).toEqual([{ filename: "notes.pdf", path: "uploads/notes.pdf" }]);
+  });
+
   it("can prefer values messages when they contain finalized tool calls", () => {
     const streamed = new AIMessage({
       id: "assistant-1",
@@ -107,6 +135,28 @@ describe("reconcileMessagesFromValues", () => {
     });
 
     expect(result.messages).toEqual([values]);
+  });
+
+  it("keeps streamed content when it has moved past a lagging values snapshot", () => {
+    const streamed = new AIMessage({
+      id: "assistant-1",
+      content: "streamed partial extra",
+    });
+    const values = new AIMessage({
+      id: "assistant-1",
+      content: "streamed partial",
+      additional_kwargs: { usage: { tokens: 1 } },
+    });
+
+    const result = reconcileMessagesFromValues({
+      valueMessages: [values],
+      currentMessages: [streamed],
+      currentIndexById: buildMessageIndex([streamed]),
+      previousValueMessageIds: new Set(),
+      preferValuesMessage: shouldPreferValuesMessage,
+    });
+
+    expect(result.messages).toEqual([streamed]);
   });
 
   it("keeps the current array identity when reconciliation is unchanged", () => {

--- a/libs/sdk/src/stream/message-reconciliation.ts
+++ b/libs/sdk/src/stream/message-reconciliation.ts
@@ -145,6 +145,10 @@ export function buildMessageIndex(
  *   - metadata enrichment with unchanged content (e.g. server-committed
  *     `additional_kwargs.attachments` on an optimistic human)
  *
+ * Preferring is asymmetric: a lagging/poorer values snapshot must not
+ * replace a richer current copy (seeded `getState()` metadata, messages-
+ * channel `usage_metadata`, etc.) merely because the two messages differ.
+ *
  * Streamed content still wins when it has moved past this snapshot, so
  * in-flight token streaming is not overwritten by a lagging values event.
  */
@@ -158,7 +162,94 @@ export function shouldPreferValuesMessage(
   if (!jsonishEqual(valuesMessage.content, streamedMessage.content)) {
     return false;
   }
-  return !messagesEqual(valuesMessage, streamedMessage);
+  return valuesAddsMetadataEnrichment(valuesMessage, streamedMessage);
+}
+
+/** Metadata fields that a values echo may enrich on a same-id message. */
+const METADATA_ENRICHMENT_KEYS = [
+  "additional_kwargs",
+  "response_metadata",
+  "usage_metadata",
+] as const;
+
+/**
+ * True when values adds metadata the current copy lacks, without
+ * stripping richer fields already present on the current copy.
+ */
+function valuesAddsMetadataEnrichment(
+  valuesMessage: BaseMessage,
+  streamedMessage: BaseMessage
+): boolean {
+  const valuesRecord = valuesMessage as unknown as Record<string, unknown>;
+  const streamedRecord = streamedMessage as unknown as Record<string, unknown>;
+
+  let enriches = false;
+  for (const key of METADATA_ENRICHMENT_KEYS) {
+    const valuesField = valuesRecord[key];
+    const streamedField = streamedRecord[key];
+    if (jsonishEqual(valuesField, streamedField)) continue;
+
+    const valuesEmpty = isEmptyMeta(valuesField);
+    const streamedEmpty = isEmptyMeta(streamedField);
+
+    if (valuesEmpty && !streamedEmpty) {
+      // Preferring values would erase richer current metadata.
+      return false;
+    }
+    if (!valuesEmpty && streamedEmpty) {
+      enriches = true;
+      continue;
+    }
+    // Both non-empty and differ: only treat as enrichment when values
+    // is a shallow object superset of the current field (adds keys,
+    // keeps existing ones). Conflicting shapes keep the current copy.
+    if (isObjectShallowSuperset(valuesField, streamedField)) {
+      enriches = true;
+      continue;
+    }
+    return false;
+  }
+  return enriches;
+}
+
+function isEmptyMeta(value: unknown): boolean {
+  if (value == null) return true;
+  if (typeof value === "string") return value.length === 0;
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>).length === 0;
+  }
+  return false;
+}
+
+function isObjectShallowSuperset(
+  candidate: unknown,
+  baseline: unknown
+): boolean {
+  if (
+    candidate == null ||
+    baseline == null ||
+    typeof candidate !== "object" ||
+    typeof baseline !== "object" ||
+    Array.isArray(candidate) ||
+    Array.isArray(baseline)
+  ) {
+    return false;
+  }
+  const candidateRecord = candidate as Record<string, unknown>;
+  const baselineRecord = baseline as Record<string, unknown>;
+  const baselineKeys = Object.keys(baselineRecord);
+  const candidateKeys = Object.keys(candidateRecord);
+  if (candidateKeys.length <= baselineKeys.length) return false;
+  for (const key of baselineKeys) {
+    if (!Object.prototype.hasOwnProperty.call(candidateRecord, key)) {
+      return false;
+    }
+    if (!jsonishEqual(candidateRecord[key], baselineRecord[key])) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /**

--- a/libs/sdk/src/stream/message-reconciliation.ts
+++ b/libs/sdk/src/stream/message-reconciliation.ts
@@ -29,7 +29,8 @@ export interface ReconcileMessagesFromValuesOptions {
   /**
    * Allows callers to keep a values message even when a streamed message with
    * the same id exists. Used by the root controller when the values message
-   * carries finalized tool-call data missing from the streamed message.
+   * carries data the current copy lacks (finalized tool calls, or
+   * same-content metadata such as committed `additional_kwargs`).
    */
   readonly preferValuesMessage?: (
     valuesMessage: BaseMessage,
@@ -55,9 +56,11 @@ export interface ReconciledMessages {
  * message projection.
  *
  * Values remain authoritative for ordering and removals. Streamed messages
- * remain authoritative for in-flight content until the server echoes them in a
- * values snapshot, and stream-only messages are preserved until they either
- * appear in values or are known to have been removed.
+ * remain authoritative for in-flight content that has moved past this
+ * snapshot. When the server echoes a same-id message with equal content
+ * plus enrichment (tool calls, `additional_kwargs`, …), values win.
+ * Stream-only messages are preserved until they either appear in values
+ * or are known to have been removed.
  */
 export function reconcileMessagesFromValues({
   valueMessages,
@@ -130,6 +133,32 @@ export function buildMessageIndex(
     if (id != null) index.set(id, idx);
   });
   return index;
+}
+
+/**
+ * Decide whether a values message should replace a same-id streamed or
+ * optimistic message.
+ *
+ * Values win when they carry data the current copy lacks:
+ *   - finalized tool-call args (see
+ *     {@link shouldPreferValuesMessageForToolCalls})
+ *   - metadata enrichment with unchanged content (e.g. server-committed
+ *     `additional_kwargs.attachments` on an optimistic human)
+ *
+ * Streamed content still wins when it has moved past this snapshot, so
+ * in-flight token streaming is not overwritten by a lagging values event.
+ */
+export function shouldPreferValuesMessage(
+  valuesMessage: BaseMessage,
+  streamedMessage: BaseMessage
+): boolean {
+  if (shouldPreferValuesMessageForToolCalls(valuesMessage, streamedMessage)) {
+    return true;
+  }
+  if (!jsonishEqual(valuesMessage.content, streamedMessage.content)) {
+    return false;
+  }
+  return !messagesEqual(valuesMessage, streamedMessage);
 }
 
 /**

--- a/libs/sdk/src/stream/projections/messages.ts
+++ b/libs/sdk/src/stream/projections/messages.ts
@@ -29,7 +29,7 @@ import { isRootNamespace, namespaceKey } from "../namespace.js";
 import {
   buildMessageIndex,
   reconcileMessagesFromValues,
-  shouldPreferValuesMessageForToolCalls,
+  shouldPreferValuesMessage,
 } from "../message-reconciliation.js";
 import { openProjectionSubscription } from "./runtime.js";
 
@@ -169,15 +169,16 @@ export function messagesProjection(
       //  1. Walk `values.messages` in order. For each id, prefer
       //     the stream-assembled entry if we have one for that id
       //     (keeps in-progress token streaming visible); otherwise
-      //     take the values-coerced instance. This self-heals the
-      //     two classes of glitch the old merge-by-id handler
-      //     targeted:
+      //     take the values-coerced instance. Same-id values still
+      //     win when they carry data the stream lacks:
       //       - tool messages arriving without `tool_call_id` on
       //         the messages channel — the values snapshot always
       //         carries it;
       //       - AI messages whose finalized `tool_calls` didn't
       //         fully land via the messages channel — the values
-      //         snapshot's AI message has them populated.
+      //         snapshot's AI message has them populated;
+      //       - metadata enrichment with unchanged content (e.g.
+      //         committed `additional_kwargs` on an echoed human).
       //
       //  2. Append any stream-only ids (seen on the messages
       //     channel but never echoed in ANY values snapshot yet)
@@ -209,7 +210,7 @@ export function messagesProjection(
           currentIndexById: indexById,
           previousValueMessageIds: valuesMessageIds,
           streamedMessageIds: streamMessageIds,
-          preferValuesMessage: shouldPreferValuesMessageForToolCalls,
+          preferValuesMessage: shouldPreferValuesMessage,
         });
         valuesMessageIds = reconciliation.valueMessageIds;
         const reconciledMessages = [...reconciliation.messages];

--- a/libs/sdk/src/stream/root-message-projection.test.ts
+++ b/libs/sdk/src/stream/root-message-projection.test.ts
@@ -1258,6 +1258,40 @@ describe("RootMessageProjection", () => {
       ).toBe(snap.messages);
     });
 
+    it("does not strip seeded metadata when a lagging values replay omits it", async () => {
+      const { store, projection } = makeProjection();
+
+      const seeded = new HumanMessage({
+        id: "h1",
+        content: "see attached",
+        additional_kwargs: {
+          attachments: [{ filename: "notes.pdf", path: "uploads/notes.pdf" }],
+        },
+      });
+      projection.applyValues({ messages: [seeded] } as State, [seeded], {
+        step: 5,
+      });
+      await drainFlush();
+
+      // Deferred pump can replay an older same-id snapshot without the
+      // committed kwargs. addOnly keeps absences from removing messages,
+      // but preferValues must not replace the richer seeded copy either.
+      const lagging = new HumanMessage({
+        id: "h1",
+        content: "see attached",
+      });
+      projection.applyValues({ messages: [lagging] } as State, [lagging], {
+        step: 4,
+      });
+      await drainFlush();
+
+      const snap = store.getSnapshot();
+      expect(snap.messages).toHaveLength(1);
+      expect(snap.messages[0].additional_kwargs.attachments).toEqual([
+        { filename: "notes.pdf", path: "uploads/notes.pdf" },
+      ]);
+    });
+
     it("adopts echoed human metadata without clobbering in-flight AI tokens", async () => {
       const { store, projection } = makeProjection();
 

--- a/libs/sdk/src/stream/root-message-projection.test.ts
+++ b/libs/sdk/src/stream/root-message-projection.test.ts
@@ -448,8 +448,15 @@ describe("RootMessageProjection", () => {
         blockStartEvent(0, { type: "text", text: "streamed" })
       );
 
-      // Values arrives with [human, ai] ordering and a stale ai content.
-      const human = new HumanMessage({ id: "h1", content: "hi" });
+      // Values arrives with [human, ai] ordering, human metadata
+      // enrichment, and stale ai content.
+      const human = new HumanMessage({
+        id: "h1",
+        content: "hi",
+        additional_kwargs: {
+          attachments: [{ filename: "notes.pdf", path: "uploads/notes.pdf" }],
+        },
+      });
       const aiFromValues = new AIMessage({ id: "a1", content: "stale" });
       projection.applyValues(
         { messages: [human, aiFromValues] } as State,
@@ -460,6 +467,9 @@ describe("RootMessageProjection", () => {
       const snap = store.getSnapshot();
       expect(snap.messages).toHaveLength(2);
       expect(snap.messages[0]).toBe(human);
+      expect(snap.messages[0].additional_kwargs.attachments).toEqual([
+        { filename: "notes.pdf", path: "uploads/notes.pdf" },
+      ]);
       // Streamed AIMessage retained for its in-flight content.
       expect(snap.messages[1].text).toBe("streamed");
     });
@@ -1214,6 +1224,74 @@ describe("RootMessageProjection", () => {
         "h1",
         "a1",
       ]);
+    });
+
+    it("replaces the optimistic human with server-authored additional_kwargs on echo", async () => {
+      const { store, projection } = makeProjection();
+
+      const optimistic = new HumanMessage({
+        id: "h1",
+        content: "see attached",
+      });
+      projection.appendOptimistic([optimistic]);
+      await drainFlush();
+
+      const echoed = new HumanMessage({
+        id: "h1",
+        content: "see attached",
+        additional_kwargs: {
+          attachments: [{ filename: "notes.pdf", path: "uploads/notes.pdf" }],
+        },
+      });
+      projection.applyValues({ messages: [echoed] } as State, [echoed]);
+      await drainFlush();
+
+      const snap = store.getSnapshot();
+      expect(snap.messages).toHaveLength(1);
+      expect(snap.messages[0].additional_kwargs.attachments).toEqual([
+        { filename: "notes.pdf", path: "uploads/notes.pdf" },
+      ]);
+      // applyValues mirrors the reconciled list into values.messages, so
+      // both transcript surfaces must carry the committed metadata.
+      expect(
+        (snap.values as State).messages as typeof snap.messages
+      ).toBe(snap.messages);
+    });
+
+    it("adopts echoed human metadata without clobbering in-flight AI tokens", async () => {
+      const { store, projection } = makeProjection();
+
+      const optimistic = new HumanMessage({
+        id: "h1",
+        content: "see attached",
+      });
+      projection.appendOptimistic([optimistic], undefined, { sync: true });
+
+      projection.handleMessage(startEvent({ id: "a1", role: "ai" }));
+      projection.handleMessage(
+        blockStartEvent(0, { type: "text", text: "streamed" })
+      );
+
+      const echoed = new HumanMessage({
+        id: "h1",
+        content: "see attached",
+        additional_kwargs: {
+          attachments: [{ filename: "notes.pdf", path: "uploads/notes.pdf" }],
+        },
+      });
+      const aiFromValues = new AIMessage({ id: "a1", content: "stale" });
+      projection.applyValues(
+        { messages: [echoed, aiFromValues] } as State,
+        [echoed, aiFromValues]
+      );
+      await drainFlush();
+
+      const snap = store.getSnapshot();
+      expect(snap.messages.map((m) => m.id)).toEqual(["h1", "a1"]);
+      expect(snap.messages[0].additional_kwargs.attachments).toEqual([
+        { filename: "notes.pdf", path: "uploads/notes.pdf" },
+      ]);
+      expect(snap.messages[1].text).toBe("streamed");
     });
   });
 

--- a/libs/sdk/src/stream/root-message-projection.ts
+++ b/libs/sdk/src/stream/root-message-projection.ts
@@ -24,7 +24,8 @@
  *
  * The reconciliation rules (delegated to
  * {@link reconcileMessagesFromValues}) preserve in-flight streamed
- * content while letting values dictate ordering and removals.
+ * content while letting values dictate ordering, removals, and
+ * same-id metadata enrichment (e.g. committed attachment kwargs).
  *
  * # Tool-message namespace correlation
  *
@@ -85,7 +86,7 @@ import {
   buildMessageIndex,
   messagesEqual,
   reconcileMessagesFromValues,
-  shouldPreferValuesMessageForToolCalls,
+  shouldPreferValuesMessage,
 } from "./message-reconciliation.js";
 
 /**
@@ -382,9 +383,10 @@ export class RootMessageProjection<
    * Reconcile a full `values` snapshot into the projection.
    *
    * Delegates the merge to {@link reconcileMessagesFromValues}:
-   * values stays authoritative for ordering and removals, while
-   * streamed in-flight messages keep their content until the server
-   * echoes them back. Empty messages just refresh the values blob.
+   * values stays authoritative for ordering, removals, and same-id
+   * metadata enrichment, while streamed in-flight messages keep
+   * content that has moved past the snapshot. Empty messages just
+   * refresh the values blob.
    *
    * Rebuilds {@link #indexById} after the merge so subsequent delta
    * applications target the new positions.
@@ -455,7 +457,7 @@ export class RootMessageProjection<
       currentMessages: baselineMessages,
       currentIndexById: this.#indexById,
       previousValueMessageIds: this.#valuesMessageIds,
-      preferValuesMessage: shouldPreferValuesMessageForToolCalls,
+      preferValuesMessage: shouldPreferValuesMessage,
       addOnly,
     });
     // A stale replay snapshot must not shrink the authoritative id set:
@@ -495,8 +497,11 @@ export class RootMessageProjection<
    * exists), preserving prior history ordering. When the server later
    * emits a `values` snapshot containing the same ids,
    * {@link applyValues} → {@link reconcileMessagesFromValues} takes over
-   * (server ordering wins, the echoed message replaces the optimistic
-   * one).
+   * (server ordering wins; the echoed message replaces the optimistic
+   * one when content matches, so server-authored metadata such as
+   * `additional_kwargs` is visible without waiting for hydration).
+   * In-flight streamed content still wins when it has moved past the
+   * snapshot.
    *
    * Non-message input keys are shallow-merged into `values` via
    * `extraValues`; they are dropped/overwritten automatically by the

--- a/libs/sdk/src/stream/root-message-projection.ts
+++ b/libs/sdk/src/stream/root-message-projection.ts
@@ -498,8 +498,10 @@ export class RootMessageProjection<
    * emits a `values` snapshot containing the same ids,
    * {@link applyValues} → {@link reconcileMessagesFromValues} takes over
    * (server ordering wins; the echoed message replaces the optimistic
-   * one when content matches, so server-authored metadata such as
-   * `additional_kwargs` is visible without waiting for hydration).
+   * one when content matches *and* values adds metadata the optimistic
+   * copy lacks, so server-authored `additional_kwargs` is visible
+   * without waiting for hydration — lagging/poorer snapshots do not
+   * strip richer current metadata).
    * In-flight streamed content still wins when it has moved past the
    * snapshot.
    *


### PR DESCRIPTION
## Summary

Optimistic humans kept winning over the values echo, so committed additional_kwargs (e.g. attachment paths) stayed off stream.messages until hydration. Prefer the server copy when content matches; streamed tokens still win when they have moved past the snapshot.

- Same-id `values` echoes of an optimistic human now take server-authored metadata (`additional_kwargs`, etc.) on `stream.messages` instead of keeping the plain optimistic copy until reload.
- In-flight AI token streaming is unchanged: streamed content still wins when it has moved past the snapshot.
