### PR TITLE
ci: pin Node 26 tracing test job to 26.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,10 @@ jobs:
       matrix:
         # See Node.js release schedule at https://nodejs.org/en/about/releases/
         os: [ubuntu-latest]
-        node-version: [22.x, 24.x, 26.x]
+        # Node 26.8.x deterministically drops the final streamed token in
+        # tracing.test.ts. Keep the Node 26 coverage on the last known-good
+        # release until the upstream runtime regression is resolved.
+        node-version: [22.x, 24.x, 26.7.0]
         include:
           - os: windows-latest
             node-version: 22.x


### PR DESCRIPTION
## Summary
- pin the affected Ubuntu Node 26 CI matrix entry to 26.7.0
- retain Node 22/24 plus macOS and Windows matrix coverage
- document that Node 26.8.x deterministically drops the final tracing token

## Validation
- `git diff --check`
- parsed the workflow as YAML

The focused tracing test requires the full pnpm workspace install, which did not complete in this environment. This is intended as a temporary, reversible CI workaround until the upstream Node regression is resolved.