### PR TITLE
fix(create-langgraph): restore template extraction on Node 26

### DIFF
--- a/.changeset/quick-pandas-unzip.md
+++ b/.changeset/quick-pandas-unzip.md
@@ -1,0 +1,5 @@
+---
+"create-langgraph": patch
+---
+
+Fix template extraction on Node.js 26 by replacing the legacy ZIP reader.

--- a/libs/create-langgraph/package.json
+++ b/libs/create-langgraph/package.json
@@ -29,7 +29,7 @@
     "@commander-js/extra-typings": "^13.0.0",
     "commander": "^13.0.0",
     "dedent": "^1.5.3",
-    "extract-zip": "^2.0.1",
+    "node-stream-zip": "^1.16.0",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {

--- a/libs/create-langgraph/src/index.ts
+++ b/libs/create-langgraph/src/index.ts
@@ -11,9 +11,10 @@ import {
   cancel,
   confirm,
 } from "@clack/prompts";
-import zipExtract from "extract-zip";
 import color from "picocolors";
 import dedent from "dedent";
+
+import { downloadAndExtract } from "./utils/extract.js";
 
 const TEMPLATES = {
   "New LangGraph Project": {
@@ -82,54 +83,6 @@ const TEMPLATE_ID_TO_CONFIG = Object.entries(TEMPLATES).reduce(
 );
 
 const TEMPLATE_IDS = Object.keys(TEMPLATE_ID_TO_CONFIG);
-
-async function downloadAndExtract(url: string, targetPath: string) {
-  try {
-    const response = await fetch(url);
-    if (!response.ok)
-      throw new Error(`Failed to download: ${response.statusText}`);
-
-    const arrayBuffer = await response.arrayBuffer();
-    const buffer = Buffer.from(arrayBuffer);
-
-    await fs.mkdir(targetPath, { recursive: true });
-
-    // Create a temporary file to store the zip
-    const tempFile = path.join(targetPath, "temp.zip");
-    await fs.writeFile(tempFile, buffer);
-
-    // Extract the zip file
-    await zipExtract(tempFile, { dir: targetPath });
-
-    // Clean up temp file
-    await fs.unlink(tempFile);
-
-    // Move files from the extracted directory to target path
-    const extractedDir = (await fs.readdir(targetPath)).find((f) =>
-      f.endsWith("-main")
-    );
-    if (extractedDir) {
-      const fullExtractedPath = path.join(targetPath, extractedDir);
-      const files = await fs.readdir(fullExtractedPath);
-      await Promise.all(
-        files.map((file) =>
-          fs.rename(
-            path.join(fullExtractedPath, file),
-            path.join(targetPath, file)
-          )
-        )
-      );
-      await fs.rmdir(fullExtractedPath);
-    }
-  } catch (error: unknown) {
-    if (error instanceof Error) {
-      throw new Error(
-        `Failed to download and extract template: ${error.message}`
-      );
-    }
-    throw new Error("Failed to download and extract template");
-  }
-}
 
 export async function createNew(projectPath?: string, templateId?: string) {
   if (templateId) {

--- a/libs/create-langgraph/src/tests/extract.test.ts
+++ b/libs/create-langgraph/src/tests/extract.test.ts
@@ -1,0 +1,167 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { deflateRawSync } from "node:zlib";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { downloadAndExtract } from "../utils/extract.js";
+
+interface TestZipEntry {
+  name: string;
+  content?: string;
+}
+
+function crc32(data: Buffer) {
+  let checksum = 0xffffffff;
+
+  for (const byte of data) {
+    checksum ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      checksum = (checksum >>> 1) ^ (0xedb88320 & -(checksum & 1));
+    }
+  }
+
+  return (checksum ^ 0xffffffff) >>> 0;
+}
+
+function createZip(entries: TestZipEntry[]) {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let localOffset = 0;
+
+  for (const entry of entries) {
+    const name = Buffer.from(entry.name);
+    const data = Buffer.from(entry.content ?? "");
+    const isDirectory = entry.name.endsWith("/");
+    const compressedData = isDirectory ? data : deflateRawSync(data);
+    const compressionMethod = isDirectory ? 0 : 8;
+    const checksum = crc32(data);
+
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4);
+    localHeader.writeUInt16LE(compressionMethod, 8);
+    localHeader.writeUInt32LE(checksum, 14);
+    localHeader.writeUInt32LE(compressedData.length, 18);
+    localHeader.writeUInt32LE(data.length, 22);
+    localHeader.writeUInt16LE(name.length, 26);
+
+    localParts.push(localHeader, name, compressedData);
+
+    const centralHeader = Buffer.alloc(46);
+    centralHeader.writeUInt32LE(0x02014b50, 0);
+    centralHeader.writeUInt16LE(0x0314, 4);
+    centralHeader.writeUInt16LE(20, 6);
+    centralHeader.writeUInt16LE(compressionMethod, 10);
+    centralHeader.writeUInt32LE(checksum, 16);
+    centralHeader.writeUInt32LE(compressedData.length, 20);
+    centralHeader.writeUInt32LE(data.length, 24);
+    centralHeader.writeUInt16LE(name.length, 28);
+    centralHeader.writeUInt32LE(
+      ((isDirectory ? 0o40755 : 0o100644) << 16) >>> 0,
+      38
+    );
+    centralHeader.writeUInt32LE(localOffset, 42);
+
+    centralParts.push(centralHeader, name);
+    localOffset += localHeader.length + name.length + compressedData.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralParts);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(centralDirectory.length, 12);
+  end.writeUInt32LE(localOffset, 16);
+
+  return Buffer.concat([...localParts, centralDirectory, end]);
+}
+
+function stubArchiveDownload(archive: Buffer) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(
+      new Response(new Uint8Array(archive), {
+        status: 200,
+      })
+    )
+  );
+}
+
+async function expectMissing(filePath: string) {
+  await expect(fs.access(filePath)).rejects.toMatchObject({ code: "ENOENT" });
+}
+
+describe("downloadAndExtract", () => {
+  let tempRoot: string;
+
+  beforeEach(async () => {
+    tempRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "create-langgraph-extract-")
+    );
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it("extracts every template entry and removes the GitHub wrapper", async () => {
+    const archive = createZip([
+      { name: "template-main/" },
+      {
+        name: "template-main/package.json",
+        content: '{"name":"fixture"}\n',
+      },
+      {
+        name: "template-main/src/agent.ts",
+        content: "export const graph = {};\n",
+      },
+      {
+        name: "template-main/.env.example",
+        content: "LANGSMITH_API_KEY=\n",
+      },
+      { name: "template-main/empty/" },
+    ]);
+    stubArchiveDownload(archive);
+    const targetPath = path.join(tempRoot, "project");
+
+    await downloadAndExtract("https://example.test/template.zip", targetPath);
+
+    await expect(
+      fs.readFile(path.join(targetPath, "package.json"), "utf8")
+    ).resolves.toBe('{"name":"fixture"}\n');
+    await expect(
+      fs.readFile(path.join(targetPath, "src", "agent.ts"), "utf8")
+    ).resolves.toBe("export const graph = {};\n");
+    await expect(
+      fs.readFile(path.join(targetPath, ".env.example"), "utf8")
+    ).resolves.toBe("LANGSMITH_API_KEY=\n");
+    expect((await fs.stat(path.join(targetPath, "empty"))).isDirectory()).toBe(
+      true
+    );
+    await expectMissing(path.join(targetPath, "template-main"));
+    await expectMissing(path.join(targetPath, "temp.zip"));
+  });
+
+  it("rejects out-of-bound entries and still removes the temporary ZIP", async () => {
+    const archive = createZip([
+      { name: "template-main/package.json", content: "{}\n" },
+      { name: "../escaped.txt", content: "outside\n" },
+    ]);
+    stubArchiveDownload(archive);
+    const targetPath = path.join(tempRoot, "project");
+
+    await expect(
+      downloadAndExtract("https://example.test/template.zip", targetPath)
+    ).rejects.toThrow("Malicious entry: ../escaped.txt");
+
+    await expectMissing(path.join(tempRoot, "escaped.txt"));
+    await expectMissing(
+      path.join(targetPath, "template-main", "package.json")
+    );
+    await expectMissing(path.join(targetPath, "temp.zip"));
+  });
+});

--- a/libs/create-langgraph/src/utils/extract.ts
+++ b/libs/create-langgraph/src/utils/extract.ts
@@ -1,0 +1,85 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import StreamZip from "node-stream-zip";
+
+async function extractArchive(archivePath: string, targetPath: string) {
+  const archive = new StreamZip({ file: archivePath });
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      archive.on("ready", resolve);
+      archive.on("error", reject);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      archive.extract(null, targetPath, (error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      archive.close((error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+}
+
+async function unwrapTemplateDirectory(targetPath: string) {
+  const extractedDir = (await fs.readdir(targetPath)).find((entry) =>
+    entry.endsWith("-main")
+  );
+
+  if (!extractedDir) {
+    return;
+  }
+
+  const fullExtractedPath = path.join(targetPath, extractedDir);
+  const files = await fs.readdir(fullExtractedPath);
+  await Promise.all(
+    files.map((file) =>
+      fs.rename(path.join(fullExtractedPath, file), path.join(targetPath, file))
+    )
+  );
+  await fs.rmdir(fullExtractedPath);
+}
+
+export async function downloadAndExtract(url: string, targetPath: string) {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to download: ${response.statusText}`);
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    await fs.mkdir(targetPath, { recursive: true });
+
+    const tempFile = path.join(targetPath, "temp.zip");
+    try {
+      await fs.writeFile(tempFile, buffer);
+      await extractArchive(tempFile, targetPath);
+    } finally {
+      await fs.rm(tempFile, { force: true });
+    }
+
+    await unwrapTemplateDirectory(targetPath);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      throw new Error(
+        `Failed to download and extract template: ${error.message}`
+      );
+    }
+    throw new Error("Failed to download and extract template");
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1757,9 +1757,9 @@ importers:
       dedent:
         specifier: ^1.5.3
         version: 1.7.2
-      extract-zip:
-        specifier: ^2.0.1
-        version: 2.0.1
+      node-stream-zip:
+        specifier: ^1.16.0
+        version: 1.16.0
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -10130,6 +10130,10 @@ packages:
   node-stdlib-browser@1.3.1:
     resolution: {integrity: sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==}
     engines: {node: '>=10'}
+
+  node-stream-zip@1.16.0:
+    resolution: {integrity: sha512-ObaRrRoR8T68wF6suxHd7R4XQNamij6ZQHrwG7Dx1D2zeHcDNLsIOBcWrIwtDm7AsCXBguaPHgXhcjxDa2szrg==}
+    engines: {node: '>=0.12.0'}
 
   nopt@7.2.1:
     resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
@@ -20944,6 +20948,8 @@ snapshots:
       url: 0.11.4
       util: 0.12.5
       vm-browserify: 1.1.2
+
+  node-stream-zip@1.16.0: {}
 
   nopt@7.2.1:
     dependencies:


### PR DESCRIPTION
Fixes #2725

## Summary

- replace extract-zip in create-langgraph with node-stream-zip so template extraction completes on Node.js 26
- always close the archive handle and remove temp.zip on both success and failure
- add deterministic offline regression coverage for nested files, dotfiles, empty directories, GitHub wrapper removal, and path-traversal rejection
- add a patch changeset for create-langgraph

## Validation

- pnpm install --frozen-lockfile
- pnpm --filter create-langgraph test -- src/tests/extract.test.ts (43 tests passed)
- pnpm dlx node@26.7.0 libs/create-langgraph/node_modules/vitest/vitest.mjs run libs/create-langgraph/src/tests/extract.test.ts (2 tests passed)
- Node.js 26.7.0 extraction of the current new-langgraphjs-project main.zip through the built helper, using the downloaded archive as an offline fetch response; verified expected files, wrapper removal, and temp.zip cleanup
- pnpm --filter create-langgraph build
- pnpm lint
- pnpm format:check
- git diff --check