### PR TITLE
fix: restore checkpoint peer ranges

### DIFF
--- a/libs/checkpoint-mongodb/package.json
+++ b/libs/checkpoint-mongodb/package.json
@@ -31,10 +31,10 @@
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.44",
-    "@langchain/langgraph-checkpoint": "workspace:^"
+    "@langchain/langgraph-checkpoint": "^1.0.0"
   },
   "devDependencies": {
-    "@langchain/langgraph-checkpoint": "workspace:^",
+    "@langchain/langgraph-checkpoint": "workspace:*",
     "@langchain/scripts": ">=0.1.3 <0.2.0",
     "@tsconfig/recommended": "^1.0.3",
     "@types/better-sqlite3": "^7.6.12",

--- a/libs/checkpoint-postgres/package.json
+++ b/libs/checkpoint-postgres/package.json
@@ -31,10 +31,10 @@
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.44",
-    "@langchain/langgraph-checkpoint": "workspace:^"
+    "@langchain/langgraph-checkpoint": "^1.0.0"
   },
   "devDependencies": {
-    "@langchain/langgraph-checkpoint": "workspace:^",
+    "@langchain/langgraph-checkpoint": "workspace:*",
     "@langchain/scripts": ">=0.1.2 <0.2.0",
     "@tsconfig/recommended": "^1.0.3",
     "@types/pg": "^8.11.8",

--- a/libs/checkpoint-redis/package.json
+++ b/libs/checkpoint-redis/package.json
@@ -31,10 +31,10 @@
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.48",
-    "@langchain/langgraph-checkpoint": "workspace:^"
+    "@langchain/langgraph-checkpoint": "^1.0.0"
   },
   "devDependencies": {
-    "@langchain/langgraph-checkpoint": "workspace:^",
+    "@langchain/langgraph-checkpoint": "workspace:*",
     "@langchain/scripts": ">=0.1.2 <0.2.0",
     "@tsconfig/recommended": "^1.0.3",
     "@types/node": "^20",

--- a/libs/checkpoint-sqlite/package.json
+++ b/libs/checkpoint-sqlite/package.json
@@ -31,10 +31,10 @@
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.44",
-    "@langchain/langgraph-checkpoint": "workspace:^"
+    "@langchain/langgraph-checkpoint": "^1.0.0"
   },
   "devDependencies": {
-    "@langchain/langgraph-checkpoint": "workspace:^",
+    "@langchain/langgraph-checkpoint": "workspace:*",
     "@langchain/scripts": ">=0.1.3 <0.2.0",
     "@tsconfig/recommended": "^1.0.3",
     "@types/better-sqlite3": "^7.6.12",

--- a/libs/checkpoint-validation/package.json
+++ b/libs/checkpoint-validation/package.json
@@ -33,10 +33,10 @@
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.44",
-    "@langchain/langgraph-checkpoint": "workspace:^"
+    "@langchain/langgraph-checkpoint": "^1.0.0"
   },
   "devDependencies": {
-    "@langchain/langgraph-checkpoint": "workspace:^",
+    "@langchain/langgraph-checkpoint": "workspace:*",
     "@langchain/langgraph-checkpoint-mongodb": "workspace:*",
     "@langchain/langgraph-checkpoint-postgres": "workspace:*",
     "@langchain/langgraph-checkpoint-redis": "workspace:*",

--- a/libs/langgraph-api/package.json
+++ b/libs/langgraph-api/package.json
@@ -86,7 +86,7 @@
   "peerDependencies": {
     "@langchain/core": "^1.1.48",
     "@langchain/langgraph": "^1.3.6",
-    "@langchain/langgraph-checkpoint": "workspace:^",
+    "@langchain/langgraph-checkpoint": "~0.0.16 || ^0.1.0 || ^1.0.0",
     "@langchain/langgraph-sdk": "^1.9.3-rc.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4"
@@ -102,7 +102,7 @@
   "devDependencies": {
     "@langchain/core": "^1.2.4",
     "@langchain/langgraph": "workspace:*",
-    "@langchain/langgraph-checkpoint": "workspace:^",
+    "@langchain/langgraph-checkpoint": "workspace:*",
     "@langchain/langgraph-sdk": "workspace:*",
     "@types/babel__code-frame": "^7.0.6",
     "@types/node": "^18.15.11",


### PR DESCRIPTION
## Summary

Restores the published checkpoint peer ranges and local development workspace references that were unintentionally narrowed by the security-release dependency edits.

## Changes

- Restore the compatible public peer ranges for checkpoint integration packages and `@langchain/langgraph-api`.
- Restore local checkpoint dev dependencies to `workspace:*`.
- Preserve the serializer security fix and avoid unnecessary peer-dependent release cascades.
