### PR TITLE
fix(sdk): apply in-place message metadata updates from values

### DIFF
--- a/.changeset/fix-inplace-message-metadata.md
+++ b/.changeset/fix-inplace-message-metadata.md
@@ -1,0 +1,11 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): apply in-place message metadata updates from values
+
+Same-id `values` snapshots that mutate nested metadata (e.g. HITL card
+`status: accepted → done`) without changing content were treated as no-ops
+because enrichment only accepted shallow key-supersets. Prefer values when
+they retain every nested key and only mutate leaves or add keys, so
+`useStream().values` reflects the update.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,12 +47,12 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v1
+        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
-          publish: pnpm release
-          version: pnpm changeset version
-          commit: "chore: version packages"
-          title: "chore: version packages"
+          publish-script: pnpm release
+          version-script: pnpm changeset version
+          commit-message: "chore: version packages"
+          pr-title: "chore: version packages"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/internal/environment_tests/scripts/docker-ci-entrypoint.sh
+++ b/internal/environment_tests/scripts/docker-ci-entrypoint.sh
@@ -61,19 +61,46 @@ for pkg in libs/*/; do
   fi
 done
 
-# Remove workspace devDependencies that aren't available in this limited workspace
-# This is needed because pnpm validates all workspace references even with --prod
-for pkg in libs/*/; do
-  if [ -f "$pkg/package.json" ]; then
-    # Remove devDependencies that reference workspace packages not in our limited set
-    sed -i 's/"@langchain\/langgraph-checkpoint-postgres": "workspace:\*",*//g' "$pkg/package.json"
-    sed -i 's/"@langchain\/langgraph-checkpoint-sqlite": "workspace:\*",*//g' "$pkg/package.json"
-    sed -i 's/"@langchain\/langgraph-api": "workspace:[^"]*",*//g' "$pkg/package.json"
-    # `@langchain/build` is an internal build-only package (lives under internal/,
-    # not libs/) and is never executed here since the libs ship prebuilt dist/.
-    sed -i 's/"@langchain\/build": "workspace:[^"]*",*//g' "$pkg/package.json"
-  fi
-done
+# Remove workspace / registry deps that aren't available or needed in this
+# limited export-test workspace. pnpm still resolves them from package.json
+# even with --prod, and registry packages like `deepagents` depend on
+# `@langchain/langgraph-sdk` at a version range that can point at an
+# unpublished workspace bump (e.g. 1.10.1) and fail the install.
+node <<'EOF'
+const fs = require("fs");
+const path = require("path");
+
+const DROP_DEPS = new Set([
+  "@langchain/langgraph-checkpoint-postgres",
+  "@langchain/langgraph-checkpoint-sqlite",
+  "@langchain/langgraph-api",
+  "@langchain/build",
+  // Test-only registry packages that pull @langchain/langgraph-sdk from npm.
+  "deepagents",
+  "langchain",
+]);
+
+for (const entry of fs.readdirSync("libs", { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const pkgPath = path.join("libs", entry.name, "package.json");
+  if (!fs.existsSync(pkgPath)) continue;
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+  let changed = false;
+  for (const field of ["dependencies", "devDependencies", "peerDependencies"]) {
+    const section = pkg[field];
+    if (section == null || typeof section !== "object") continue;
+    for (const name of DROP_DEPS) {
+      if (Object.prototype.hasOwnProperty.call(section, name)) {
+        delete section[name];
+        changed = true;
+      }
+    }
+  }
+  if (changed) {
+    fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+  }
+}
+EOF
 
 # Match the test app's direct @langchain/core dependency to the local LangGraph peer.
 # This lets the environment tests follow dev builds that are not covered by ^1.x.

--- a/libs/sdk/src/stream/message-reconciliation.test.ts
+++ b/libs/sdk/src/stream/message-reconciliation.test.ts
@@ -228,4 +228,82 @@ describe("reconcileMessagesFromValues", () => {
 
     expect(result.messages).toBe(current);
   });
+
+  it("prefers values when response_metadata mutates nested fields in place", () => {
+    // Customer flow: HITL card status accepted → done on the same message id.
+    // Content is unchanged; only nested response_metadata.card.status updates.
+    const accepted = new AIMessage({
+      id: "assistant-1",
+      content: "Please confirm",
+      response_metadata: {
+        card: { action: "confirm", status: "accepted" },
+      },
+    });
+    const done = new AIMessage({
+      id: "assistant-1",
+      content: "Please confirm",
+      response_metadata: {
+        card: { action: "confirm", status: "done" },
+      },
+    });
+
+    expect(shouldPreferValuesMessage(done, accepted)).toBe(true);
+
+    const result = reconcileMessagesFromValues({
+      valueMessages: [done],
+      currentMessages: [accepted],
+      currentIndexById: buildMessageIndex([accepted]),
+      previousValueMessageIds: new Set(["assistant-1"]),
+      preferValuesMessage: shouldPreferValuesMessage,
+    });
+
+    expect(result.messages).toEqual([done]);
+    expect(
+      (
+        (result.messages[0] as AIMessage).response_metadata as {
+          card: { status: string };
+        }
+      ).card.status
+    ).toBe("done");
+  });
+
+  it("still keeps richer current metadata when values would drop nested keys", () => {
+    const richer = new AIMessage({
+      id: "assistant-1",
+      content: "Please confirm",
+      response_metadata: {
+        card: {
+          action: "confirm",
+          status: "accepted",
+          detail: "keep me",
+        },
+      },
+    });
+    const poorer = new AIMessage({
+      id: "assistant-1",
+      content: "Please confirm",
+      response_metadata: {
+        card: { action: "confirm", status: "done" },
+      },
+    });
+
+    expect(shouldPreferValuesMessage(poorer, richer)).toBe(false);
+
+    const result = reconcileMessagesFromValues({
+      valueMessages: [poorer],
+      currentMessages: [richer],
+      currentIndexById: buildMessageIndex([richer]),
+      previousValueMessageIds: new Set(["assistant-1"]),
+      preferValuesMessage: shouldPreferValuesMessage,
+    });
+
+    expect(result.messages).toEqual([richer]);
+    expect(
+      (
+        (result.messages[0] as AIMessage).response_metadata as {
+          card: { detail: string };
+        }
+      ).card.detail
+    ).toBe("keep me");
+  });
 });

--- a/libs/sdk/src/stream/message-reconciliation.test.ts
+++ b/libs/sdk/src/stream/message-reconciliation.test.ts
@@ -267,6 +267,52 @@ describe("reconcileMessagesFromValues", () => {
     ).toBe("done");
   });
 
+  it("does not prefer stale leaf mutations when allowInPlaceMutations is false", () => {
+    // Reconnect/addOnly: seeded current has done; lagging values still
+    // says accepted. Must keep current — not roll status backward.
+    const done = new AIMessage({
+      id: "assistant-1",
+      content: "Please confirm",
+      response_metadata: {
+        card: { action: "confirm", status: "done" },
+      },
+    });
+    const accepted = new AIMessage({
+      id: "assistant-1",
+      content: "Please confirm",
+      response_metadata: {
+        card: { action: "confirm", status: "accepted" },
+      },
+    });
+
+    expect(
+      shouldPreferValuesMessage(accepted, done, {
+        allowInPlaceMutations: false,
+      })
+    ).toBe(false);
+
+    const result = reconcileMessagesFromValues({
+      valueMessages: [accepted],
+      currentMessages: [done],
+      currentIndexById: buildMessageIndex([done]),
+      previousValueMessageIds: new Set(["assistant-1"]),
+      preferValuesMessage: (valuesMessage, streamedMessage) =>
+        shouldPreferValuesMessage(valuesMessage, streamedMessage, {
+          allowInPlaceMutations: false,
+        }),
+      addOnly: true,
+    });
+
+    expect(result.messages).toEqual([done]);
+    expect(
+      (
+        (result.messages[0] as AIMessage).response_metadata as {
+          card: { status: string };
+        }
+      ).card.status
+    ).toBe("done");
+  });
+
   it("still keeps richer current metadata when values would drop nested keys", () => {
     const richer = new AIMessage({
       id: "assistant-1",

--- a/libs/sdk/src/stream/message-reconciliation.ts
+++ b/libs/sdk/src/stream/message-reconciliation.ts
@@ -151,12 +151,29 @@ export function buildMessageIndex(
  * channel `usage_metadata`, etc.) merely because the two messages differ.
  * Values that would drop nested metadata keys keep the current copy.
  *
+ * In-place leaf mutations are only applied when
+ * {@link ShouldPreferValuesMessageOptions.allowInPlaceMutations} is true
+ * (the default). Callers pass `false` for stale/`addOnly` reconnect
+ * snapshots so an older `accepted` card cannot overwrite a newer `done`.
+ *
  * Streamed content still wins when it has moved past this snapshot, so
  * in-flight token streaming is not overwritten by a lagging values event.
  */
+export interface ShouldPreferValuesMessageOptions {
+  /**
+   * When false, only prefer values for key-adding enrichment (or filling
+   * empty metadata), not for same-key nested leaf mutations. Used for
+   * lagging reconnect/`addOnly` snapshots.
+   *
+   * @default true
+   */
+  readonly allowInPlaceMutations?: boolean;
+}
+
 export function shouldPreferValuesMessage(
   valuesMessage: BaseMessage,
-  streamedMessage: BaseMessage
+  streamedMessage: BaseMessage,
+  options?: ShouldPreferValuesMessageOptions
 ): boolean {
   if (shouldPreferValuesMessageForToolCalls(valuesMessage, streamedMessage)) {
     return true;
@@ -164,7 +181,7 @@ export function shouldPreferValuesMessage(
   if (!jsonishEqual(valuesMessage.content, streamedMessage.content)) {
     return false;
   }
-  return valuesAddsMetadataEnrichment(valuesMessage, streamedMessage);
+  return valuesAddsMetadataEnrichment(valuesMessage, streamedMessage, options);
 }
 
 /** Metadata fields that a values echo may enrich on a same-id message. */
@@ -179,14 +196,17 @@ const METADATA_ENRICHMENT_KEYS = [
  * fields already present on the current copy.
  *
  * Covers both key additions (optimistic human gaining
- * `additional_kwargs.attachments`) and in-place nested mutations of
+ * `additional_kwargs.attachments`) and — when
+ * `allowInPlaceMutations` is true — in-place nested mutations of
  * existing keys (HITL card `status: accepted → done`) as long as every
  * nested key on the current field is retained.
  */
 function valuesAddsMetadataEnrichment(
   valuesMessage: BaseMessage,
-  streamedMessage: BaseMessage
+  streamedMessage: BaseMessage,
+  options?: ShouldPreferValuesMessageOptions
 ): boolean {
+  const allowInPlaceMutations = options?.allowInPlaceMutations !== false;
   const valuesRecord = valuesMessage as unknown as Record<string, unknown>;
   const streamedRecord = streamedMessage as unknown as Record<string, unknown>;
 
@@ -207,11 +227,21 @@ function valuesAddsMetadataEnrichment(
       enriches = true;
       continue;
     }
-    // Both non-empty and differ: prefer values when it retains every
-    // nested key from the current field (nested value mutations and
-    // added keys allowed). Dropping keys would erase richer current
-    // metadata — keep the current copy.
-    if (retainsAllNestedKeys(valuesField, streamedField)) {
+    // Both non-empty and differ.
+    if (allowInPlaceMutations) {
+      // Prefer values when it retains every nested key (leaf mutations
+      // and added keys allowed). Dropping keys would erase richer
+      // current metadata — keep the current copy.
+      if (retainsAllNestedKeys(valuesField, streamedField)) {
+        enriches = true;
+        continue;
+      }
+      return false;
+    }
+    // Stale/addOnly snapshots: only treat as enrichment when values is
+    // a shallow key-superset with equal existing values. Same-key leaf
+    // mutations must not roll current metadata backward.
+    if (isObjectShallowSuperset(valuesField, streamedField)) {
       enriches = true;
       continue;
     }
@@ -228,6 +258,41 @@ function isEmptyMeta(value: unknown): boolean {
     return Object.keys(value as Record<string, unknown>).length === 0;
   }
   return false;
+}
+
+/**
+ * True when `candidate` is a shallow object superset of `baseline`:
+ * every baseline key is present with an equal value, and candidate has
+ * at least one extra key.
+ */
+function isObjectShallowSuperset(
+  candidate: unknown,
+  baseline: unknown
+): boolean {
+  if (
+    candidate == null ||
+    baseline == null ||
+    typeof candidate !== "object" ||
+    typeof baseline !== "object" ||
+    Array.isArray(candidate) ||
+    Array.isArray(baseline)
+  ) {
+    return false;
+  }
+  const candidateRecord = candidate as Record<string, unknown>;
+  const baselineRecord = baseline as Record<string, unknown>;
+  const baselineKeys = Object.keys(baselineRecord);
+  const candidateKeys = Object.keys(candidateRecord);
+  if (candidateKeys.length <= baselineKeys.length) return false;
+  for (const key of baselineKeys) {
+    if (!Object.prototype.hasOwnProperty.call(candidateRecord, key)) {
+      return false;
+    }
+    if (!jsonishEqual(candidateRecord[key], baselineRecord[key])) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /**

--- a/libs/sdk/src/stream/message-reconciliation.ts
+++ b/libs/sdk/src/stream/message-reconciliation.ts
@@ -142,12 +142,14 @@ export function buildMessageIndex(
  * Values win when they carry data the current copy lacks:
  *   - finalized tool-call args (see
  *     {@link shouldPreferValuesMessageForToolCalls})
- *   - metadata enrichment with unchanged content (e.g. server-committed
- *     `additional_kwargs.attachments` on an optimistic human)
+ *   - metadata enrichment or in-place nested metadata mutations with
+ *     unchanged content (e.g. server-committed `additional_kwargs`, or
+ *     `response_metadata.card.status` updating from `accepted` → `done`)
  *
  * Preferring is asymmetric: a lagging/poorer values snapshot must not
  * replace a richer current copy (seeded `getState()` metadata, messages-
  * channel `usage_metadata`, etc.) merely because the two messages differ.
+ * Values that would drop nested metadata keys keep the current copy.
  *
  * Streamed content still wins when it has moved past this snapshot, so
  * in-flight token streaming is not overwritten by a lagging values event.
@@ -173,8 +175,13 @@ const METADATA_ENRICHMENT_KEYS = [
 ] as const;
 
 /**
- * True when values adds metadata the current copy lacks, without
- * stripping richer fields already present on the current copy.
+ * True when values adds or mutates metadata without stripping richer
+ * fields already present on the current copy.
+ *
+ * Covers both key additions (optimistic human gaining
+ * `additional_kwargs.attachments`) and in-place nested mutations of
+ * existing keys (HITL card `status: accepted → done`) as long as every
+ * nested key on the current field is retained.
  */
 function valuesAddsMetadataEnrichment(
   valuesMessage: BaseMessage,
@@ -200,10 +207,11 @@ function valuesAddsMetadataEnrichment(
       enriches = true;
       continue;
     }
-    // Both non-empty and differ: only treat as enrichment when values
-    // is a shallow object superset of the current field (adds keys,
-    // keeps existing ones). Conflicting shapes keep the current copy.
-    if (isObjectShallowSuperset(valuesField, streamedField)) {
+    // Both non-empty and differ: prefer values when it retains every
+    // nested key from the current field (nested value mutations and
+    // added keys allowed). Dropping keys would erase richer current
+    // metadata — keep the current copy.
+    if (retainsAllNestedKeys(valuesField, streamedField)) {
       enriches = true;
       continue;
     }
@@ -222,30 +230,43 @@ function isEmptyMeta(value: unknown): boolean {
   return false;
 }
 
-function isObjectShallowSuperset(
-  candidate: unknown,
-  baseline: unknown
-): boolean {
+/**
+ * True when `candidate` retains every nested key present on `baseline`.
+ * Nested leaf values may differ (in-place mutations); missing keys mean
+ * preferring candidate would erase richer current metadata.
+ */
+function retainsAllNestedKeys(candidate: unknown, baseline: unknown): boolean {
+  if (baseline == null || typeof baseline !== "object") {
+    // Leaf baseline — candidate may replace the value in place.
+    return true;
+  }
   if (
     candidate == null ||
-    baseline == null ||
     typeof candidate !== "object" ||
-    typeof baseline !== "object" ||
-    Array.isArray(candidate) ||
-    Array.isArray(baseline)
+    Array.isArray(baseline) !== Array.isArray(candidate)
   ) {
     return false;
   }
+
+  if (Array.isArray(baseline)) {
+    const candidateArr = candidate as unknown[];
+    const baselineArr = baseline as unknown[];
+    if (candidateArr.length < baselineArr.length) return false;
+    for (let i = 0; i < baselineArr.length; i += 1) {
+      if (!retainsAllNestedKeys(candidateArr[i], baselineArr[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   const candidateRecord = candidate as Record<string, unknown>;
   const baselineRecord = baseline as Record<string, unknown>;
-  const baselineKeys = Object.keys(baselineRecord);
-  const candidateKeys = Object.keys(candidateRecord);
-  if (candidateKeys.length <= baselineKeys.length) return false;
-  for (const key of baselineKeys) {
+  for (const key of Object.keys(baselineRecord)) {
     if (!Object.prototype.hasOwnProperty.call(candidateRecord, key)) {
       return false;
     }
-    if (!jsonishEqual(candidateRecord[key], baselineRecord[key])) {
+    if (!retainsAllNestedKeys(candidateRecord[key], baselineRecord[key])) {
       return false;
     }
   }

--- a/libs/sdk/src/stream/root-message-projection.test.ts
+++ b/libs/sdk/src/stream/root-message-projection.test.ts
@@ -1301,6 +1301,43 @@ describe("RootMessageProjection", () => {
       ).toBe("done");
     });
 
+    it("does not roll card status backward on a lagging addOnly values replay", async () => {
+      const { store, projection } = makeProjection();
+
+      const done = new AIMessage({
+        id: "a1",
+        content: "Please confirm",
+        response_metadata: {
+          card: { action: "confirm", status: "done" },
+        },
+      });
+      projection.applyValues({ messages: [done] } as State, [done], {
+        step: 5,
+      });
+      await drainFlush();
+
+      const accepted = new AIMessage({
+        id: "a1",
+        content: "Please confirm",
+        response_metadata: {
+          card: { action: "confirm", status: "accepted" },
+        },
+      });
+      projection.applyValues({ messages: [accepted] } as State, [accepted], {
+        step: 4,
+      });
+      await drainFlush();
+
+      const snap = store.getSnapshot();
+      expect(
+        (
+          (snap.messages[0] as AIMessage).response_metadata as {
+            card: { status: string };
+          }
+        ).card.status
+      ).toBe("done");
+    });
+
     it("does not strip seeded metadata when a lagging values replay omits it", async () => {
       const { store, projection } = makeProjection();
 

--- a/libs/sdk/src/stream/root-message-projection.test.ts
+++ b/libs/sdk/src/stream/root-message-projection.test.ts
@@ -1258,6 +1258,49 @@ describe("RootMessageProjection", () => {
       ).toBe(snap.messages);
     });
 
+    it("applies in-place response_metadata mutations from a later values snapshot", async () => {
+      // Customer HITL flow: card status accepted (after respond) → done
+      // (after tool runs). Same message id, same content; only nested
+      // response_metadata.card.status changes. Must surface on both
+      // messages and values.messages (useStream().values).
+      const { store, projection } = makeProjection();
+
+      const accepted = new AIMessage({
+        id: "a1",
+        content: "Please confirm",
+        response_metadata: {
+          card: { action: "confirm", status: "accepted" },
+        },
+      });
+      projection.applyValues({ messages: [accepted] } as State, [accepted]);
+      await drainFlush();
+
+      const done = new AIMessage({
+        id: "a1",
+        content: "Please confirm",
+        response_metadata: {
+          card: { action: "confirm", status: "done" },
+        },
+      });
+      projection.applyValues({ messages: [done] } as State, [done]);
+      await drainFlush();
+
+      const snap = store.getSnapshot();
+      expect(snap.messages).toHaveLength(1);
+      const cardStatus = (
+        (snap.messages[0] as AIMessage).response_metadata as {
+          card: { status: string };
+        }
+      ).card.status;
+      expect(cardStatus).toBe("done");
+      expect(
+        (
+          ((snap.values as State).messages as AIMessage[])[0]
+            .response_metadata as { card: { status: string } }
+        ).card.status
+      ).toBe("done");
+    });
+
     it("does not strip seeded metadata when a lagging values replay omits it", async () => {
       const { store, projection } = makeProjection();
 

--- a/libs/sdk/src/stream/root-message-projection.ts
+++ b/libs/sdk/src/stream/root-message-projection.ts
@@ -457,7 +457,12 @@ export class RootMessageProjection<
       currentMessages: baselineMessages,
       currentIndexById: this.#indexById,
       previousValueMessageIds: this.#valuesMessageIds,
-      preferValuesMessage: shouldPreferValuesMessage,
+      preferValuesMessage: (valuesMessage, streamedMessage) =>
+        shouldPreferValuesMessage(valuesMessage, streamedMessage, {
+          // Lagging reconnect snapshots must not roll nested metadata
+          // backward (e.g. card status done → accepted).
+          allowInPlaceMutations: !addOnly,
+        }),
       addOnly,
     });
     // A stale replay snapshot must not shrink the authoritative id set:

--- a/libs/sdk/src/stream/root-message-projection.ts
+++ b/libs/sdk/src/stream/root-message-projection.ts
@@ -498,10 +498,12 @@ export class RootMessageProjection<
    * emits a `values` snapshot containing the same ids,
    * {@link applyValues} → {@link reconcileMessagesFromValues} takes over
    * (server ordering wins; the echoed message replaces the optimistic
-   * one when content matches *and* values adds metadata the optimistic
-   * copy lacks, so server-authored `additional_kwargs` is visible
-   * without waiting for hydration — lagging/poorer snapshots do not
-   * strip richer current metadata).
+   * one when content matches *and* values adds or mutates nested
+   * metadata without dropping keys the optimistic copy already has, so
+   * server-authored `additional_kwargs` / in-place
+   * `response_metadata` updates are visible without waiting for
+   * hydration — lagging/poorer snapshots do not strip richer current
+   * metadata).
    * In-flight streamed content still wins when it has moved past the
    * snapshot.
    *


### PR DESCRIPTION
Same-id `values` echoes that mutate nested message metadata without changing content (e.g. HITL card `status: accepted → done`) were treated as no-ops during reconciliation, so `useStream().values` kept the stale copy. Prefer the values message when it retains every nested metadata key and only updates leaves or adds keys.


<!--
Thank you for contributing to LangGraph.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langgraphjs/blob/main/CONTRIBUTING.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

