### PR TITLE
fix(sdk): reconnect protocol SSE after clean EOF

### DIFF
--- a/.changeset/steady-streams-reconnect.md
+++ b/.changeset/steady-streams-reconnect.md
@@ -1,0 +1,8 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): reconnect thread SSE streams after clean EOF
+
+Treat a clean EOF as an unexpected disconnect while the stream handle is
+active, using the existing retry, backoff, and reconnect callback path.

--- a/.changeset/steady-streams-reconnect.md
+++ b/.changeset/steady-streams-reconnect.md
@@ -5,4 +5,6 @@
 fix(sdk): reconnect thread SSE streams after clean EOF
 
 Treat a clean EOF as an unexpected disconnect while the stream handle is
-active, using the existing retry, backoff, and reconnect callback path.
+active, using the existing retry, backoff, and reconnect callback path. The
+retry budget now tracks consecutive failures: a decoded event resets it, while
+successful responses that end before delivering an event remain bounded.

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -499,7 +499,8 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
       attempt: 1,
       cause: expect.any(Error),
     });
-    expect(reconnectDelayMs).toHaveBeenCalledExactlyOnceWith(1);
+    expect(reconnectDelayMs).toHaveBeenCalledTimes(1);
+    expect(reconnectDelayMs).toHaveBeenCalledWith(1);
 
     await transport.close();
   });

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -448,7 +448,7 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
   it("reconnects after clean EOF and continues on the original handle", async () => {
     let streamOpens = 0;
     const onReconnect = vi.fn();
-    const reconnectDelayMs = vi.fn(() => 0);
+    const reconnectDelayMs = vi.fn((_attempt: number) => 0);
     const fetchImpl = vi.fn(
       (input: URL | RequestInfo, init?: RequestInit) => {
         if (!String(input).includes("/stream/events")) {
@@ -502,6 +502,47 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
     expect(reconnectDelayMs).toHaveBeenCalledTimes(1);
     expect(reconnectDelayMs).toHaveBeenCalledWith(1);
 
+    await transport.close();
+  });
+
+  it("exhausts the consecutive-failure budget on empty 200 responses", async () => {
+    const onReconnect = vi.fn();
+    const reconnectDelayMs = vi.fn((_attempt: number) => 0);
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(
+        new Response(null, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        })
+      )
+    ) as MockFetch;
+
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: THREAD_ID,
+      fetch: fetchImpl,
+      maxReconnectAttempts: 2,
+      reconnectDelayMs,
+      onReconnect,
+      idleReconnect: 0,
+    });
+
+    const handle = transport.openEventStream({ channels: ["values"] });
+    await handle.ready;
+    const iterator = handle.events[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).rejects.toThrow(
+      "Protocol SSE stream ended unexpectedly."
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(onReconnect.mock.calls.map(([options]) => options.attempt)).toEqual([
+      1, 2,
+    ]);
+    expect(reconnectDelayMs.mock.calls.map(([attempt]) => attempt)).toEqual([
+      1, 2,
+    ]);
+
+    handle.close();
     await transport.close();
   });
 

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -25,6 +25,32 @@ function streamEventBodies(fetchImpl: MockFetch): Record<string, unknown>[] {
     .filter((body): body is Record<string, unknown> => body != null);
 }
 
+function protocolEventResponse(
+  eventId: string,
+  seq: number,
+  options: {
+    keepOpen?: boolean;
+    onStart?: (
+      controller: ReadableStreamDefaultController<Uint8Array>
+    ) => void;
+  } = {}
+): Response {
+  const frame = `event: values\ndata: {"type":"event","method":"values","seq":${seq},"event_id":"${eventId}"}\n\n`;
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(frame));
+        options.onStart?.(controller);
+        if (!options.keepOpen) controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    }
+  );
+}
+
 describe("ProtocolSseTransportAdapter URL resolution", () => {
   it("preserves apiUrl path prefix for protocol commands", async () => {
     const { calls, fetch } = createFetchRecorder();
@@ -418,6 +444,148 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
 
     await transport.close();
   });
+
+  it("reconnects after clean EOF and continues on the original handle", async () => {
+    let streamOpens = 0;
+    const onReconnect = vi.fn();
+    const reconnectDelayMs = vi.fn(() => 0);
+    const fetchImpl = vi.fn(
+      (input: URL | RequestInfo, init?: RequestInit) => {
+        if (!String(input).includes("/stream/events")) {
+          return Promise.resolve(protocolSuccessResponse());
+        }
+        streamOpens += 1;
+        if (streamOpens === 1) {
+          return Promise.resolve(protocolEventResponse("e1", 1));
+        }
+        return Promise.resolve(
+          protocolEventResponse("e2", 2, {
+            keepOpen: true,
+            onStart(controller) {
+              init?.signal?.addEventListener(
+                "abort",
+                () => controller.close(),
+                { once: true }
+              );
+            },
+          })
+        );
+      }
+    ) as MockFetch;
+
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: THREAD_ID,
+      fetch: fetchImpl,
+      maxReconnectAttempts: 3,
+      reconnectDelayMs,
+      onReconnect,
+      idleReconnect: 0,
+    });
+
+    const handle = transport.openEventStream({ channels: ["values"] });
+    await handle.ready;
+
+    const received: Array<{ event_id?: string }> = [];
+    for await (const message of handle.events) {
+      received.push(message as { event_id?: string });
+      if (message.event_id === "e2") break;
+    }
+
+    expect(received.map((message) => message.event_id)).toEqual(["e1", "e2"]);
+    expect(streamOpens).toBe(2);
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+    expect(onReconnect).toHaveBeenCalledWith({
+      attempt: 1,
+      cause: expect.any(Error),
+    });
+    expect(reconnectDelayMs).toHaveBeenCalledExactlyOnceWith(1);
+
+    await transport.close();
+  });
+
+  it("fails without reconnecting when clean EOF exhausts the retry budget", async () => {
+    const onReconnect = vi.fn();
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(protocolEventResponse("e1", 1))
+    ) as MockFetch;
+
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: THREAD_ID,
+      fetch: fetchImpl,
+      maxReconnectAttempts: 0,
+      onReconnect,
+      idleReconnect: 0,
+    });
+
+    const handle = transport.openEventStream({ channels: ["values"] });
+    await handle.ready;
+    const iterator = handle.events[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { event_id: "e1" },
+    });
+    await expect(iterator.next()).rejects.toThrow(
+      "Protocol SSE stream ended unexpectedly."
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(onReconnect).not.toHaveBeenCalled();
+
+    handle.close();
+    await transport.close();
+  });
+
+  it.each(["handle", "transport"] as const)(
+    "does not reconnect after explicit %s close",
+    async (closeMode) => {
+      const onReconnect = vi.fn();
+      let streamController:
+        | ReadableStreamDefaultController<Uint8Array>
+        | undefined;
+      const fetchImpl = vi.fn(() =>
+        Promise.resolve(
+          protocolEventResponse("e1", 1, {
+            keepOpen: true,
+            onStart(controller) {
+              streamController = controller;
+            },
+          })
+        )
+      ) as MockFetch;
+
+      const transport = new ProtocolSseTransportAdapter({
+        apiUrl: "http://localhost:8123",
+        threadId: THREAD_ID,
+        fetch: fetchImpl,
+        maxReconnectAttempts: 3,
+        reconnectDelayMs: () => 0,
+        onReconnect,
+        idleReconnect: 0,
+      });
+
+      const handle = transport.openEventStream({ channels: ["values"] });
+      await handle.ready;
+      const iterator = handle.events[Symbol.asyncIterator]();
+      await expect(iterator.next()).resolves.toMatchObject({
+        done: false,
+        value: { event_id: "e1" },
+      });
+
+      if (closeMode === "handle") {
+        handle.close();
+      } else {
+        await transport.close();
+      }
+      streamController?.close();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      expect(onReconnect).not.toHaveBeenCalled();
+      await transport.close();
+    }
+  );
 
   it("honors caller since on the initial open but omits it on reconnect", async () => {
     let streamOpens = 0;

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -323,6 +323,11 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
           const iterable = IterableReadableStream.fromReadableStream(stream);
 
           for await (const event of iterable) {
+            // A decoded SSE event proves this connection was live. Treat the
+            // retry limit as a consecutive-failure budget so healthy streams
+            // can reconnect throughout a long-lived handle, while repeated
+            // `200 -> immediate EOF` responses still exhaust the budget.
+            attempt = 0;
             if (ac.signal.aborted || this.closed) {
               break;
             }

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -330,8 +330,11 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
               streamQueue.push(event.data as Message);
             }
           }
-          streamQueue.close();
-          return;
+          if (ac.signal.aborted || this.closed) {
+            streamQueue.close();
+            return;
+          }
+          throw new Error("Protocol SSE stream ended unexpectedly.");
         } catch (error) {
           if (ac.signal.aborted || this.closed) {
             if (!readySettled) {

--- a/libs/sdk/src/client/stream/transport/types.ts
+++ b/libs/sdk/src/client/stream/transport/types.ts
@@ -44,7 +44,9 @@ export interface ProtocolSseTransportOptions {
   asyncCaller?: AsyncCaller;
   paths?: ProtocolTransportPaths;
   /**
-   * Maximum reconnect attempts after an unexpected SSE disconnect.
+   * Maximum consecutive reconnect attempts after an unexpected SSE
+   * disconnect. Receiving a decoded event resets the attempt counter, while a
+   * successful response that ends before delivering an event does not.
    * Defaults to `DEFAULT_MAX_RECONNECT_ATTEMPTS` from `utils/reconnect`.
    * Set to 0 to disable automatic reconnection.
    *

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -4,7 +4,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { StreamController } from "./controller.js";
 import { messagesProjection } from "./projections/messages.js";
-import type { ThreadStream } from "../client/stream/index.js";
+import { ThreadStream } from "../client/stream/index.js";
+import { ProtocolSseTransportAdapter } from "../client/stream/transport/http.js";
 
 interface State {
   messages?: unknown[];
@@ -205,6 +206,37 @@ function namespacedLifecycleEvent(
   } as Event;
 }
 
+function protocolEventStreamResponse(
+  events: Event[],
+  options: {
+    keepOpen?: boolean;
+    onStart?: (
+      controller: ReadableStreamDefaultController<Uint8Array>
+    ) => void;
+  } = {}
+): Response {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const event of events) {
+          controller.enqueue(
+            encoder.encode(
+              `event: ${event.method}\ndata: ${JSON.stringify(event)}\n\n`
+            )
+          );
+        }
+        options.onStart?.(controller);
+        if (!options.keepOpen) controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    }
+  );
+}
+
 async function waitForExpectation(assertion: () => void): Promise<void> {
   const started = Date.now();
   let lastError: unknown;
@@ -223,6 +255,173 @@ async function waitForExpectation(assertion: () => void): Promise<void> {
 describe("StreamController", () => {
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("keeps both SSE pumps live across repeated clean EOFs between runs", async () => {
+    type Pump = "root" | "watcher";
+    const repeatedLiveEofs = 6;
+    const streamOpens: Record<Pump, number> = { root: 0, watcher: 0 };
+    const finalStreams: Partial<
+      Record<Pump, ReadableStreamDefaultController<Uint8Array>>
+    > = {};
+    const onReconnect = vi.fn();
+    const reconnectDelayMs = vi.fn(() => 0);
+    const encoder = new TextEncoder();
+    let commandRequests = 0;
+
+    const fetchImpl = vi.fn(
+      async (input: URL | RequestInfo, init?: RequestInit) => {
+        if (!String(input).includes("/stream/events")) {
+          commandRequests += 1;
+          const command = JSON.parse(String(init?.body)) as { id?: number };
+          return new Response(
+            JSON.stringify({
+              type: "success",
+              id: command.id ?? 1,
+              result: { run_id: "run-2" },
+            }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }
+          );
+        }
+
+        const body = JSON.parse(String(init?.body)) as {
+          namespaces?: string[][];
+        };
+        const pump: Pump = body.namespaces != null ? "root" : "watcher";
+        streamOpens[pump] += 1;
+        const open = streamOpens[pump];
+
+        if (open <= repeatedLiveEofs) {
+          const event =
+            pump === "root"
+              ? valuesEvent(
+                  [
+                    {
+                      type: "ai",
+                      content: "run 1 response",
+                      id: "run-1-ai",
+                    },
+                  ],
+                  open
+                )
+              : namespacedLifecycleEvent(
+                  [`worker:run-1-${open}`],
+                  "started",
+                  100 + open
+                );
+          return protocolEventStreamResponse([event]);
+        }
+
+        return protocolEventStreamResponse([], {
+          keepOpen: true,
+          onStart(controller) {
+            finalStreams[pump] = controller;
+            init?.signal?.addEventListener("abort", () => controller.close(), {
+              once: true,
+            });
+          },
+        });
+      }
+    ) as typeof fetch;
+
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: "thread-repeated-eof",
+      fetch: fetchImpl,
+      maxReconnectAttempts: 5,
+      reconnectDelayMs,
+      onReconnect,
+      idleReconnect: 0,
+    });
+    const thread = new ThreadStream(transport, { assistantId: "deep-agent" });
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({
+          values: {},
+          next: ["agent"],
+          tasks: [],
+        })),
+        getHistory: vi.fn(async () => []),
+        stream: vi.fn(() => thread),
+      },
+    };
+    const controller = new StreamController<State, unknown>({
+      assistantId: "deep-agent",
+      client: client as never,
+      threadId: "thread-repeated-eof",
+      maxReconnectAttempts: 5,
+      reconnectDelayMs,
+      onReconnect,
+    });
+
+    try {
+      await controller.hydrationPromise;
+      await waitForExpectation(() => {
+        expect(
+          controller.rootStore.getSnapshot().messages.map((message) =>
+            message.text
+          )
+        ).toEqual(["run 1 response"]);
+        expect(streamOpens).toEqual({ root: 7, watcher: 7 });
+      });
+
+      const submission = controller.submit({
+        messages: [{ type: "human", content: "run 2", id: "run-2-human" }],
+      });
+      await waitForExpectation(() => {
+        expect(commandRequests).toBe(1);
+      });
+
+      const run2Values = valuesEvent(
+        [
+          { type: "human", content: "run 2", id: "run-2-human" },
+          { type: "ai", content: "run 2 response", id: "run-2-ai" },
+        ],
+        1_000
+      );
+      const nestedInterrupt = inputRequestedEvent(
+        "nested-run-2",
+        { prompt: "Approve run 2?" },
+        ["worker:run-2"]
+      );
+      const interrupted = lifecycleEvent("interrupted", 1_002);
+
+      finalStreams.root?.enqueue(
+        encoder.encode(
+          `event: values\ndata: ${JSON.stringify(run2Values)}\n\n` +
+            `event: lifecycle\ndata: ${JSON.stringify(interrupted)}\n\n`
+        )
+      );
+      finalStreams.watcher?.enqueue(
+        encoder.encode(
+          `event: input.requested\ndata: ${JSON.stringify(nestedInterrupt)}\n\n`
+        )
+      );
+      await submission;
+
+      const snapshot = controller.rootStore.getSnapshot();
+      expect(snapshot.messages.map((message) => message.text)).toEqual([
+        "run 2",
+        "run 2 response",
+      ]);
+      expect(snapshot.interrupts).toEqual([
+        expect.objectContaining({
+          id: "nested-run-2",
+          namespace: ["worker:run-2"],
+        }),
+      ]);
+      expect(streamOpens).toEqual({ root: 7, watcher: 7 });
+      expect(onReconnect).toHaveBeenCalledTimes(12);
+      expect(
+        onReconnect.mock.calls.map(([options]) => options.attempt)
+      ).toEqual(Array.from({ length: 12 }, () => 1));
+      expect(reconnectDelayMs).toHaveBeenCalledTimes(12);
+    } finally {
+      await controller.dispose();
+    }
   });
 
   it("mirrors root interrupts observed by the wildcard watcher into root state", async () => {


### PR DESCRIPTION
## Summary

- treat clean SSE EOF as an unexpected disconnect while the event-stream handle remains active
- route it through the existing reconnect callback, retry budget, and backoff path
- preserve terminal behavior for explicit handle or transport close
- add focused coverage for event delivery across reconnect, zero retry budget, and explicit close

## Root cause

`ProtocolSseTransportAdapter.openEventStream()` only reached its reconnect logic when stream consumption threw. A successful SSE response that ended normally closed the shared queue and returned, leaving the retained thread stream handle unable to observe later events.

The fix keeps explicit abort/shutdown terminal, but turns an otherwise clean EOF into the same existing unexpected-disconnect path. It does not introduce a second retry loop or change replay cursor behavior. PR #2689 modifies adjacent durable cursor handling and should compose with this narrow EOF-boundary change.

## Test plan

- `pnpm exec vitest run src/client/stream/transport/http.test.ts --reporter=verbose` (from `libs/sdk`): 20 passed, no type errors
- `pnpm --filter @langchain/langgraph-sdk test`: 53 files / 778 tests passed, no type errors
- `pnpm format:check`: passed (440 files)
- `pnpm lint`: passed (1,162 files, 0 warnings/errors)
- `pnpm --filter @langchain/langgraph-sdk build`: passed, including attw and publint
- `pnpm build`: 25/25 tasks passed

Fixes #2701