### PR TITLE
fix(api): preserve additional_kwargs in protocol state normalizer

### DIFF
--- a/.changeset/preserve-additional-kwargs-stream.md
+++ b/.changeset/preserve-additional-kwargs-stream.md
@@ -1,0 +1,12 @@
+---
+"@langchain/langgraph-api": patch
+"@langchain/langgraph-cli": patch
+"@langchain/langgraph-ui": patch
+---
+
+fix(langgraph-api): preserve additional_kwargs in protocol state normalizer
+
+Forward non-empty `additional_kwargs` in values snapshots so server-authored
+message metadata (e.g. committed attachment paths) reaches live subscribers.
+Omit keys already lifted into first-class AI message fields (`tool_calls`,
+`audio`, `tool_outputs`) to avoid duplicating normalized data on the wire.

--- a/libs/langgraph-api/src/protocol/session/state-normalizers.mts
+++ b/libs/langgraph-api/src/protocol/session/state-normalizers.mts
@@ -397,6 +397,38 @@ export const normalizeProtocolStateToolCalls = (value: unknown) => {
  * @param value - Raw message object.
  * @returns The normalized message shape.
  */
+/**
+ * `additional_kwargs` keys that the protocol already exposes as first-class
+ * fields on an AI message: `tool_calls` is lifted into `tool_calls`, and
+ * `audio` / `tool_outputs` are lifted into protocol content blocks. Forwarding
+ * them again would duplicate normalized data on the wire.
+ */
+const LIFTED_AI_ADDITIONAL_KWARGS = new Set([
+  "tool_calls",
+  "audio",
+  "tool_outputs",
+]);
+
+/**
+ * Select the `additional_kwargs` entries worth forwarding on a normalized
+ * message, or `undefined` when nothing remains.
+ *
+ * @param additionalKwargs - The message's `additional_kwargs` record.
+ * @param type - The normalized protocol message type.
+ * @returns The forwardable subset, or `undefined`.
+ */
+const pickForwardableAdditionalKwargs = (
+  additionalKwargs: Record<string, unknown> | undefined,
+  type: string
+) => {
+  if (additionalKwargs == null) return undefined;
+  const entries = Object.entries(additionalKwargs).filter(
+    ([key]) => type !== "ai" || !LIFTED_AI_ADDITIONAL_KWARGS.has(key)
+  );
+  if (entries.length === 0) return undefined;
+  return Object.fromEntries(entries);
+};
+
 export const normalizeProtocolStateMessage = (
   value: Record<string, unknown>
 ) => {
@@ -434,6 +466,21 @@ export const normalizeProtocolStateMessage = (
     Object.keys(value.response_metadata).length > 0
   ) {
     message.response_metadata = value.response_metadata;
+  }
+  // Preserve `additional_kwargs` for the same reason. It is the field
+  // LangChain designates for application and provider metadata travelling
+  // with a message, and graphs write to it during a run (e.g. a middleware
+  // committing file attachments onto the human message via `add_messages`
+  // same-id replacement). Dropping it here makes such a write invisible to a
+  // live subscriber while `GET /threads/:id/state` still returns it, so the
+  // same message has two shapes depending on which endpoint you ask, and
+  // `useStream`'s same-id reconciliation has no enrichment to prefer.
+  const forwardedKwargs = pickForwardableAdditionalKwargs(
+    additionalKwargs,
+    type
+  );
+  if (forwardedKwargs != null) {
+    message.additional_kwargs = forwardedKwargs;
   }
   if (
     (type === "ai" || type === "human") &&

--- a/libs/langgraph-api/tests/protocol-session.test.mts
+++ b/libs/langgraph-api/tests/protocol-session.test.mts
@@ -574,6 +574,69 @@ describe("RunProtocolSession", () => {
   });
 
 
+  it("preserves non-empty additional_kwargs inside values snapshots", async () => {
+    const sent: unknown[] = [];
+    const session = createSession(sent);
+    await session.start();
+    sent.length = 0;
+
+    await session.handleCommand(
+      JSON.stringify({
+        id: 1,
+        method: "subscription.subscribe",
+        params: { channels: ["values"] },
+      })
+    );
+    sent.length = 0;
+
+    await session.ingestSourceEvent({
+      id: "1",
+      event: "values",
+      data: {
+        messages: [
+          {
+            id: "human_1",
+            type: "human",
+            content: "What columns are in this file?",
+            additional_kwargs: {
+              attachments: [
+                { filename: "sample.csv", path: "/uploads/sample.csv" },
+              ],
+            },
+            response_metadata: {},
+          },
+        ],
+      },
+    });
+
+    expect(sent).toEqual([
+      {
+        type: "event",
+        event_id: expect.any(String),
+        seq: expect.any(Number),
+        method: "values",
+        params: {
+          namespace: [],
+          timestamp: expect.any(Number),
+          data: {
+            messages: [
+              {
+                id: "human_1",
+                type: "human",
+                content: "What columns are in this file?",
+                additional_kwargs: {
+                  attachments: [
+                    { filename: "sample.csv", path: "/uploads/sample.csv" },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    ]);
+  });
+
   it("returns an agent tree built from observed namespaces", async () => {
     const sent: unknown[] = [];
     const session = createSession(sent);


### PR DESCRIPTION
Related: langchain-ai/langgraph#8704 (same defect in the Python `langgraph-api`, where I first hit it)

## Problem

`normalizeProtocolStateMessage` doesn't pass a message through — it rebuilds one from an allowlist of `type`, `content`, `id`, `name`, `example`, and tool fields. `additional_kwargs` is read locally to lift AI audio blocks and legacy `tool_calls` out of it, then discarded.

The result is that server-authored message metadata never reaches a live subscriber. Every message in every `values` event loses `additional_kwargs`, while `GET /threads/:id/state` returns it in full — so the same message has two different shapes depending on which endpoint you ask.

That breaks a documented client guarantee. `RootMessageProjection.appendOptimistic()` states that a same-id server echo replaces the optimistic copy "so server-authored `additional_kwargs` is visible without waiting for hydration". Over this transport the reconciler never receives any enrichment to prefer, so #2692 can't take effect.

Concretely, in my case: a `before_agent` middleware commits an uploaded file and writes canonical attachment metadata onto the human message via `add_messages` same-id replacement. The write and the checkpoint are correct; the UI never sees it, so an attachment chip stays pending indefinitely and only resolves on reload. Any feature where the server annotates a message mid-run has the same shape: correct on the server, correct after a refresh, invisible while the user is watching.

Existing coverage can't catch this — `tests/protocol-session.test.mts` only ever passes `additional_kwargs: {}` (plus the legacy `tool_calls` lifting path), so it passes whether the field survives or not.

## Change

Forward a non-empty `additional_kwargs`, mirroring the existing `response_metadata` passthrough and its rationale.

One refinement over a plain passthrough: the keys the protocol already exposes as first-class fields on AI messages — `tool_calls`, `audio`, `tool_outputs`, all lifted into `tool_calls` or content blocks above — are omitted, so normalized data isn't duplicated on the wire. That also keeps the existing AI-message expectations in `tests/protocol-session.test.mts` unchanged; the only behavioural difference is that metadata which previously vanished now survives.

## Test

Adds `preserves non-empty additional_kwargs inside values snapshots`, which fails on `main`:

```
- "additional_kwargs": { "attachments": [ { "filename": "sample.csv", "path": "/uploads/sample.csv" } ] },
  "content": "What columns are in this file?",
  "id": "human_1",
  "type": "human",
```

and passes with the change.

## Verification

- `vitest run tests/protocol-session.test.mts` → 11 passed, including the pre-existing AI-message/`tool_calls` normalization test.
- Full `vitest run` for `@langchain/langgraph-api`: identical before and after — 67 failed / 101 passed on `main` vs 67 failed / 102 passed here, the delta being this test. The 67 are pre-existing environment failures in `api.test.mts` (401s from calls needing credentials), unrelated to this change.
- `pnpm lint` → 0 warnings, 0 errors. `pnpm format:check` → clean.

## Note on scope

I hit this on the Python `langgraph-api`, whose `_normalize_state_message` has the same allowlist and the same `response_metadata` passthrough with the same comment text. I couldn't find a public repo for that package, so this PR fixes the TypeScript server and is offered as a reference diff if you'd like to mirror it there — details and a four-line Python reproduction are in langchain-ai/langgraph#8704.

Happy to adjust the approach, split the `tool_calls`/`audio`/`tool_outputs` filtering into a separate discussion, or hold this until a maintainer has weighed in on #8704.
