### PR TITLE
fix(sdk): don't re-show resolved interrupts after reload

### DIFF
--- a/.changeset/fix-resolved-interrupt-replay.md
+++ b/.changeset/fix-resolved-interrupt-replay.md
@@ -1,0 +1,10 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): don't re-show resolved interrupts after reload
+
+After a reload, the next submit used to replay the old `input.requested`
+event, so the HITL form came back even though the interrupt was already
+answered. Keep filtering historical interrupts after the command is
+accepted, using the response's `applied_through_seq` as the cutoff.

--- a/libs/sdk-angular/src/tests/components/InterruptReloadStream.ts
+++ b/libs/sdk-angular/src/tests/components/InterruptReloadStream.ts
@@ -1,0 +1,117 @@
+import {
+  Component,
+  DestroyRef,
+  Injectable,
+  computed,
+  inject as angularInject,
+  signal,
+} from "@angular/core";
+import { inject } from "vitest";
+
+import { injectStream } from "../../index.js";
+import { createDurableReplayFetch } from "../fixtures/durable-replay-fetch.js";
+
+const serverUrl = inject("serverUrl");
+
+interface InterruptState {
+  request: string;
+  decision: Record<string, unknown> | null;
+  completedTurns: number;
+}
+
+@Injectable()
+class InterruptReloadState {
+  readonly threadId = signal<string | undefined>(undefined);
+  readonly session = signal(0);
+  readonly mounted = signal(true);
+  readonly sessions = computed(() =>
+    this.mounted() ? [this.session()] : []
+  );
+  readonly durable = createDurableReplayFetch();
+  readonly replayedFrames = signal(0);
+  readonly #destroyRef = angularInject(DestroyRef);
+  #reloadTimer: number | undefined;
+
+  readonly onThreadId = (id: string): void => this.threadId.set(id);
+
+  constructor() {
+    const replayTimer = window.setInterval(() => {
+      this.replayedFrames.set(this.durable.replayedFrameCount());
+    }, 50);
+    this.#destroyRef.onDestroy(() => {
+      window.clearInterval(replayTimer);
+      window.clearTimeout(this.#reloadTimer);
+    });
+  }
+
+  reload(): void {
+    this.mounted.set(false);
+    this.#reloadTimer = window.setTimeout(() => {
+      this.session.update((value) => value + 1);
+      this.mounted.set(true);
+    }, 100);
+  }
+}
+
+@Component({
+  selector: "lg-interrupt-reload-session",
+  template: `
+    <div data-testid="interrupt-count">{{ stream.interrupts().length }}</div>
+    <div data-testid="interrupt-ids">
+      {{ interruptIds() }}
+    </div>
+    <div data-testid="completed-turns">
+      {{ stream.values()?.completedTurns ?? 0 }}
+    </div>
+    <div data-testid="loading">
+      {{ stream.isLoading() ? "Loading..." : "Not loading" }}
+    </div>
+    <div data-testid="thread-loading">
+      {{ stream.isThreadLoading() ? "Hydrating..." : "Ready" }}
+    </div>
+    <button data-testid="submit" (click)="submit()">Submit</button>
+    <button data-testid="resume" (click)="resume()">Resume</button>
+  `,
+})
+class InterruptReloadSessionComponent {
+  readonly state = angularInject(InterruptReloadState);
+  readonly stream = injectStream<InterruptState>({
+    assistantId: "interrupt_once_graph",
+    apiUrl: serverUrl,
+    threadId: this.state.threadId,
+    onThreadId: this.state.onThreadId,
+    fetch: this.state.durable.fetch,
+  });
+  readonly interruptIds = computed(() =>
+    this.stream
+      .interrupts()
+      .map((item) => item.id ?? "?")
+      .join(",")
+  );
+
+  submit(): void {
+    void this.stream.submit({ request: "ship it" });
+  }
+
+  resume(): void {
+    if (this.stream.interrupt()) {
+      void this.stream.respond({ approved: true });
+    }
+  }
+}
+
+@Component({
+  imports: [InterruptReloadSessionComponent],
+  providers: [InterruptReloadState],
+  template: `
+    <div data-testid="session">{{ state.session() }}</div>
+    <div data-testid="replayed-frames">{{ state.replayedFrames() }}</div>
+    <button data-testid="reload" (click)="state.reload()">Reload</button>
+    @for (session of state.sessions(); track session) {
+      <lg-interrupt-reload-session />
+    }
+  `,
+})
+export class InterruptReloadStreamComponent {
+  readonly state = angularInject(InterruptReloadState);
+}

--- a/libs/sdk-angular/src/tests/fixtures/durable-replay-fetch.ts
+++ b/libs/sdk-angular/src/tests/fixtures/durable-replay-fetch.ts
@@ -1,0 +1,102 @@
+interface RecordedFrame {
+  eventId: string;
+  seq: number;
+  raw: string;
+}
+
+function eventStreamThreadId(input: RequestInfo | URL): string | null {
+  const href =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url;
+  const pathname = new URL(href, "http://localhost").pathname;
+  return /\/threads\/([^/]+)\/stream\/events$/.exec(pathname)?.[1] ?? null;
+}
+
+function parseInputRequestedFrame(raw: string): RecordedFrame | null {
+  const eventId = /^id:\s*(.+)$/m.exec(raw)?.[1];
+  const method = /^event:\s*(.+)$/m.exec(raw)?.[1];
+  const data = /^data:\s*(.+)$/m.exec(raw)?.[1];
+  if (eventId == null || method !== "input.requested" || data == null) {
+    return null;
+  }
+  return {
+    eventId,
+    seq: Number((JSON.parse(data) as { seq?: unknown }).seq ?? 0),
+    raw,
+  };
+}
+
+export function createDurableReplayFetch() {
+  const baseFetch = globalThis.fetch.bind(globalThis);
+  const history = new Map<string, RecordedFrame[]>();
+  let replayedFrames = 0;
+
+  const fetch: typeof globalThis.fetch = async (input, init) => {
+    const threadId = eventStreamThreadId(input);
+    if (threadId == null) return baseFetch(input, init);
+
+    const response = await baseFetch(input, init);
+    if (response.body == null) return response;
+
+    const body = JSON.parse(String(init?.body ?? "{}")) as {
+      channels?: string[];
+      since?: number;
+    };
+    const recorded = history.get(threadId) ?? [];
+    history.set(threadId, recorded);
+    const replay =
+      body.channels?.includes("input") === false
+        ? []
+        : recorded.filter(
+            (frame) => body.since == null || frame.seq > body.since
+          );
+
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    const reader = response.body.getReader();
+    let pending = "";
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const frame of replay) {
+          replayedFrames += 1;
+          controller.enqueue(encoder.encode(`${frame.raw}\n\n`));
+        }
+      },
+      async pull(controller) {
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+        pending += decoder.decode(value, { stream: true });
+        const parts = pending.split("\n\n");
+        pending = parts.pop() ?? "";
+        for (const part of parts) {
+          const frame = parseInputRequestedFrame(part);
+          if (
+            frame != null &&
+            !recorded.some((seen) => seen.eventId === frame.eventId)
+          ) {
+            recorded.push(frame);
+          }
+        }
+      },
+      cancel(reason) {
+        void reader.cancel(reason);
+      },
+    });
+
+    return new Response(stream, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };
+
+  return { fetch, replayedFrameCount: () => replayedFrames };
+}

--- a/libs/sdk-angular/src/tests/fixtures/interrupt-once-graph.ts
+++ b/libs/sdk-angular/src/tests/fixtures/interrupt-once-graph.ts
@@ -1,0 +1,40 @@
+import {
+  END,
+  interrupt,
+  START,
+  StateGraph,
+  StateSchema,
+} from "@langchain/langgraph";
+import { MemorySaver } from "@langchain/langgraph-checkpoint";
+import { z } from "zod/v4";
+
+const GraphState = new StateSchema({
+  request: z.string(),
+  decision: z.record(z.string(), z.unknown()).nullable().default(null),
+  completedTurns: z.number().default(0),
+});
+
+const reviewNode = (state: typeof GraphState.State) => {
+  if (state.decision != null) {
+    return { completedTurns: state.completedTurns + 1 };
+  }
+
+  const decision = interrupt({
+    prompt: "Approve the outbound action?",
+    request: state.request,
+  });
+
+  return {
+    decision:
+      decision != null && typeof decision === "object"
+        ? (decision as Record<string, unknown>)
+        : { value: decision },
+    completedTurns: state.completedTurns + 1,
+  };
+};
+
+export const graph = new StateGraph(GraphState)
+  .addNode("review", reviewNode)
+  .addEdge(START, "review")
+  .addEdge("review", END)
+  .compile({ checkpointer: new MemorySaver() });

--- a/libs/sdk-angular/src/tests/fixtures/mock-server.ts
+++ b/libs/sdk-angular/src/tests/fixtures/mock-server.ts
@@ -49,6 +49,7 @@ import { getLocationTool } from "./browser-fixtures.js";
 import { graph as multiInterruptGraph } from "./multi-interrupt-graph.js";
 import { graph as nestedInterruptGraph } from "./nested-interrupt-graph.js";
 import { graph as deepAgentInterruptGraph } from "./deep-agent-interrupt.js";
+import { graph as interruptOnceGraph } from "./interrupt-once-graph.js";
 
 declare module "vitest" {
   export interface ProvidedContext {
@@ -692,6 +693,7 @@ const interruptCardGraph = createAgent({
 const graphs: Record<string, AnyPregel> = {
   agent,
   interruptAgent,
+  interrupt_once_graph: interruptOnceGraph as unknown as AnyPregel,
   interrupt_card_graph: interruptCardGraph,
   multi_interrupt_graph: multiInterruptGraph as unknown as AnyPregel,
   nested_interrupt_graph: nestedInterruptGraph as unknown as AnyPregel,

--- a/libs/sdk-angular/src/tests/stream.interrupts.test.ts
+++ b/libs/sdk-angular/src/tests/stream.interrupts.test.ts
@@ -3,6 +3,7 @@ import { render } from "vitest-browser-angular";
 
 import { InterruptStreamComponent } from "./components/InterruptStream.js";
 import { InterruptReconnectStreamComponent } from "./components/InterruptReconnectStream.js";
+import { InterruptReloadStreamComponent } from "./components/InterruptReloadStream.js";
 import { MultiInterruptStreamComponent } from "./components/MultiInterruptStream.js";
 
 it("surfaces the first interrupt on submit()", async () => {
@@ -120,6 +121,64 @@ it(
     await expect
       .element(screen.getByTestId("interrupt-count"))
       .toHaveTextContent("0");
+  }
+);
+
+it(
+  "keeps a resolved interrupt hidden after a reload and a follow-up submit",
+  { timeout: 30_000 },
+  async () => {
+    const screen = await render(InterruptReloadStreamComponent);
+
+    await screen.getByTestId("submit").click();
+    await expect
+      .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
+      .toHaveTextContent("1");
+
+    await screen.getByTestId("resume").click();
+    await expect
+      .element(screen.getByTestId("completed-turns"), { timeout: 10_000 })
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("interrupt-count"))
+      .toHaveTextContent("0");
+
+    await screen.getByTestId("reload").click();
+    await expect
+      .element(screen.getByTestId("session"), { timeout: 10_000 })
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("thread-loading"), { timeout: 10_000 })
+      .toHaveTextContent("Ready");
+
+    await screen.getByTestId("submit").click();
+    await expect
+      .element(screen.getByTestId("completed-turns"), { timeout: 10_000 })
+      .toHaveTextContent("2");
+    await expect
+      .element(screen.getByTestId("loading"))
+      .toHaveTextContent("Not loading");
+    await expect
+      .poll(
+        () =>
+          Number(
+            screen.getByTestId("replayed-frames").element().textContent ?? "0"
+          ),
+        { timeout: 5_000 }
+      )
+      .toBeGreaterThan(0);
+
+    const observedIds = new Set<string>();
+    const deadline = Date.now() + 1_000;
+    while (Date.now() < deadline) {
+      const ids = screen
+        .getByTestId("interrupt-ids")
+        .element()
+        .textContent?.trim();
+      if (ids) observedIds.add(ids);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    expect([...observedIds]).toEqual([]);
   }
 );
 

--- a/libs/sdk-angular/vitest.config.ts
+++ b/libs/sdk-angular/vitest.config.ts
@@ -6,6 +6,8 @@ import { fileURLToPath } from "node:url";
 
 const nonAngularFiles = [
   /mock-server\.ts/,
+  /interrupt-once-graph\.ts/,
+  /durable-replay-fetch\.ts/,
   /multi-interrupt-graph\.ts/,
   /nested-interrupt-graph\.ts/,
   /deep-agent-interrupt\.ts/,

--- a/libs/sdk-react/src/tests/components/InterruptReloadStream.tsx
+++ b/libs/sdk-react/src/tests/components/InterruptReloadStream.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { useStream } from "../../index.js";
+import { createDurableReplayFetch } from "../fixtures/durable-replay-fetch.js";
+
+interface InterruptState {
+  request: string;
+  decision: Record<string, unknown> | null;
+  completedTurns: number;
+}
+
+interface Props {
+  apiUrl: string;
+  assistantId?: string;
+}
+
+interface SessionProps extends Props {
+  threadId: string | null;
+  onThreadId: (threadId: string) => void;
+  fetch: typeof fetch;
+}
+
+/** Milliseconds the hook stays unmounted while a reload is simulated. */
+const RELOAD_GAP_MS = 100;
+
+function InterruptSession({
+  apiUrl,
+  assistantId = "interrupt_once_graph",
+  threadId,
+  onThreadId,
+  fetch: fetchImpl,
+}: SessionProps) {
+  const thread = useStream<InterruptState>({
+    assistantId,
+    apiUrl,
+    threadId,
+    onThreadId,
+    fetch: fetchImpl,
+  });
+
+  return (
+    <div>
+      <div data-testid="interrupt-count">{thread.interrupts.length}</div>
+      <div data-testid="interrupt-ids">
+        {thread.interrupts.map((item) => item.id ?? "?").join(",")}
+      </div>
+      <div data-testid="completed-turns">
+        {thread.values?.completedTurns ?? 0}
+      </div>
+      <div data-testid="loading">
+        {thread.isLoading ? "Loading..." : "Not loading"}
+      </div>
+      <div data-testid="thread-loading">
+        {thread.isThreadLoading ? "Hydrating..." : "Ready"}
+      </div>
+      <button
+        data-testid="submit"
+        onClick={() => void thread.submit({ request: "ship it" })}
+      >
+        Submit
+      </button>
+      <button
+        data-testid="resume"
+        onClick={() => {
+          if (thread.interrupt) {
+            void thread.respond({ approved: true });
+          }
+        }}
+      >
+        Resume
+      </button>
+    </div>
+  );
+}
+
+/**
+ * HITL harness that can drop and rebuild its `useStream` session while
+ * keeping the same `threadId`, the way a browser reload does. The
+ * remounted hook re-hydrates from persisted server state and has no
+ * memory of interrupts the previous session resolved.
+ *
+ * Event history outlives the reload, as it does on LangGraph Platform, so
+ * the reconnecting session replays the interrupt the previous one resolved.
+ */
+export function InterruptReloadStream({ apiUrl, assistantId }: Props) {
+  const durable = useMemo(() => createDurableReplayFetch(), []);
+  const [threadId, setThreadId] = useState<string | null>(null);
+  const [session, setSession] = useState(0);
+  const [mounted, setMounted] = useState(true);
+  const [replayedFrames, setReplayedFrames] = useState(0);
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setReplayedFrames(durable.replayedFrameCount());
+    }, 50);
+    return () => window.clearInterval(id);
+  }, [durable]);
+
+  useEffect(() => {
+    if (mounted) return undefined;
+    const timer = window.setTimeout(() => {
+      setSession((current) => current + 1);
+      setMounted(true);
+    }, RELOAD_GAP_MS);
+    return () => window.clearTimeout(timer);
+  }, [mounted]);
+
+  return (
+    <div>
+      <div data-testid="session">{session}</div>
+      <div data-testid="thread-id">{threadId ?? "none"}</div>
+      <div data-testid="replayed-frames">{replayedFrames}</div>
+      <button data-testid="reload" onClick={() => setMounted(false)}>
+        Reload
+      </button>
+      {mounted ? (
+        <InterruptSession
+          key={session}
+          apiUrl={apiUrl}
+          assistantId={assistantId}
+          threadId={threadId}
+          onThreadId={setThreadId}
+          fetch={durable.fetch}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/libs/sdk-react/src/tests/fixtures/durable-replay-fetch.ts
+++ b/libs/sdk-react/src/tests/fixtures/durable-replay-fetch.ts
@@ -1,0 +1,166 @@
+/**
+ * `fetch` wrapper that gives `/stream/events` the durable replay semantics of
+ * LangGraph Platform: every connection that opens without a `since` cursor
+ * receives the thread's full event history before its live events.
+ *
+ * The embedded dev server used by these tests drops its buffered events on
+ * resume, so a reconnect there never replays the `input.requested` of an
+ * already-resolved interrupt. Platform keeps that history, which is what makes
+ * a resolved interrupt re-surface on the next run. Recording the frames here
+ * and re-emitting them on later opens reproduces that on the wire, leaving the
+ * SDK to do the filtering it does in production.
+ */
+
+interface RecordedFrame {
+  eventId: string;
+  seq: number;
+  method: string;
+  raw: string;
+}
+
+function requestHref(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function eventStreamThreadId(href: string): string | null {
+  let pathname: string;
+  try {
+    pathname = new URL(href, "http://localhost").pathname;
+  } catch {
+    pathname = href;
+  }
+  const match = /\/threads\/([^/]+)\/stream\/events$/.exec(pathname);
+  return match?.[1] ?? null;
+}
+
+function parseFrame(raw: string): RecordedFrame | null {
+  let eventId: string | undefined;
+  let method: string | undefined;
+  let data: string | undefined;
+  for (const line of raw.split("\n")) {
+    if (line.startsWith("id:")) eventId = line.slice(3).trim();
+    else if (line.startsWith("event:")) method = line.slice(6).trim();
+    else if (line.startsWith("data:")) data = line.slice(5).trim();
+  }
+  if (eventId == null || method == null || data == null) return null;
+  let seq = 0;
+  try {
+    seq = Number((JSON.parse(data) as { seq?: unknown }).seq ?? 0);
+  } catch {
+    return null;
+  }
+  return { eventId, seq, method, raw };
+}
+
+/** `input.requested` belongs to the `input` channel, and so on. */
+function frameChannel(method: string): string {
+  return method.split(".")[0];
+}
+
+export interface DurableReplayFetchOptions {
+  baseFetch?: typeof fetch;
+  /**
+   * Event methods kept in the durable history. Defaults to the interrupt
+   * requests, which is what the dev server discards on resume; replaying
+   * whole lifecycles would re-drive run state the dev server already
+   * delivers correctly.
+   */
+  methods?: string[];
+}
+
+export interface DurableReplayFetch {
+  /** Custom fetch suitable for `useStream({ fetch })`. */
+  fetch: typeof fetch;
+  /** Number of `/stream/events` opens observed (includes reconnects). */
+  eventStreamOpenCount: () => number;
+  /** Number of historical frames replayed across all opens. */
+  replayedFrameCount: () => number;
+}
+
+export function createDurableReplayFetch(
+  options: DurableReplayFetchOptions = {}
+): DurableReplayFetch {
+  const baseFetch = options.baseFetch ?? globalThis.fetch.bind(globalThis);
+  const methods = new Set(options.methods ?? ["input.requested"]);
+  const history = new Map<string, RecordedFrame[]>();
+  let eventStreamOpens = 0;
+  let replayedFrames = 0;
+
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const threadId = eventStreamThreadId(requestHref(input));
+    if (threadId == null) return baseFetch(input, init);
+
+    eventStreamOpens += 1;
+    const response = await baseFetch(input, init);
+    if (response.body == null) return response;
+
+    let channels: string[] | undefined;
+    let since: number | undefined;
+    try {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        channels?: string[];
+        since?: number;
+      };
+      channels = body.channels;
+      since = body.since;
+    } catch {
+      // Unparseable body: replay everything recorded.
+    }
+
+    const recorded = history.get(threadId) ?? [];
+    history.set(threadId, recorded);
+    const replay = recorded.filter(
+      (frame) =>
+        (since == null || frame.seq > since) &&
+        (channels == null || channels.includes(frameChannel(frame.method)))
+    );
+
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    const reader = response.body.getReader();
+    let pending = "";
+
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        for (const frame of replay) {
+          replayedFrames += 1;
+          controller.enqueue(encoder.encode(`${frame.raw}\n\n`));
+        }
+      },
+      async pull(controller) {
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+        pending += decoder.decode(value, { stream: true });
+        const parts = pending.split("\n\n");
+        pending = parts.pop() ?? "";
+        for (const part of parts) {
+          const frame = parseFrame(part);
+          if (frame == null || !methods.has(frame.method)) continue;
+          if (recorded.some((seen) => seen.eventId === frame.eventId)) continue;
+          recorded.push(frame);
+        }
+      },
+      cancel(reason) {
+        void reader.cancel(reason);
+      },
+    });
+
+    return new Response(stream, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };
+
+  return {
+    fetch: fetchImpl,
+    eventStreamOpenCount: () => eventStreamOpens,
+    replayedFrameCount: () => replayedFrames,
+  };
+}

--- a/libs/sdk-react/src/tests/fixtures/interrupt-once-graph.ts
+++ b/libs/sdk-react/src/tests/fixtures/interrupt-once-graph.ts
@@ -1,0 +1,50 @@
+import {
+  END,
+  interrupt,
+  START,
+  StateGraph,
+  StateSchema,
+} from "@langchain/langgraph";
+import { MemorySaver } from "@langchain/langgraph-checkpoint";
+import { z } from "zod/v4";
+
+/**
+ * Approval is requested once per thread. Every later turn runs straight
+ * through, mirroring a HITL tool review that stays resolved for the rest
+ * of the conversation — so any interrupt surfacing on turn two is stale
+ * replay rather than a genuine request.
+ */
+
+const GraphState = new StateSchema({
+  request: z.string(),
+  decision: z.record(z.string(), z.unknown()).nullable().default(null),
+  completedTurns: z.number().default(0),
+});
+
+const reviewNode = (state: typeof GraphState.State) => {
+  if (state.decision != null) {
+    return { completedTurns: state.completedTurns + 1 };
+  }
+
+  const decision = interrupt({
+    prompt: "Approve the outbound action?",
+    request: state.request,
+  });
+
+  return {
+    decision:
+      decision != null && typeof decision === "object"
+        ? (decision as Record<string, unknown>)
+        : { value: decision },
+    completedTurns: state.completedTurns + 1,
+  };
+};
+
+const workflow = new StateGraph(GraphState)
+  .addNode("review", reviewNode)
+  .addEdge(START, "review")
+  .addEdge("review", END);
+
+export const graph = workflow.compile({
+  checkpointer: new MemorySaver(),
+});

--- a/libs/sdk-react/src/tests/mock-server.ts
+++ b/libs/sdk-react/src/tests/mock-server.ts
@@ -21,6 +21,7 @@ import { graph as createAgentGraph } from "./fixtures/create-agent.js";
 import { graph as deepAgentGraph } from "./fixtures/deep-agent.js";
 import { graph as interruptGraph } from "./fixtures/interrupt-graph.js";
 import { graph as interruptCardGraph } from "./fixtures/interrupt-card-graph.js";
+import { graph as interruptOnceGraph } from "./fixtures/interrupt-once-graph.js";
 import { graph as multiInterruptGraph } from "./fixtures/multi-interrupt-graph.js";
 import { graph as nestedInterruptGraph } from "./fixtures/nested-interrupt-graph.js";
 import { graph as deepAgentInterruptGraph } from "./fixtures/deep-agent-interrupt.js";
@@ -81,6 +82,7 @@ const graphs: Record<string, AnyPregel> = {
   deep_agent: deepAgentGraph as unknown as AnyPregel,
   interrupt_graph: interruptGraph as unknown as AnyPregel,
   interrupt_card_graph: interruptCardGraph as unknown as AnyPregel,
+  interrupt_once_graph: interruptOnceGraph as unknown as AnyPregel,
   multi_interrupt_graph: multiInterruptGraph as unknown as AnyPregel,
   nested_interrupt_graph: nestedInterruptGraph as unknown as AnyPregel,
   deep_agent_interrupt: deepAgentInterruptGraph as unknown as AnyPregel,

--- a/libs/sdk-react/src/tests/stream.interrupts.test.tsx
+++ b/libs/sdk-react/src/tests/stream.interrupts.test.tsx
@@ -3,6 +3,7 @@ import { render } from "vitest-browser-react";
 
 import { InterruptStream } from "./components/InterruptStream.js";
 import { InterruptReconnectStream } from "./components/InterruptReconnectStream.js";
+import { InterruptReloadStream } from "./components/InterruptReloadStream.js";
 import { MultiInterruptStream } from "./components/MultiInterruptStream.js";
 import { apiUrl, cleanupRender } from "./test-utils.js";
 
@@ -116,6 +117,96 @@ it(
       await expect
         .element(screen.getByTestId("interrupt-count"))
         .toHaveTextContent("0");
+    } finally {
+      await cleanupRender(screen);
+    }
+  }
+);
+
+it(
+  "keeps a resolved interrupt hidden after a reload and a follow-up submit",
+  { timeout: 30_000 },
+  async () => {
+    // Regression: a reloaded session has no memory of the interrupt it
+    // resolved before the reload. The follow-up submit opens fresh pumps
+    // that replay the thread's history, and that historical
+    // `input.requested` used to re-surface the resolved form.
+    const screen = await render(<InterruptReloadStream apiUrl={apiUrl} />);
+
+    try {
+      await screen.getByTestId("submit").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
+        .toHaveTextContent("1");
+
+      const resolvedInterruptId = screen
+        .getByTestId("interrupt-ids")
+        .element()
+        .textContent?.trim();
+      expect(resolvedInterruptId).toBeTruthy();
+
+      await screen.getByTestId("resume").click();
+
+      await expect
+        .element(screen.getByTestId("completed-turns"), { timeout: 10_000 })
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("interrupt-count"))
+        .toHaveTextContent("0");
+
+      await screen.getByTestId("reload").click();
+
+      await expect
+        .element(screen.getByTestId("session"), { timeout: 10_000 })
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("thread-loading"), { timeout: 10_000 })
+        .toHaveTextContent("Ready");
+
+      // Hydration alone already filtered the resolved interrupt before
+      // this fix; the replay only leaks once a new run is dispatched.
+      await expect
+        .element(screen.getByTestId("interrupt-count"))
+        .toHaveTextContent("0");
+      await expect
+        .element(screen.getByTestId("completed-turns"))
+        .toHaveTextContent("1");
+
+      await screen.getByTestId("submit").click();
+
+      await expect
+        .element(screen.getByTestId("completed-turns"), { timeout: 10_000 })
+        .toHaveTextContent("2");
+      await expect
+        .element(screen.getByTestId("loading"), { timeout: 10_000 })
+        .toHaveTextContent("Not loading");
+
+      // Guard the setup itself: without the replayed interrupt on the
+      // wire this test would pass for the wrong reason.
+      await expect
+        .poll(
+          () =>
+            Number(
+              screen.getByTestId("replayed-frames").element().textContent ?? "0"
+            ),
+          { timeout: 5_000 }
+        )
+        .toBeGreaterThan(0);
+
+      // The replayed event can land after the run settles, so watch for a
+      // window rather than sampling a single frame.
+      const observedIds = new Set<string>();
+      const deadline = Date.now() + 1_000;
+      while (Date.now() < deadline) {
+        const ids = screen
+          .getByTestId("interrupt-ids")
+          .element()
+          .textContent?.trim();
+        if (ids) observedIds.add(ids);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+      expect([...observedIds]).toEqual([]);
     } finally {
       await cleanupRender(screen);
     }

--- a/libs/sdk-svelte/src/tests/components/InterruptReloadSession.svelte
+++ b/libs/sdk-svelte/src/tests/components/InterruptReloadSession.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import { useStream } from "../../index.js";
+
+  interface InterruptState {
+    request: string;
+    decision: Record<string, unknown> | null;
+    completedTurns: number;
+  }
+
+  interface Props {
+    apiUrl: string;
+    threadId?: string;
+    onThreadId: (threadId: string) => void;
+    fetch: typeof globalThis.fetch;
+  }
+
+  const { apiUrl, threadId, onThreadId, fetch }: Props = $props();
+  const stream = useStream<InterruptState>({
+    assistantId: "interrupt_once_graph",
+    apiUrl,
+    threadId,
+    onThreadId,
+    fetch,
+  });
+</script>
+
+<div data-testid="interrupt-count">{stream.interrupts.length}</div>
+<div data-testid="interrupt-ids">
+  {stream.interrupts.map((item) => item.id ?? "?").join(",")}
+</div>
+<div data-testid="completed-turns">
+  {stream.values?.completedTurns ?? 0}
+</div>
+<div data-testid="loading">
+  {stream.isLoading ? "Loading..." : "Not loading"}
+</div>
+<div data-testid="thread-loading">
+  {stream.isThreadLoading ? "Hydrating..." : "Ready"}
+</div>
+<button
+  data-testid="submit"
+  onclick={() => void stream.submit({ request: "ship it" })}
+>
+  Submit
+</button>
+<button
+  data-testid="resume"
+  onclick={() => {
+    if (stream.interrupt) {
+      void stream.respond({ approved: true });
+    }
+  }}
+>
+  Resume
+</button>

--- a/libs/sdk-svelte/src/tests/components/InterruptReloadStream.svelte
+++ b/libs/sdk-svelte/src/tests/components/InterruptReloadStream.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+
+  import { createDurableReplayFetch } from "../fixtures/durable-replay-fetch.js";
+  import InterruptReloadSession from "./InterruptReloadSession.svelte";
+
+  interface Props {
+    apiUrl: string;
+  }
+
+  const { apiUrl }: Props = $props();
+  const durable = createDurableReplayFetch();
+  let threadId = $state<string>();
+  let session = $state(0);
+  let mounted = $state(true);
+  let replayedFrames = $state(0);
+  let reloadTimer: number | undefined;
+
+  onMount(() => {
+    const replayTimer = window.setInterval(() => {
+      replayedFrames = durable.replayedFrameCount();
+    }, 50);
+    return () => {
+      window.clearInterval(replayTimer);
+      window.clearTimeout(reloadTimer);
+    };
+  });
+
+  function reload() {
+    mounted = false;
+    reloadTimer = window.setTimeout(() => {
+      session += 1;
+      mounted = true;
+    }, 100);
+  }
+</script>
+
+<div data-testid="session">{session}</div>
+<div data-testid="replayed-frames">{replayedFrames}</div>
+<button data-testid="reload" onclick={reload}>Reload</button>
+{#key session}
+  {#if mounted}
+    <InterruptReloadSession
+      {apiUrl}
+      {threadId}
+      onThreadId={(id) => (threadId = id)}
+      fetch={durable.fetch}
+    />
+  {/if}
+{/key}

--- a/libs/sdk-svelte/src/tests/fixtures/durable-replay-fetch.ts
+++ b/libs/sdk-svelte/src/tests/fixtures/durable-replay-fetch.ts
@@ -1,0 +1,102 @@
+interface RecordedFrame {
+  eventId: string;
+  seq: number;
+  raw: string;
+}
+
+function eventStreamThreadId(input: RequestInfo | URL): string | null {
+  const href =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url;
+  const pathname = new URL(href, "http://localhost").pathname;
+  return /\/threads\/([^/]+)\/stream\/events$/.exec(pathname)?.[1] ?? null;
+}
+
+function parseInputRequestedFrame(raw: string): RecordedFrame | null {
+  const eventId = /^id:\s*(.+)$/m.exec(raw)?.[1];
+  const method = /^event:\s*(.+)$/m.exec(raw)?.[1];
+  const data = /^data:\s*(.+)$/m.exec(raw)?.[1];
+  if (eventId == null || method !== "input.requested" || data == null) {
+    return null;
+  }
+  return {
+    eventId,
+    seq: Number((JSON.parse(data) as { seq?: unknown }).seq ?? 0),
+    raw,
+  };
+}
+
+export function createDurableReplayFetch() {
+  const baseFetch = globalThis.fetch.bind(globalThis);
+  const history = new Map<string, RecordedFrame[]>();
+  let replayedFrames = 0;
+
+  const fetch: typeof globalThis.fetch = async (input, init) => {
+    const threadId = eventStreamThreadId(input);
+    if (threadId == null) return baseFetch(input, init);
+
+    const response = await baseFetch(input, init);
+    if (response.body == null) return response;
+
+    const body = JSON.parse(String(init?.body ?? "{}")) as {
+      channels?: string[];
+      since?: number;
+    };
+    const recorded = history.get(threadId) ?? [];
+    history.set(threadId, recorded);
+    const replay =
+      body.channels?.includes("input") === false
+        ? []
+        : recorded.filter(
+            (frame) => body.since == null || frame.seq > body.since
+          );
+
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    const reader = response.body.getReader();
+    let pending = "";
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const frame of replay) {
+          replayedFrames += 1;
+          controller.enqueue(encoder.encode(`${frame.raw}\n\n`));
+        }
+      },
+      async pull(controller) {
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+        pending += decoder.decode(value, { stream: true });
+        const parts = pending.split("\n\n");
+        pending = parts.pop() ?? "";
+        for (const part of parts) {
+          const frame = parseInputRequestedFrame(part);
+          if (
+            frame != null &&
+            !recorded.some((seen) => seen.eventId === frame.eventId)
+          ) {
+            recorded.push(frame);
+          }
+        }
+      },
+      cancel(reason) {
+        void reader.cancel(reason);
+      },
+    });
+
+    return new Response(stream, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };
+
+  return { fetch, replayedFrameCount: () => replayedFrames };
+}

--- a/libs/sdk-svelte/src/tests/fixtures/interrupt-once-graph.ts
+++ b/libs/sdk-svelte/src/tests/fixtures/interrupt-once-graph.ts
@@ -1,0 +1,40 @@
+import {
+  END,
+  interrupt,
+  START,
+  StateGraph,
+  StateSchema,
+} from "@langchain/langgraph";
+import { MemorySaver } from "@langchain/langgraph-checkpoint";
+import { z } from "zod/v4";
+
+const GraphState = new StateSchema({
+  request: z.string(),
+  decision: z.record(z.string(), z.unknown()).nullable().default(null),
+  completedTurns: z.number().default(0),
+});
+
+const reviewNode = (state: typeof GraphState.State) => {
+  if (state.decision != null) {
+    return { completedTurns: state.completedTurns + 1 };
+  }
+
+  const decision = interrupt({
+    prompt: "Approve the outbound action?",
+    request: state.request,
+  });
+
+  return {
+    decision:
+      decision != null && typeof decision === "object"
+        ? (decision as Record<string, unknown>)
+        : { value: decision },
+    completedTurns: state.completedTurns + 1,
+  };
+};
+
+export const graph = new StateGraph(GraphState)
+  .addNode("review", reviewNode)
+  .addEdge(START, "review")
+  .addEdge("review", END)
+  .compile({ checkpointer: new MemorySaver() });

--- a/libs/sdk-svelte/src/tests/fixtures/mock-server.ts
+++ b/libs/sdk-svelte/src/tests/fixtures/mock-server.ts
@@ -48,6 +48,7 @@ import { getLocationTool } from "./browser-fixtures.js";
 import { graph as multiInterruptGraph } from "./multi-interrupt-graph.js";
 import { graph as nestedInterruptGraph } from "./nested-interrupt-graph.js";
 import { graph as deepAgentInterruptGraph } from "./deep-agent-interrupt.js";
+import { graph as interruptOnceGraph } from "./interrupt-once-graph.js";
 
 declare module "vitest" {
   export interface ProvidedContext {
@@ -691,6 +692,7 @@ const graphs: Record<string, AnyPregel> = {
   agent,
   stategraph_text: stategraphText,
   interruptAgent,
+  interrupt_once_graph: interruptOnceGraph as unknown as AnyPregel,
   interrupt_card_graph: interruptCardGraph,
   multi_interrupt_graph: multiInterruptGraph as unknown as AnyPregel,
   nested_interrupt_graph: nestedInterruptGraph as unknown as AnyPregel,

--- a/libs/sdk-svelte/src/tests/stream.interrupts.test.ts
+++ b/libs/sdk-svelte/src/tests/stream.interrupts.test.ts
@@ -3,6 +3,7 @@ import { render } from "vitest-browser-svelte";
 
 import InterruptStream from "./components/InterruptStream.svelte";
 import InterruptReconnectStream from "./components/InterruptReconnectStream.svelte";
+import InterruptReloadStream from "./components/InterruptReloadStream.svelte";
 import MultiInterruptStream from "./components/MultiInterruptStream.svelte";
 
 const serverUrl = inject("serverUrl");
@@ -99,6 +100,64 @@ it(
     await expect
       .element(screen.getByTestId("interrupt-count"))
       .toHaveTextContent("0");
+  }
+);
+
+it(
+  "keeps a resolved interrupt hidden after a reload and a follow-up submit",
+  { timeout: 30_000 },
+  async () => {
+    const screen = await render(InterruptReloadStream, { apiUrl: serverUrl });
+
+    await screen.getByTestId("submit").click();
+    await expect
+      .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
+      .toHaveTextContent("1");
+
+    await screen.getByTestId("resume").click();
+    await expect
+      .element(screen.getByTestId("completed-turns"), { timeout: 10_000 })
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("interrupt-count"))
+      .toHaveTextContent("0");
+
+    await screen.getByTestId("reload").click();
+    await expect
+      .element(screen.getByTestId("session"), { timeout: 10_000 })
+      .toHaveTextContent("1");
+    await expect
+      .element(screen.getByTestId("thread-loading"), { timeout: 10_000 })
+      .toHaveTextContent("Ready");
+
+    await screen.getByTestId("submit").click();
+    await expect
+      .element(screen.getByTestId("completed-turns"), { timeout: 10_000 })
+      .toHaveTextContent("2");
+    await expect
+      .element(screen.getByTestId("loading"))
+      .toHaveTextContent("Not loading");
+    await expect
+      .poll(
+        () =>
+          Number(
+            screen.getByTestId("replayed-frames").element().textContent ?? "0"
+          ),
+        { timeout: 5_000 }
+      )
+      .toBeGreaterThan(0);
+
+    const observedIds = new Set<string>();
+    const deadline = Date.now() + 1_000;
+    while (Date.now() < deadline) {
+      const ids = screen
+        .getByTestId("interrupt-ids")
+        .element()
+        .textContent?.trim();
+      if (ids) observedIds.add(ids);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    expect([...observedIds]).toEqual([]);
   }
 );
 

--- a/libs/sdk-vue/src/tests/components/InterruptReloadStream.tsx
+++ b/libs/sdk-vue/src/tests/components/InterruptReloadStream.tsx
@@ -1,0 +1,128 @@
+import {
+  defineComponent,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  type PropType,
+} from "vue";
+
+import { useStream } from "../../index.js";
+import { createDurableReplayFetch } from "../fixtures/durable-replay-fetch.js";
+
+interface InterruptState {
+  request: string;
+  decision: Record<string, unknown> | null;
+  completedTurns: number;
+}
+
+const InterruptReloadSession = defineComponent({
+  props: {
+    apiUrl: { type: String, required: true },
+    threadId: { type: String, default: undefined },
+    onThreadId: {
+      type: Function as PropType<(threadId: string) => void>,
+      required: true,
+    },
+    fetch: {
+      type: Function as PropType<typeof globalThis.fetch>,
+      required: true,
+    },
+  },
+  setup(props) {
+    const stream = useStream<InterruptState>({
+      assistantId: "interrupt_once_graph",
+      apiUrl: props.apiUrl,
+      threadId: props.threadId,
+      onThreadId: props.onThreadId,
+      fetch: props.fetch,
+    });
+
+    return () => (
+      <div>
+        <div data-testid="interrupt-count">{stream.interrupts.value.length}</div>
+        <div data-testid="interrupt-ids">
+          {stream.interrupts.value.map((item) => item.id ?? "?").join(",")}
+        </div>
+        <div data-testid="completed-turns">
+          {stream.values.value?.completedTurns ?? 0}
+        </div>
+        <div data-testid="loading">
+          {stream.isLoading.value ? "Loading..." : "Not loading"}
+        </div>
+        <div data-testid="thread-loading">
+          {stream.isThreadLoading.value ? "Hydrating..." : "Ready"}
+        </div>
+        <button
+          data-testid="submit"
+          onClick={() => void stream.submit({ request: "ship it" })}
+        >
+          Submit
+        </button>
+        <button
+          data-testid="resume"
+          onClick={() => {
+            if (stream.interrupt.value) {
+              void stream.respond({ approved: true });
+            }
+          }}
+        >
+          Resume
+        </button>
+      </div>
+    );
+  },
+});
+
+export const InterruptReloadStream = defineComponent({
+  props: {
+    apiUrl: { type: String, required: true },
+  },
+  setup(props) {
+    const durable = createDurableReplayFetch();
+    const threadId = ref<string>();
+    const session = ref(0);
+    const mounted = ref(true);
+    const replayedFrames = ref(0);
+    let reloadTimer: number | undefined;
+    let replayTimer: number | undefined;
+
+    onMounted(() => {
+      replayTimer = window.setInterval(() => {
+        replayedFrames.value = durable.replayedFrameCount();
+      }, 50);
+    });
+    onBeforeUnmount(() => {
+      window.clearTimeout(reloadTimer);
+      window.clearInterval(replayTimer);
+    });
+
+    const reload = () => {
+      mounted.value = false;
+      reloadTimer = window.setTimeout(() => {
+        session.value += 1;
+        mounted.value = true;
+      }, 100);
+    };
+
+    return () => (
+      <div>
+        <div data-testid="session">{session.value}</div>
+        <div data-testid="replayed-frames">{replayedFrames.value}</div>
+        <button data-testid="reload" onClick={reload}>
+          Reload
+        </button>
+        {mounted.value ? (
+          <InterruptReloadSession
+            key={session.value}
+            apiUrl={props.apiUrl}
+            threadId={threadId.value}
+            onThreadId={(id) => {
+              threadId.value = id;
+            }}
+            fetch={durable.fetch}
+          />
+        ) : null}
+      </div>
+    );
+  },
+});

--- a/libs/sdk-vue/src/tests/fixtures/durable-replay-fetch.ts
+++ b/libs/sdk-vue/src/tests/fixtures/durable-replay-fetch.ts
@@ -1,0 +1,102 @@
+interface RecordedFrame {
+  eventId: string;
+  seq: number;
+  raw: string;
+}
+
+function eventStreamThreadId(input: RequestInfo | URL): string | null {
+  const href =
+    typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url;
+  const pathname = new URL(href, "http://localhost").pathname;
+  return /\/threads\/([^/]+)\/stream\/events$/.exec(pathname)?.[1] ?? null;
+}
+
+function parseInputRequestedFrame(raw: string): RecordedFrame | null {
+  const eventId = /^id:\s*(.+)$/m.exec(raw)?.[1];
+  const method = /^event:\s*(.+)$/m.exec(raw)?.[1];
+  const data = /^data:\s*(.+)$/m.exec(raw)?.[1];
+  if (eventId == null || method !== "input.requested" || data == null) {
+    return null;
+  }
+  return {
+    eventId,
+    seq: Number((JSON.parse(data) as { seq?: unknown }).seq ?? 0),
+    raw,
+  };
+}
+
+export function createDurableReplayFetch() {
+  const baseFetch = globalThis.fetch.bind(globalThis);
+  const history = new Map<string, RecordedFrame[]>();
+  let replayedFrames = 0;
+
+  const fetch: typeof globalThis.fetch = async (input, init) => {
+    const threadId = eventStreamThreadId(input);
+    if (threadId == null) return baseFetch(input, init);
+
+    const response = await baseFetch(input, init);
+    if (response.body == null) return response;
+
+    const body = JSON.parse(String(init?.body ?? "{}")) as {
+      channels?: string[];
+      since?: number;
+    };
+    const recorded = history.get(threadId) ?? [];
+    history.set(threadId, recorded);
+    const replay =
+      body.channels?.includes("input") === false
+        ? []
+        : recorded.filter(
+            (frame) => body.since == null || frame.seq > body.since
+          );
+
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+    const reader = response.body.getReader();
+    let pending = "";
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const frame of replay) {
+          replayedFrames += 1;
+          controller.enqueue(encoder.encode(`${frame.raw}\n\n`));
+        }
+      },
+      async pull(controller) {
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+        pending += decoder.decode(value, { stream: true });
+        const parts = pending.split("\n\n");
+        pending = parts.pop() ?? "";
+        for (const part of parts) {
+          const frame = parseInputRequestedFrame(part);
+          if (
+            frame != null &&
+            !recorded.some((seen) => seen.eventId === frame.eventId)
+          ) {
+            recorded.push(frame);
+          }
+        }
+      },
+      cancel(reason) {
+        void reader.cancel(reason);
+      },
+    });
+
+    return new Response(stream, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };
+
+  return { fetch, replayedFrameCount: () => replayedFrames };
+}

--- a/libs/sdk-vue/src/tests/fixtures/interrupt-once-graph.ts
+++ b/libs/sdk-vue/src/tests/fixtures/interrupt-once-graph.ts
@@ -1,0 +1,40 @@
+import {
+  END,
+  interrupt,
+  START,
+  StateGraph,
+  StateSchema,
+} from "@langchain/langgraph";
+import { MemorySaver } from "@langchain/langgraph-checkpoint";
+import { z } from "zod/v4";
+
+const GraphState = new StateSchema({
+  request: z.string(),
+  decision: z.record(z.string(), z.unknown()).nullable().default(null),
+  completedTurns: z.number().default(0),
+});
+
+const reviewNode = (state: typeof GraphState.State) => {
+  if (state.decision != null) {
+    return { completedTurns: state.completedTurns + 1 };
+  }
+
+  const decision = interrupt({
+    prompt: "Approve the outbound action?",
+    request: state.request,
+  });
+
+  return {
+    decision:
+      decision != null && typeof decision === "object"
+        ? (decision as Record<string, unknown>)
+        : { value: decision },
+    completedTurns: state.completedTurns + 1,
+  };
+};
+
+export const graph = new StateGraph(GraphState)
+  .addNode("review", reviewNode)
+  .addEdge(START, "review")
+  .addEdge("review", END)
+  .compile({ checkpointer: new MemorySaver() });

--- a/libs/sdk-vue/src/tests/fixtures/mock-server.ts
+++ b/libs/sdk-vue/src/tests/fixtures/mock-server.ts
@@ -48,6 +48,7 @@ import { getLocationTool } from "./browser-fixtures.js";
 import { graph as multiInterruptGraph } from "./multi-interrupt-graph.js";
 import { graph as nestedInterruptGraph } from "./nested-interrupt-graph.js";
 import { graph as deepAgentInterruptGraph } from "./deep-agent-interrupt.js";
+import { graph as interruptOnceGraph } from "./interrupt-once-graph.js";
 
 declare module "vitest" {
   export interface ProvidedContext {
@@ -676,6 +677,7 @@ const interruptCardGraph = createAgent({
 const graphs: Record<string, AnyPregel> = {
   agent,
   interruptAgent,
+  interrupt_once_graph: interruptOnceGraph as unknown as AnyPregel,
   interrupt_card_graph: interruptCardGraph,
   multi_interrupt_graph: multiInterruptGraph as unknown as AnyPregel,
   nested_interrupt_graph: nestedInterruptGraph as unknown as AnyPregel,

--- a/libs/sdk-vue/src/tests/stream.interrupts.test.tsx
+++ b/libs/sdk-vue/src/tests/stream.interrupts.test.tsx
@@ -3,6 +3,7 @@ import { render } from "vitest-browser-vue";
 
 import { InterruptStream } from "./components/InterruptStream.js";
 import { InterruptReconnectStream } from "./components/InterruptReconnectStream.js";
+import { InterruptReloadStream } from "./components/InterruptReloadStream.js";
 import { MultiInterruptStream } from "./components/MultiInterruptStream.js";
 import { apiUrl } from "./test-utils.js";
 
@@ -110,6 +111,68 @@ it(
       await expect
         .element(screen.getByTestId("interrupt-count"))
         .toHaveTextContent("0");
+    } finally {
+      await screen.unmount();
+    }
+  }
+);
+
+it(
+  "keeps a resolved interrupt hidden after a reload and a follow-up submit",
+  { timeout: 30_000 },
+  async () => {
+    const screen = await render(InterruptReloadStream, { props: { apiUrl } });
+
+    try {
+      await screen.getByTestId("submit").click();
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
+        .toHaveTextContent("1");
+
+      await screen.getByTestId("resume").click();
+      await expect
+        .element(screen.getByTestId("completed-turns"), { timeout: 10_000 })
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("interrupt-count"))
+        .toHaveTextContent("0");
+
+      await screen.getByTestId("reload").click();
+      await expect
+        .element(screen.getByTestId("session"), { timeout: 10_000 })
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("thread-loading"), { timeout: 10_000 })
+        .toHaveTextContent("Ready");
+
+      await screen.getByTestId("submit").click();
+      await expect
+        .element(screen.getByTestId("completed-turns"), { timeout: 10_000 })
+        .toHaveTextContent("2");
+      await expect
+        .element(screen.getByTestId("loading"))
+        .toHaveTextContent("Not loading");
+      await expect
+        .poll(
+          () =>
+            Number(
+              screen.getByTestId("replayed-frames").element().textContent ?? "0"
+            ),
+          { timeout: 5_000 }
+        )
+        .toBeGreaterThan(0);
+
+      const observedIds = new Set<string>();
+      const deadline = Date.now() + 1_000;
+      while (Date.now() < deadline) {
+        const ids = screen
+          .getByTestId("interrupt-ids")
+          .element()
+          .textContent?.trim();
+        if (ids) observedIds.add(ids);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+      expect([...observedIds]).toEqual([]);
     } finally {
       await screen.unmount();
     }

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -920,6 +920,132 @@ describe("StreamController", () => {
     await submitPromise;
   });
 
+  it("does not hide the active run's interrupt when a follow-up submit is enqueued", async () => {
+    const eventListeners = new Set<(event: Event) => void>();
+    let resolveSubmit: (() => void) | undefined;
+    const ordering: ThreadStream["ordering"] = {};
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        eventListeners.add(listener);
+        return vi.fn(() => {
+          eventListeners.delete(listener);
+        });
+      }),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      ordering,
+      submitRun: vi.fn(async () => {
+        await new Promise<void>((resolve) => {
+          resolveSubmit = resolve;
+        });
+        ordering.lastAppliedThroughSeq = 10;
+        return { run_id: "run-active" };
+      }),
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {}, tasks: [] })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const onCreated = vi.fn();
+    const controller = new StreamController<State, unknown>({
+      assistantId: "human-in-the-loop",
+      client: client as never,
+      threadId: "thread-enqueue-interrupt",
+      onCreated,
+    });
+    await controller.hydrationPromise;
+
+    const first = controller.submit(null);
+    await waitForExpectation(() => expect(resolveSubmit).toBeDefined());
+    resolveSubmit?.();
+    await waitForExpectation(() => expect(onCreated).toHaveBeenCalled());
+
+    await controller.submit(null, { multitaskStrategy: "enqueue" });
+
+    const emit = (event: Event) => {
+      for (const listener of eventListeners) listener(event);
+    };
+    emit(inputRequestedEvent("live-from-active-run", {}, [], 12));
+    expect(
+      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+    ).toEqual(["live-from-active-run"]);
+
+    emit(lifecycleEvent("interrupted", 13));
+    await controller.dispose();
+    await first;
+  });
+
+  it("keeps a live interrupt when the run interrupts before run.start returns", async () => {
+    const eventListeners = new Set<(event: Event) => void>();
+    let resolveSubmit: (() => void) | undefined;
+    const ordering: ThreadStream["ordering"] = {};
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        eventListeners.add(listener);
+        return vi.fn(() => {
+          eventListeners.delete(listener);
+        });
+      }),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      ordering,
+      submitRun: vi.fn(async () => {
+        await new Promise<void>((resolve) => {
+          resolveSubmit = resolve;
+        });
+        ordering.lastAppliedThroughSeq = 10;
+        return { run_id: "run-fast-interrupt" };
+      }),
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {}, tasks: [] })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const onCreated = vi.fn();
+    const controller = new StreamController<State, unknown>({
+      assistantId: "human-in-the-loop",
+      client: client as never,
+      threadId: "thread-fast-interrupt",
+      onCreated,
+    });
+    await controller.hydrationPromise;
+
+    const submitPromise = controller.submit(null);
+    await waitForExpectation(() => expect(resolveSubmit).toBeDefined());
+
+    const emit = (event: Event) => {
+      for (const listener of eventListeners) listener(event);
+    };
+    emit(inputRequestedEvent("fast-interrupt", {}, [], 11));
+    emit(lifecycleEvent("interrupted", 12));
+
+    await waitForExpectation(() => {
+      expect(controller.rootStore.getSnapshot().isLoading).toBe(false);
+    });
+    expect(
+      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+    ).toEqual([]);
+
+    resolveSubmit?.();
+    await waitForExpectation(() => expect(onCreated).toHaveBeenCalled());
+    expect(
+      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+    ).toEqual(["fast-interrupt"]);
+
+    await controller.dispose();
+    await submitPromise;
+  });
+
   it("filters replayed interrupts while accepting newer interrupts after respond", async () => {
     // Fan out to every registered listener — respond()'s background
     // terminal watch also calls thread.onEvent, and a single-slot

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -93,12 +93,13 @@ function inputRequestedEvent(
       },
     ],
   },
-  namespace: string[] = []
+  namespace: string[] = [],
+  seq = 1
 ): Event {
   return {
     type: "event",
-    event_id: `input-${interruptId}`,
-    seq: 1,
+    event_id: `input-${interruptId}-${seq}`,
+    seq,
     method: "input.requested",
     params: {
       namespace,
@@ -843,67 +844,10 @@ describe("StreamController", () => {
     await controller.dispose();
   });
 
-  it("does not filter genuinely new interrupts after submit() clears the allowlist", async () => {
-    let onEvent: ((event: Event) => void) | undefined;
-    const thread = {
-      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
-      onEvent: vi.fn((listener: (event: Event) => void) => {
-        onEvent = listener;
-        return vi.fn();
-      }),
-      close: vi.fn(async () => undefined),
-      interrupts: [],
-      // submitRun never resolves on its own — we abort via dispose()
-      // once the test assertions have run.
-      // submitRun rejects immediately so submit() unwinds through its
-      // error path without needing a real lifecycle terminal. The
-      // onSubmitStart hook (which clears the allowlist) fires
-      // synchronously before submitRun is invoked.
-      submitRun: vi.fn(async () => {
-        throw new Error("test-stub-submit-rejected");
-      }),
-      startLifecycleWatcher: vi.fn(() => undefined),
-    } as unknown as ThreadStream;
-    const client = {
-      threads: {
-        getState: vi.fn(async () => ({
-          values: {},
-          tasks: [{ interrupts: [{ id: "old-interrupt", value: {} }] }],
-        })),
-        stream: vi.fn(() => thread),
-      },
-    };
-
-    const controller = new StreamController<State, unknown>({
-      assistantId: "human-in-the-loop",
-      client: client as never,
-      threadId: "thread-new-live",
-    });
-    await controller.hydrationPromise;
-
-    // Hydrate populates allowlist with [old-interrupt]. Without
-    // submit() clearing it, a brand-new live interrupt id would be
-    // dropped as "historical".
-    const submitPromise = controller.submit(null).catch(() => undefined);
-    // Yield so submit's synchronous onSubmitStart hook runs (which
-    // clears the allowlist) before the next event is delivered.
-    await Promise.resolve();
-    onEvent?.(inputRequestedEvent("brand-new-interrupt"));
-
-    expect(
-      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
-    ).toContain("brand-new-interrupt");
-
-    await controller.dispose();
-    await submitPromise;
-  });
-
-  it("does not filter genuinely new interrupts after respond() clears the allowlist", async () => {
-    // Fan out to every registered listener — respond()'s background
-    // terminal watch also calls thread.onEvent, and a single-slot
-    // capture would overwrite the wildcard that mirrors interrupts.
+  it("filters replayed interrupts while accepting newer interrupts after submit", async () => {
     const eventListeners = new Set<(event: Event) => void>();
-    const respondInput = vi.fn(async () => undefined);
+    let resolveSubmit: (() => void) | undefined;
+    const ordering: ThreadStream["ordering"] = {};
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
@@ -913,6 +857,88 @@ describe("StreamController", () => {
         });
       }),
       close: vi.fn(async () => undefined),
+      interrupts: [],
+      ordering,
+      submitRun: vi.fn(async () => {
+        await new Promise<void>((resolve) => {
+          resolveSubmit = resolve;
+        });
+        ordering.lastAppliedThroughSeq = 10;
+        return { run_id: "run-new" };
+      }),
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({
+          values: {},
+          // The previous interrupt was already answered, so server state has
+          // no pending interrupts when this finished thread is hydrated.
+          tasks: [],
+        })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const onCreated = vi.fn();
+    const controller = new StreamController<State, unknown>({
+      assistantId: "human-in-the-loop",
+      client: client as never,
+      threadId: "thread-new-live",
+      onCreated,
+    });
+    await controller.hydrationPromise;
+
+    const submitPromise = controller.submit(null);
+    await waitForExpectation(() => expect(resolveSubmit).toBeDefined());
+
+    // The root stream can replay old events while run.start is in flight.
+    // They must remain filtered before the command response establishes
+    // its sequence barrier.
+    const emit = (event: Event) => {
+      for (const listener of eventListeners) listener(event);
+    };
+    emit(inputRequestedEvent("resolved-before-dispatch", {}, [], 2));
+    emit(inputRequestedEvent("live-before-dispatch-response", {}, [], 11));
+    expect(
+      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+    ).toEqual([]);
+
+    resolveSubmit?.();
+    await waitForExpectation(() => expect(onCreated).toHaveBeenCalled());
+
+    // Replay can continue after run.start returns. Events at or below
+    // applied_through_seq are historical; newer events belong to the new run.
+    emit(inputRequestedEvent("resolved-after-dispatch", {}, [], 3));
+    emit(inputRequestedEvent("brand-new-interrupt", {}, [], 12));
+
+    expect(
+      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+    ).toEqual(["live-before-dispatch-response", "brand-new-interrupt"]);
+
+    await controller.dispose();
+    await submitPromise;
+  });
+
+  it("filters replayed interrupts while accepting newer interrupts after respond", async () => {
+    // Fan out to every registered listener — respond()'s background
+    // terminal watch also calls thread.onEvent, and a single-slot
+    // capture would overwrite the wildcard that mirrors interrupts.
+    const eventListeners = new Set<(event: Event) => void>();
+    const ordering: ThreadStream["ordering"] = {};
+    const respondInput = vi.fn(async () => {
+      ordering.lastAppliedThroughSeq = 10;
+    });
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        eventListeners.add(listener);
+        return vi.fn(() => {
+          eventListeners.delete(listener);
+        });
+      }),
+      close: vi.fn(async () => undefined),
+      ordering,
       interrupts: [
         {
           interruptId: "old-interrupt",
@@ -947,26 +973,28 @@ describe("StreamController", () => {
     await controller.hydrationPromise;
     expect(eventListeners.size).toBeGreaterThan(0);
 
-    // Hydrate seeded allowlist with [old-interrupt]. respond() must
-    // clear it the same way submit() does — otherwise the follow-on
-    // HITL from the resumed run is dropped as "historical" and
-    // stream.interrupt stays empty while the server is still paused.
     await controller.respond({ approved: true });
     expect(respondInput).toHaveBeenCalled();
     expect(
       controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
     ).toEqual([]);
 
-    const followOn = inputRequestedEvent("brand-new-interrupt", {
-      prompt: "Again?",
-    });
-    for (const listener of eventListeners) {
-      listener(followOn);
+    const replayed = inputRequestedEvent("resolved-replayed", {}, [], 2);
+    const followOn = inputRequestedEvent(
+      "brand-new-interrupt",
+      { prompt: "Again?" },
+      [],
+      11
+    );
+    for (const event of [replayed, followOn]) {
+      for (const listener of eventListeners) {
+        listener(event);
+      }
     }
 
     expect(
       controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
-    ).toContain("brand-new-interrupt");
+    ).toEqual(["brand-new-interrupt"]);
     expect(controller.rootStore.getSnapshot().interrupt?.id).toBe(
       "brand-new-interrupt"
     );

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -444,7 +444,11 @@ export class StreamController<
       },
       onRunCompleted: (reason, runId) => this.#notifyCompleted(reason, runId),
       onRunEnd: () => {
-        this.#discardPendingInterruptEvents();
+        // Stop buffering new events, but keep any already-queued
+        // `input.requested` frames. A fast run can emit its interrupt
+        // and terminal before `run.start` returns; `onRunCreated` still
+        // has to classify those frames against `applied_through_seq`.
+        this.#interruptCommandPending = false;
         this.#markLocalRunEnd();
       },
       beginOptimistic: (input) => this.#beginOptimistic(input),

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -248,11 +248,24 @@ export class StreamController<
    * SSE replay re-adds historically-requested interrupts that have
    * since been resolved (no `input.responded` event exists in the
    * protocol, so the SDK has no other way to tell replay from live
-   * for an idle thread). `null` outside the hydrate-window so
-   * genuinely new live interrupts on an active run aren't filtered;
-   * cleared at the start of `submit()` for the same reason.
+   * for an idle thread). After a command is accepted, events newer
+   * than {@link #interruptReplayThroughSeq} bypass the allowlist.
    */
   #hydratedActiveInterruptIds: Set<string> | null = null;
+  /**
+   * Highest event sequence already applied when the latest run command
+   * was accepted. Interrupts outside the hydrate-time allowlist remain
+   * filtered through this sequence, while newer events are live output
+   * from the newly-started run and must be accepted.
+   */
+  #interruptReplayThroughSeq: number | undefined;
+  /**
+   * Unknown interrupt events received between local command dispatch and its
+   * response. The response supplies the sequence barrier needed to classify
+   * each event as historical replay or live output from the new run.
+   */
+  #pendingInterruptEvents: Event[] = [];
+  #interruptCommandPending = false;
   /**
    * Monotonic counter bumped at the start of each `submit()` and used
    * by {@link hydrate} to skip its post-fetch allowlist write when a
@@ -415,18 +428,25 @@ export class StreamController<
       awaitResumedRunTerminal: (signal) =>
         this.#awaitResumedRunTerminal(signal),
       onSubmitStart: () => {
-        // Clear the hydrate-window allowlist so genuinely-new live
-        // interrupts on the just-started run (submit *or* respond /
-        // respondAll via dispatchResume) aren't filtered. Bump the
-        // generation so any in-flight hydrate skips its allowlist
-        // write on return (see #hydratedActiveInterruptIds).
-        this.#hydratedActiveInterruptIds = null;
+        // Bump the generation so any in-flight hydrate skips its
+        // allowlist write on return. Keep an existing allowlist until
+        // dispatch is accepted: the root pump may still be replaying
+        // historical events while the command is in flight.
         this.#submitGeneration += 1;
+        this.#interruptCommandPending =
+          this.#hydratedActiveInterruptIds != null;
+        this.#pendingInterruptEvents = [];
       },
       onRunStart: () => this.#markLocalRunStart(),
-      onRunCreated: (runId) => this.#notifyCreated(runId),
+      onRunCreated: (runId) => {
+        this.#advanceInterruptReplayBarrier();
+        this.#notifyCreated(runId);
+      },
       onRunCompleted: (reason, runId) => this.#notifyCompleted(reason, runId),
-      onRunEnd: () => this.#markLocalRunEnd(),
+      onRunEnd: () => {
+        this.#discardPendingInterruptEvents();
+        this.#markLocalRunEnd();
+      },
       beginOptimistic: (input) => this.#beginOptimistic(input),
       settleOptimistic: (handle, event) =>
         this.#settleOptimistic(handle, event),
@@ -741,11 +761,12 @@ export class StreamController<
           interrupt: activeInterrupts[0],
         }));
         // Only seed the allowlist when no submit started while the
-        // state fetch was in flight. If one did, the cleared
-        // (null) allowlist must stay null so the new run's live
-        // interrupts are not filtered.
+        // state fetch was in flight. If one did, leave the existing
+        // filter untouched so this stale fetch cannot overwrite the
+        // active run's replay boundary.
         if (this.#submitGeneration === generationAtFetch) {
           this.#hydratedActiveInterruptIds = activeIds;
+          this.#interruptReplayThroughSeq = undefined;
         }
       }
     } catch (error) {
@@ -1388,9 +1409,11 @@ export class StreamController<
           config: options?.config,
           metadata: options?.metadata,
         });
+        this.#advanceInterruptReplayBarrier();
         this.#markInterruptResolvedInRootStore(resolved.interruptId);
       }, prepared?.handle);
     } catch (error) {
+      this.#discardPendingInterruptEvents();
       if (this.#disposed && isAbortLikeError(error)) {
         return;
       }
@@ -1485,11 +1508,13 @@ export class StreamController<
           config: options?.config,
           metadata: options?.metadata,
         });
+        this.#advanceInterruptReplayBarrier();
         for (const { interrupt_id: interruptId } of responses) {
           this.#markInterruptResolvedInRootStore(interruptId);
         }
       }, prepared?.handle);
     } catch (error) {
+      this.#discardPendingInterruptEvents();
       if (this.#disposed && isAbortLikeError(error)) {
         return;
       }
@@ -1745,6 +1770,8 @@ export class StreamController<
     // Drop the hydrate-window allowlist — the next thread's hydrate
     // will repopulate it from that thread's `state.tasks[].interrupts`.
     this.#hydratedActiveInterruptIds = null;
+    this.#interruptReplayThroughSeq = undefined;
+    this.#discardPendingInterruptEvents();
     this.queueStore.setState(
       () => EMPTY_QUEUE as SubmissionQueueSnapshot<StateType>
     );
@@ -2339,17 +2366,24 @@ export class StreamController<
     ) {
       return;
     }
-    // Strict allowlist when populated by the most-recent hydrate: SSE
-    // replay of `input.requested` carries no signal distinguishing
-    // historical (already-resolved) interrupts from live ones, so we
-    // accept only ids the server reported as currently active in
-    // `state.tasks[].interrupts`. `null` (outside the hydrate window
-    // / after a submit clears it) disables filtering entirely so new
-    // live interrupts on an active run pass through.
-    if (
+    // Before a run command is accepted, accept only ids the hydrated
+    // state reported as active. After acceptance, the command response's
+    // `applied_through_seq` separates replayed history from live events:
+    // unknown ids at or below the barrier are stale, while newer ids are
+    // interrupts raised by the new run.
+    const eventSeq = typeof event.seq === "number" ? event.seq : undefined;
+    const isUnknownInterrupt =
       this.#hydratedActiveInterruptIds != null &&
-      !this.#hydratedActiveInterruptIds.has(interruptId)
-    ) {
+      !this.#hydratedActiveInterruptIds.has(interruptId);
+    if (isUnknownInterrupt && this.#interruptCommandPending) {
+      this.#pendingInterruptEvents.push(event);
+      return;
+    }
+    const isHistoricalUnknownInterrupt =
+      isUnknownInterrupt &&
+      (this.#interruptReplayThroughSeq == null ||
+        (eventSeq != null && eventSeq <= this.#interruptReplayThroughSeq));
+    if (isHistoricalUnknownInterrupt) {
       return;
     }
     const namespace = Array.isArray(event.params.namespace)
@@ -2365,6 +2399,38 @@ export class StreamController<
       const interrupts = [...s.interrupts, interrupt];
       return { ...s, interrupts, interrupt: interrupts[0] };
     });
+  }
+
+  /**
+   * Convert the hydrate-time allowlist into a replay barrier after a command
+   * is accepted. Built-in transports update `lastAppliedThroughSeq` from the
+   * command response before resolving `submitRun` / `respondInput`.
+   */
+  #advanceInterruptReplayBarrier(): void {
+    if (this.#hydratedActiveInterruptIds == null) {
+      this.#discardPendingInterruptEvents();
+      return;
+    }
+    const throughSeq = this.#thread?.ordering?.lastAppliedThroughSeq;
+    if (typeof throughSeq === "number") {
+      this.#interruptReplayThroughSeq = throughSeq;
+    } else {
+      // Custom transports may not implement sequence metadata. Preserve the
+      // previous behavior so their genuinely new interrupts are not dropped.
+      this.#hydratedActiveInterruptIds = null;
+      this.#interruptReplayThroughSeq = undefined;
+    }
+    this.#interruptCommandPending = false;
+    const pendingEvents = this.#pendingInterruptEvents;
+    this.#pendingInterruptEvents = [];
+    for (const event of pendingEvents) {
+      this.#recordInterrupt(event);
+    }
+  }
+
+  #discardPendingInterruptEvents(): void {
+    this.#interruptCommandPending = false;
+    this.#pendingInterruptEvents = [];
   }
 
   /**

--- a/libs/sdk/src/stream/submit-coordinator.ts
+++ b/libs/sdk/src/stream/submit-coordinator.ts
@@ -301,7 +301,6 @@ export class SubmitCoordinator<
     options?: StreamSubmitOptions<StateType, ConfigurableType>
   ): Promise<void> {
     if (this.#getDisposed()) return;
-    this.#onSubmitStart();
 
     // Per-submit thread override: rebind first so the rest of the
     // submit operates against the new thread.
@@ -367,6 +366,11 @@ export class SubmitCoordinator<
       this.#enqueueSubmission(input, options);
       return;
     }
+
+    // Only once this submit will actually dispatch a command. Enqueue /
+    // reject return above so they cannot reset the in-flight run's
+    // interrupt replay barrier or drop events buffered for it.
+    this.#onSubmitStart();
 
     // Rollback: abort the previous run before starting a new one.
     this.#runAbort?.abort();


### PR DESCRIPTION
After you resolve a HITL interrupt, reload, and send another message, the old interrupt form used to come back. The stream replays historical `input.requested` events on the next run, and the SDK treated them as live.

This keeps filtering those events after the command is accepted, using `applied_through_seq` as the cutoff so only interrupts from the new run get through.
