### PR TITLE
fix(sdk): keep stream.interrupts truthful after sequential multi-interrupt resume

### DIFF
--- a/.changeset/fix-stale-multi-interrupt.md
+++ b/.changeset/fix-stale-multi-interrupt.md
@@ -1,0 +1,13 @@
+---
+"@langchain/langgraph-sdk": patch
+"@langchain/react": patch
+---
+
+fix(sdk): keep stream.interrupts truthful after sequential multi-interrupt resume
+
+Locally-resolved interrupt ids are no longer permanently suppressed: live
+`input.requested` events after the resume barrier can reappear, and a
+post-resume reconcile against `threads.getState().tasks[].interrupts`
+restores siblings the server still has pending. Prevents a stale-empty
+`stream.interrupts` from driving a free-text `submit()` into an ambiguous
+`Command(resume=…)` when multiple interrupts remain.

--- a/libs/sdk-react/src/tests/components/MultiInterruptSequentialStream.tsx
+++ b/libs/sdk-react/src/tests/components/MultiInterruptSequentialStream.tsx
@@ -1,0 +1,130 @@
+import { useRef, useState } from "react";
+import { useStream } from "../../index.js";
+
+interface MultiInterruptState {
+  prompts: string[];
+  decisions: Record<string, unknown>;
+  completed: boolean;
+}
+
+interface Props {
+  apiUrl: string;
+  assistantId?: string;
+}
+
+/**
+ * Resume parallel interrupts one-at-a-time (the pattern that used to
+ * leave `stream.interrupts` stale/empty while the server still had
+ * pending siblings).
+ */
+export function MultiInterruptSequentialStream({
+  apiUrl,
+  assistantId = "multi_interrupt_graph",
+}: Props) {
+  const thread = useStream<MultiInterruptState>({
+    assistantId,
+    apiUrl,
+  });
+  const [submitError, setSubmitError] = useState("");
+  const [resumeError, setResumeError] = useState("");
+  const [interruptsAtSubmit, setInterruptsAtSubmit] = useState<number | null>(
+    null
+  );
+  const resumingRef = useRef(false);
+
+  const pendingInterrupts = thread.getThread()?.interrupts ?? [];
+
+  return (
+    <div>
+      <div data-testid="interrupt-count">{thread.interrupts.length}</div>
+      <div data-testid="thread-interrupt-count">
+        {pendingInterrupts.length}
+      </div>
+      <div data-testid="interrupt-ids">
+        {thread.interrupts
+          .map((entry) => entry.id)
+          .filter((id): id is string => typeof id === "string")
+          .sort()
+          .join(",")}
+      </div>
+      <div data-testid="completed">
+        {thread.values?.completed ? "true" : "false"}
+      </div>
+      <div data-testid="decisions">
+        {thread.values?.decisions
+          ? JSON.stringify(thread.values.decisions)
+          : "{}"}
+      </div>
+      <div data-testid="loading">
+        {thread.isLoading ? "Loading..." : "Not loading"}
+      </div>
+      <div data-testid="submit-error">{submitError}</div>
+      <div data-testid="resume-error">{resumeError}</div>
+      <div data-testid="interrupts-at-submit">
+        {interruptsAtSubmit == null ? "" : String(interruptsAtSubmit)}
+      </div>
+      <button
+        data-testid="submit"
+        onClick={() => {
+          setSubmitError("");
+          void thread
+            .submit({ prompts: ["A", "B"] })
+            .catch((error: unknown) => {
+              setSubmitError(
+                error instanceof Error ? error.message : String(error)
+              );
+            });
+        }}
+      >
+        Submit
+      </button>
+      <button
+        data-testid="resume-next"
+        onClick={() => {
+          if (resumingRef.current) return;
+          const next = thread.interrupts[0];
+          if (next?.id == null) return;
+          resumingRef.current = true;
+          setResumeError("");
+          const action =
+            next.value != null &&
+            typeof next.value === "object" &&
+            "action" in next.value
+              ? String((next.value as { action?: unknown }).action ?? "")
+              : "";
+          void thread
+            .respond(
+              action === "A" ? { approved: true } : { approved: false },
+              { interruptId: next.id }
+            )
+            .catch((error: unknown) => {
+              setResumeError(
+                error instanceof Error ? error.message : String(error)
+              );
+            })
+            .finally(() => {
+              resumingRef.current = false;
+            });
+        }}
+      >
+        Resume next
+      </button>
+      <button
+        data-testid="follow-up-submit"
+        onClick={() => {
+          setInterruptsAtSubmit(thread.interrupts.length);
+          setSubmitError("");
+          void thread
+            .submit({ prompts: ["follow-up"] })
+            .catch((error: unknown) => {
+              setSubmitError(
+                error instanceof Error ? error.message : String(error)
+              );
+            });
+        }}
+      >
+        Follow-up submit
+      </button>
+    </div>
+  );
+}

--- a/libs/sdk-react/src/tests/components/MultiInterruptSequentialStream.tsx
+++ b/libs/sdk-react/src/tests/components/MultiInterruptSequentialStream.tsx
@@ -13,9 +13,9 @@ interface Props {
 }
 
 /**
- * Resume parallel interrupts one-at-a-time (the pattern that used to
- * leave `stream.interrupts` stale/empty while the server still had
- * pending siblings).
+ * Resume parallel interrupts one-at-a-time, then finish with respondAll.
+ * Guards the stale-empty `stream.interrupts` regression: after a partial
+ * sequential resume the UI must not look "done" while siblings remain.
  */
 export function MultiInterruptSequentialStream({
   apiUrl,
@@ -40,20 +40,8 @@ export function MultiInterruptSequentialStream({
       <div data-testid="thread-interrupt-count">
         {pendingInterrupts.length}
       </div>
-      <div data-testid="interrupt-ids">
-        {thread.interrupts
-          .map((entry) => entry.id)
-          .filter((id): id is string => typeof id === "string")
-          .sort()
-          .join(",")}
-      </div>
       <div data-testid="completed">
         {thread.values?.completed ? "true" : "false"}
-      </div>
-      <div data-testid="decisions">
-        {thread.values?.decisions
-          ? JSON.stringify(thread.values.decisions)
-          : "{}"}
       </div>
       <div data-testid="loading">
         {thread.isLoading ? "Loading..." : "Not loading"}
@@ -108,6 +96,42 @@ export function MultiInterruptSequentialStream({
         }}
       >
         Resume next
+      </button>
+      <button
+        data-testid="resume-all"
+        onClick={() => {
+          const interrupts = thread.getThread()?.interrupts ?? [];
+          if (interrupts.length === 0) return;
+          setResumeError("");
+          void thread
+            .respondAll(
+              Object.fromEntries(
+                interrupts.map((entry) => {
+                  const action =
+                    entry.payload != null &&
+                    typeof entry.payload === "object" &&
+                    "action" in entry.payload
+                      ? String(
+                          (entry.payload as { action?: unknown }).action ?? ""
+                        )
+                      : "";
+                  return [
+                    entry.interruptId,
+                    action === "A"
+                      ? { approved: true }
+                      : { approved: false },
+                  ];
+                })
+              )
+            )
+            .catch((error: unknown) => {
+              setResumeError(
+                error instanceof Error ? error.message : String(error)
+              );
+            });
+        }}
+      >
+        Resume all
       </button>
       <button
         data-testid="follow-up-submit"

--- a/libs/sdk-react/src/tests/stream.interrupts.test.tsx
+++ b/libs/sdk-react/src/tests/stream.interrupts.test.tsx
@@ -246,14 +246,14 @@ it("resumes several parallel interrupts via respondAll()", { timeout: 15_000 }, 
 });
 
 it(
-  "keeps stream.interrupts in sync after sequential multi-interrupt resume",
+  "keeps stream.interrupts non-empty after a partial sequential multi-interrupt resume",
   { timeout: 30_000 },
   async () => {
-    // Regression: after resuming parallel interrupts one-at-a-time,
-    // stream.interrupts must not go empty while a sibling is still
-    // pending — otherwise a follow-up submit() is auto-converted to
-    // Command(resume=input) and fails with "must specify the interrupt
-    // id when resuming".
+    // Regression: sequential respond() of parallel interrupts must not
+    // leave stream.interrupts empty while the run is still interrupted.
+    // An empty list makes clients free-text submit(), which the API turns
+    // into an ambiguous Command(resume) when siblings remain pending.
+    // Finishing still requires respondAll (protocol batch resume).
     const screen = await render(
       <MultiInterruptSequentialStream apiUrl={apiUrl} />
     );
@@ -267,18 +267,30 @@ it(
 
       await screen.getByTestId("resume-next").click();
 
-      // Remaining sibling must stay visible (not flicker to []).
+      // Wait until the first respond settles (loading clears). The UI
+      // must still show at least one pending interrupt — either the
+      // remaining sibling, or both if the server kept them pending and
+      // reconcile restored the list.
       await expect
-        .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
-        .toHaveTextContent("1");
+        .element(screen.getByTestId("loading"), { timeout: 10_000 })
+        .toHaveTextContent("Not loading");
       await expect
-        .element(screen.getByTestId("resume-error"))
-        .toHaveTextContent("");
+        .poll(
+          () =>
+            Number(
+              screen.getByTestId("interrupt-count").element().textContent ?? "0"
+            ),
+          { timeout: 10_000 }
+        )
+        .toBeGreaterThan(0);
       await expect
         .element(screen.getByTestId("completed"))
         .toHaveTextContent("false");
+      await expect
+        .element(screen.getByTestId("resume-error"))
+        .toHaveTextContent("");
 
-      await screen.getByTestId("resume-next").click();
+      await screen.getByTestId("resume-all").click();
 
       await expect
         .element(screen.getByTestId("completed"), { timeout: 10_000 })
@@ -286,11 +298,7 @@ it(
       await expect
         .element(screen.getByTestId("interrupt-count"))
         .toHaveTextContent("0");
-      await expect
-        .element(screen.getByTestId("resume-error"))
-        .toHaveTextContent("");
 
-      // Follow-up submit must NOT hit the multi-interrupt resume error.
       await screen.getByTestId("follow-up-submit").click();
       await expect
         .element(screen.getByTestId("interrupts-at-submit"))

--- a/libs/sdk-react/src/tests/stream.interrupts.test.tsx
+++ b/libs/sdk-react/src/tests/stream.interrupts.test.tsx
@@ -5,6 +5,7 @@ import { InterruptStream } from "./components/InterruptStream.js";
 import { InterruptReconnectStream } from "./components/InterruptReconnectStream.js";
 import { InterruptReloadStream } from "./components/InterruptReloadStream.js";
 import { MultiInterruptStream } from "./components/MultiInterruptStream.js";
+import { MultiInterruptSequentialStream } from "./components/MultiInterruptSequentialStream.js";
 import { apiUrl, cleanupRender } from "./test-utils.js";
 
 it("surfaces the first interrupt on submit()", async () => {
@@ -243,3 +244,62 @@ it("resumes several parallel interrupts via respondAll()", { timeout: 15_000 }, 
     await cleanupRender(screen);
   }
 });
+
+it(
+  "keeps stream.interrupts in sync after sequential multi-interrupt resume",
+  { timeout: 30_000 },
+  async () => {
+    // Regression: after resuming parallel interrupts one-at-a-time,
+    // stream.interrupts must not go empty while a sibling is still
+    // pending — otherwise a follow-up submit() is auto-converted to
+    // Command(resume=input) and fails with "must specify the interrupt
+    // id when resuming".
+    const screen = await render(
+      <MultiInterruptSequentialStream apiUrl={apiUrl} />
+    );
+
+    try {
+      await screen.getByTestId("submit").click();
+
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
+        .toHaveTextContent("2");
+
+      await screen.getByTestId("resume-next").click();
+
+      // Remaining sibling must stay visible (not flicker to []).
+      await expect
+        .element(screen.getByTestId("interrupt-count"), { timeout: 10_000 })
+        .toHaveTextContent("1");
+      await expect
+        .element(screen.getByTestId("resume-error"))
+        .toHaveTextContent("");
+      await expect
+        .element(screen.getByTestId("completed"))
+        .toHaveTextContent("false");
+
+      await screen.getByTestId("resume-next").click();
+
+      await expect
+        .element(screen.getByTestId("completed"), { timeout: 10_000 })
+        .toHaveTextContent("true");
+      await expect
+        .element(screen.getByTestId("interrupt-count"))
+        .toHaveTextContent("0");
+      await expect
+        .element(screen.getByTestId("resume-error"))
+        .toHaveTextContent("");
+
+      // Follow-up submit must NOT hit the multi-interrupt resume error.
+      await screen.getByTestId("follow-up-submit").click();
+      await expect
+        .element(screen.getByTestId("interrupts-at-submit"))
+        .toHaveTextContent("0");
+      await expect
+        .element(screen.getByTestId("submit-error"), { timeout: 10_000 })
+        .toHaveTextContent("");
+    } finally {
+      await cleanupRender(screen);
+    }
+  }
+);

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -2363,6 +2363,227 @@ describe("StreamController", () => {
     await controller.dispose();
   });
 
+  it("reconciles pending interrupts via transport.getState when present", async () => {
+    const eventListeners = new Set<(event: Event) => void>();
+    const ordering: ThreadStream["ordering"] = {};
+    const respondInput = vi.fn(async () => {
+      ordering.lastAppliedThroughSeq = 10;
+    });
+    const transportGetState = vi
+      .fn()
+      .mockResolvedValueOnce({
+        values: {},
+        next: ["review"],
+        tasks: [
+          {
+            interrupts: [
+              { id: "int-1", value: { prompt: "First?" } },
+              { id: "int-2", value: { prompt: "Second?" } },
+            ],
+          },
+        ],
+      })
+      .mockResolvedValue({
+        values: {},
+        next: ["review"],
+        tasks: [
+          {
+            interrupts: [{ id: "int-2", value: { prompt: "Second?" } }],
+          },
+        ],
+      });
+    const clientGetState = vi.fn(async () => {
+      throw new Error("client getState should not run during reconcile");
+    });
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        eventListeners.add(listener);
+        return vi.fn(() => {
+          eventListeners.delete(listener);
+        });
+      }),
+      close: vi.fn(async () => undefined),
+      ordering,
+      interrupts: [
+        {
+          interruptId: "int-1",
+          payload: { prompt: "First?" },
+          namespace: [],
+        },
+        {
+          interruptId: "int-2",
+          payload: { prompt: "Second?" },
+          namespace: [],
+        },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: clientGetState,
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, { prompt: string }>({
+      assistantId: "custom-backend",
+      client: client as never,
+      threadId: "thread-transport-reconcile",
+      transport: { getState: transportGetState } as never,
+    });
+    await controller.hydrationPromise;
+
+    const emit = (event: Event) => {
+      for (const listener of eventListeners) listener(event);
+    };
+    emit(inputRequestedEvent("int-1", { prompt: "First?" }, [], 1));
+    emit(inputRequestedEvent("int-2", { prompt: "Second?" }, [], 2));
+
+    await controller.respond({ approved: true }, { interruptId: "int-1" });
+    expect(
+      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+    ).toEqual(["int-2"]);
+
+    emit(lifecycleEvent("running", 11));
+    emit(lifecycleEvent("interrupted", 12));
+
+    await waitForExpectation(() => {
+      expect(transportGetState.mock.calls.length).toBeGreaterThan(1);
+    });
+    expect(clientGetState).not.toHaveBeenCalled();
+    expect(
+      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+    ).toEqual(["int-2"]);
+
+    await controller.dispose();
+  });
+
+  it("drops a stale post-resume interrupt reconcile after thread swap", async () => {
+    const eventListeners = new Set<(event: Event) => void>();
+    const ordering: ThreadStream["ordering"] = {};
+    const respondInput = vi.fn(async () => {
+      ordering.lastAppliedThroughSeq = 10;
+    });
+    let resolveReconcileGetState!: (value: unknown) => void;
+    const getState = vi
+      .fn()
+      .mockResolvedValueOnce({
+        values: {},
+        next: ["review"],
+        tasks: [
+          {
+            interrupts: [
+              { id: "int-1", value: { prompt: "First?" } },
+              { id: "int-2", value: { prompt: "Second?" } },
+            ],
+          },
+        ],
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveReconcileGetState = resolve;
+          })
+      )
+      .mockResolvedValue({
+        values: { messages: [{ type: "human", content: "other thread" }] },
+        next: [],
+        tasks: [],
+      });
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        eventListeners.add(listener);
+        return vi.fn(() => {
+          eventListeners.delete(listener);
+        });
+      }),
+      close: vi.fn(async () => undefined),
+      ordering,
+      interrupts: [
+        {
+          interruptId: "int-1",
+          payload: { prompt: "First?" },
+          namespace: [],
+        },
+        {
+          interruptId: "int-2",
+          payload: { prompt: "Second?" },
+          namespace: [],
+        },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const otherThread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState,
+        stream: vi.fn((id: string) =>
+          id === "thread-other" ? otherThread : thread
+        ),
+      },
+    };
+
+    const controller = new StreamController<State, { prompt: string }>({
+      assistantId: "interrupt_graph",
+      client: client as never,
+      threadId: "thread-stale-reconcile",
+    });
+    await controller.hydrationPromise;
+
+    const emit = (event: Event) => {
+      for (const listener of eventListeners) listener(event);
+    };
+    emit(inputRequestedEvent("int-1", { prompt: "First?" }, [], 1));
+    emit(inputRequestedEvent("int-2", { prompt: "Second?" }, [], 2));
+
+    await controller.respond({ approved: true }, { interruptId: "int-1" });
+    await controller.respond({ approved: false }, { interruptId: "int-2" });
+    expect(
+      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+    ).toEqual([]);
+
+    emit(lifecycleEvent("running", 20));
+    emit(lifecycleEvent("interrupted", 21));
+
+    await waitForExpectation(() => {
+      expect(resolveReconcileGetState).toBeDefined();
+    });
+
+    await controller.hydrate("thread-other");
+    resolveReconcileGetState({
+      values: {},
+      next: ["review"],
+      tasks: [
+        {
+          interrupts: [
+            { id: "int-1", value: { prompt: "First?" } },
+            { id: "int-2", value: { prompt: "Second?" } },
+          ],
+        },
+      ],
+    });
+
+    // Give the abandoned reconcile a tick; it must not overwrite the
+    // new thread's empty interrupt list with the old thread's tasks.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(
+      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+    ).toEqual([]);
+    expect(controller.rootStore.getSnapshot().threadId).toBe("thread-other");
+
+    await controller.dispose();
+  });
+
   it("respond() resolves namespace from thread.interrupts when only interruptId is provided", async () => {
     const respondInput = vi.fn(async () => undefined);
     const nestedNamespace = ["subgraph:child", "tools:tc-1"];

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -2167,6 +2167,202 @@ describe("StreamController", () => {
     await controller.dispose();
   });
 
+  it("re-surfaces still-pending interrupts after sequential respond if the server re-emits them", async () => {
+    // User report: sequential respond of parallel interrupts clears
+    // stream.interrupts client-side, but the server still has them
+    // pending. A follow-up submit() is then auto-converted to
+    // Command(resume=input) and fails with "must specify the interrupt
+    // id when resuming". If the server re-emits the still-pending
+    // input.requested events (or they arrive via the lifecycle
+    // watcher), the client must not permanently suppress them via
+    // #resolvedInterrupts.
+    const eventListeners = new Set<(event: Event) => void>();
+    const ordering: ThreadStream["ordering"] = {};
+    const respondInput = vi.fn(async () => {
+      ordering.lastAppliedThroughSeq = 10;
+    });
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        eventListeners.add(listener);
+        return vi.fn(() => {
+          eventListeners.delete(listener);
+        });
+      }),
+      close: vi.fn(async () => undefined),
+      ordering,
+      interrupts: [
+        {
+          interruptId: "int-1",
+          payload: { prompt: "First?" },
+          namespace: [],
+        },
+        {
+          interruptId: "int-2",
+          payload: { prompt: "Second?" },
+          namespace: [],
+        },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({
+          values: {},
+          next: ["review"],
+          tasks: [
+            {
+              interrupts: [
+                { id: "int-1", value: { prompt: "First?" } },
+                { id: "int-2", value: { prompt: "Second?" } },
+              ],
+            },
+          ],
+        })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, { prompt: string }>({
+      assistantId: "interrupt_graph",
+      client: client as never,
+      threadId: "thread-multi-stale",
+    });
+    await controller.hydrationPromise;
+
+    const emit = (event: Event) => {
+      for (const listener of eventListeners) listener(event);
+    };
+    emit(inputRequestedEvent("int-1", { prompt: "First?" }, [], 1));
+    emit(inputRequestedEvent("int-2", { prompt: "Second?" }, [], 2));
+    expect(
+      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+    ).toEqual(["int-1", "int-2"]);
+
+    // Sequential resume — client marks each resolved. Server (in the
+    // user report) still has both pending.
+    await controller.respond({ approved: true }, { interruptId: "int-1" });
+    await controller.respond({ approved: false }, { interruptId: "int-2" });
+    expect(
+      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+    ).toEqual([]);
+
+    // Server re-emits the still-pending interrupts as live events on
+    // the resumed run (seq above the respond barrier).
+    emit(inputRequestedEvent("int-1", { prompt: "First?" }, [], 11));
+    emit(inputRequestedEvent("int-2", { prompt: "Second?" }, [], 12));
+
+    expect(
+      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+    ).toEqual(["int-1", "int-2"]);
+
+    await controller.dispose();
+  });
+
+  it("reconciles still-pending interrupts from getState after resume settles", async () => {
+    // When the server keeps siblings pending but does not re-emit
+    // input.requested (session map already holds the id), the resumed
+    // run's interrupted terminal must pull tasks[].interrupts so
+    // stream.interrupts is not left empty after sequential respond.
+    const eventListeners = new Set<(event: Event) => void>();
+    const ordering: ThreadStream["ordering"] = {};
+    let respondCount = 0;
+    const respondInput = vi.fn(async () => {
+      respondCount += 1;
+      ordering.lastAppliedThroughSeq = 10 + respondCount;
+    });
+    const getState = vi
+      .fn()
+      .mockResolvedValueOnce({
+        values: {},
+        next: ["review"],
+        tasks: [
+          {
+            interrupts: [
+              { id: "int-1", value: { prompt: "First?" } },
+              { id: "int-2", value: { prompt: "Second?" } },
+            ],
+          },
+        ],
+      })
+      .mockResolvedValue({
+        values: {},
+        next: ["review"],
+        // Server still reports both pending despite sequential respond.
+        tasks: [
+          {
+            interrupts: [
+              { id: "int-1", value: { prompt: "First?" } },
+              { id: "int-2", value: { prompt: "Second?" } },
+            ],
+          },
+        ],
+      });
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        eventListeners.add(listener);
+        return vi.fn(() => {
+          eventListeners.delete(listener);
+        });
+      }),
+      close: vi.fn(async () => undefined),
+      ordering,
+      interrupts: [
+        {
+          interruptId: "int-1",
+          payload: { prompt: "First?" },
+          namespace: [],
+        },
+        {
+          interruptId: "int-2",
+          payload: { prompt: "Second?" },
+          namespace: [],
+        },
+      ],
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState,
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, { prompt: string }>({
+      assistantId: "interrupt_graph",
+      client: client as never,
+      threadId: "thread-multi-reconcile",
+    });
+    await controller.hydrationPromise;
+
+    const emit = (event: Event) => {
+      for (const listener of eventListeners) listener(event);
+    };
+    emit(inputRequestedEvent("int-1", { prompt: "First?" }, [], 1));
+    emit(inputRequestedEvent("int-2", { prompt: "Second?" }, [], 2));
+
+    await controller.respond({ approved: true }, { interruptId: "int-1" });
+    await controller.respond({ approved: false }, { interruptId: "int-2" });
+    expect(
+      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+    ).toEqual([]);
+
+    emit(lifecycleEvent("running", 20));
+    emit(lifecycleEvent("interrupted", 21));
+
+    await waitForExpectation(() => {
+      expect(
+        controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+      ).toEqual(["int-1", "int-2"]);
+    });
+    expect(getState.mock.calls.length).toBeGreaterThan(1);
+
+    await controller.dispose();
+  });
+
   it("respond() resolves namespace from thread.interrupts when only interruptId is provided", async () => {
     const respondInput = vi.fn(async () => undefined);
     const nestedNamespace = ["subgraph:child", "tools:tc-1"];

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -2496,12 +2496,24 @@ export class StreamController<
    * does not re-emit `input.requested` for them (session map already
    * holds the id), this restore keeps `stream.interrupts` truthful so
    * callers do not free-text `submit()` into an ambiguous resume.
+   *
+   * Uses the same transport-aware state fetch as {@link hydrate}, and
+   * drops the result if the thread swapped or a new submit/respond
+   * started while the fetch was in flight.
    */
   async #reconcilePendingInterruptsFromServer(): Promise<void> {
     const threadId = this.#currentThreadId;
     if (threadId == null || this.#disposed) return;
+    const generationAtFetch = this.#submitGeneration;
     try {
-      const state = await this.#options.client.threads.getState(threadId);
+      const state = await this.#fetchHydrationState();
+      if (
+        this.#disposed ||
+        this.#currentThreadId !== threadId ||
+        this.#submitGeneration !== generationAtFetch
+      ) {
+        return;
+      }
       if (!Array.isArray(state?.tasks)) return;
       const { activeInterrupts, activeIds } =
         collectActiveInterruptsFromTasks<InterruptType>(state.tasks);
@@ -2719,9 +2731,7 @@ function extractAndCoerceMessagesWithFallback(
  * reconcile path so both stay aligned on namespace derivation and
  * id dedupe.
  */
-function collectActiveInterruptsFromTasks<InterruptType>(
-  tasks: unknown[]
-): {
+function collectActiveInterruptsFromTasks<InterruptType>(tasks: unknown[]): {
   activeInterrupts: Interrupt<InterruptType>[];
   activeIds: Set<string>;
 } {

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -238,6 +238,16 @@ export class StreamController<
   #threadEventUnsubscribe: (() => void) | undefined;
   #disposed = false;
   #pendingDisposeTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * Interrupt ids this controller has locally marked resolved via
+   * {@link respond} / {@link respondAll}. Used only to suppress
+   * *historical* SSE replay of those `input.requested` events (there
+   * is no `input.responded` protocol event). Live events after the
+   * resume barrier — or a post-resume reconcile against
+   * `state.tasks[].interrupts` — clear an id from this set so a
+   * still-pending server interrupt can reappear on
+   * `rootStore.interrupts`.
+   */
   readonly #resolvedInterrupts = new Set<string>();
   /**
    * Set of interrupt IDs the server reports as currently *active* on
@@ -729,35 +739,13 @@ export class StreamController<
        */
       if (Array.isArray(state?.tasks)) {
         const generationAtFetch = this.#submitGeneration;
-        const activeInterrupts: Interrupt<InterruptType>[] = [];
-        const activeIds = new Set<string>();
-        for (const task of state.tasks) {
-          if (!Array.isArray(task?.interrupts)) continue;
-          const checkpointNs = (
-            task as { checkpoint?: { checkpoint_ns?: unknown } | null }
-          )?.checkpoint?.checkpoint_ns;
-          const namespace =
-            typeof checkpointNs === "string" && checkpointNs.length > 0
-              ? checkpointNs.split("|").filter((segment) => segment.length > 0)
-              : [...ROOT_NAMESPACE];
-          for (const interrupt of task.interrupts) {
-            const typed = interrupt as
-              | { id?: string; value?: unknown; namespace?: string[] }
-              | null
-              | undefined;
-            const id = typed?.id;
-            if (typeof id !== "string" || activeIds.has(id)) continue;
-            activeIds.add(id);
-            activeInterrupts.push(
-              normalizeInterruptForClient({
-                id,
-                value: typed?.value as InterruptType,
-                namespace: Array.isArray(typed?.namespace)
-                  ? [...typed.namespace]
-                  : namespace,
-              })
-            );
-          }
+        const { activeInterrupts, activeIds } =
+          collectActiveInterruptsFromTasks<InterruptType>(state.tasks);
+        // Server still lists these as pending — drop any local
+        // "resolved" tombstone so live replay / later reconcile can
+        // keep them visible.
+        for (const id of activeIds) {
+          this.#resolvedInterrupts.delete(id);
         }
         this.rootStore.setState((s) => ({
           ...s,
@@ -2364,10 +2352,7 @@ export class StreamController<
       payload?: unknown;
     };
     const interruptId = data?.interrupt_id;
-    if (
-      typeof interruptId !== "string" ||
-      this.#resolvedInterrupts.has(interruptId)
-    ) {
+    if (typeof interruptId !== "string") {
       return;
     }
     // Before a run command is accepted, accept only ids the hydrated
@@ -2376,6 +2361,20 @@ export class StreamController<
     // unknown ids at or below the barrier are stale, while newer ids are
     // interrupts raised by the new run.
     const eventSeq = typeof event.seq === "number" ? event.seq : undefined;
+    // Locally-resolved ids: still drop historical replay, but accept a
+    // live reappearance (server still pending after sequential
+    // multi-interrupt resume, or the same interrupt site re-raised).
+    if (this.#resolvedInterrupts.has(interruptId)) {
+      const isLiveReappearance =
+        this.#hydratedActiveInterruptIds == null ||
+        (typeof this.#interruptReplayThroughSeq === "number" &&
+          eventSeq != null &&
+          eventSeq > this.#interruptReplayThroughSeq);
+      if (!isLiveReappearance) {
+        return;
+      }
+      this.#resolvedInterrupts.delete(interruptId);
+    }
     const isUnknownInterrupt =
       this.#hydratedActiveInterruptIds != null &&
       !this.#hydratedActiveInterruptIds.has(interruptId);
@@ -2461,8 +2460,12 @@ export class StreamController<
   }
 
   /**
-   * Mark an interrupt resolved for replay filtering and mirror the
-   * removal into the root snapshot the framework hooks read.
+   * Mark an interrupt resolved for historical-replay filtering and
+   * mirror the removal into the root snapshot the framework hooks read.
+   *
+   * Tombstones are not permanent: a live `input.requested` after the
+   * resume barrier, or {@link #reconcilePendingInterruptsFromServer},
+   * clears the id when the server still reports it as pending.
    */
   #markInterruptResolvedInRootStore(interruptId: string): void {
     this.#resolvedInterrupts.add(interruptId);
@@ -2482,6 +2485,38 @@ export class StreamController<
         interrupt: interrupts[0],
       };
     });
+  }
+
+  /**
+   * Re-sync `rootStore.interrupts` from the server's authoritative
+   * `state.tasks[].interrupts` after a resumed run settles.
+   *
+   * Sequential `respond()` of parallel interrupts optimistically clears
+   * each id client-side. When the server still has siblings pending and
+   * does not re-emit `input.requested` for them (session map already
+   * holds the id), this restore keeps `stream.interrupts` truthful so
+   * callers do not free-text `submit()` into an ambiguous resume.
+   */
+  async #reconcilePendingInterruptsFromServer(): Promise<void> {
+    const threadId = this.#currentThreadId;
+    if (threadId == null || this.#disposed) return;
+    try {
+      const state = await this.#options.client.threads.getState(threadId);
+      if (!Array.isArray(state?.tasks)) return;
+      const { activeInterrupts, activeIds } =
+        collectActiveInterruptsFromTasks<InterruptType>(state.tasks);
+      for (const id of activeIds) {
+        this.#resolvedInterrupts.delete(id);
+      }
+      this.rootStore.setState((s) => ({
+        ...s,
+        interrupts: activeInterrupts,
+        interrupt: activeInterrupts[0],
+      }));
+      this.#hydratedActiveInterruptIds = activeIds;
+    } catch {
+      /* best-effort — leave the optimistic interrupt list alone */
+    }
   }
 
   /**
@@ -2515,14 +2550,26 @@ export class StreamController<
    * but before `respondInput` calls `#prepareForNextRun`; accepting that
    * terminal would unsubscribe the watcher before the resumed run's `failed`
    * terminal arrives.
+   *
+   * On `interrupted` / `completed`, reconciles pending interrupts from
+   * server state so optimistic clears from {@link respond} cannot leave
+   * `stream.interrupts` empty while the checkpoint still has siblings.
    */
-  #awaitResumedRunTerminal(signal: AbortSignal): Promise<{
+  async #awaitResumedRunTerminal(signal: AbortSignal): Promise<{
     event: "completed" | "failed" | "interrupted" | "aborted";
     error?: string;
   }> {
-    return this.#awaitRootTerminal(signal, {
+    const terminal = await this.#awaitRootTerminal(signal, {
       skipInterruptedUntilRunning: true,
     });
+    if (
+      !signal.aborted &&
+      !this.#disposed &&
+      (terminal.event === "interrupted" || terminal.event === "completed")
+    ) {
+      await this.#reconcilePendingInterruptsFromServer();
+    }
+    return terminal;
   }
 
   #awaitRootTerminal(
@@ -2663,6 +2710,56 @@ function extractAndCoerceMessagesWithFallback(
   return ensureMessageInstances(
     raw as (Message | BaseMessage)[]
   ) as BaseMessage[];
+}
+
+/**
+ * Collect pending interrupts from a `threads.getState()` `tasks` array.
+ *
+ * Shared by {@link StreamController.hydrate} and the post-resume
+ * reconcile path so both stay aligned on namespace derivation and
+ * id dedupe.
+ */
+function collectActiveInterruptsFromTasks<InterruptType>(
+  tasks: unknown[]
+): {
+  activeInterrupts: Interrupt<InterruptType>[];
+  activeIds: Set<string>;
+} {
+  const activeInterrupts: Interrupt<InterruptType>[] = [];
+  const activeIds = new Set<string>();
+  for (const task of tasks) {
+    if (!Array.isArray((task as { interrupts?: unknown } | null)?.interrupts)) {
+      continue;
+    }
+    const typedTask = task as {
+      interrupts: unknown[];
+      checkpoint?: { checkpoint_ns?: unknown } | null;
+    };
+    const checkpointNs = typedTask.checkpoint?.checkpoint_ns;
+    const namespace =
+      typeof checkpointNs === "string" && checkpointNs.length > 0
+        ? checkpointNs.split("|").filter((segment) => segment.length > 0)
+        : [...ROOT_NAMESPACE];
+    for (const interrupt of typedTask.interrupts) {
+      const typed = interrupt as
+        | { id?: string; value?: unknown; namespace?: string[] }
+        | null
+        | undefined;
+      const id = typed?.id;
+      if (typeof id !== "string" || activeIds.has(id)) continue;
+      activeIds.add(id);
+      activeInterrupts.push(
+        normalizeInterruptForClient({
+          id,
+          value: typed?.value as InterruptType,
+          namespace: Array.isArray(typed?.namespace)
+            ? [...typed.namespace]
+            : namespace,
+        })
+      );
+    }
+  }
+  return { activeInterrupts, activeIds };
 }
 
 // Unused import guard — `AIMessage` is only referenced by type tests.


### PR DESCRIPTION
After sequential `respond()` on parallel interrupts, `stream.interrupts` could stay empty while the server still had pending siblings. Clients then called `submit()`, the API treated that as `Command(resume=…)`, and LangGraph rejected it with "must specify the interrupt id when resuming".

Locally resolved ids are only suppressed for historical replay now. Live `input.requested` after the resume barrier can come back, and when a resumed run settles we re-sync from `getState().tasks[].interrupts`.
