### PR TITLE
chore: release compatible peer dependents

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -25,6 +25,6 @@
     "@examples/*"
   ],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
-    "onlyUpdatePeerDependentsWhenOutOfRange": true
+    "onlyUpdatePeerDependentsWhenOutOfRange": false
   }
 }


### PR DESCRIPTION
temporary fix in service of #2709 and #2710. we adopted caret ranges for @langchain/langgraph-checkpoint which means we need a package bump for each dependant package
