### PR TITLE
fix(langgraph): don't crash or stop checkpointing on saver failure

### DIFF
--- a/.changeset/rotten-checkpoint-chain.md
+++ b/.changeset/rotten-checkpoint-chain.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph": patch
+---
+
+Report checkpointer failures under "async" durability without crashing the process, and keep checkpointing after a failed `put()` instead of silently skipping the rest of the run.

--- a/libs/langgraph-core/src/pregel/loop.ts
+++ b/libs/langgraph-core/src/pregel/loop.ts
@@ -400,6 +400,9 @@ export class PregelLoop {
       }
     );
     this.checkpointerPromises.add(tracked);
+    // Detached observer: without it a rejection before the finalize barrier is
+    // unhandled. `tracked` still rejects, so the barrier's Promise.all sees it.
+    tracked.catch(() => {});
   }
 
   /**
@@ -732,14 +735,20 @@ export class PregelLoop {
     metadata: CheckpointMetadata;
     newVersions: Record<string, string | number>;
   }) {
+    const put = () =>
+      this.checkpointer?.put(
+        input.config,
+        input.checkpoint,
+        input.metadata,
+        input.newVersions
+      );
+    // Matches Python's `try/finally`: put() attempts even after a failed
+    // predecessor, and the earlier failure still propagates down the chain.
     this._checkpointerChainedPromise = this._checkpointerChainedPromise.then(
-      () => {
-        return this.checkpointer?.put(
-          input.config,
-          input.checkpoint,
-          input.metadata,
-          input.newVersions
-        );
+      () => put(),
+      async (error) => {
+        await put();
+        throw error;
       }
     );
     this._trackCheckpointerPromise(this._checkpointerChainedPromise);

--- a/libs/langgraph-core/src/tests/durability.persistence_failure.test.ts
+++ b/libs/langgraph-core/src/tests/durability.persistence_failure.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Covers how a failing checkpointer is reported under "async" durability,
+ * where nothing awaits persistence until the run's finalize barrier. A
+ * rejection must reach that barrier without Node seeing it as unhandled, and
+ * one failed `put()` must not cancel the checkpoints queued behind it.
+ */
+
+import type { RunnableConfig } from "@langchain/core/runnables";
+import { MemorySaver } from "@langchain/langgraph-checkpoint";
+import type {
+  Checkpoint,
+  CheckpointMetadata,
+  PendingWrite,
+} from "@langchain/langgraph-checkpoint";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Annotation, StateGraph } from "../graph/index.js";
+import { END, START } from "../constants.js";
+
+function macrotask(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 10);
+  });
+}
+
+class FailingWritesSaver extends MemorySaver {
+  private shouldFailNextWrites = true;
+
+  override async putWrites(
+    config: RunnableConfig,
+    writes: PendingWrite[],
+    taskId: string,
+  ): Promise<void> {
+    if (this.shouldFailNextWrites) {
+      this.shouldFailNextWrites = false;
+      throw new Error("putWrites failed");
+    }
+    return super.putWrites(config, writes, taskId);
+  }
+}
+
+class FailFirstCheckpointSaver extends MemorySaver {
+  readonly attemptedSteps: number[] = [];
+
+  private shouldFailNextPut = true;
+
+  override async put(
+    config: RunnableConfig,
+    checkpoint: Checkpoint,
+    metadata: CheckpointMetadata,
+  ): Promise<RunnableConfig> {
+    this.attemptedSteps.push(metadata.step);
+    if (this.shouldFailNextPut) {
+      this.shouldFailNextPut = false;
+      throw new Error("put failed");
+    }
+    return super.put(config, checkpoint, metadata);
+  }
+}
+
+function createGraph() {
+  const State = Annotation.Root({ value: Annotation<string> });
+  return new StateGraph(State)
+    .addNode("first", () => ({ value: "first" }))
+    .addNode("second", async () => {
+      await macrotask();
+      return { value: "second" };
+    })
+    .addNode("third", () => ({ value: "third" }))
+    .addEdge(START, "first")
+    .addEdge("first", "second")
+    .addEdge("second", "third")
+    .addEdge("third", END);
+}
+
+describe("async durability persistence failures", () => {
+  const unhandled: unknown[] = [];
+  const onUnhandledRejection = (reason: unknown) => {
+    unhandled.push(reason);
+  };
+
+  afterEach(() => {
+    process.off("unhandledRejection", onUnhandledRejection);
+    unhandled.length = 0;
+  });
+
+  it("surfaces a putWrites failure at the end of the run without an unhandled rejection", async () => {
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    const graph = createGraph().compile({ checkpointer: new FailingWritesSaver() });
+
+    await expect(
+      graph.invoke(
+        { value: "input" },
+        { configurable: { thread_id: "async-put-writes-failure" } },
+      ),
+    ).rejects.toThrow("putWrites failed");
+
+    // Give Node a turn to flag any rejection it considers unobserved.
+    await macrotask();
+
+    expect(unhandled).toEqual([]);
+  });
+
+  it("keeps checkpointing after a failed put instead of skipping the rest of the run", async () => {
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    const saver = new FailFirstCheckpointSaver();
+    const graph = createGraph().compile({ checkpointer: saver });
+    const config = { configurable: { thread_id: "async-put-failure" } };
+
+    await expect(graph.invoke({ value: "input" }, config)).rejects.toThrow(
+      "put failed",
+    );
+
+    await macrotask();
+
+    expect(saver.attemptedSteps.length).toBeGreaterThan(1);
+    expect(unhandled).toEqual([]);
+
+    const persisted = await saver.getTuple(config);
+    expect(persisted?.checkpoint).toBeDefined();
+    expect(persisted?.metadata?.step).toBe(
+      saver.attemptedSteps[saver.attemptedSteps.length - 1],
+    );
+  });
+});


### PR DESCRIPTION
Found while investigating repeated process crashes in a Node service that runs many concurrent graphs against `PostgresSaver`. Two independent problems, both only visible under the default `durability: "async"`.

**1. Checkpointer failures are reported as unhandled rejections.** `_trackCheckpointerPromise` stores a derived promise with no rejection handler. Under `"async"` the only await is the finalize barrier, so a mid-run failure (for us, a pg-pool checkout timeout in `putWrites`) is flagged by Node long before that — fatal under `--unhandled-rejections=strict`, or with any logger-installed handler that exits. Introduced in #2242. The fix attaches a detached no-op catch; the stored promise still rejects, so the barrier's `Promise.all` reports the error unchanged.

**2. One failed `put()` silently skips every later checkpoint.** `_checkpointerPutAfterPrevious` chains with `.then(onFulfilled)` only, so after the first rejection the fulfilled callback never runs again — the run keeps streaming to the user with zero persistence, and each skipped link adds another rejection. Python does `try: await prev / finally: await put()` (`_loop.py`), i.e. the put attempts regardless. This aligns JS with that.

Minimal conditions for (1): a Node process, more than one concurrent graph, a checkpointer that can fail transiently, and any process-level `unhandledRejection` policy — Node's own default since v15 qualifies. Nothing about the surrounding stack is involved. A caller cannot defend against it either: the rejecting promise is derived inside `PregelLoop` and kept in a private Set, so no public API can attach to it, and wrapping the stream in try/catch only surfaces the error at the finalize barrier — after Node has already emitted the event.

Repro: a `MemorySaver` subclass whose first `putWrites`/`put` rejects, plus a graph node that awaits a macrotask. Added as `durability.persistence_failure.test.ts`; each test fails on main for its own defect.

The two fixes must land together — (2) alone increases the unhandled rejections that (1) addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
