### PR TITLE
fix(langgraph): pushMessage emits on the streamEvents v3 messages channel

### DIFF
--- a/.changeset/tender-showers-mate.md
+++ b/.changeset/tender-showers-mate.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph": patch
+---
+
+fix(langgraph): pushMessage emits on the streamEvents v3 messages channel

--- a/libs/langgraph-core/src/graph/message.test.ts
+++ b/libs/langgraph-core/src/graph/message.test.ts
@@ -65,4 +65,31 @@ describe("pushMessage", () => {
 
     expect(values).toEqual(messages);
   });
+
+  it("should push messages onto the streamEvents v3 messages channel", async () => {
+    const graph = new StateGraph(MessagesAnnotation)
+      .addNode("chat", (state, config) => {
+        pushMessage(new AIMessage({ id: "1", content: "First" }), config);
+        return state;
+      })
+      .addEdge(START, "chat")
+      .compile();
+
+    const stream = await graph.streamEvents(
+      { messages: [] },
+      { version: "v3" }
+    );
+
+    const messageEvents: { event?: string; id?: string }[] = [];
+    for await (const event of stream) {
+      if (event.method === "messages") {
+        messageEvents.push(event.params.data as { event?: string; id?: string });
+      }
+    }
+
+    expect(
+      messageEvents.some((e) => e.event === "message-start" && e.id === "1")
+    ).toBe(true);
+    expect(messageEvents.some((e) => e.event === "message-finish")).toBe(true);
+  });
 });

--- a/libs/langgraph-core/src/graph/message.ts
+++ b/libs/langgraph-core/src/graph/message.ts
@@ -87,17 +87,22 @@ export function pushMessage(
       (metadata.langgraph_checkpoint_ns ?? "") as string
     ).split("|");
 
-    messagesHandler?._emit([namespace, metadata], validMessage, undefined, false);
-    // streamEvents v3 registers StreamProtocolMessagesHandler instead of
-    // StreamMessagesHandler; without this branch, pushed messages are
-    // silently absent from the live `messages` channel and only surface in
-    // state at node end.
-    protocolMessagesHandler?.emitFinalMessage(
-      [namespace, metadata],
-      validMessage,
-      undefined,
-      false
-    );
+    if (messagesHandler) {
+      messagesHandler._emit([namespace, metadata], validMessage, undefined, false);
+    } else if (protocolMessagesHandler) {
+      // streamEvents v3 registers StreamProtocolMessagesHandler instead of
+      // StreamMessagesHandler; without this branch, pushed messages are
+      // silently absent from the live `messages` channel and only surface in
+      // state at node end. else-if: the handlers are mutually exclusive per
+      // stream, and a single emission path avoids double emits if a caller
+      // ever registers both.
+      protocolMessagesHandler.emitFinalMessage(
+        [namespace, metadata],
+        validMessage,
+        undefined,
+        false
+      );
+    }
   }
 
   if (stateKey) {

--- a/libs/langgraph-core/src/graph/message.ts
+++ b/libs/langgraph-core/src/graph/message.ts
@@ -7,6 +7,7 @@ import type { RunnableConfig } from "@langchain/core/runnables";
 import { StateGraph } from "./state.js";
 import { ensureLangGraphConfig } from "../pregel/utils/config.js";
 import type { StreamMessagesHandler } from "../pregel/messages.js";
+import type { StreamProtocolMessagesHandler } from "../pregel/messages-v2.js";
 import { messagesStateReducer, type Messages } from "./messages_reducer.js";
 
 /** @ignore */
@@ -75,14 +76,23 @@ export function pushMessage(
     (cb): cb is StreamMessagesHandler =>
       "name" in cb && cb.name === "StreamMessagesHandler"
   );
+  const protocolMessagesHandler = callbacks.find(
+    (cb): cb is StreamProtocolMessagesHandler =>
+      "name" in cb && cb.name === "StreamProtocolMessagesHandler"
+  );
 
-  if (messagesHandler) {
+  if (messagesHandler || protocolMessagesHandler) {
     const metadata = config.metadata ?? {};
     const namespace = (
       (metadata.langgraph_checkpoint_ns ?? "") as string
     ).split("|");
 
-    messagesHandler._emit(
+    messagesHandler?._emit([namespace, metadata], validMessage, undefined, false);
+    // streamEvents v3 registers StreamProtocolMessagesHandler instead of
+    // StreamMessagesHandler; without this branch, pushed messages are
+    // silently absent from the live `messages` channel and only surface in
+    // state at node end.
+    protocolMessagesHandler?.emitFinalMessage(
       [namespace, metadata],
       validMessage,
       undefined,

--- a/libs/langgraph-core/src/graph/message.ts
+++ b/libs/langgraph-core/src/graph/message.ts
@@ -88,7 +88,12 @@ export function pushMessage(
     ).split("|");
 
     if (messagesHandler) {
-      messagesHandler._emit([namespace, metadata], validMessage, undefined, false);
+      messagesHandler._emit(
+        [namespace, metadata],
+        validMessage,
+        undefined,
+        false
+      );
     } else if (protocolMessagesHandler) {
       // streamEvents v3 registers StreamProtocolMessagesHandler instead of
       // StreamMessagesHandler; without this branch, pushed messages are

--- a/libs/langgraph-core/src/pregel/messages-v2.ts
+++ b/libs/langgraph-core/src/pregel/messages-v2.ts
@@ -169,7 +169,13 @@ export class StreamProtocolMessagesHandler extends BaseCallbackHandler {
     this.streamFn([meta[0], "messages", [data, metadata]]);
   }
 
-  private emitFinalMessage(
+  /**
+   * Emit a complete message as protocol events (message-start, content
+   * blocks, message-finish). Public so `pushMessage` can deliver manually
+   * created messages when this handler is registered (streamEvents v3),
+   * mirroring `StreamMessagesHandler._emit` on the classic path.
+   */
+  emitFinalMessage(
     meta: Meta,
     message: BaseMessage,
     runId: string | undefined,


### PR DESCRIPTION
## Problem

`pushMessage` looks up the callback handler by the name `StreamMessagesHandler`. `streamEvents({ version: "v3" })` registers `StreamProtocolMessagesHandler` instead, so on the v3 path (which `@langchain/langgraph-api` uses to serve run streams) manually pushed messages never reach the live `messages` channel. The state-persistence half still runs, so the pushed messages only appear in `values` snapshots at node end — the live emission is lost silently.

Reproduction: a node that calls `pushMessage(new AIMessage({ id: "1", content: "First" }), config)` emits nothing on the `messages` channel under `streamEvents(..., { version: "v3" })`, while the same graph under `graph.stream(..., { streamMode: "messages" })` emits the tuple as documented.

## Fix

`pushMessage` now finds either handler and delivers through the v3 handler's `emitFinalMessage` (made public, mirroring the classic handler's public `_emit`), producing the standard `message-start` / content block / `message-finish` sequence. No behavior change on the classic path.

## Test

Adds a regression test to `message.test.ts`: pushed message must surface as `message-start`/`message-finish` events on the v3 protocol stream. Red on current main, green with the fix; the four existing tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)