### PR TITLE
fix(langgraph): give node outputs distinct message ids

### DIFF
--- a/.changeset/distinct-ids-for-node-outputs.md
+++ b/.changeset/distinct-ids-for-node-outputs.md
@@ -1,0 +1,17 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(langgraph): give node outputs distinct message ids
+
+`StreamMessagesHandler._emit` assigned every id-less message of a run the same
+`stableMessageIdMap[runId]`. That map exists so the chunks of one LLM run share
+an id and clients can merge them, but `handleChainEnd` reused it for node
+outputs, which are distinct messages rather than chunks of one. Since
+`messagesStateReducer` deduplicates by id, a node returning two id-less messages
+lost one of them from graph state — and only under `streamMode: "messages"`, so
+the same graph kept both under `"updates"` and `"values"`.
+
+Node outputs are now distinguished by their position, the way tool messages are
+already distinguished by tool call id. The token path is untouched: the new
+argument is only ever passed from `handleChainEnd`.

--- a/libs/langgraph-core/src/pregel/messages.test.ts
+++ b/libs/langgraph-core/src/pregel/messages.test.ts
@@ -450,16 +450,56 @@ describe("StreamMessagesHandler", () => {
       const message = new AIMessage({ content: "chain result" });
       handler.handleChainEnd(message, runId);
 
-      // Should emit the message with dedupe=true
+      // Should emit the message with dedupe=true and its output index
       expect(handler._emit).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ content: "chain result" }),
         runId,
         true,
+        0,
       );
 
       // Should clean up
       expect(handler.metadatas[runId]).toBeUndefined();
+    });
+
+    it("should give distinct ids to id-less messages of the same run", () => {
+      const streamFn = vi.fn();
+      const handler = new StreamMessagesHandler(streamFn);
+
+      const runId = "chain-123";
+      handler.metadatas[runId] = [["ns1"], { name: "test" }];
+
+      // Both messages are returned by the same node and neither carries an id —
+      // the shape produced by a graph that appends a message to a subagent's
+      // output. They used to share `stableMessageIdMap[runId]`, and
+      // `messagesStateReducer` deduplicates by id, so one of them silently
+      // disappeared from the graph state under `streamMode: "messages"` while
+      // `"updates"` and `"values"` kept both.
+      const first = new AIMessage({ content: "appended by the caller" });
+      const second = new AIMessage({ content: "transferring back" });
+
+      handler.handleChainEnd([first, second], runId);
+
+      expect(first.id).toBeDefined();
+      expect(second.id).toBeDefined();
+      expect(first.id).not.toBe(second.id);
+    });
+
+    it("should not renumber messages that already carry an id", () => {
+      const streamFn = vi.fn();
+      const handler = new StreamMessagesHandler(streamFn);
+
+      const runId = "chain-123";
+      handler.metadatas[runId] = [["ns1"], { name: "test" }];
+
+      const withId = new AIMessage({ id: "caller-chosen", content: "kept" });
+      const withoutId = new AIMessage({ content: "assigned" });
+
+      handler.handleChainEnd([withId, withoutId], runId);
+
+      expect(withId.id).toBe("caller-chosen");
+      expect(withoutId.id).not.toBe("caller-chosen");
     });
 
     it("should emit messages from an array output", () => {

--- a/libs/langgraph-core/src/pregel/messages.ts
+++ b/libs/langgraph-core/src/pregel/messages.ts
@@ -77,7 +77,8 @@ export class StreamMessagesHandler extends BaseCallbackHandler {
     meta: Meta,
     message: BaseMessage,
     runId: string | undefined,
-    dedupe = false
+    dedupe = false,
+    outputIdx?: number
   ) {
     if (
       dedupe &&
@@ -93,6 +94,12 @@ export class StreamMessagesHandler extends BaseCallbackHandler {
       if (isToolMessage(message)) {
         // Distinguish tool messages by tool call ID.
         messageId ??= `run-${runId}-tool-${message.tool_call_id}`;
+      } else if (outputIdx !== undefined) {
+        // Node outputs are distinct messages, not chunks of one, so they must
+        // not share an id: `messagesStateReducer` deduplicates by id and would
+        // drop all but one of them. Distinguish them by their position in the
+        // output, the same way tool messages are distinguished by tool call ID.
+        messageId ??= `run-${runId}-out-${outputIdx}`;
       } else {
         // For instance in ChatAnthropic, the first chunk has an message ID
         // but the subsequent chunks do not. To avoid clients seeing two messages
@@ -225,22 +232,26 @@ export class StreamMessagesHandler extends BaseCallbackHandler {
     const metadata = this.metadatas[runId];
     delete this.metadatas[runId];
     if (metadata !== undefined) {
+      let outputIdx = 0;
       if (isBaseMessage(outputs)) {
-        this._emit(metadata, outputs, runId, true);
+        this._emit(metadata, outputs, runId, true, outputIdx);
       } else if (Array.isArray(outputs)) {
         for (const value of outputs) {
           if (isBaseMessage(value)) {
-            this._emit(metadata, value, runId, true);
+            this._emit(metadata, value, runId, true, outputIdx);
+            outputIdx += 1;
           }
         }
       } else if (outputs != null && typeof outputs === "object") {
         for (const value of Object.values(outputs)) {
           if (isBaseMessage(value)) {
-            this._emit(metadata, value, runId, true);
+            this._emit(metadata, value, runId, true, outputIdx);
+            outputIdx += 1;
           } else if (Array.isArray(value)) {
             for (const item of value) {
               if (isBaseMessage(item)) {
-                this._emit(metadata, item, runId, true);
+                this._emit(metadata, item, runId, true, outputIdx);
+                outputIdx += 1;
               }
             }
           }


### PR DESCRIPTION
Fixes #2730

### The problem

`StreamMessagesHandler._emit` assigns every id-less message of a run the same `stableMessageIdMap[runId]`. `messagesStateReducer` deduplicates by id, so a node returning **two id-less messages** loses one of them from graph state — silently, and only under `streamMode: "messages"`:

| `streamMode` | both messages in state |
| --- | --- |
| `"messages"` | **no** |
| `"updates"` | yes |
| `"values"` | yes |

The state a graph persists shouldn't depend on which stream mode the caller picked.

### Why it happens

The comment above that branch says what the map is for:

> For instance in ChatAnthropic, the first chunk has an message ID but the subsequent chunks do not. To avoid clients seeing two messages we rename the message ID if it's being auto-set to `run-${runId}`.

That is a **chunk-merging** concern, and it is correct for `handleLLMNewToken` / `handleLLMEnd`. But `handleChainEnd` routes through the same branch, and node outputs are distinct messages rather than chunks of one, so sharing an id there has no upside — it only collides.

`ToolMessage` is already exempt for exactly this reason: it gets `run-${runId}-tool-${tool_call_id}` and never collides.

### The change

Node outputs are distinguished by their position, the same way tool messages are distinguished by tool call id:

```ts
} else if (outputIdx !== undefined) {
  messageId ??= `run-${runId}-out-${outputIdx}`;
}
```

with `handleChainEnd` passing an incrementing index.

The token path is untouched — `outputIdx` is only ever passed from `handleChainEnd`, never from `handleLLMNewToken` or `handleLLMEnd`, so chunks keep sharing their run id. A message that already carries an id keeps it (`??=`), and the `dedupe` check still skips anything already streamed.

### Tests

Two regression tests in `messages.test.ts`, both verified to fail without the change:

- id-less messages of the same run get distinct ids
- a message that already carries an id is not renumbered

One existing assertion was updated for the new argument. `oxfmt --check` and `oxlint` are clean, and the package's unit suite is unchanged apart from the two additions.

### How it was found

A supervisor delegates to a subagent whose graph is wrapped so it appends one `AIMessage` to the return value of `.invoke` — the pattern for rendering a `returnDirect` tail instead of leaving an orphan `ToolMessage`. With `addHandoffBackMessages: true`, `makeCallAgent` then appends the id-less `AIMessage` from `createHandoffBackMessages`. The two collide.

Giving our own message an explicit id doesn't help — because of `stableMessageIdMap[runId] ??= messageId` it becomes the run's stable id and the *library's* message inherits it, so the state ends up holding our id with the library's content. The collision is bidirectional.

In our case the dropped message carried the marker a downstream guard reads to recognise a proposal the user had already confirmed. Without it the guard re-proposed, and users were asked to confirm the same plan three times in a row. We're running this as a local patch in the meantime.
