### PR TITLE
feat: route LangSmith traces from thread streams

### DIFF
--- a/.changeset/smooth-tracers-route.md
+++ b/.changeset/smooth-tracers-route.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": minor
+---
+
+Add LangSmith replica routing to thread-stream run starts.

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -19,7 +19,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@langchain/protocol": "^0.0.18",
+    "@langchain/protocol": "^0.0.19",
     "@types/json-schema": "^7.0.15",
     "p-queue": "^9.0.1",
     "p-retry": "^7.1.1"

--- a/libs/sdk/src/client/stream/index.test.ts
+++ b/libs/sdk/src/client/stream/index.test.ts
@@ -157,6 +157,29 @@ describe("ThreadStream", () => {
     }
   });
 
+  it("forwards LangSmith replica routing on run.start", async () => {
+    const transport = new MockTransport();
+    const thread = new ThreadStream(transport, { assistantId: "agent" });
+
+    await thread.run.start({
+      input: { step: 1 },
+      langsmith_tracer: {
+        project_name: "replica-project",
+        example_id: "example-1",
+      },
+    });
+
+    const command = transport.sentCommands.find(
+      (item) => item.method === "run.start"
+    );
+    expect(command?.params).toMatchObject({
+      langsmith_tracer: {
+        project_name: "replica-project",
+        example_id: "example-1",
+      },
+    });
+  });
+
   it("exposes the bound assistantId as thread.assistantId", () => {
     const transport = new MockTransport();
     const thread = new ThreadStream(transport, {

--- a/libs/sdk/src/client/stream/types.ts
+++ b/libs/sdk/src/client/stream/types.ts
@@ -35,10 +35,6 @@ export {
 export interface ExtendedRunStartParams extends RunStartParams {
   forkFrom?: string;
   multitaskStrategy?: "reject" | "rollback" | "interrupt" | "enqueue";
-  langsmith_tracer?: {
-    project_name?: string;
-    example_id?: string;
-  };
 }
 
 export type SubscribeOptions = Omit<SubscribeParams, "channels">;

--- a/libs/sdk/src/client/stream/types.ts
+++ b/libs/sdk/src/client/stream/types.ts
@@ -35,6 +35,10 @@ export {
 export interface ExtendedRunStartParams extends RunStartParams {
   forkFrom?: string;
   multitaskStrategy?: "reject" | "rollback" | "interrupt" | "enqueue";
+  langsmith_tracer?: {
+    project_name?: string;
+    example_id?: string;
+  };
 }
 
 export type SubscribeOptions = Omit<SubscribeParams, "channels">;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2259,8 +2259,8 @@ importers:
   libs/sdk:
     dependencies:
       '@langchain/protocol':
-        specifier: ^0.0.18
-        version: 0.0.18
+        specifier: ^0.0.19
+        version: 0.0.19
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
@@ -3908,6 +3908,9 @@ packages:
 
   '@langchain/protocol@0.0.18':
     resolution: {integrity: sha512-XW1egQtPfsGI41w2AMZNFZrUIwFSQHTjVMZs0OaTpCAvht/QLoaPN8FQcsysMVypOhupG28J29yOorrc70otBQ==}
+
+  '@langchain/protocol@0.0.19':
+    resolution: {integrity: sha512-9hKcRrH7cBX6gfutdfXPoft1OCchHe4FEpALoDJMl5Qu+n/YG5ynZmyu8+8cxORlPwHBoKTxggvXz+76M1yX1Q==}
 
   '@langchain/quickjs@1.0.0':
     resolution: {integrity: sha512-QdNWVK8Ydi3+knzO6FfX/2WRoPd5ClJIuyGxNwvGiSUmPshQA1XQ9tXvWIQmZ2VLuxpkM2GqEeGWYq/KENJIpA==}
@@ -14027,6 +14030,8 @@ snapshots:
   '@langchain/protocol@0.0.16': {}
 
   '@langchain/protocol@0.0.18': {}
+
+  '@langchain/protocol@0.0.19': {}
 
   '@langchain/quickjs@1.0.0(deepagents@1.10.5(@opentelemetry/api@1.9.0)(langsmith@0.8.9(@opentelemetry/api@1.9.0)(openai@6.48.0(ws@8.21.1)(zod@4.3.6))(ws@8.21.1))(openai@6.48.0(ws@8.21.1)(zod@4.3.6))(ws@8.21.1)(zod-to-json-schema@3.25.2(zod@4.3.6)))':
     dependencies:


### PR DESCRIPTION
## Description
Expose LangSmith tracer settings on JavaScript thread-stream run starts and forward them through the protocol.

## Release Note
JavaScript thread streams can route traces to an additional LangSmith project per run.

## Test Plan
- [x] Verify run-start commands preserve tracing settings

## Related PRs
- langchain-ai/agent-protocol#95
- langchain-ai/langgraph#8723
- langchain-ai/langgraph-api#4033

Made by [Open SWE](https://openswe.vercel.app/agents/90a39a94-54b7-5ba4-88f0-daf97804120b)
