### PR TITLE
fix(langgraph): dedupe merged callback handlers by identity

### DIFF
--- a/.changeset/fix-nested-stream-token-doubling.md
+++ b/.changeset/fix-nested-stream-token-doubling.md
@@ -1,0 +1,10 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(langgraph): dedupe merged callback handlers by identity
+
+`mergeCallbacks` concatenated `handlers` and `inheritableHandlers` while
+deduping `tags`, so a handler inherited by both the ambient and the explicit
+config picked up an extra registration at every graph boundary. With tracing
+on, a nested `streamMode: "messages"` run delivered every token twice.

--- a/libs/langgraph-core/src/pregel/utils/config.test.ts
+++ b/libs/langgraph-core/src/pregel/utils/config.test.ts
@@ -16,6 +16,10 @@ import {
   CHECKPOINT_NAMESPACE_END,
 } from "../../constants.js";
 
+class SentinelHandler extends BaseCallbackHandler {
+  name = "sentinel";
+}
+
 describe("ensureLangGraphConfig", () => {
   // Save original to restore after tests
   const originalGetRunnableConfig =
@@ -133,9 +137,6 @@ describe("ensureLangGraphConfig", () => {
       .fn()
       .mockReturnValue(undefined);
 
-    class SentinelHandler extends BaseCallbackHandler {
-      name = "sentinel";
-    }
     const cbA = new SentinelHandler();
     const cbB = new SentinelHandler();
 
@@ -188,6 +189,65 @@ describe("ensureLangGraphConfig", () => {
       "base-inheritable",
       "provided-inheritable",
     ]);
+  });
+
+  it("should dedupe a shared handler instance when both callbacks are managers", () => {
+    AsyncLocalStorageProviderSingleton.getRunnableConfig = vi
+      .fn()
+      .mockReturnValue(undefined);
+
+    // Every nested Pregel entry merges the ambient config against an explicit
+    // config that already carries the same inherited handler. CallbackManager
+    // fans each event out per array entry, so concatenating made the
+    // duplicated StreamMessagesHandler emit every token twice.
+    const shared = new SentinelHandler();
+
+    const baseManager = new CallbackManager();
+    baseManager.addHandler(shared, true);
+
+    const providedManager = new CallbackManager();
+    providedManager.addHandler(shared, true);
+
+    const result = ensureLangGraphConfig(
+      { callbacks: baseManager },
+      { callbacks: providedManager }
+    );
+
+    const merged = result.callbacks as CallbackManager;
+    expect(merged.handlers).toHaveLength(1);
+    expect(merged.handlers[0]).toBe(shared);
+    expect(merged.inheritableHandlers).toHaveLength(1);
+    expect(merged.inheritableHandlers[0]).toBe(shared);
+  });
+
+  it("should keep distinct handlers that share a name when both callbacks are managers", () => {
+    AsyncLocalStorageProviderSingleton.getRunnableConfig = vi
+      .fn()
+      .mockReturnValue(undefined);
+
+    // Dedupe is by identity, not by name: two LangChainTracers both answer to
+    // "langchain_tracer", so collapsing by name would drop a live handler.
+    const outer = new SentinelHandler();
+    const inner = new SentinelHandler();
+
+    const baseManager = new CallbackManager();
+    baseManager.addHandler(outer, true);
+
+    const providedManager = new CallbackManager();
+    providedManager.addHandler(inner, true);
+
+    const result = ensureLangGraphConfig(
+      { callbacks: baseManager },
+      { callbacks: providedManager }
+    );
+
+    const merged = result.callbacks as CallbackManager;
+    expect(merged.handlers).toHaveLength(2);
+    expect(merged.handlers[0]).toBe(outer);
+    expect(merged.handlers[1]).toBe(inner);
+    expect(merged.inheritableHandlers).toHaveLength(2);
+    expect(merged.inheritableHandlers[0]).toBe(outer);
+    expect(merged.inheritableHandlers[1]).toBe(inner);
   });
 
   it("should not mutate the input configs when merging", () => {

--- a/libs/langgraph-core/src/pregel/utils/config.ts
+++ b/libs/langgraph-core/src/pregel/utils/config.ts
@@ -127,9 +127,9 @@ function mergeCallbacks(
   }
   // both are managers
   return new CallbackManager(provided._parentRunId, {
-    handlers: base.handlers.concat(provided.handlers),
-    inheritableHandlers: base.inheritableHandlers.concat(
-      provided.inheritableHandlers
+    handlers: Array.from(new Set(base.handlers.concat(provided.handlers))),
+    inheritableHandlers: Array.from(
+      new Set(base.inheritableHandlers.concat(provided.inheritableHandlers))
     ),
     tags: Array.from(new Set(base.tags.concat(provided.tags))),
     inheritableTags: Array.from(

--- a/libs/langgraph-core/src/tests/tracing.test.ts
+++ b/libs/langgraph-core/src/tests/tracing.test.ts
@@ -174,7 +174,7 @@ it("merges graph-bound callbacks with invoke-time callbacks in streamEvents (no 
 });
 
 
-it("does not double stream tokens from a nested graph under tracing w", async () => {
+it("does not double stream tokens from a nested graph under tracing", async () => {
   // Regression for double-streaming: tracing installs the real
   // AsyncLocalStorage config, so a nested Pregel entry merges an ambient
   // config against an explicit config that already carries the same
@@ -211,7 +211,7 @@ it("does not double stream tokens from a nested graph under tracing w", async ()
       { streamMode: ["messages", "updates"], subgraphs: true }
     )) {
       if (mode !== "messages") continue;
-      const [message] = data as [BaseMessage];
+      const [message] = data;
       if (
         message?.getType?.() === "ai" &&
         typeof message.content === "string"
@@ -241,7 +241,12 @@ it("does not double stream tokens from a nested graph under tracing w", async ()
       .addEdge("delegate", END)
       .compile({ name: "Outer" });
 
-    await streamAndCollect(outer);
+    await gatherIterator(
+      outer.stream(
+        { messages: [{ role: "user", content: "say hello" }] },
+        { streamMode: ["messages", "updates"], subgraphs: true }
+      )
+    );
     expect(innerText).toBe(ANSWER);
   } finally {
     delete process.env.LANGSMITH_TRACING;

--- a/libs/langgraph-core/src/tests/tracing.test.ts
+++ b/libs/langgraph-core/src/tests/tracing.test.ts
@@ -6,9 +6,10 @@ import { AIMessage, BaseMessage, HumanMessage } from "@langchain/core/messages";
 import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
 import { LangChainTracer } from "@langchain/core/tracers/tracer_langchain";
 import { _AnyIdAIMessage, _AnyIdAIMessageChunk } from "./utils.js";
-import { FakeToolCallingChatModel } from "./utils.models.js";
+import { FakeChatModel, FakeToolCallingChatModel } from "./utils.models.js";
 // Import from main `@langchain/langgraph` endpoint to turn on automatic config passing
 import { Annotation, END, START, StateGraph } from "../web.js";
+import { MessagesAnnotation } from "../graph/messages_annotation.js";
 import { gatherIterator } from "../utils.js";
 import { createReactAgent } from "../prebuilt/react_agent_executor.js";
 
@@ -170,6 +171,82 @@ it("merges graph-bound callbacks with invoke-time callbacks in streamEvents (no 
   expect(boundCb.chainStarts).toBeGreaterThan(0);
   expect(userCb.chainStarts).toBeGreaterThan(0);
   expect(boundCb.chainStarts).toBe(userCb.chainStarts);
+});
+
+
+it("does not double stream tokens from a nested graph under tracing w", async () => {
+  // Regression for double-streaming: tracing installs the real
+  // AsyncLocalStorage config, so a nested Pregel entry merges an ambient
+  // config against an explicit config that already carries the same
+  // StreamMessagesHandler. Before the `mergeCallbacks` dedupe fix,
+  // concatenating registered it twice and `streamMode: "messages"`
+  // delivered every token twice.
+  const ANSWER = "Hello world from langgraph";
+
+  const buildInnerGraph = () => {
+    const model = new FakeChatModel({
+      responses: [new AIMessage(ANSWER)],
+    }).withConfig({ runName: "model_call" });
+    return new StateGraph(MessagesAnnotation)
+      .addNode("agent", async () => {
+        // Stream so handleLLMNewToken fires per token.
+        const chunks = await model.stream("say hello");
+        const parts: string[] = [];
+        for await (const chunk of chunks) {
+          if (typeof chunk.content === "string") parts.push(chunk.content);
+        }
+        return { messages: [new AIMessage(parts.join(""))] };
+      })
+      .addEdge(START, "agent")
+      .addEdge("agent", END)
+      .compile({ name: "Inner" });
+  };
+
+  const streamAndCollect = async (
+    graph: ReturnType<typeof buildInnerGraph>
+  ) => {
+    let text = "";
+    for await (const [, mode, data] of await graph.stream(
+      { messages: [{ role: "user", content: "say hello" }] },
+      { streamMode: ["messages", "updates"], subgraphs: true }
+    )) {
+      if (mode !== "messages") continue;
+      const [message] = data as [BaseMessage];
+      if (
+        message?.getType?.() === "ai" &&
+        typeof message.content === "string"
+      ) {
+        text += message.content;
+      }
+    }
+    return text;
+  };
+
+  // Turn tracing on so the real AsyncLocalStorage config is installed and
+  // the ambient/explicit config merge path is exercised. Override the
+  // fetch implementation langsmith uses (via its well-known symbol key) so
+  // core's auto-built LangChainTracer can't reach the network.
+  process.env.LANGSMITH_TRACING = "true";
+  const fetchKey = Symbol.for("ls:fetch_implementation");
+  const noopFetch = async () => new Response("{}", { status: 200 });
+  (globalThis as Record<symbol, unknown>)[fetchKey] = noopFetch;
+  try {
+    let innerText = "";
+    const outer = new StateGraph(MessagesAnnotation)
+      .addNode("delegate", async () => {
+        innerText = await streamAndCollect(buildInnerGraph());
+        return {};
+      })
+      .addEdge(START, "delegate")
+      .addEdge("delegate", END)
+      .compile({ name: "Outer" });
+
+    await streamAndCollect(outer);
+    expect(innerText).toBe(ANSWER);
+  } finally {
+    delete process.env.LANGSMITH_TRACING;
+    delete (globalThis as Record<symbol, unknown>)[fetchKey];
+  }
 });
 
 it("stream events for a multi-node graph", async () => {


### PR DESCRIPTION
This fixes a double-streaming bug in certain nested graph case scenarios.

`mergeCallbacks` concatenated `handlers` and `inheritableHandlers` while deduping tags, so a handler inherited by both the parent and nested config (in nested graphs) picked up an extra registration at every nesting level with tracing on. With tracing on, a nested streamMode: "messages" run delivered every token twice or more.
