### PR TITLE
feat(langgraph): add getRuntime helper for typescript

### DIFF
--- a/libs/langgraph-core/src/pregel/utils/config.test.ts
+++ b/libs/langgraph-core/src/pregel/utils/config.test.ts
@@ -8,6 +8,7 @@ import {
   getStore,
   getWriter,
   getConfig,
+  getRuntime,
   recastCheckpointNamespace,
   getParentCheckpointNamespace,
 } from "./config.js";
@@ -545,6 +546,126 @@ describe("getStore, getWriter, getConfig", () => {
     const result = getConfig();
 
     expect(result).toBe(mockConfig);
+  });
+});
+
+describe("getRuntime", () => {
+  // Save original to restore after tests
+  const originalGetRunnableConfig =
+    AsyncLocalStorageProviderSingleton.getRunnableConfig;
+
+  beforeEach(() => {
+    // Reset the mock before each test
+    AsyncLocalStorageProviderSingleton.getRunnableConfig = vi.fn();
+  });
+
+  afterAll(() => {
+    // Restore the original after all tests
+    AsyncLocalStorageProviderSingleton.getRunnableConfig =
+      originalGetRunnableConfig;
+  });
+
+  it("should throw when there is no ambient config", () => {
+    AsyncLocalStorageProviderSingleton.getRunnableConfig = vi
+      .fn()
+      .mockReturnValue(undefined);
+
+    expect(() => getRuntime()).toThrowError(
+      /getRuntime\(\) called outside of an active graph execution/
+    );
+  });
+
+  it("should throw when the ambient config is not a graph task config", () => {
+    // A plain (non-graph) runnable config has no task-internals marker
+    AsyncLocalStorageProviderSingleton.getRunnableConfig = vi
+      .fn()
+      .mockReturnValue({ tags: ["plain-runnable"] });
+
+    expect(() => getRuntime()).toThrowError(
+      /getRuntime\(\) called outside of an active graph execution/
+    );
+  });
+
+  it("should project all runtime fields off the ambient task config", () => {
+    const mockStore = {} as BaseStore;
+    const signal = new AbortController().signal;
+    const interrupt = () => undefined;
+    const control = {} as never;
+    const executionInfo = {
+      checkpointId: "cp-1",
+      checkpointNs: "",
+      taskId: "task-1",
+      threadId: "t-1",
+      runId: "run-1",
+      nodeAttempt: 1,
+    };
+    const serverInfo = {
+      assistantId: "asst-1",
+      graphId: "graph-1",
+    };
+    AsyncLocalStorageProviderSingleton.getRunnableConfig = vi
+      .fn()
+      .mockReturnValue({
+        configurable: { thread_id: "t-1", __pregel_task_id: "task-1" },
+        context: { user_id: "user-1" },
+        store: mockStore,
+        interrupt,
+        signal,
+        executionInfo,
+        serverInfo,
+        control,
+      });
+
+    const runtime = getRuntime();
+
+    expect(Object.isFrozen(runtime)).toBe(true);
+    expect(runtime.configurable).toEqual({
+      thread_id: "t-1",
+      __pregel_task_id: "task-1",
+    });
+    expect(runtime.context).toEqual({ user_id: "user-1" });
+    expect(runtime.store).toBe(mockStore);
+    expect(runtime.interrupt).toBe(interrupt);
+    expect(runtime.signal).toBe(signal);
+    expect(runtime.executionInfo).toBe(executionInfo);
+    expect(runtime.serverInfo).toBe(serverInfo);
+    expect(runtime.control).toBe(control);
+  });
+
+  it("should default writer and heartbeat to no-ops when absent", () => {
+    AsyncLocalStorageProviderSingleton.getRunnableConfig = vi
+      .fn()
+      .mockReturnValue({
+        configurable: { __pregel_task_id: "task-1" },
+      });
+
+    const runtime = getRuntime();
+
+    expect(() => runtime.writer({ any: "chunk" })).not.toThrow();
+    expect(() => runtime.heartbeat?.()).not.toThrow();
+  });
+
+  it("should pass an existing writer through, including from configurable", () => {
+    const mockWriter = () => undefined;
+    AsyncLocalStorageProviderSingleton.getRunnableConfig = vi
+      .fn()
+      .mockReturnValue({
+        configurable: { __pregel_task_id: "task-1", writer: mockWriter },
+      });
+
+    expect(getRuntime().writer).toBe(mockWriter);
+  });
+
+  it("should cast the context to the provided generic type", () => {
+    AsyncLocalStorageProviderSingleton.getRunnableConfig = vi
+      .fn()
+      .mockReturnValue({
+        configurable: { __pregel_task_id: "task-1" },
+        context: { user_id: "user-1" },
+      });
+
+    const runtime = getRuntime<{ user_id: string }>();
+    expect(runtime.context?.user_id).toBe("user-1");
   });
 });
 

--- a/libs/langgraph-core/src/pregel/utils/config.ts
+++ b/libs/langgraph-core/src/pregel/utils/config.ts
@@ -6,12 +6,13 @@ import {
   type Callbacks,
 } from "@langchain/core/callbacks/manager";
 import { BaseStore } from "@langchain/langgraph-checkpoint";
-import { LangGraphRunnableConfig } from "../runnable_types.js";
+import { LangGraphRunnableConfig, Runtime } from "../runnable_types.js";
 import {
   CHECKPOINT_NAMESPACE_END,
   CHECKPOINT_NAMESPACE_SEPARATOR,
   CONFIG_KEY_READ,
   CONFIG_KEY_SCRATCHPAD,
+  CONFIG_KEY_TASK_ID,
 } from "../../constants.js";
 
 const COPIABLE_KEYS = ["tags", "metadata", "callbacks", "configurable"];
@@ -380,6 +381,69 @@ export function getCurrentTaskInput<T = unknown>(
   }
 
   return runConfig!.configurable![CONFIG_KEY_SCRATCHPAD]!.currentTaskInput as T;
+}
+
+/**
+ * A helper utility function that returns the {@link Runtime} for the currently
+ * executing graph run. Equivalent of Python langgraph's `get_runtime()`.
+ *
+ * Returns a fresh, frozen projection of the runtime carried by the current
+ * execution configuration: `context`, `configurable`, `store`, `writer`,
+ * `interrupt`, `signal`, `heartbeat`, `executionInfo`, `serverInfo`, and
+ * `control`. Absent `writer`/`heartbeat` are replaced with no-ops so calling
+ * them never crashes; `previous` is not carried on the runtime — use
+ * `getPreviousState()` instead.
+ *
+ * The type parameter is typing-only (no runtime validation), mirroring
+ * Python's `context_schema` argument.
+ *
+ * Note: This relies on `node:async_hooks` / `AsyncLocalStorage`, which is
+ * available in many JavaScript environments (Node.js, Deno, Cloudflare
+ * Workers) but not in web browsers. In environments without
+ * `AsyncLocalStorage` support, read the runtime fields from the `config`
+ * (second argument) that your node/tool function receives directly.
+ *
+ * Tip: Inside a tool run by a `ToolNode`, prefer the second tool argument
+ * (typed as `ToolRuntime` from `@langchain/core/tools`). It carries the full
+ * runtime, including `context`/`executionInfo`, in every runtime — the
+ * ambient config inside a tool func is reduced by `@langchain/core` to
+ * standard `RunnableConfig` keys (`configurable`, `signal`, `store`).
+ *
+ * @returns the {@link Runtime} for the current graph run
+ * @throws an `Error` when called outside of an active graph execution
+ */
+export function getRuntime<
+  TContext = Record<string, unknown>,
+>(): Runtime<TContext> {
+  const runConfig = AsyncLocalStorageProviderSingleton.getRunnableConfig() as
+    | LangGraphRunnableConfig
+    | undefined;
+
+  if (
+    runConfig === undefined ||
+    runConfig.configurable?.[CONFIG_KEY_TASK_ID] === undefined
+  ) {
+    throw new Error(
+      [
+        "getRuntime() called outside of an active graph execution.",
+        "Call it from within a node, task, tool, or middleware executing inside a LangGraph graph.",
+        "Note: ambient access relies on AsyncLocalStorage, which some environments (e.g. web browsers) do not provide.",
+      ].join("\n")
+    );
+  }
+
+  return Object.freeze({
+    configurable: runConfig.configurable,
+    context: runConfig.context,
+    store: runConfig.store,
+    writer: runConfig.writer ?? runConfig.configurable?.writer ?? (() => {}),
+    interrupt: runConfig.interrupt,
+    signal: runConfig.signal,
+    heartbeat: runConfig.heartbeat ?? (() => {}),
+    executionInfo: runConfig.executionInfo,
+    serverInfo: runConfig.serverInfo,
+    control: runConfig.control,
+  }) as Runtime<TContext>;
 }
 
 export function recastCheckpointNamespace(namespace: string): string {

--- a/libs/langgraph-core/src/tests/get_runtime.test.ts
+++ b/libs/langgraph-core/src/tests/get_runtime.test.ts
@@ -1,0 +1,191 @@
+import { it, expect, describe } from "vitest";
+import { z } from "zod";
+import { tool } from "@langchain/core/tools";
+import { AIMessage } from "@langchain/core/messages";
+import {
+  BaseStore,
+  InMemoryStore,
+  MemorySaver,
+} from "@langchain/langgraph-checkpoint";
+import {
+  Annotation,
+  MessagesAnnotation,
+  StateGraph,
+  START,
+  END,
+  entrypoint,
+  task,
+} from "../web.js";
+import type { Runtime } from "../web.js";
+import { ToolNode } from "../prebuilt/tool_node.js";
+import { getRuntime } from "../pregel/utils/config.js";
+import { gatherIterator } from "../utils.js";
+
+const State = Annotation.Root({
+  message: Annotation<string>,
+});
+
+const contextSchema = z.object({ user_id: z.string() });
+
+describe("getRuntime", () => {
+  it("should project the full runtime inside a node", async () => {
+    const store = new InMemoryStore();
+    let captured: Runtime | undefined;
+
+    const graph = new StateGraph({ state: State, context: contextSchema })
+      .addNode("capture", (_state) => {
+        const runtime = getRuntime<{ user_id: string }>();
+        captured = runtime;
+        // No-op writer/heartbeat defaults must not throw
+        runtime.writer({ some: "chunk" });
+        runtime.heartbeat?.();
+        return { message: "done" };
+      })
+      .addEdge(START, "capture")
+      .addEdge("capture", END)
+      .compile({ checkpointer: new MemorySaver(), store });
+
+    await graph.invoke(
+      { message: "hi" },
+      {
+        configurable: { thread_id: "t-1" },
+        context: { user_id: "user-1" },
+      }
+    );
+
+    expect(captured).toBeDefined();
+    expect(Object.isFrozen(captured)).toBe(true);
+    expect(captured!.context).toEqual({ user_id: "user-1" });
+    // Pregel may wrap the compiled store at run time, so assert the type
+    // rather than identity
+    expect(captured!.store).toBeInstanceOf(BaseStore);
+    expect(captured!.signal).toBeInstanceOf(AbortSignal);
+    expect(captured!.executionInfo).toBeDefined();
+    expect(captured!.executionInfo!.taskId).toEqual(expect.any(String));
+    expect(captured!.executionInfo!.threadId).toBe("t-1");
+    expect(captured!.executionInfo!.nodeAttempt).toBe(1);
+  });
+
+  it("should pass a real stream writer through", async () => {
+    const graph = new StateGraph(State)
+      .addNode("emit", () => {
+        getRuntime().writer("hello from runtime");
+        return { message: "done" };
+      })
+      .addEdge(START, "emit")
+      .addEdge("emit", END)
+      .compile();
+
+    const written = await gatherIterator(
+      await graph.stream({ message: "hi" }, { streamMode: "custom" })
+    );
+
+    expect(written).toEqual(["hello from runtime"]);
+  });
+
+  it("should work inside a subgraph node", async () => {
+    let captured: Runtime | undefined;
+
+    const child = new StateGraph(State)
+      .addNode("child_node", () => {
+        captured = getRuntime();
+        return { message: "child done" };
+      })
+      .addEdge(START, "child_node")
+      .addEdge("child_node", END)
+      .compile();
+
+    const parent = new StateGraph(State)
+      .addNode("child", child)
+      .addEdge(START, "child")
+      .addEdge("child", END)
+      .compile({ checkpointer: new MemorySaver() });
+
+    await parent.invoke(
+      { message: "hi" },
+      { configurable: { thread_id: "t-sub" } }
+    );
+
+    expect(captured).toBeDefined();
+    expect(captured!.executionInfo?.taskId).toEqual(expect.any(String));
+    expect(captured!.configurable?.thread_id).toBe("t-sub");
+  });
+
+  it("should work inside a functional API task", async () => {
+    let captured: Runtime | undefined;
+
+    const mapper = task("mapper", (input: number) => {
+      captured = getRuntime();
+      return `${input}${input}`;
+    });
+
+    const graph = entrypoint(
+      { name: "graph" },
+      async (inputs: number[]) => Promise.all(inputs.map((i) => mapper(i)))
+    );
+
+    const result = await graph.invoke([1, 2]);
+    expect(result).toEqual(["11", "22"]);
+    expect(captured).toBeDefined();
+    expect(captured!.executionInfo).toBeDefined();
+  });
+
+  it("should work inside a tool executed by ToolNode", async () => {
+    let captured: Runtime | undefined;
+
+    const echo = tool(
+      async () => {
+        captured = getRuntime();
+        return "ok";
+      },
+      { name: "echo", description: "Echo tool", schema: z.object({}) }
+    );
+
+    const graph = new StateGraph(MessagesAnnotation)
+      .addNode("agent", () => ({
+        messages: [
+          new AIMessage({
+            content: "",
+            tool_calls: [{ name: "echo", args: {}, id: "call_1" }],
+          }),
+        ],
+      }))
+      .addNode("tools", new ToolNode([echo]))
+      .addEdge(START, "agent")
+      .addEdge("agent", "tools")
+      .addEdge("tools", END)
+      .compile({ checkpointer: new MemorySaver() });
+
+    const result = await graph.invoke(
+      { messages: [] },
+      { configurable: { thread_id: "t-tool" } }
+    );
+
+    expect(result.messages.at(-1)?.content).toBe("ok");
+    // getRuntime() is ambient inside the tool func. The ambient config there
+    // is reduced by @langchain/core's tool wrapper to standard
+    // RunnableConfig keys, so only configurable/signal/store are guaranteed;
+    // the tool's second argument (ToolRuntime) carries the full runtime.
+    expect(captured).toBeDefined();
+    expect(captured!.configurable?.thread_id).toBe("t-tool");
+    expect(captured!.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("should throw when called outside of an active graph execution", async () => {
+    expect(() => getRuntime()).toThrowError(
+      /getRuntime\(\) called outside of an active graph execution/
+    );
+
+    // Also throws after a run has completed (no ambient config remains)
+    const graph = new StateGraph(State)
+      .addNode("noop", () => ({ message: "done" }))
+      .addEdge(START, "noop")
+      .addEdge("noop", END)
+      .compile();
+
+    await graph.invoke({ message: "hi" });
+    expect(() => getRuntime()).toThrowError(
+      /getRuntime\(\) called outside of an active graph execution/
+    );
+  });
+});

--- a/libs/langgraph-core/src/web.ts
+++ b/libs/langgraph-core/src/web.ts
@@ -184,6 +184,11 @@ export type {
 export { writer } from "./writer.js";
 export type { InferWriterType } from "./writer.js";
 export { pushMessage } from "./graph/message.js";
-export { getStore, getWriter, getConfig } from "./pregel/utils/config.js";
+export {
+  getStore,
+  getWriter,
+  getConfig,
+  getRuntime,
+} from "./pregel/utils/config.js";
 export { getPreviousState } from "./func/index.js";
 export { getCurrentTaskInput } from "./pregel/utils/config.js";


### PR DESCRIPTION
So I was migrating my agent to typescript and realised I cannot get runtime info like in Python, so I wanted to have this possibility in the TS SDK and decided to make this PR
