### PR TITLE
fix(sdk): keep isLoading true across interrupt→running hydration

### DIFF
--- a/.changeset/fix-lifecycle-loading-interrupted-running.md
+++ b/.changeset/fix-lifecycle-loading-interrupted-running.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): keep isLoading true across interrupt→running hydration
+
+Deferred terminal resets no longer clear isLoading when a newer running lifecycle has already arrived (HITL resume / SSE replay).

--- a/libs/sdk/src/stream/lifecycle-loading-tracker.test.ts
+++ b/libs/sdk/src/stream/lifecycle-loading-tracker.test.ts
@@ -155,6 +155,41 @@ describe("LifecycleLoadingTracker", () => {
     expect(store.getSnapshot().isLoading).toBe(true);
   });
 
+  it("keeps isLoading true when a newer running supersedes a deferred interrupt reset", () => {
+    // Hydration / SSE replay of an answered HITL interrupt delivers
+    // interrupted → running in the same turn. The interrupt's deferred
+    // isLoading=false must not stomp the subsequent running.
+    const store = makeStore();
+    const tracker = new LifecycleLoadingTracker({
+      store,
+      isDisposed: () => false,
+    });
+
+    tracker.handle(lifecycleEvent({ event: "running" }, { seq: 1 }));
+    tracker.handle(lifecycleEvent({ event: "interrupted" }, { seq: 34 }));
+    tracker.handle(lifecycleEvent({ event: "running" }, { seq: 35 }));
+
+    expect(store.getSnapshot().isLoading).toBe(true);
+
+    vi.runAllTimers();
+    expect(store.getSnapshot().isLoading).toBe(true);
+  });
+
+  it("still clears isLoading when a deferred terminal is not superseded", () => {
+    const store = makeStore();
+    const tracker = new LifecycleLoadingTracker({
+      store,
+      isDisposed: () => false,
+    });
+
+    tracker.handle(lifecycleEvent({ event: "running" }, { seq: 1 }));
+    tracker.handle(lifecycleEvent({ event: "interrupted" }, { seq: 34 }));
+
+    expect(store.getSnapshot().isLoading).toBe(true);
+    vi.runAllTimers();
+    expect(store.getSnapshot().isLoading).toBe(false);
+  });
+
   it("running events without a seq always pass through", () => {
     const store = makeStore();
     const tracker = new LifecycleLoadingTracker({
@@ -204,6 +239,24 @@ describe("LifecycleLoadingTracker", () => {
     // After reset, an old-seq running is no longer considered stale.
     tracker.handle(lifecycleEvent({ event: "running" }, { seq: 1 }));
     expect(store.getSnapshot().isLoading).toBe(true);
+  });
+
+  it("reset() clears the running-seq guard so a prior deferred terminal can settle", () => {
+    const store = makeStore();
+    const tracker = new LifecycleLoadingTracker({
+      store,
+      isDisposed: () => false,
+    });
+
+    tracker.handle(lifecycleEvent({ event: "running" }, { seq: 1 }));
+    tracker.handle(lifecycleEvent({ event: "interrupted" }, { seq: 34 }));
+    tracker.handle(lifecycleEvent({ event: "running" }, { seq: 35 }));
+    tracker.reset();
+    tracker.handle(lifecycleEvent({ event: "running" }, { seq: 1 }));
+    tracker.handle(lifecycleEvent({ event: "completed" }, { seq: 2 }));
+
+    vi.runAllTimers();
+    expect(store.getSnapshot().isLoading).toBe(false);
   });
 
   it("does not emit a redundant store update when isLoading is already true", () => {

--- a/libs/sdk/src/stream/lifecycle-loading-tracker.ts
+++ b/libs/sdk/src/stream/lifecycle-loading-tracker.ts
@@ -31,6 +31,10 @@
  *      iterators in framework bindings — one event-loop tick to
  *      observe terminal-related state (e.g. the final assistant
  *      message landing in `values`) before `isLoading` settles.
+ *      The deferred callback re-checks whether a newer `running`
+ *      arrived in the meantime (HITL interrupt → resume, or SSE
+ *      history replay of interrupted → running) and bails if so,
+ *      so a stale terminal reset cannot stomp an active run.
  *
  * # Why it's safe to register the listener as `controller.onEvent`
  *
@@ -74,6 +78,14 @@ export class LifecycleLoadingTracker<T extends LoadingSnapshot> {
   #lastTerminalLifecycleSeq = -1;
 
   /**
+   * Highest sequence number of a `running` lifecycle we've observed.
+   * Deferred terminal resets compare against this so an
+   * `interrupted`/`completed`/`failed` whose macrotask fires after a
+   * newer `running` does not incorrectly clear `isLoading`.
+   */
+  #lastRunningLifecycleSeq = -1;
+
+  /**
    * @param params.store      - Store whose `isLoading` slot we drive.
    * @param params.isDisposed - Disposal probe consulted from deferred callbacks.
    */
@@ -94,11 +106,12 @@ export class LifecycleLoadingTracker<T extends LoadingSnapshot> {
   /**
    * Reset internal state when rebinding to a new thread.
    *
-   * The terminal-seq guard is per-thread: a new thread's `running`
-   * events are not stale relative to the old thread's terminals.
+   * The seq guards are per-thread: a new thread's lifecycle events
+   * are not stale relative to the old thread's.
    */
   reset(): void {
     this.#lastTerminalLifecycleSeq = -1;
+    this.#lastRunningLifecycleSeq = -1;
   }
 
   /**
@@ -123,6 +136,12 @@ export class LifecycleLoadingTracker<T extends LoadingSnapshot> {
       if (seq != null && seq <= this.#lastTerminalLifecycleSeq) {
         return;
       }
+      if (seq != null) {
+        this.#lastRunningLifecycleSeq = Math.max(
+          this.#lastRunningLifecycleSeq,
+          seq
+        );
+      }
       this.#store.setState((s) =>
         s.isLoading ? s : { ...s, isLoading: true }
       );
@@ -142,9 +161,12 @@ export class LifecycleLoadingTracker<T extends LoadingSnapshot> {
       // Flip `isLoading=false` on the next macrotask so synchronous
       // consumers iterating events get one tick to observe terminal
       // state (the final values snapshot etc.) before the loading
-      // indicator drops.
+      // indicator drops. Bail if a newer `running` arrived since this
+      // terminal was scheduled (answered HITL interrupt, back-to-back
+      // runs, or history replay of interrupted → running).
       setTimeout(() => {
         if (this.#isDisposed()) return;
+        if (seq != null && this.#lastRunningLifecycleSeq > seq) return;
         this.#store.setState((s) =>
           s.isLoading ? { ...s, isLoading: false } : s
         );


### PR DESCRIPTION
After a HITL interrupt is answered, replaying `interrupted` → `running` on hydrate could leave `useStream().isLoading` stuck `false`: the deferred interrupt reset fired after the later `running` and stomped it. Deferred terminal resets now skip clearing when a newer `running` seq has already been seen.


<!--
Thank you for contributing to LangGraph.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langgraphjs/blob/main/CONTRIBUTING.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

Fixes # (issue)
