### PR TITLE
fix(checkpoint): narrow re-constructable types in JsonPlusSerializer

### DIFF
--- a/.changeset/busy-seas-pay.md
+++ b/.changeset/busy-seas-pay.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint": patch
+---
+
+fix(checkpoint): narrow re-constructable types in JsonPlusSerializer

--- a/libs/checkpoint-mongodb/package.json
+++ b/libs/checkpoint-mongodb/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.44",
-    "@langchain/langgraph-checkpoint": "^1.0.0"
+    "@langchain/langgraph-checkpoint": "workspace:*"
   },
   "devDependencies": {
     "@langchain/langgraph-checkpoint": "workspace:*",

--- a/libs/checkpoint-mongodb/package.json
+++ b/libs/checkpoint-mongodb/package.json
@@ -31,10 +31,10 @@
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.44",
-    "@langchain/langgraph-checkpoint": "workspace:*"
+    "@langchain/langgraph-checkpoint": "workspace:^"
   },
   "devDependencies": {
-    "@langchain/langgraph-checkpoint": "workspace:*",
+    "@langchain/langgraph-checkpoint": "workspace:^",
     "@langchain/scripts": ">=0.1.3 <0.2.0",
     "@tsconfig/recommended": "^1.0.3",
     "@types/better-sqlite3": "^7.6.12",

--- a/libs/checkpoint-postgres/package.json
+++ b/libs/checkpoint-postgres/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.44",
-    "@langchain/langgraph-checkpoint": "^1.0.0"
+    "@langchain/langgraph-checkpoint": "workspace:*"
   },
   "devDependencies": {
     "@langchain/langgraph-checkpoint": "workspace:*",

--- a/libs/checkpoint-postgres/package.json
+++ b/libs/checkpoint-postgres/package.json
@@ -31,10 +31,10 @@
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.44",
-    "@langchain/langgraph-checkpoint": "workspace:*"
+    "@langchain/langgraph-checkpoint": "workspace:^"
   },
   "devDependencies": {
-    "@langchain/langgraph-checkpoint": "workspace:*",
+    "@langchain/langgraph-checkpoint": "workspace:^",
     "@langchain/scripts": ">=0.1.2 <0.2.0",
     "@tsconfig/recommended": "^1.0.3",
     "@types/pg": "^8.11.8",

--- a/libs/checkpoint-redis/package.json
+++ b/libs/checkpoint-redis/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.48",
-    "@langchain/langgraph-checkpoint": "^1.0.0"
+    "@langchain/langgraph-checkpoint": "workspace:*"
   },
   "devDependencies": {
     "@langchain/langgraph-checkpoint": "workspace:*",

--- a/libs/checkpoint-redis/package.json
+++ b/libs/checkpoint-redis/package.json
@@ -31,10 +31,10 @@
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.48",
-    "@langchain/langgraph-checkpoint": "workspace:*"
+    "@langchain/langgraph-checkpoint": "workspace:^"
   },
   "devDependencies": {
-    "@langchain/langgraph-checkpoint": "workspace:*",
+    "@langchain/langgraph-checkpoint": "workspace:^",
     "@langchain/scripts": ">=0.1.2 <0.2.0",
     "@tsconfig/recommended": "^1.0.3",
     "@types/node": "^20",

--- a/libs/checkpoint-sqlite/package.json
+++ b/libs/checkpoint-sqlite/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.44",
-    "@langchain/langgraph-checkpoint": "^1.0.0"
+    "@langchain/langgraph-checkpoint": "workspace:*"
   },
   "devDependencies": {
     "@langchain/langgraph-checkpoint": "workspace:*",

--- a/libs/checkpoint-sqlite/package.json
+++ b/libs/checkpoint-sqlite/package.json
@@ -31,10 +31,10 @@
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.44",
-    "@langchain/langgraph-checkpoint": "workspace:*"
+    "@langchain/langgraph-checkpoint": "workspace:^"
   },
   "devDependencies": {
-    "@langchain/langgraph-checkpoint": "workspace:*",
+    "@langchain/langgraph-checkpoint": "workspace:^",
     "@langchain/scripts": ">=0.1.3 <0.2.0",
     "@tsconfig/recommended": "^1.0.3",
     "@types/better-sqlite3": "^7.6.12",

--- a/libs/checkpoint-validation/package.json
+++ b/libs/checkpoint-validation/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.44",
-    "@langchain/langgraph-checkpoint": "^1.0.0"
+    "@langchain/langgraph-checkpoint": "workspace:*"
   },
   "devDependencies": {
     "@langchain/langgraph-checkpoint": "workspace:*",

--- a/libs/checkpoint-validation/package.json
+++ b/libs/checkpoint-validation/package.json
@@ -33,10 +33,10 @@
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.44",
-    "@langchain/langgraph-checkpoint": "workspace:*"
+    "@langchain/langgraph-checkpoint": "workspace:^"
   },
   "devDependencies": {
-    "@langchain/langgraph-checkpoint": "workspace:*",
+    "@langchain/langgraph-checkpoint": "workspace:^",
     "@langchain/langgraph-checkpoint-mongodb": "workspace:*",
     "@langchain/langgraph-checkpoint-postgres": "workspace:*",
     "@langchain/langgraph-checkpoint-redis": "workspace:*",

--- a/libs/checkpoint/src/serde/jsonplus.ts
+++ b/libs/checkpoint/src/serde/jsonplus.ts
@@ -3,7 +3,7 @@
 import { load } from "@langchain/core/load";
 import { SerializerProtocol } from "./base.js";
 import { stringify } from "./utils/fast-safe-stringify/index.js";
-import { DeltaSnapshot } from "./types.js";
+import { type ConstructorRecord, DeltaSnapshot } from "./types.js";
 
 function isLangChainSerializedObject(value: Record<string, unknown>) {
   return (
@@ -12,6 +12,124 @@ function isLangChainSerializedObject(value: Record<string, unknown>) {
     value.type === "constructor" &&
     Array.isArray(value.id)
   );
+}
+
+function isUndefinedRecord(value: Record<string, unknown>): boolean {
+  return value.lc === 2 && value.type === "undefined";
+}
+
+function isDeltaSnapshotRecord(value: Record<string, unknown>): boolean {
+  return (
+    value.lc === 2 &&
+    value.type === "delta_snapshot" &&
+    Object.prototype.hasOwnProperty.call(value, "value")
+  );
+}
+
+function isConstructorRecord(
+  value: Record<string, unknown>
+): value is ConstructorRecord {
+  return value.lc === 2 && value.type === "constructor";
+}
+
+function hasConstructorId(record: ConstructorRecord, name: string): boolean {
+  return (
+    Array.isArray(record.id) && record.id.length === 1 && record.id[0] === name
+  );
+}
+
+function hasNoMethod(record: ConstructorRecord): boolean {
+  return record.method === undefined || record.method === null;
+}
+
+function hasSingleArrayArg(
+  record: ConstructorRecord
+): record is ConstructorRecord & { args: unknown[][] } {
+  return (
+    Array.isArray(record.args) &&
+    record.args.length === 1 &&
+    Array.isArray(record.args[0])
+  );
+}
+
+function isByteArray(value: unknown[]): value is number[] {
+  return value.every(
+    (item) =>
+      typeof item === "number" &&
+      Number.isInteger(item) &&
+      item >= 0 &&
+      item <= 255
+  );
+}
+
+/**
+ * Reconstruct only the closed set of lc:2 values written by `_default`.
+ *
+ * A constructor record is serialized data, not an instruction to resolve a
+ * property or invoke a method. Invalid and unsupported records are kept inert
+ * by the caller so old or attacker-controlled checkpoint data cannot execute.
+ */
+function reviveConstructorRecord(
+  record: ConstructorRecord
+): unknown | undefined {
+  if (hasConstructorId(record, "Set") && hasNoMethod(record)) {
+    if (!hasSingleArrayArg(record)) return undefined;
+    return new Set(record.args[0]);
+  }
+
+  if (hasConstructorId(record, "Map") && hasNoMethod(record)) {
+    if (
+      !hasSingleArrayArg(record) ||
+      !record.args[0].every(
+        (entry) => Array.isArray(entry) && entry.length === 2
+      )
+    ) {
+      return undefined;
+    }
+    return new Map(record.args[0] as [unknown, unknown][]);
+  }
+
+  if (hasConstructorId(record, "RegExp") && hasNoMethod(record)) {
+    if (
+      !Array.isArray(record.args) ||
+      record.args.length !== 2 ||
+      typeof record.args[0] !== "string" ||
+      typeof record.args[1] !== "string"
+    ) {
+      return undefined;
+    }
+    try {
+      return new RegExp(record.args[0], record.args[1]);
+    } catch {
+      // Invalid patterns are malformed persisted data and stay inert.
+      return undefined;
+    }
+  }
+
+  if (hasConstructorId(record, "Error") && hasNoMethod(record)) {
+    if (
+      !Array.isArray(record.args) ||
+      record.args.length !== 1 ||
+      typeof record.args[0] !== "string"
+    ) {
+      return undefined;
+    }
+    return new Error(record.args[0]);
+  }
+
+  if (
+    hasConstructorId(record, "Uint8Array") &&
+    (hasNoMethod(record) || record.method === "from")
+  ) {
+    if (!hasSingleArrayArg(record) || !isByteArray(record.args[0])) {
+      return undefined;
+    }
+    // `from` is a legacy format tag. Do not forward its serialized method or
+    // any extra arguments: the validated bytes are the entire persisted form.
+    return new Uint8Array(record.args[0]);
+  }
+
+  return undefined;
 }
 
 /**
@@ -30,54 +148,18 @@ async function _reviver(value: any): Promise<any> {
       );
       return revivedArray;
     } else {
-      const revivedObj: any = {};
+      const revivedObj: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(value)) {
         revivedObj[k] = await _reviver(v);
       }
 
-      if (revivedObj.lc === 2 && revivedObj.type === "undefined") {
+      if (isUndefinedRecord(revivedObj)) {
         return undefined;
-      } else if (revivedObj.lc === 2 && revivedObj.type === "delta_snapshot") {
+      } else if (isDeltaSnapshotRecord(revivedObj)) {
         // Wrapped value is already revived (bottom-up traversal).
         return new DeltaSnapshot(revivedObj.value);
-      } else if (
-        revivedObj.lc === 2 &&
-        revivedObj.type === "constructor" &&
-        Array.isArray(revivedObj.id)
-      ) {
-        try {
-          const constructorName = revivedObj.id[revivedObj.id.length - 1];
-          let constructor: any;
-
-          switch (constructorName) {
-            case "Set":
-              constructor = Set;
-              break;
-            case "Map":
-              constructor = Map;
-              break;
-            case "RegExp":
-              constructor = RegExp;
-              break;
-            case "Error":
-              constructor = Error;
-              break;
-            case "Uint8Array":
-              constructor = Uint8Array;
-              break;
-            default:
-              return revivedObj;
-          }
-          if (revivedObj.method) {
-            return (constructor as any)[revivedObj.method](
-              ...(revivedObj.args || [])
-            );
-          } else {
-            return new (constructor as any)(...(revivedObj.args || []));
-          }
-        } catch {
-          return revivedObj;
-        }
+      } else if (isConstructorRecord(revivedObj)) {
+        return reviveConstructorRecord(revivedObj) ?? revivedObj;
       } else if (isLangChainSerializedObject(revivedObj)) {
         return load(JSON.stringify(revivedObj));
       }
@@ -126,7 +208,7 @@ function _default(obj: any): any {
   } else if (obj instanceof RegExp) {
     return _encodeConstructorArgs(RegExp, undefined, [obj.source, obj.flags]);
   } else if (obj instanceof Error) {
-    return _encodeConstructorArgs(obj.constructor, undefined, [obj.message]);
+    return _encodeConstructorArgs(Error, undefined, [obj.message]);
     // TODO: Remove special case
   } else if (obj?.lg_name === "Send") {
     return {

--- a/libs/checkpoint/src/serde/tests/jsonplus.test.ts
+++ b/libs/checkpoint/src/serde/tests/jsonplus.test.ts
@@ -1,6 +1,7 @@
 import { it, expect } from "vitest";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import { uuid6 } from "../../id.js";
+import { DeltaSnapshot } from "../types.js";
 import { JsonPlusSerializer } from "../jsonplus.js";
 
 const messageWithToolCall = new AIMessage({
@@ -156,6 +157,204 @@ it("Should serialize a Send without a timeout unchanged", async () => {
   const [type, serialized] = await serde.dumpsTyped(packet);
   const loaded = await serde.loadsTyped(type, serialized);
   expect(loaded).toEqual({ node: "worker", args: { x: 1 } });
+});
+
+it("round-trips DeltaSnapshot values", async () => {
+  const serde = new JsonPlusSerializer();
+  const value = new DeltaSnapshot({
+    nested: new Set(["checkpoint"]),
+    bytes: new Uint8Array([1, 2, 3]),
+  });
+
+  const [type, serialized] = await serde.dumpsTyped(value);
+  const restored = await serde.loadsTyped(type, serialized);
+
+  expect(restored).toBeInstanceOf(DeltaSnapshot);
+  expect(restored).toEqual(value);
+  assertTypedArraysPreserved(value, restored);
+});
+
+it("restores canonical Uint8Array constructor records", async () => {
+  const serde = new JsonPlusSerializer();
+  const restored = await serde.loadsTyped(
+    "json",
+    JSON.stringify({
+      lc: 2,
+      type: "constructor",
+      id: ["Uint8Array"],
+      method: null,
+      args: [[0, 127, 255]],
+      kwargs: {},
+    })
+  );
+
+  expect(restored).toBeInstanceOf(Uint8Array);
+  expect(Array.from(restored)).toEqual([0, 127, 255]);
+});
+
+it("does not invoke forged Map.groupBy constructor records", async () => {
+  const serde = new JsonPlusSerializer();
+  const markerKey = "__langgraph_jsonplus_map_groupby_test_marker__";
+  const marker = { invoked: false };
+  (globalThis as Record<string, unknown>)[markerKey] = marker;
+
+  const forgedCallback = {
+    lc: 2,
+    type: "constructor",
+    id: ["Uint8Array"],
+    method: "constructor",
+    args: [`globalThis.${markerKey}.invoked = true`],
+    kwargs: {},
+  };
+  const forgedOuterRecord = {
+    lc: 2,
+    type: "constructor",
+    id: ["Map"],
+    method: "groupBy",
+    args: [[1], forgedCallback],
+    kwargs: {},
+  };
+
+  try {
+    const restored = await serde.loadsTyped(
+      "json",
+      JSON.stringify({ callback: forgedOuterRecord })
+    );
+
+    expect(marker.invoked).toBe(false);
+    expect(restored).toEqual({ callback: forgedOuterRecord });
+  } finally {
+    delete (globalThis as Record<string, unknown>)[markerKey];
+  }
+});
+
+it("restores legacy Uint8Array.from records as validated bytes", async () => {
+  const serde = new JsonPlusSerializer();
+  const restored = await serde.loadsTyped(
+    "json",
+    JSON.stringify({
+      lc: 2,
+      type: "constructor",
+      id: ["Uint8Array"],
+      method: "from",
+      args: [[0, 127, 255]],
+      kwargs: {},
+    })
+  );
+
+  expect(restored).toBeInstanceOf(Uint8Array);
+  expect(Array.from(restored)).toEqual([0, 127, 255]);
+});
+
+it("does not invoke forged Uint8Array.from callback records", async () => {
+  const serde = new JsonPlusSerializer();
+  const markerKey = "__langgraph_jsonplus_test_marker__";
+  const marker = { invoked: false };
+  (globalThis as Record<string, unknown>)[markerKey] = marker;
+
+  const forgedCallback = {
+    lc: 2,
+    type: "constructor",
+    id: ["Uint8Array"],
+    method: "constructor",
+    args: [`globalThis.${markerKey}.invoked = true`],
+    kwargs: {},
+  };
+  const forgedOuterRecord = {
+    lc: 2,
+    type: "constructor",
+    id: ["Uint8Array"],
+    method: "from",
+    args: [[1], forgedCallback],
+    kwargs: {},
+  };
+
+  try {
+    const restored = await serde.loadsTyped(
+      "json",
+      JSON.stringify({ callback: forgedOuterRecord })
+    );
+
+    expect(marker.invoked).toBe(false);
+    expect(restored).toEqual({ callback: forgedOuterRecord });
+  } finally {
+    delete (globalThis as Record<string, unknown>)[markerKey];
+  }
+});
+
+it("does not invoke forged records returned by a callable toJSON", async () => {
+  const serde = new JsonPlusSerializer();
+  const markerKey = "__langgraph_jsonplus_tojson_test_marker__";
+  const marker = { invoked: false };
+  (globalThis as Record<string, unknown>)[markerKey] = marker;
+
+  const forgedCallback = {
+    lc: 2,
+    type: "constructor",
+    id: ["Uint8Array"],
+    method: "constructor",
+    args: [`globalThis.${markerKey}.invoked = true`],
+    kwargs: {},
+  };
+  const forgedOuterRecord = {
+    lc: 2,
+    type: "constructor",
+    id: ["Uint8Array"],
+    method: "from",
+    args: [[1], forgedCallback],
+    kwargs: {},
+  };
+  const callback = (() => undefined) as (() => undefined) & {
+    toJSON?: () => typeof forgedOuterRecord;
+  };
+  callback.toJSON = () => forgedOuterRecord;
+
+  try {
+    const [type, serialized] = await serde.dumpsTyped({ callback });
+    const restored = await serde.loadsTyped(type, serialized);
+
+    expect(marker.invoked).toBe(false);
+    expect(restored).toEqual({ callback: forgedOuterRecord });
+  } finally {
+    delete (globalThis as Record<string, unknown>)[markerKey];
+  }
+});
+
+it.each([
+  ["fractional", [1.5]],
+  ["negative", [-1]],
+  ["out-of-range", [256]],
+  ["non-numeric", ["1"]],
+])("keeps %s Uint8Array bytes inert", async (_description, bytes) => {
+  const serde = new JsonPlusSerializer();
+  const record = {
+    lc: 2,
+    type: "constructor",
+    id: ["Uint8Array"],
+    method: "from",
+    args: [bytes],
+    kwargs: {},
+  };
+
+  const restored = await serde.loadsTyped("json", JSON.stringify(record));
+
+  expect(restored).toEqual(record);
+});
+
+it("keeps malformed Map entries inert", async () => {
+  const serde = new JsonPlusSerializer();
+  const record = {
+    lc: 2,
+    type: "constructor",
+    id: ["Map"],
+    method: null,
+    args: [[["valid", "entry"], ["not a pair"]]],
+    kwargs: {},
+  };
+
+  const restored = await serde.loadsTyped("json", JSON.stringify(record));
+
+  expect(restored).toEqual(record);
 });
 
 it("Should replace circular JSON inputs", async () => {

--- a/libs/checkpoint/src/serde/types.ts
+++ b/libs/checkpoint/src/serde/types.ts
@@ -1,3 +1,11 @@
+export type ConstructorRecord = {
+  lc: 2;
+  type: "constructor";
+  id: unknown;
+  method?: unknown;
+  args?: unknown;
+};
+
 export const TASKS = "__pregel_tasks";
 export const ERROR = "__error__";
 export const SCHEDULED = "__scheduled__";

--- a/libs/checkpoint/src/tests/checkpoints.test.ts
+++ b/libs/checkpoint/src/tests/checkpoints.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { HumanMessage } from "@langchain/core/messages";
 import type { RunnableConfig } from "@langchain/core/runnables";
 import {
   type Checkpoint,
@@ -265,7 +266,102 @@ describe("MemorySaver", () => {
     ).toBeDefined();
   });
 
-  it("should delete thread", async () => {
+  it("keeps metadata constructor records inert on a later read", async () => {
+    const memorySaver = new MemorySaver();
+    const markerKey = "__langgraph_checkpoint_metadata_marker__";
+    const marker = { invoked: false };
+    (globalThis as Record<string, unknown>)[markerKey] = marker;
+    const forgedCallback = {
+      lc: 2,
+      type: "constructor",
+      id: ["Uint8Array"],
+      method: "constructor",
+      args: [`globalThis.${markerKey}.invoked = true`],
+      kwargs: {},
+    };
+    const forgedRecord = {
+      lc: 2,
+      type: "constructor",
+      id: ["Uint8Array"],
+      method: "from",
+      args: [[1], forgedCallback],
+      kwargs: {},
+    };
+    const config = { configurable: { thread_id: "metadata-security" } };
+
+    try {
+      await memorySaver.put(config, checkpoint1, {
+        source: "update",
+        step: -1,
+        parents: {},
+        forged: forgedRecord,
+      } as CheckpointMetadata);
+
+      const restored = await memorySaver.getTuple(config);
+
+      expect(marker.invoked).toBe(false);
+      expect(restored?.metadata).toMatchObject({ forged: forgedRecord });
+    } finally {
+      delete (globalThis as Record<string, unknown>)[markerKey];
+    }
+  });
+
+    it("keeps forged additional_kwargs constructor records inert on restore", async () => {
+      const memorySaver = new MemorySaver();
+      const markerKey = "__langgraph_checkpoint_message_marker__";
+      const marker = { invoked: false };
+      (globalThis as Record<string, unknown>)[markerKey] = marker;
+      const forgedCallback = {
+        lc: 2,
+        type: "constructor",
+        id: ["Uint8Array"],
+        method: "constructor",
+        args: [`globalThis.${markerKey}.invoked = true`],
+        kwargs: {},
+      };
+      const forgedRecord = {
+        lc: 2,
+        type: "constructor",
+        id: ["Uint8Array"],
+        method: "from",
+        args: [[1], forgedCallback],
+        kwargs: {},
+      };
+      const config = { configurable: { thread_id: "message-security" } };
+
+      try {
+        const savedConfig = await memorySaver.put(config, checkpoint1, {
+          source: "update",
+          step: -1,
+          parents: {},
+        });
+        await memorySaver.putWrites(
+          savedConfig,
+          [
+            [
+              "messages",
+              new HumanMessage({
+                content: "ordinary message",
+                additional_kwargs: { forged: forgedRecord },
+              }),
+            ],
+          ],
+          "message-security-task"
+        );
+
+        const restored = await memorySaver.getTuple(savedConfig);
+        const message = restored?.pendingWrites?.[0]?.[2] as HumanMessage;
+
+        expect(marker.invoked).toBe(false);
+        expect(message.additional_kwargs).toMatchObject({
+      forged: forgedRecord,
+    });
+      } finally {
+        delete (globalThis as Record<string, unknown>)[markerKey];
+      }
+    });
+
+    it("should delete thread", async () => {
     const memorySaver = new MemorySaver();
     const thread1 = { configurable: { thread_id: "1", checkpoint_ns: "" } };
     const thread2 = { configurable: { thread_id: "2", checkpoint_ns: "" } };

--- a/libs/langgraph-api/package.json
+++ b/libs/langgraph-api/package.json
@@ -86,7 +86,7 @@
   "peerDependencies": {
     "@langchain/core": "^1.1.48",
     "@langchain/langgraph": "^1.3.6",
-    "@langchain/langgraph-checkpoint": "workspace:*",
+    "@langchain/langgraph-checkpoint": "workspace:^",
     "@langchain/langgraph-sdk": "^1.9.3-rc.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4"
@@ -102,7 +102,7 @@
   "devDependencies": {
     "@langchain/core": "^1.2.4",
     "@langchain/langgraph": "workspace:*",
-    "@langchain/langgraph-checkpoint": "workspace:*",
+    "@langchain/langgraph-checkpoint": "workspace:^",
     "@langchain/langgraph-sdk": "workspace:*",
     "@types/babel__code-frame": "^7.0.6",
     "@types/node": "^18.15.11",

--- a/libs/langgraph-api/package.json
+++ b/libs/langgraph-api/package.json
@@ -86,7 +86,7 @@
   "peerDependencies": {
     "@langchain/core": "^1.1.48",
     "@langchain/langgraph": "^1.3.6",
-    "@langchain/langgraph-checkpoint": "~0.0.16 || ^0.1.0 || ^1.0.0",
+    "@langchain/langgraph-checkpoint": "workspace:*",
     "@langchain/langgraph-sdk": "^1.9.3-rc.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4"

--- a/libs/langgraph-core/package.json
+++ b/libs/langgraph-core/package.json
@@ -29,7 +29,7 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "@langchain/langgraph-checkpoint": "workspace:*",
+    "@langchain/langgraph-checkpoint": "workspace:^",
     "@langchain/langgraph-sdk": "workspace:~",
     "@langchain/protocol": "^0.0.18",
     "@standard-schema/spec": "1.1.0"

--- a/libs/langgraph-core/package.json
+++ b/libs/langgraph-core/package.json
@@ -29,7 +29,7 @@
   "author": "LangChain",
   "license": "MIT",
   "dependencies": {
-    "@langchain/langgraph-checkpoint": "workspace:^",
+    "@langchain/langgraph-checkpoint": "workspace:*",
     "@langchain/langgraph-sdk": "workspace:~",
     "@langchain/protocol": "^0.0.18",
     "@standard-schema/spec": "1.1.0"

--- a/libs/langgraph-core/src/tests/checkpointer.test.ts
+++ b/libs/langgraph-core/src/tests/checkpointer.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { HumanMessage } from "@langchain/core/messages";
+import { MemorySaver } from "@langchain/langgraph-checkpoint";
+import { END, START } from "../constants.js";
+import { StateGraph } from "../graph/state.js";
+import { MessagesAnnotation } from "../graph/messages_annotation.js";
+
+function createForgedConstructorRecord(markerKey: string) {
+  const forgedCallback = {
+    lc: 2,
+    type: "constructor",
+    id: ["Uint8Array"],
+    method: "constructor",
+    args: [`globalThis.${markerKey}.invoked = true`],
+    kwargs: {},
+  };
+
+  return {
+    lc: 2,
+    type: "constructor",
+    id: ["Uint8Array"],
+    method: "from",
+    args: [[1], forgedCallback],
+    kwargs: {},
+  };
+}
+
+function createGraph(checkpointer: MemorySaver) {
+  return new StateGraph(MessagesAnnotation)
+    .addNode("noop", () => ({}))
+    .addEdge(START, "noop")
+    .addEdge("noop", END)
+    .compile({ checkpointer });
+}
+
+describe("JsonPlusSerializer checkpoint restoration security", () => {
+  it("does not execute a forged value in run metadata during state restoration", async () => {
+    const markerKey = "__langgraph_graph_metadata_marker__";
+    const marker = { invoked: false };
+    (globalThis as Record<string, unknown>)[markerKey] = marker;
+    const graph = createGraph(new MemorySaver());
+    const config = { configurable: { thread_id: "jsonplus-metadata-security" } };
+
+    try {
+      await graph.invoke(
+        { messages: [new HumanMessage("ordinary metadata-path input")] },
+        {
+          ...config,
+          metadata: { probe: createForgedConstructorRecord(markerKey) },
+        }
+      );
+      expect(marker.invoked).toBe(false);
+
+      await graph.getState(config);
+      expect(marker.invoked).toBe(false);
+    } finally {
+      delete (globalThis as Record<string, unknown>)[markerKey];
+    }
+  });
+
+  it("does not execute a forged value in additional_kwargs during a later run", async () => {
+    const markerKey = "__langgraph_graph_message_marker__";
+    const marker = { invoked: false };
+    (globalThis as Record<string, unknown>)[markerKey] = marker;
+    const graph = createGraph(new MemorySaver());
+    const config = { configurable: { thread_id: "jsonplus-message-security" } };
+
+    try {
+      await graph.invoke(
+        {
+          messages: [
+            new HumanMessage({
+              content: "ordinary message",
+              additional_kwargs: {
+                probe: createForgedConstructorRecord(markerKey),
+              },
+            }),
+          ],
+        },
+        config
+      );
+      expect(marker.invoked).toBe(false);
+
+      await graph.invoke(
+        { messages: [new HumanMessage("benign follow-up")] },
+        config
+      );
+      expect(marker.invoked).toBe(false);
+    } finally {
+      delete (globalThis as Record<string, unknown>)[markerKey];
+    }
+  });
+});


### PR DESCRIPTION
* Narrows an overly broad condition when restoring native objects inside of JsonPlusSerializer
  * instead of relying on a spread operator to bring in arguments to a native object's constructor (which can be created from arbitrary inputs inside of a serialized envelope) we're strictly reconstructing objects

also adds tests that demonstrate this