### PR TITLE
test(langgraph): unskip toolCallId callback test

### DIFF
--- a/libs/langgraph-core/src/tests/prebuilt.test.ts
+++ b/libs/langgraph-core/src/tests/prebuilt.test.ts
@@ -2908,8 +2908,7 @@ describe("ToolNode", () => {
     expect(observedUserId).toBe("user_123");
   });
 
-  // Unskip once @langchain/core passes toolCallId as 8th param to handleToolStart (see langchainjs PR #10102)
-  it.skip("passes toolCallId to handleToolStart when invoking a tool", async () => {
+  it("passes toolCallId to handleToolStart when invoking a tool", async () => {
     let capturedToolCallId: string | undefined;
     const recordingTool = tool(async (_args: { x: number }) => "ok", {
       name: "recorder",


### PR DESCRIPTION
## Summary

- Enable the existing ToolNode regression test for forwarding the tool call ID to `handleToolStart`.
- Remove the obsolete skip comment: langchain-ai/langchainjs#10102 has been merged, and the locked `@langchain/core@1.2.3` supports the callback parameter.

The focused test is skipped before this change and passes after it.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @langchain/langgraph build`
- `pnpm --filter @langchain/langgraph test src/tests/prebuilt.test.ts -t "passes toolCallId to handleToolStart when invoking a tool"`
- `pnpm --filter @langchain/langgraph test src/tests/prebuilt.test.ts src/tests/pregel/stream.test.ts` — 141 passed, 1 existing skip
- `pnpm lint`
- `pnpm format:check`

Test-only change. No production code, public API, or dependency changes; no Changeset required.
