### PR TITLE
fix(sdk): validate protocol SSE content type

### DIFF
--- a/.changeset/steady-sse-validation.md
+++ b/.changeset/steady-sse-validation.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+Reject protocol SSE stream responses with non-SSE content types before marking subscriptions ready.

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -331,6 +331,38 @@ describe("ProtocolSseTransportAdapter AsyncCaller", () => {
 });
 
 describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
+  it("rejects non-SSE content types before marking the stream ready", async () => {
+    const fetchImpl = vi.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      )
+    ) as MockFetch;
+
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: THREAD_ID,
+      fetch: fetchImpl,
+      maxReconnectAttempts: 0,
+      idleReconnect: 0,
+    });
+
+    const handle = transport.openEventStream({ channels: ["values"] });
+
+    await expect(handle.ready).rejects.toThrow(
+      "Expected response header Content-Type to contain 'text/event-stream'"
+    );
+    await expect(
+      handle.events[Symbol.asyncIterator]().next()
+    ).rejects.toThrow(
+      "Expected response header Content-Type to contain 'text/event-stream'"
+    );
+
+    await transport.close();
+  });
+
   it("reconnects after a mid-stream failure when a custom auth fetch is supplied", async () => {
     let streamOpens = 0;
     const onReconnect = vi.fn();

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -292,6 +292,15 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
             { stream: true }
           );
 
+          const contentType = response.headers
+            .get("content-type")
+            ?.split(";")[0];
+          if (contentType && !contentType.includes("text/event-stream")) {
+            throw new Error(
+              `Expected response header Content-Type to contain 'text/event-stream', got '${contentType}'`
+            );
+          }
+
           if (!readySettled) {
             readySettled = true;
             resolveReady();


### PR DESCRIPTION
## Summary

A successful non-SSE response (for example, a JSON error page) could be treated as a ready protocol stream, leaving consumers with an empty event iterator. Validate the response Content-Type before resolving the stream readiness promise, and propagate the failure to the event iterator. Add regression coverage and a patch changeset.

## Verification

- `pnpm --filter @langchain/langgraph-sdk test src/client/stream/transport/http.test.ts` (17 passed)
- `pnpm exec oxfmt --check libs/sdk/src/client/stream/transport/http.ts libs/sdk/src/client/stream/transport/http.test.ts .changeset/steady-sse-validation.md`
- `pnpm exec oxlint libs/sdk/src/client/stream/transport/http.ts libs/sdk/src/client/stream/transport/http.test.ts`