### PR TITLE
fix(sdk): keep discovered subgraph messages out of root state

### DIFF
--- a/.changeset/fix-subgraph-root-message-leak.md
+++ b/.changeset/fix-subgraph-root-message-leak.md
@@ -1,0 +1,9 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): keep discovered subgraph messages out of root state
+
+Messages scoped to a confirmed subgraph namespace no longer appear in
+`rootStore`, while ordinary root-owned depth-one nodes continue to stream
+normally.

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -112,14 +112,18 @@ function inputRequestedEvent(
   } as Event;
 }
 
-function valuesEvent(messages: unknown[], seq: number): Event {
+function valuesEvent(
+  messages: unknown[],
+  seq: number,
+  namespace: string[] = []
+): Event {
   return {
     type: "event",
     event_id: `values-${seq}`,
     seq,
     method: "values",
     params: {
-      namespace: [],
+      namespace,
       timestamp: 0,
       data: {
         messages,
@@ -156,14 +160,19 @@ function lifecycleEvent(event: string, seq: number): Event {
   } as Event;
 }
 
-function messageStartEvent(id: string, seq: number, role = "ai"): Event {
+function messageStartEvent(
+  id: string,
+  seq: number,
+  role = "ai",
+  namespace: string[] = []
+): Event {
   return {
     type: "event",
     event_id: `msg-start-${id}-${seq}`,
     seq,
     method: "messages",
     params: {
-      namespace: [],
+      namespace,
       timestamp: 0,
       data: { event: "message-start", id, role },
     },
@@ -1472,6 +1481,64 @@ describe("StreamController", () => {
       "ai-1",
     ]);
     expect((messages[1] as { text?: string }).text).toBe("All done.");
+
+    await controller.dispose();
+  });
+
+  it("keeps discovered subgraph messages out of root state", async () => {
+    const rootSubscription = makePushableSubscription();
+    let onEvent: ((event: Event) => void) | undefined;
+    const thread = {
+      subscribe: vi.fn(async () => rootSubscription),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        onEvent = listener;
+        return vi.fn();
+      }),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {}, next: ["agent"] })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State>({
+      assistantId: "subgraph-agent",
+      client: client as never,
+      threadId: "thread-1",
+    });
+    await controller.hydrationPromise;
+    await rootSubscription.started;
+    expect(onEvent).toBeDefined();
+
+    const subgraphNamespace = [
+      "worker:00000000-0000-0000-0000-000000000001",
+    ];
+    const discoveryEvent = valuesEvent([], 1, subgraphNamespace);
+    onEvent?.(discoveryEvent);
+    rootSubscription.push(discoveryEvent);
+
+    expect(
+      [...controller.subgraphStore.getSnapshot().values()].map(
+        (subgraph) => subgraph.namespace
+      )
+    ).toContainEqual(subgraphNamespace);
+
+    rootSubscription.push(
+      messageStartEvent("child-message", 2, "ai", subgraphNamespace)
+    );
+    rootSubscription.push(
+      messageStartEvent("root-message", 3, "ai", ["model:root-run"])
+    );
+
+    await waitForExpectation(() => {
+      expect(
+        controller.rootStore.getSnapshot().messages.map((message) => message.id)
+      ).toEqual(["root-message"]);
+    });
 
     await controller.dispose();
   });

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -2059,17 +2059,23 @@ export class StreamController<
      *     `useToolCalls(stream, subagent)`.
      *
      * We therefore drop `messages` events from any namespace that
-     * contains a `task:*` or `tools:*` segment; the authoritative
-     * tool-result text lands in `root.messages` via the root
+     * contains a `task:*` or `tools:*` segment, as well as an exact
+     * namespace already confirmed by discovery as a subgraph host. The
+     * latter remains available through its scoped message projection;
+     * ordinary depth-one node namespaces that have not been discovered
+     * as subgraphs continue to feed the root projection. Authoritative
+     * tool-result text still lands in `root.messages` via the root
      * `values.messages` snapshot merge in `#applyValues`.
      */
     const isInternalNamespace = isInternalWorkNamespace(event.params.namespace);
     const hasLegacySubagentNamespace = isLegacySubagentNamespace(
       event.params.namespace
     );
-
     if (event.method === "messages") {
-      if (!isInternalNamespace) {
+      const isDiscoveredSubgraphNamespace = this.#subgraphs.snapshot.has(
+        namespaceKey(event.params.namespace)
+      );
+      if (!isInternalNamespace && !isDiscoveredSubgraphNamespace) {
         this.#rootMessages.handleMessage(event as MessagesEvent);
       }
       return;


### PR DESCRIPTION
## Summary

- exclude message events from exact namespaces already confirmed as subgraph hosts
- preserve messages from ordinary root-owned depth-one node namespaces
- add a StreamController regression test covering discovery and root routing

## Testing

- `pnpm --filter @langchain/langgraph-sdk test`
- `pnpm --filter @langchain/langgraph-sdk build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`

Fixes #2716
