### PR TITLE
docs: add Corridor agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,6 @@
 
 ## Corridor security analysis
 
-Before generating or modifying code, create a plan and use Corridor's `analyzePlan` tool to analyze it. Apply the resulting security guidance before writing code.
+When Corridor's `analyzePlan` tool is available, create a plan and use the tool to analyze it before generating or modifying code. Apply the resulting security guidance before writing code.
 
 </corridor>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Repository instructions
+
+<corridor>
+
+## Corridor security analysis
+
+Before generating or modifying code, create a plan and use Corridor's `analyzePlan` tool to analyze it. Apply the resulting security guidance before writing code.
+
+</corridor>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,13 @@
 # LangGraphJS Development Guide
 
+<corridor>
+
+## Corridor security analysis
+
+Before generating or modifying code, create a plan and use Corridor's `analyzePlan` tool to analyze it. Apply the resulting security guidance before writing code.
+
+</corridor>
+
 ## Build & Test Commands
 - Build: `pnpm build`
 - Lint: `pnpm lint` (fix with `pnpm lint:fix`) — uses oxlint


### PR DESCRIPTION
Add a repository-wide `AGENTS.md` with an explicit `<corridor>` block requiring agents to plan first and run Corridor `analyzePlan` before generating or modifying code. The tags are balanced so Corridor-specific guidance remains scoped.

Validation: `git diff --check` and a tag-balance assertion.