### PR TITLE
fix(sdk): drop unused svelte and vue peer dependencies

### DIFF
--- a/.changeset/drop-unused-svelte-vue-peers.md
+++ b/.changeset/drop-unused-svelte-vue-peers.md
@@ -1,0 +1,12 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): drop unused svelte and vue peer dependencies
+
+The Svelte and Vue adapters live in `@langchain/svelte` and
+`@langchain/vue`, but the core SDK still declared both as optional peers.
+Scanners like Socket count optional peers as part of the package graph, so
+the SDK was being flagged for obfuscated-code alerts in `clsx` and
+`entities` — packages it never loads. React stays a peer because `./react`
+and `./react-ui` still ship here.

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -37,31 +37,21 @@
     "langchain": "^1.5.4",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "svelte": "^5.56.8",
     "typescript": "^4.9.5 || ^5.4.5",
     "vitest": "^4.1.10",
-    "vue": "^3.5.40",
     "ws": "^8.21.0",
     "zod": "^4.3.5"
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.48",
     "react": "^18 || ^19",
-    "react-dom": "^18 || ^19",
-    "svelte": "^4.0.0 || ^5.0.0",
-    "vue": "^3.0.0"
+    "react-dom": "^18 || ^19"
   },
   "peerDependenciesMeta": {
     "react": {
       "optional": true
     },
     "react-dom": {
-      "optional": true
-    },
-    "svelte": {
-      "optional": true
-    },
-    "vue": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2307,18 +2307,12 @@ importers:
       react-dom:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
-      svelte:
-        specifier: ^5.56.8
-        version: 5.56.8(@typescript-eslint/types@8.59.2)
       typescript:
         specifier: ^4.9.5 || ^5.4.5
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@18.19.130)(@vitest/browser-playwright@4.1.10)(@vitest/browser-webdriverio@4.1.10)(msw@2.12.10(@types/node@18.19.130)(typescript@5.9.3))(vite@8.2.0(@types/node@18.19.130)(esbuild@0.28.1)(jiti@2.6.1)(sass@1.101.0)(tsx@4.21.0)(yaml@2.9.0))
-      vue:
-        specifier: ^3.5.40
-        version: 3.5.40(typescript@5.9.3)
       ws:
         specifier: ^8.21.0
         version: 8.21.0
@@ -8502,6 +8496,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'


### PR DESCRIPTION
`@langchain/langgraph-sdk` declared `svelte` and `vue` as optional peer dependencies, but the adapters for both moved to `@langchain/svelte` and `@langchain/vue` and the core SDK never imports either one.

Socket (and similar scanners) treat optional peers as part of the package graph, so the SDK was showing two high alerts for obfuscated code in `clsx` and `entities` — transitive deps of Svelte and Vue that the SDK never loads. Removing the peers drops the reported dependency count from 9 to 7 and clears both alerts.

React is unchanged: `./react` and `./react-ui` still ship from this package, so it stays an optional peer.