### PR TITLE
Fix Docker path detection on Linux

### DIFF
--- a/.changeset/lucky-paths-build.md
+++ b/.changeset/lucky-paths-build.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-cli": patch
+---
+
+Detect Docker using the current process PATH on Linux and other platforms.

--- a/libs/langgraph-cli/src/docker/shell.mts
+++ b/libs/langgraph-cli/src/docker/shell.mts
@@ -2,13 +2,12 @@ import { $, type ExecaScriptMethod } from "execa";
 import { homedir } from "node:os";
 let PATH: string | undefined = undefined;
 
-// TODO: macOS related only
 async function getUserShell() {
-  const dscl = await $({
-    shell: true,
-  })`dscl . -read ~/ UserShell | sed 's/UserShell: //'`;
+  return process.env.SHELL || "/bin/sh";
+}
 
-  return dscl.stdout.trim();
+async function getProcessPath() {
+  return process.env.PATH || "";
 }
 
 async function verifyDockerPath(PATH: string) {
@@ -16,9 +15,8 @@ async function verifyDockerPath(PATH: string) {
   return PATH;
 }
 
-// TODO: macOS related only
 async function extractPathFromShell() {
-  const pathToShell = await getUserShell().catch(() => "/bin/zsh");
+  const pathToShell = await getUserShell();
 
   const args = pathToShell.includes("csh")
     ? ["-c", "echo $PATH"]
@@ -27,13 +25,14 @@ async function extractPathFromShell() {
   return shell.stdout.trim();
 }
 
-// TODO: macOS related only
 async function guessUserPath() {
   return [
     "/bin",
     "/usr/bin",
+    "/usr/local/bin",
     "/sbin",
     "/usr/sbin",
+    "/usr/local/sbin",
     "/opt/homebrew/bin",
     "/opt/homebrew/sbin",
     `${homedir()}/.local/bin`,
@@ -51,23 +50,26 @@ async function guessUserPath() {
 async function getLoginPath() {
   if (PATH) return { PATH };
 
-  const [fromShell, fromBackup] = await Promise.allSettled(
-    [extractPathFromShell(), guessUserPath()].map((promise) =>
+  const [fromProcess, fromShell, fromBackup] = await Promise.allSettled(
+    [getProcessPath(), extractPathFromShell(), guessUserPath()].map((promise) =>
       promise.then(verifyDockerPath)
     )
   );
 
-  if (fromShell.status === "fulfilled") {
+  if (fromProcess.status === "fulfilled") {
+    PATH = fromProcess.value;
+  } else if (fromShell.status === "fulfilled") {
     PATH = fromShell.value;
   } else if (fromBackup.status === "fulfilled") {
     PATH = fromBackup.value;
   } else {
     console.error(
-      "Failed to get PATH from shell or backup",
+      "Failed to get PATH from process, shell, or backup",
+      fromProcess.reason,
       fromShell.reason,
       fromBackup.reason
     );
-    throw fromShell.reason || fromBackup.reason;
+    throw fromProcess.reason || fromShell.reason || fromBackup.reason;
   }
 
   return { PATH };

--- a/libs/langgraph-cli/tests/shell.test.mts
+++ b/libs/langgraph-cli/tests/shell.test.mts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getExecaOptions } from "../src/docker/shell.mjs";
+
+const originalPath = process.env.PATH;
+let testDirectory: string | undefined;
+
+afterEach(async () => {
+  process.env.PATH = originalPath;
+  if (testDirectory) await rm(testDirectory, { recursive: true });
+});
+
+describe("getExecaOptions", () => {
+  it("uses Docker from the current process PATH", async () => {
+    testDirectory = await mkdtemp(join(tmpdir(), "langgraph-cli-"));
+    const dockerPath = join(testDirectory, "docker");
+    await writeFile(dockerPath, "#!/bin/sh\nexit 0\n");
+    await chmod(dockerPath, 0o755);
+    const path = `${testDirectory}:${originalPath}`;
+    process.env.PATH = path;
+
+    await expect(getExecaOptions()).resolves.toMatchObject({
+      env: { PATH: path },
+    });
+  });
+});


### PR DESCRIPTION
Detect Docker using the current process `PATH` before falling back to a login shell or known installation paths. This preserves Linux CI/container paths, removes the macOS-only `dscl` dependency, and adds common `/usr/local` locations to the fallback.

Added focused coverage for finding Docker through the process environment and a patch changeset.

### Verification
- `pnpm --dir libs/langgraph-cli exec vitest run tests/shell.test.mts --no-color`
- `pnpm --dir . exec oxlint libs/langgraph-cli/src/docker/shell.mts libs/langgraph-cli/tests/shell.test.mts`
- `pnpm --dir libs/langgraph-cli build`
- `pnpm --dir libs/langgraph-cli typecheck` *(blocked by pre-existing unresolved workspace packages `@langchain/langgraph-api` and `create-langgraph`; the package build, which builds workspace dependencies, succeeds)*

Made by [Open SWE](https://openswe.vercel.app/agents/01a05891-b125-766d-bd43-e1513978b9a8)