### PR TITLE
docs: fix typo in cache policy comment

### DIFF
--- a/libs/langgraph-core/src/func/index.ts
+++ b/libs/langgraph-core/src/func/index.ts
@@ -136,7 +136,7 @@ export function task<ArgsT extends unknown[], OutputT>(
 
   const cachePolicy =
     options.cachePolicy ??
-    // `cache` was mistakingly used as an alias for `cachePolicy` in v0.3.x,
+    // `cache` was mistakenly used as an alias for `cachePolicy` in v0.3.x,
     // TODO: remove in 1.x
     ("cache" in options ? (options.cache as CachePolicy) : undefined);
 


### PR DESCRIPTION
## Summary

Correct the spelling of `mistakenly` in the comment explaining the legacy
`cache` alias for `cachePolicy`.

No runtime behavior or public API changes.

## Testing

- `pnpm dlx oxfmt@0.42.0 --check libs/langgraph-core/src/func/index.ts`
- `git diff --check`

Comment-only change. No tests or changeset required.