### PR TITLE
fix(sdk): keep caller-supplied metadata.graph_id in threads.create()

### DIFF
--- a/.changeset/threads-create-metadata-graph-id.md
+++ b/.changeset/threads-create-metadata-graph-id.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+Stop `threads.create()` from overwriting a caller-supplied `metadata.graph_id` when the `graphId` shorthand is absent or empty, which deleted the key from the request body. `graph_id` is now written only when `graphId` actually has a value, matching the Python SDK. The shorthand still takes precedence when both are given.

--- a/libs/sdk/src/client/threads/index.test.ts
+++ b/libs/sdk/src/client/threads/index.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Client } from "../../client.js";
+import { overrideFetchImplementation } from "../../singletons/fetch.js";
+
+type MockFetch = ReturnType<typeof vi.fn> & typeof fetch;
+
+const createMockFetch = () => vi.fn() as MockFetch;
+
+describe("threads.create", () => {
+  let fetchMock: MockFetch;
+
+  beforeEach(() => {
+    fetchMock = createMockFetch();
+    overrideFetchImplementation(fetchMock);
+    (globalThis as any).fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockThread() {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ thread_id: "thread_123" }),
+      text: () => Promise.resolve(""),
+      headers: new Headers({}),
+    });
+  }
+
+  function parseFetchCall() {
+    const [url, options] = fetchMock.mock.calls[0];
+    return {
+      url: new URL(url),
+      method: options?.method,
+      body: JSON.parse(options.body),
+    };
+  }
+
+  it("keeps a caller-supplied metadata.graph_id", async () => {
+    mockThread();
+
+    const client = new Client({ apiKey: "test-api-key" });
+    await client.threads.create({
+      metadata: { graph_id: "my-graph", owner: "me" },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const { url, method, body } = parseFetchCall();
+    expect(method).toBe("POST");
+    expect(url.pathname).toBe("/threads");
+    expect(body.metadata).toEqual({ graph_id: "my-graph", owner: "me" });
+  });
+
+  it("lets the graphId shorthand win over metadata.graph_id", async () => {
+    mockThread();
+
+    const client = new Client({ apiKey: "test-api-key" });
+    await client.threads.create({
+      graphId: "shorthand-graph",
+      metadata: { graph_id: "in-metadata", owner: "me" },
+    });
+
+    expect(parseFetchCall().body.metadata).toEqual({
+      graph_id: "shorthand-graph",
+      owner: "me",
+    });
+  });
+
+  it("omits graph_id when neither the shorthand nor metadata supplies one", async () => {
+    mockThread();
+
+    const client = new Client({ apiKey: "test-api-key" });
+    await client.threads.create({ metadata: { owner: "me" } });
+
+    expect(parseFetchCall().body.metadata).toEqual({ owner: "me" });
+  });
+
+  it("ignores an empty-string graphId instead of erasing metadata.graph_id", async () => {
+    mockThread();
+
+    const client = new Client({ apiKey: "test-api-key" });
+    await client.threads.create({
+      graphId: "",
+      metadata: { graph_id: "in-metadata" },
+    });
+
+    expect(parseFetchCall().body.metadata).toEqual({ graph_id: "in-metadata" });
+  });
+});

--- a/libs/sdk/src/client/threads/index.ts
+++ b/libs/sdk/src/client/threads/index.ts
@@ -75,7 +75,7 @@ export class ThreadsClient<
       json: {
         metadata: {
           ...payload?.metadata,
-          graph_id: payload?.graphId,
+          ...(payload?.graphId ? { graph_id: payload.graphId } : {}),
         },
         thread_id: payload?.threadId,
         if_exists: payload?.ifExists,


### PR DESCRIPTION
## Summary

`ThreadsClient.create()` builds its request metadata as (`libs/sdk/src/client/threads/index.ts:76-79`):

```ts
metadata: {
  ...payload?.metadata,
  graph_id: payload?.graphId,
},
```

The shorthand is written unconditionally, so a caller who supplies `graph_id` inside `metadata` loses it whenever `graphId` itself has no usable value — with `undefined` the key is dropped by `JSON.stringify` entirely, and with `""` it is replaced by an empty string. Either way the thread is created without the intended `graph_id`, and no error is raised at the call site.

The Python SDK has never had this bug — it writes the key only when the shorthand is truthy (`libs/sdk-py/langgraph_sdk/_async/threads.py`):

```python
if metadata or graph_id:
    payload["metadata"] = {
        **(metadata or {}),
        **({"graph_id": graph_id} if graph_id else {}),
    }
```

This ports that guard to the JS SDK.

## Reproduction

Real `Client`, stub `callerOptions.fetch` capturing the outgoing body. Only the `graph_id`-losing rows change:

| call | `metadata` sent — before | after |
|---|---|---|
| `create({ metadata: { graph_id: "real", owner: "me" } })` | `{"owner":"me"}` | `{"graph_id":"real","owner":"me"}` |
| `create({ graphId: "", metadata: { graph_id: "real" } })` | `{"graph_id":""}` | `{"graph_id":"real"}` |
| `create({ graphId: "sh", metadata: { owner: "me" } })` | `{"owner":"me","graph_id":"sh"}` | unchanged |
| `create({ graphId: "sh", metadata: { graph_id: "in-meta" } })` | `{"graph_id":"sh"}` | unchanged |
| `create({ metadata: { owner: "me" } })` | `{"owner":"me"}` | unchanged |
| `update("t1", { metadata: { graph_id: "real" } })` | `{"graph_id":"real"}` | unchanged |

The last row is `ThreadsClient.update()` in the same file (`:163`), which passes `metadata` through verbatim — that is the behaviour this aligns `create()` with.

The empty-string row matters in practice because `graphId={someState}` is an ordinary React spelling and `someState` is `""` before it is populated.

## Why it is visible to callers

Against the reference server in this repo, the loss is not always silent:

- **Immediate 400.** `POST /threads` runs `state.bulk` in the same request when `supersteps` are present (`libs/langgraph-api/src/api/threads.mts:25-27`), and `State.bulk` rejects a thread with no `graph_id` (`libs/langgraph-api/src/storage/ops.mts:1189-1194`, `Thread <id> has no graph ID`). So `create({ metadata: { graph_id }, supersteps })` fails outright before the fix. `threads.updateState()` has the same guard (`ops.mts:1122-1128`).
- **Between create and the first run**, `threads.search({ metadata: { graph_id } })` does not match the thread, and `getState`/`getHistory` return an empty snapshot (`ops.mts:1052-1060`, `:1252-1253`).

In fairness: once a run starts on the thread, the server writes `graph_id` into the thread metadata itself (`ops.mts:1416`, `:1435`), so for the plain create-then-run flow the value repairs itself. The `supersteps` path and the pre-first-run window are the cases it cannot repair.

## The change

One line — write `graph_id` only when the shorthand is truthy:

```ts
...(payload?.graphId ? { graph_id: payload.graphId } : {}),
```

`graphId` still takes precedence when both are given; that is pinned by one of the tests so it cannot regress later.

## Tests

`libs/sdk/src/client/threads` had no test file; added `index.test.ts` following the `crons/index.test.ts` / `runs/index.test.ts` harness (`overrideFetchImplementation`, a `parseFetchCall()` helper, URL/method/call-count assertions). Four cases:

1. a caller-supplied `metadata.graph_id` survives
2. the `graphId` shorthand still wins over `metadata.graph_id`
3. no `graph_id` key is sent when neither is supplied
4. an empty-string `graphId` does not erase `metadata.graph_id`

**Reverse-verified against three variants of the guard:**

| `graph_id` written when… | failing cases |
|---|---|
| unconditionally (pre-fix) | **2 fail** — cases 1 and 4 |
| `graphId != null` | **1 fail** — case 4 (`expected { graph_id: '' } to deeply equal { graph_id: 'in-metadata' }`) |
| `graphId` is truthy (this PR) | **0 fail** |

So cases 2 and 3 are genuine guard rails rather than assertions the fix invented, and case 4 is what distinguishes a truthy guard from a null check.

With the change applied, `pnpm test` in `libs/sdk` gives **54 files / 792 tests passing, no type errors**; `pnpm lint` and `pnpm format:check` are clean at the repo root. A changeset is included (`@langchain/langgraph-sdk`: patch).

---

*This contribution was prepared with AI assistance.*
