### PR TITLE
fix(langgraph): isolate DeltaChannel state in updateState forks

### DIFF
--- a/.changeset/update-state-fork-delta-channel-merge.md
+++ b/.changeset/update-state-fork-delta-channel-merge.md
@@ -1,0 +1,21 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(langgraph): isolate DeltaChannel state in updateState forks
+
+`updateState` persisted its channel writes under the parent checkpoint,
+which parallel branches forked from the same root (e.g. the empty
+`ffff-` root) share. DeltaChannel state reconstruction walks the ancestor
+chain and replays every pending write stored under that checkpoint id, so
+the writes of all sibling branches were merged into each branch's state
+(#2737).
+
+Delta channels written by `updateState` are now force-snapshotted into the
+new branch checkpoint (terminating the ancestor walk there) and their
+pending writes are no longer persisted under the shared parent. The
+snapshotted channel's version is also bumped past the thread head's
+version, because blob-based savers (e.g. PostgresSaver) key channel values
+by `(thread_id, checkpoint_ns, channel, version)` with no checkpoint id —
+without the bump, sibling branches would derive the same version and the
+snapshot blob would be dropped by the insert's ON CONFLICT DO NOTHING.

--- a/libs/langgraph-core/src/pregel/index.ts
+++ b/libs/langgraph-core/src/pregel/index.ts
@@ -32,6 +32,7 @@ import {
   BaseChannel,
   createCheckpoint,
   channelsFromCheckpoint,
+  isDeltaChannel,
   getOnlyChannels,
 } from "../channels/base.js";
 import {
@@ -1722,9 +1723,31 @@ export class Pregel<
         );
       }
 
+      // Delta channels written by this update are force-snapshotted into the
+      // new checkpoint. Pending writes live under the parent checkpoint, which
+      // may be shared by parallel branches (e.g. two `updateState` forks off
+      // the same root); the ancestor walk used to reconstruct a DeltaChannel
+      // would replay such shared writes and merge the timelines. Materializing
+      // the value here terminates the walk at this checkpoint, isolating the
+      // branch — mirroring how the run loop force-snapshots Overwrite writes.
+      const snapshotChannels = new Set<string>();
       for (const task of tasks) {
-        // channel writes are saved to current checkpoint
-        const channelWrites = task.writes.filter((w) => w[0] !== PUSH);
+        for (const write of task.writes) {
+          const channel = this.channels[write[0] as keyof Channels];
+          if (channel != null && isDeltaChannel(channel)) {
+            snapshotChannels.add(write[0] as string);
+          }
+        }
+      }
+
+      for (const task of tasks) {
+        // channel writes are saved to current checkpoint. Writes to channels
+        // snapshotted above are skipped: their value is materialized in the
+        // new checkpoint, and persisting them under the (possibly shared)
+        // parent would make them visible to sibling branches.
+        const channelWrites = task.writes.filter(
+          (w) => w[0] !== PUSH && !snapshotChannels.has(w[0] as string)
+        );
         // save task writes
         if (saved !== undefined && channelWrites.length > 0) {
           await checkpointer.putWrites(
@@ -1737,7 +1760,7 @@ export class Pregel<
 
       // apply to checkpoint
       // TODO: Why does keyof StrRecord allow number and symbol?
-      _applyWrites(
+      const updatedChannels = _applyWrites(
         checkpoint,
         channels,
         tasks as PregelExecutableTask<string, string>[],
@@ -1745,13 +1768,53 @@ export class Pregel<
         this.triggerToNodes
       );
 
+      // Savers that store channel values as version-keyed blobs (e.g.
+      // PostgresSaver) key them by (thread, ns, channel, version) with no
+      // checkpoint id. Sibling branches forking from the same parent derive
+      // the same next version, so the snapshot must not reuse the parent's
+      // version numbering: bump it past the thread head's version for that
+      // channel, or the snapshot blob would collide with a sibling's (and be
+      // dropped by the insert's ON CONFLICT DO NOTHING).
+      if (snapshotChannels.size > 0) {
+        const headTuple = await checkpointer.getTuple({
+          configurable: {
+            thread_id: checkpointConfig.configurable?.thread_id,
+            checkpoint_ns: checkpointConfig.configurable?.checkpoint_ns,
+          },
+        });
+        if (headTuple !== undefined) {
+          for (const ch of snapshotChannels) {
+            const headVersion = headTuple.checkpoint.channel_versions[ch];
+            if (headVersion === undefined) continue;
+            if (
+              compareChannelVersions(
+                headVersion,
+                checkpoint.channel_versions[ch]
+              ) >= 0
+            ) {
+              // Cast mirrors the loose `getNextVersion.bind(...)` typing used
+              // for `_applyWrites` above; savers with string channel versions
+              // override `getNextVersion` and accept both.
+              checkpoint.channel_versions[ch] = checkpointer.getNextVersion(
+                headVersion as number
+              );
+            }
+          }
+        }
+      }
+
       const newVersions = getNewChannelVersions(
         checkpointPreviousVersions,
         checkpoint.channel_versions
       );
       const nextConfig = await checkpointer.put(
         checkpointConfig,
-        createCheckpoint(checkpoint, channels, step + 1),
+        createCheckpoint(checkpoint, channels, step + 1, {
+          channelsToSnapshot: snapshotChannels,
+          updatedChannels,
+          getNextVersion: (current) =>
+            checkpointer.getNextVersion(current as number),
+        }),
         {
           source: "update",
           step: step + 1,

--- a/libs/langgraph-core/src/tests/delta_channel.postgres.int.test.ts
+++ b/libs/langgraph-core/src/tests/delta_channel.postgres.int.test.ts
@@ -4,6 +4,7 @@ import {
   AIMessage,
   BaseMessage,
   HumanMessage,
+  SystemMessage,
 } from "@langchain/core/messages";
 import { isDeltaSnapshot } from "@langchain/langgraph-checkpoint";
 import { PostgresSaver } from "@langchain/langgraph-checkpoint-postgres";
@@ -644,4 +645,103 @@ describe("DeltaChannel end-to-end with PostgresSaver", () => {
       "reply:b",
     ]);
   });
+});
+
+// Regression test for langgraphjs#2737: `updateState` forking from the shared
+// empty (ffff-) root checkpoint merged the DeltaChannel pending writes of all
+// branches that forked from that root, because the writes are stored under the
+// parent checkpoint id and the ancestor walk replays them all.
+describe("DeltaChannel updateState fork isolation (langgraphjs#2737)", () => {
+  let checkpointer: PostgresSaver;
+
+  beforeAll(async () => {
+    checkpointer = await createPostgresSaver();
+  }, 60_000);
+
+  afterAll(async () => {
+    await checkpointer?.end();
+  }, 60_000);
+
+  for (const durability of ["async", "sync", "exit"] as const) {
+    it(`isolates a branch forked from the root checkpoint (durability=${durability})`, async () => {
+      const State = Annotation.Root({
+        messages: new DeltaChannel<BaseMessage[], Messages>(
+          messagesDeltaReducer
+        ),
+      });
+      const graph = new StateGraph(State)
+        .addNode("a", (state) => ({
+          messages: [
+            new HumanMessage({
+              id: `h-${idCounter++}`,
+              content: `${state.messages[state.messages.length - 1].content}_a`,
+            }),
+          ],
+        }))
+        .addEdge(START, "a")
+        .addEdge("a", END)
+        .compile({ checkpointer });
+
+      const thread_id = `fork-root-${durability}-${Date.now()}`;
+      // 1. First execution writes [sys, human1] as pending writes to the
+      //    empty ffff- root checkpoint.
+      await graph.invoke(
+        {
+          messages: [
+            new SystemMessage({ id: "sys-1", content: "sys" }),
+            new HumanMessage({ id: "h-1", content: "human1" }),
+          ],
+        },
+        { configurable: { thread_id }, durability }
+      );
+
+      // 2. Find the empty ffff- root checkpoint.
+      const snaps: { values: unknown; parentConfig?: { configurable?: { checkpoint_id?: string } } }[] = [];
+      for await (const snap of graph.getStateHistory({
+        configurable: { thread_id },
+      })) {
+        snaps.push(snap as never);
+      }
+      const startSnap = snaps
+        .slice()
+        .reverse()
+        .find(
+          (s) =>
+            Array.isArray((s.values as { messages?: unknown[] } | undefined)?.messages) &&
+            ((s.values as { messages: unknown[] }).messages.length ?? 0) > 0
+        );
+      const emptyCid = startSnap?.parentConfig?.configurable?.checkpoint_id;
+      expect(emptyCid).toBeDefined();
+
+      // Pin the original timeline's tip before forking: afterwards the thread
+      // head legitimately points at the fork branch (newest checkpoint id).
+      const origTip = await graph.getState({ configurable: { thread_id } });
+      const origTipConfig = origTip.config;
+
+      // 3. Fork a parallel branch from the root containing ONLY [sys2].
+      const forkConfig = await graph.updateState(
+        {
+          configurable: { thread_id, checkpoint_id: emptyCid, checkpoint_ns: "" },
+        },
+        { messages: [new SystemMessage({ id: "sys-2", content: "sys2" })] },
+        "__start__"
+      );
+
+      // 4. The fork's state must contain only its own write.
+      const forkState = await graph.getState(forkConfig);
+      expect(
+        (messagesOf(forkState.values) as BaseMessage[]).map(
+          (m) => `${m.getType()}:${m.content}`
+        )
+      ).toEqual(["system:sys2"]);
+
+      // 5. The original timeline is unaffected by the fork.
+      const origAfter = await graph.getState(origTipConfig);
+      expect(
+        (messagesOf(origAfter.values) as BaseMessage[]).map(
+          (m) => `${m.getType()}:${m.content}`
+        )
+      ).toEqual(["system:sys", "human:human1", "human:human1_a"]);
+    });
+  }
 });

--- a/libs/langgraph-core/src/tests/delta_channel.test.ts
+++ b/libs/langgraph-core/src/tests/delta_channel.test.ts
@@ -1006,3 +1006,158 @@ describe("DELTA_MAX_SUPERSTEPS_SINCE_SNAPSHOT", () => {
     expect((state.values as { counter: number[] }).counter).toEqual([1, 1, 1, 1]);
   });
 });
+
+describe("DeltaChannel updateState fork isolation (langgraphjs issue)", () => {
+  let idCounter = 0;
+  // Graph whose `messages` key is a DeltaChannel; node "a" echoes the last
+  // message content with an "_a" suffix.
+  function echoGraph(saver: MemorySaver) {
+    const State = Annotation.Root({
+      messages: new DeltaChannel<BaseMessage[], Messages>(
+        messagesDeltaReducer
+      ),
+    });
+    return new StateGraph(State)
+      .addNode("a", (state) => ({
+        messages: [
+          new HumanMessage({ id: `h-a-${idCounter++}`, content: `${state.messages[state.messages.length - 1].content}_a` }),
+        ],
+      }))
+      .addEdge(START, "a")
+      .addEdge("a", END)
+      .compile({ checkpointer: saver });
+  }
+
+  // Find the id of the empty root (ffff-) checkpoint: the parent of the first
+  // checkpoint that carries any state.
+  async function rootCheckpointId(
+    graph: ReturnType<typeof echoGraph>,
+    thread_id: string
+  ): Promise<string | undefined> {
+    const snaps = [];
+    for await (const snap of graph.getStateHistory({
+      configurable: { thread_id },
+    })) {
+      snaps.push(snap);
+    }
+    const first = snaps
+      .reverse()
+      .find(
+        (s) =>
+          Array.isArray(s.values?.messages) && s.values.messages.length > 0
+      );
+    return first?.parentConfig?.configurable?.checkpoint_id;
+  }
+
+  it("updateState forking from the root checkpoint isolates the new branch", async () => {
+    const saver = new MemorySaver();
+    const graph = echoGraph(saver);
+    const thread_id = "fork-root-isolation";
+    for await (const _ of await graph.stream(
+      {
+        messages: [
+          new HumanMessage({ id: "h-orig-1", content: "human1" }),
+        ],
+      },
+      { configurable: { thread_id } }
+    )) {
+      // consume
+    }
+
+    const emptyCid = await rootCheckpointId(graph, thread_id);
+    expect(emptyCid).toBeDefined();
+
+    // Fork a parallel branch from the root with ONLY this message.
+    const forkConfig = await graph.updateState(
+      { configurable: { thread_id, checkpoint_id: emptyCid, checkpoint_ns: "" } },
+      { messages: [new HumanMessage({ id: "h-fork-1", content: "fork1" })] },
+      "__start__"
+    );
+
+    const forkState = await graph.getState(forkConfig);
+    expect(forkState.values.messages.map((m: BaseMessage) => m.content)).toEqual([
+      "fork1",
+    ]);
+  });
+
+  it("updateState fork does not contaminate the original timeline", async () => {
+    const saver = new MemorySaver();
+    const graph = echoGraph(saver);
+    const thread_id = "fork-no-back-contamination";
+    for await (const _ of await graph.stream(
+      { messages: [new HumanMessage({ id: "h-orig-1", content: "human1" })] },
+      { configurable: { thread_id } }
+    )) {
+      // consume
+    }
+
+    // The checkpoint right after the root: values [human1], task "a" pending.
+    const snaps = [];
+    for await (const snap of graph.getStateHistory({
+      configurable: { thread_id },
+    })) {
+      snaps.push(snap);
+    }
+    const ordered = snaps.slice().reverse();
+    const afterRoot = ordered[1];
+    expect(afterRoot.values.messages.map((m: BaseMessage) => m.content)).toEqual([
+      "human1",
+    ]);
+
+    const emptyCid = afterRoot.parentConfig?.configurable?.checkpoint_id;
+    await graph.updateState(
+      { configurable: { thread_id, checkpoint_id: emptyCid, checkpoint_ns: "" } },
+      { messages: [new HumanMessage({ id: "h-fork-1", content: "fork1" })] },
+      "__start__"
+    );
+
+    const after = await graph.getState(afterRoot.config);
+    expect(after.values.messages.map((m: BaseMessage) => m.content)).toEqual(["human1"]);
+  });
+
+  it("forked branch stays isolated after resuming", async () => {
+    const saver = new MemorySaver();
+    const graph = echoGraph(saver);
+    const thread_id = "fork-resume-isolation";
+    const origConfig = { configurable: { thread_id } };
+    for await (const _ of await graph.stream(
+      { messages: [new HumanMessage({ id: "h-orig-1", content: "human1" })] },
+      origConfig
+    )) {
+      // consume
+    }
+    const origState = await graph.getState(origConfig);
+    expect(origState.values.messages.map((m: BaseMessage) => m.content)).toEqual([
+      "human1",
+      "human1_a",
+    ]);
+    // Pin the original timeline's tip: after the fork, the thread head
+    // legitimately points at the fork branch (newest checkpoint id).
+    const origTipConfig = origState.config;
+
+    const emptyCid = await rootCheckpointId(graph, thread_id);
+    const forkConfig = await graph.updateState(
+      { configurable: { thread_id, checkpoint_id: emptyCid, checkpoint_ns: "" } },
+      { messages: [new HumanMessage({ id: "h-fork-1", content: "fork1" })] },
+      "__start__"
+    );
+
+    // Resume the forked branch from the new checkpoint (no new input).
+    for await (const _ of await graph.stream(null, forkConfig)) {
+      // consume
+    }
+
+    // The fork keeps only its own writes... (an `as_node: "__start__"` update
+    // does not re-trigger downstream nodes, matching non-delta behavior)
+    const forkState = await graph.getState(forkConfig);
+    expect(forkState.values.messages.map((m: BaseMessage) => m.content)).toEqual([
+      "fork1",
+    ]);
+    // ...and the original timeline is unaffected by the fork.
+    const origAfter = await graph.getState(origTipConfig);
+    expect(origAfter.values.messages.map((m: BaseMessage) => m.content)).toEqual([
+      "human1",
+      "human1_a",
+    ]);
+  });
+});


### PR DESCRIPTION
## Description

Fixes #2737

`updateState` persisted its channel writes under the **parent** checkpoint. When parallel branches fork from the same parent (e.g. two `updateState` calls off the empty `ffff-` root), they share that parent checkpoint id, and `DeltaChannel` state reconstruction — which walks the ancestor chain and replays *every* pending write stored under that id — silently merged both timelines into each branch.

## Root cause (two layers)

1. **Write placement** — `updateSuperStep` saved the update's channel writes via `putWrites(parentCheckpoint)`. Sibling branches share that parent, so the ancestor walk replayed both branches' writes.
2. **Blob keying** — savers that store channel values as version-keyed blobs (Postgres) key them by `(thread_id, checkpoint_ns, channel, version)` with **no checkpoint id**. Simply materializing a snapshot on the fork isn't enough: sibling branches derive the same next version, so the fork's snapshot blob collides with the sibling's and is dropped by `ON CONFLICT DO NOTHING`.

## Fix

In `updateSuperStep` (`libs/langgraph-core/src/pregel/index.ts`), when the update writes to delta channels:

- Force-snapshot those channels into the new branch checkpoint (mirrors the existing Overwrite force-snapshot pattern in the run loop). A materialized value in `channel_values` terminates the ancestor walk at the fork, isolating the branch.
- Skip persisting those delta writes under the shared parent, so sibling branches never see them.
- Bump the snapshotted channel's version past the thread head's version for that channel, so blob-keyed savers cannot collide across sibling branches.

This is saver-agnostic: the merge reproduced with `MemorySaver` as well, and the fix covers both inline-storage and blob-keyed savers.

## Testing

TDD (red → green → refactor):

- **Unit** (`delta_channel.test.ts`): 3 new tests — fork-from-root isolation, no reverse contamination of the original timeline, and isolation preserved after resuming the fork.
- **Integration** (`delta_channel.postgres.int.test.ts`): regression test mirroring the issue repro against `PostgresSaver` across `async`/`sync`/`exit` durabilities, asserting both the fork's isolation *and* the original timeline's integrity.
- Full unit suite passes (1648 tests), `oxlint`/`oxfmt` clean. (The pre-existing failures in `pregel.postgres_saver.int.test.ts` in `int` mode also occur on `main` — unrelated ALS setup issue.)