### PR TITLE
feat(langgraph): `tracePolicy`

### DIFF
--- a/.changeset/node-trace-policy.md
+++ b/.changeset/node-trace-policy.md
@@ -1,0 +1,9 @@
+---
+"@langchain/langgraph": patch
+---
+
+feat(langgraph): add per-node `tracePolicy` input/output processors and `omitPayload`
+
+Transform the payloads recorded on a node's own trace run while retaining its span and timing. Processors receive raw values and fall back to the original payload if they throw. Graph state, root runs, and child runs remain unchanged when processors do not mutate their arguments.
+
+Matches Python's callback-level behavior: transforms also affect chain events and message streaming, so omitting outputs can suppress messages returned directly by nodes and omitting inputs can affect message deduplication.

--- a/libs/langgraph-core/src/graph/state.ts
+++ b/libs/langgraph-core/src/graph/state.ts
@@ -77,6 +77,7 @@ import type {
   CachePolicy,
   RetryPolicy,
   TimeoutPolicy,
+  TracePolicy,
 } from "../pregel/utils/index.js";
 import { coerceTimeoutPolicy } from "../pregel/utils/index.js";
 import { isPregelLike } from "../pregel/utils/subgraph.js";
@@ -201,6 +202,7 @@ export type StateGraphNodeSpec<RunInput, RunOutput> = NodeSpec<
 > &
   NodePolicies & {
     input?: StateDefinition;
+    tracePolicy?: TracePolicy;
   };
 
 /**
@@ -222,6 +224,8 @@ export type StateGraphAddNodeOptions<
   Update = unknown,
 > = {
   input?: InputSchema;
+  /** Transform this node's trace payloads. See {@link TracePolicy} for scope and streaming behavior. */
+  tracePolicy?: TracePolicy;
   /**
    * Optional node-level error handler. Runs only after this node's
    * {@link RetryPolicy} is exhausted. Receives a {@link NodeError} with the
@@ -1221,6 +1225,7 @@ export class StateGraph<
         retryPolicy: options?.retryPolicy,
         cachePolicy,
         timeout: coerceTimeoutPolicy(options?.timeout),
+        tracePolicy: options?.tracePolicy,
         metadata: options?.metadata,
         input: inputSpec ?? this._schemaDefinition,
         subgraphs: isPregelLike(runnable)
@@ -1957,6 +1962,7 @@ export class CompiledStateGraph<
         retryPolicy: node?.retryPolicy,
         cachePolicy,
         timeout: node?.timeout,
+        tracePolicy: node?.tracePolicy,
         subgraphs: node?.subgraphs,
         ends: node?.ends,
         isErrorHandler: node?.isErrorHandler,

--- a/libs/langgraph-core/src/pregel/read.test.ts
+++ b/libs/langgraph-core/src/pregel/read.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { RunnableConfig } from "@langchain/core/runnables";
-import { CONFIG_KEY_READ } from "../constants.js";
+import { CONFIG_KEY_READ, CONFIG_KEY_SEND } from "../constants.js";
 import { LastValue } from "../channels/last_value.js";
 import { ChannelRead, PregelNode } from "./read.js";
 import { ChannelWrite } from "./write.js";
+import { RunnableCallable } from "../utils.js";
+import { FakeTracer } from "../tests/utils.js";
+import { omitPayload } from "./utils/index.js";
 
 describe("ChannelRead", () => {
   it("should read a single channel value", async () => {
@@ -111,6 +114,69 @@ describe("ChannelRead", () => {
 });
 
 describe("PregelNode", () => {
+  it("preserves trace policies across join and every pipe branch", async () => {
+    const tracePolicy = {
+      processInputs: omitPayload,
+      processOutputs: omitPayload,
+    };
+    const base = new PregelNode({
+      channels: { input: "input" },
+      triggers: ["input"],
+      tracePolicy,
+    });
+    const action = new RunnableCallable({
+      func: (input: number) => input + 1,
+      trace: false,
+    });
+    const bound = base.pipe(action);
+    const twice = bound.pipe(action);
+    const writer = new ChannelWrite([{ channel: "output", value: "written" }]);
+    const withWriter = twice.pipe(writer);
+    const joined = withWriter.join(["extra"]);
+    for (const node of [base, bound, twice, withWriter, joined]) {
+      expect(node.tracePolicy).toBe(tracePolicy);
+    }
+    const tracer = new FakeTracer();
+    const send = vi.fn();
+    expect(
+      await joined
+        .getNode()
+        ?.invoke(1, {
+          callbacks: [tracer],
+          configurable: { [CONFIG_KEY_SEND]: send },
+        })
+    ).toBe(3);
+    expect(send).toHaveBeenCalledWith([["output", "written"]]);
+    expect(tracer.runs[0].inputs).toEqual({});
+    expect(tracer.runs[0].outputs).toEqual({});
+    expect(tracer.runs[0].child_runs[0].inputs).toEqual({ input: 1 });
+  });
+
+  it("applies policies to multiple writers and preserves single-step shortcuts", async () => {
+    const tracePolicy = {
+      processInputs: omitPayload,
+      processOutputs: omitPayload,
+    };
+    const base = { channels: ["input"], triggers: ["input"], tracePolicy };
+    const action = new RunnableCallable({
+      func: (input: number) => input + 1,
+      trace: false,
+    });
+    expect(new PregelNode(base).getNode()).toBeUndefined();
+    expect(new PregelNode({ ...base, writers: [action] }).getNode()).toBe(
+      action
+    );
+    expect(new PregelNode({ ...base, bound: action }).getNode()).toBe(action);
+    const tracer = new FakeTracer();
+    const node = new PregelNode({
+      ...base,
+      writers: [action, action],
+    }).getNode();
+    expect(await node?.invoke(1, { callbacks: [tracer] })).toBe(3);
+    expect(tracer.runs[0].inputs).toEqual({});
+    expect(tracer.runs[0].outputs).toEqual({});
+  });
+
   it("should create a node that subscribes to channels", () => {
     const node = new PregelNode({
       channels: ["input", "context"],

--- a/libs/langgraph-core/src/pregel/read.ts
+++ b/libs/langgraph-core/src/pregel/read.ts
@@ -11,7 +11,13 @@ import {
 import { CONFIG_KEY_READ } from "../constants.js";
 import { ChannelWrite } from "./write.js";
 import { RunnableCallable } from "../utils.js";
-import type { CachePolicy, RetryPolicy, TimeoutPolicy } from "./utils/index.js";
+import type {
+  CachePolicy,
+  RetryPolicy,
+  TimeoutPolicy,
+  TracePolicy,
+} from "./utils/index.js";
+import { RunnableSeq } from "./runnable.js";
 
 export class ChannelRead<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -87,6 +93,7 @@ interface PregelNodeArgs<RunInput, RunOutput> extends Partial<
   retryPolicy?: RetryPolicy;
   cachePolicy?: CachePolicy;
   timeout?: TimeoutPolicy;
+  tracePolicy?: TracePolicy;
   subgraphs?: Runnable[];
   ends?: string[];
   /** Whether this node is an auto-generated node-level error handler. */
@@ -131,6 +138,8 @@ export class PregelNode<
 
   timeout?: TimeoutPolicy;
 
+  tracePolicy?: TracePolicy;
+
   subgraphs?: Runnable[];
 
   ends?: string[];
@@ -151,6 +160,7 @@ export class PregelNode<
       retryPolicy,
       cachePolicy,
       timeout,
+      tracePolicy,
       tags,
       subgraphs,
       ends,
@@ -184,6 +194,7 @@ export class PregelNode<
     this.retryPolicy = retryPolicy;
     this.cachePolicy = cachePolicy;
     this.timeout = timeout;
+    this.tracePolicy = tracePolicy;
     this.subgraphs = subgraphs;
     this.ends = ends;
     this.isErrorHandler = isErrorHandler;
@@ -214,19 +225,27 @@ export class PregelNode<
 
   getNode(): Runnable<RunInput, RunOutput> | undefined {
     const writers = this.getWriters();
+    const sequence = (
+      fields: ConstructorParameters<
+        typeof RunnableSequence<RunInput, RunOutput>
+      >[0]
+    ) =>
+      this.tracePolicy
+        ? new RunnableSeq({ ...fields, tracePolicy: this.tracePolicy })
+        : new RunnableSequence(fields);
     if (this.bound === defaultRunnableBound && writers.length === 0) {
       return undefined;
     } else if (this.bound === defaultRunnableBound && writers.length === 1) {
       return writers[0];
     } else if (this.bound === defaultRunnableBound) {
-      return new RunnableSequence({
+      return sequence({
         first: writers[0],
         middle: writers.slice(1, writers.length - 1),
         last: writers[writers.length - 1],
         omitSequenceTags: true,
       });
     } else if (writers.length > 0) {
-      return new RunnableSequence({
+      return sequence({
         first: this.bound,
         middle: writers.slice(0, writers.length - 1),
         last: writers[writers.length - 1],
@@ -259,6 +278,7 @@ export class PregelNode<
       retryPolicy: this.retryPolicy,
       cachePolicy: this.cachePolicy,
       timeout: this.timeout,
+      tracePolicy: this.tracePolicy,
     });
   }
 
@@ -280,6 +300,7 @@ export class PregelNode<
         retryPolicy: this.retryPolicy,
         cachePolicy: this.cachePolicy,
         timeout: this.timeout,
+        tracePolicy: this.tracePolicy,
       });
     } else if (this.bound === defaultRunnableBound) {
       return new PregelNode<RunInput, Exclude<NewRunOutput, Error>>({
@@ -293,6 +314,7 @@ export class PregelNode<
         retryPolicy: this.retryPolicy,
         cachePolicy: this.cachePolicy,
         timeout: this.timeout,
+        tracePolicy: this.tracePolicy,
       });
     } else {
       return new PregelNode<RunInput, Exclude<NewRunOutput, Error>>({
@@ -306,6 +328,7 @@ export class PregelNode<
         retryPolicy: this.retryPolicy,
         cachePolicy: this.cachePolicy,
         timeout: this.timeout,
+        tracePolicy: this.tracePolicy,
       });
     }
   }

--- a/libs/langgraph-core/src/pregel/runnable.test.ts
+++ b/libs/langgraph-core/src/pregel/runnable.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+import { RunnableLambda } from "@langchain/core/runnables";
+import { FakeTracer } from "../tests/utils.js";
+import { gatherIterator, RunnableCallable } from "../utils.js";
+import { RunnableSeq } from "./runnable.js";
+import { omitPayload } from "./utils/index.js";
+
+describe("RunnableSeq tracing", () => {
+  it.each([42, [1, 2], null, undefined, new Date("2026-01-01")])(
+    "passes raw input/output values to processors: %s",
+    async (value) => {
+      const processInputs = vi.fn(() => "summarized input");
+      const processOutputs = vi.fn(() => null);
+      const tracer = new FakeTracer();
+      const identity = new RunnableCallable({
+        func: (input: unknown) => input,
+        trace: false,
+      });
+      const sequence = new RunnableSeq({
+        first: identity,
+        last: identity,
+        tracePolicy: { processInputs, processOutputs },
+      });
+      expect(await sequence.invoke(value, { callbacks: [tracer] })).toBe(value);
+      expect(processInputs).toHaveBeenCalledExactlyOnceWith(value);
+      expect(processOutputs).toHaveBeenCalledExactlyOnceWith(value);
+      expect(tracer.runs[0].inputs).toEqual({ input: "summarized input" });
+      expect(tracer.runs[0].outputs).toEqual({ output: null });
+    }
+  );
+
+  it("streams original chunks and transforms the accumulated output once", async () => {
+    const processOutputs = vi.fn(omitPayload);
+    const tracer = new FakeTracer();
+    const sequence = new RunnableSeq({
+      first: new RunnableCallable({
+        func: (input: string) => input,
+        trace: false,
+      }),
+      last: RunnableLambda.from(async function* (input: string) {
+        yield input;
+        yield "!";
+      }),
+      tracePolicy: { processInputs: omitPayload, processOutputs },
+    });
+    expect(
+      await gatherIterator(sequence.stream("hello", { callbacks: [tracer] }))
+    ).toEqual(["hello", "!"]);
+    expect(processOutputs).toHaveBeenCalledExactlyOnceWith("hello!");
+    expect(tracer.runs[0].inputs).toEqual({});
+    expect(tracer.runs[0].outputs).toEqual({});
+    expect(tracer.runs[0].child_runs[0].outputs).toEqual({ output: "hello!" });
+  });
+
+  it("records stream errors without processing an incomplete output", async () => {
+    const processOutputs = vi.fn(omitPayload);
+    const tracer = new FakeTracer();
+    const error = new Error("stream failed");
+    const sequence = new RunnableSeq({
+      first: new RunnableCallable({
+        func: (input: string) => input,
+        trace: false,
+      }),
+      last: RunnableLambda.from(async function* () {
+        yield "partial";
+        throw error;
+      }),
+      tracePolicy: { processOutputs },
+    });
+    await expect(
+      gatherIterator(sequence.stream("input", { callbacks: [tracer] }))
+    ).rejects.toBe(error);
+    expect(processOutputs).not.toHaveBeenCalled();
+    expect(tracer.runs[0].error).toContain("stream failed");
+  });
+
+  it("keeps concurrent batch payloads and errors associated with each input", async () => {
+    const processInputs = vi.fn((input) => ({ summarized: input }));
+    const processOutputs = vi.fn((output) => ({ summarized: output }));
+    const tracer = new FakeTracer();
+    const error = new Error("negative");
+    const sequence = new RunnableSeq({
+      first: new RunnableCallable({
+        func: async (input: number) => {
+          await Promise.resolve();
+          if (input < 0) throw error;
+          return input + 1;
+        },
+        trace: false,
+      }),
+      last: new RunnableCallable({
+        func: (input: number) => input * 2,
+        trace: false,
+      }),
+      tracePolicy: { processInputs, processOutputs },
+    });
+    expect(
+      await sequence.batch(
+        [1, -1, 3],
+        { callbacks: [tracer], maxConcurrency: 2 },
+        { returnExceptions: true }
+      )
+    ).toEqual([4, error, 8]);
+    expect(processInputs).toHaveBeenCalledTimes(3);
+    expect(processOutputs).toHaveBeenCalledTimes(2);
+    for (const [input, output] of [
+      [1, 4],
+      [3, 8],
+    ]) {
+      const run = tracer.runs.find((run) => run.inputs.summarized === input);
+      expect(run?.outputs).toEqual({ summarized: output });
+    }
+    expect(
+      tracer.runs.find((run) => run.inputs.summarized === -1)?.error
+    ).toContain("negative");
+    expect(await sequence.batch([])).toEqual([]);
+    await expect(sequence.batch([-1])).rejects.toBe(error);
+  });
+
+  it("honors cancellation before channel writers execute", async () => {
+    const controller = new AbortController();
+    const error = new Error("cancelled");
+    const writer = vi.fn((input: number) => input);
+    const processOutputs = vi.fn(omitPayload);
+    const tracer = new FakeTracer();
+    const sequence = new RunnableSeq({
+      first: new RunnableCallable({
+        func: (input: number) => {
+          controller.abort(error);
+          return input;
+        },
+        trace: false,
+      }),
+      last: new RunnableCallable({ func: writer, trace: false }),
+      tracePolicy: { processInputs: omitPayload, processOutputs },
+    });
+    await expect(
+      sequence.invoke(1, { signal: controller.signal, callbacks: [tracer] })
+    ).rejects.toBe(error);
+    expect(writer).not.toHaveBeenCalled();
+    expect(processOutputs).not.toHaveBeenCalled();
+    expect(tracer.runs[0].error).toContain("cancelled");
+  });
+});

--- a/libs/langgraph-core/src/pregel/runnable.test.ts
+++ b/libs/langgraph-core/src/pregel/runnable.test.ts
@@ -1,11 +1,103 @@
 import { describe, expect, it, vi } from "vitest";
-import { RunnableLambda } from "@langchain/core/runnables";
+import { RunnableLambda, RunnableSequence } from "@langchain/core/runnables";
 import { FakeTracer } from "../tests/utils.js";
 import { gatherIterator, RunnableCallable } from "../utils.js";
 import { RunnableSeq } from "./runnable.js";
 import { omitPayload } from "./utils/index.js";
 
 describe("RunnableSeq tracing", () => {
+  it.each([{}, { processInputs: omitPayload, processOutputs: omitPayload }])(
+    "preserves child batch implementations with policy %s",
+    async (tracePolicy) => {
+      const firstInvoke = vi.fn((input: number) => input);
+      const middleInvoke = vi.fn((input: number) => input);
+      const lastInvoke = vi.fn((input: number) => input);
+      const first = new RunnableCallable<number, number>({
+        func: firstInvoke,
+        trace: false,
+      });
+      const middle = new RunnableCallable<number, number>({
+        func: middleInvoke,
+        trace: false,
+      });
+      const last = new RunnableCallable<number, number>({
+        func: lastInvoke,
+        trace: false,
+      });
+      const firstBatch = vi
+        .spyOn(first, "batch")
+        .mockImplementation(async (inputs) =>
+          inputs.map((value) => value + 100)
+        );
+      const middleBatch = vi
+        .spyOn(middle, "batch")
+        .mockImplementation(async (inputs) => inputs.map((value) => value * 2));
+      const lastBatch = vi
+        .spyOn(last, "batch")
+        .mockImplementation(async (inputs) => inputs.map((value) => value - 3));
+      const fields = { first, middle: [middle], last, omitSequenceTags: true };
+      const expected = await new RunnableSequence(fields).batch([1, 2]);
+      for (const mock of [firstBatch, middleBatch, lastBatch]) mock.mockClear();
+
+      const tracer = new FakeTracer();
+      tracer.awaitHandlers = true;
+      const controller = new AbortController();
+      const options = [1, 2].map((id) => ({
+        callbacks: [tracer],
+        configurable: { id },
+        tags: ["batch-tag"],
+        signal: controller.signal,
+      }));
+      const batchOptions = {
+        maxConcurrency: 2,
+        returnExceptions: true,
+      } as const;
+      const sequence = new RunnableSeq({ ...fields, tracePolicy });
+      expect(await sequence.batch([1, 2], options, batchOptions)).toEqual(
+        expected
+      );
+      expect(expected).toEqual([199, 201]);
+      expect(firstBatch).toHaveBeenCalledExactlyOnceWith(
+        [1, 2],
+        expect.any(Array),
+        batchOptions
+      );
+      expect(middleBatch).toHaveBeenCalledExactlyOnceWith(
+        [101, 102],
+        expect.any(Array),
+        batchOptions
+      );
+      expect(lastBatch).toHaveBeenCalledExactlyOnceWith(
+        [202, 204],
+        expect.any(Array),
+        batchOptions
+      );
+      for (const mock of [firstInvoke, middleInvoke, lastInvoke])
+        expect(mock).not.toHaveBeenCalled();
+      for (const mock of [firstBatch, middleBatch, lastBatch]) {
+        expect(mock.mock.calls[0][1]).toEqual(
+          [1, 2].map((id, index) =>
+            expect.objectContaining({
+              configurable: { id },
+              signal: controller.signal,
+              callbacks: expect.objectContaining({
+                _parentRunId: tracer.runs[index].id,
+              }),
+            })
+          )
+        );
+      }
+      expect(tracer.runs.map((run) => run.inputs)).toEqual(
+        tracePolicy.processInputs ? [{}, {}] : [{ input: 1 }, { input: 2 }]
+      );
+      expect(tracer.runs.map((run) => run.outputs)).toEqual(
+        tracePolicy.processOutputs
+          ? [{}, {}]
+          : [{ output: 199 }, { output: 201 }]
+      );
+    }
+  );
+
   it.each([42, [1, 2], null, undefined, new Date("2026-01-01")])(
     "passes raw input/output values to processors: %s",
     async (value) => {
@@ -78,6 +170,7 @@ describe("RunnableSeq tracing", () => {
     const processInputs = vi.fn((input) => ({ summarized: input }));
     const processOutputs = vi.fn((output) => ({ summarized: output }));
     const tracer = new FakeTracer();
+    tracer.awaitHandlers = true;
     const error = new Error("negative");
     const sequence = new RunnableSeq({
       first: new RunnableCallable({
@@ -89,7 +182,10 @@ describe("RunnableSeq tracing", () => {
         trace: false,
       }),
       last: new RunnableCallable({
-        func: (input: number) => input * 2,
+        // With returnExceptions, Core passes exceptions returned by earlier
+        // batches to the following step. Preserve that contract here too.
+        func: (input: number | Error) =>
+          typeof input === "number" ? input * 2 : input,
         trace: false,
       }),
       tracePolicy: { processInputs, processOutputs },
@@ -102,7 +198,7 @@ describe("RunnableSeq tracing", () => {
       )
     ).toEqual([4, error, 8]);
     expect(processInputs).toHaveBeenCalledTimes(3);
-    expect(processOutputs).toHaveBeenCalledTimes(2);
+    expect(processOutputs).toHaveBeenCalledTimes(3);
     for (const [input, output] of [
       [1, 4],
       [3, 8],
@@ -111,10 +207,40 @@ describe("RunnableSeq tracing", () => {
       expect(run?.outputs).toEqual({ summarized: output });
     }
     expect(
-      tracer.runs.find((run) => run.inputs.summarized === -1)?.error
-    ).toContain("negative");
+      tracer.runs.find((run) => run.inputs.summarized === -1)?.outputs
+    ).toEqual({ summarized: error });
     expect(await sequence.batch([])).toEqual([]);
     await expect(sequence.batch([-1])).rejects.toBe(error);
+  });
+
+  it("reports a rejected child batch on every sequence run", async () => {
+    const error = new Error("batch failed");
+    const processOutputs = vi.fn(omitPayload);
+    const first = new RunnableCallable({
+      func: (input: number) => input,
+      trace: false,
+    });
+    vi.spyOn(first, "batch").mockRejectedValue(error);
+    const last = new RunnableCallable({
+      func: (input: number) => input,
+      trace: false,
+    });
+    const lastBatch = vi.spyOn(last, "batch");
+    const tracer = new FakeTracer();
+    tracer.awaitHandlers = true;
+    const sequence = new RunnableSeq({
+      first,
+      last,
+      tracePolicy: { processOutputs },
+    });
+
+    await expect(sequence.batch([1, 2], { callbacks: [tracer] })).rejects.toBe(
+      error
+    );
+    expect(lastBatch).not.toHaveBeenCalled();
+    expect(processOutputs).not.toHaveBeenCalled();
+    expect(tracer.runs).toHaveLength(2);
+    for (const run of tracer.runs) expect(run.error).toContain("batch failed");
   });
 
   it("honors cancellation before channel writers execute", async () => {

--- a/libs/langgraph-core/src/pregel/runnable.ts
+++ b/libs/langgraph-core/src/pregel/runnable.ts
@@ -4,7 +4,6 @@ import {
   getCallbackManagerForConfig,
   patchConfig,
   raceWithSignal,
-  Runnable,
   RunnableSequence,
   type RunnableBatchOptions,
   type RunnableConfig,
@@ -133,19 +132,49 @@ export class RunnableSeq<
     options?: Partial<RunnableConfig> | Partial<RunnableConfig>[],
     batchOptions?: RunnableBatchOptions
   ): Promise<(RunOutput | Error)[]>;
-  override batch(
+  override async batch(
     inputs: RunInput[],
     options?: Partial<RunnableConfig> | Partial<RunnableConfig>[],
     batchOptions?: RunnableBatchOptions
   ): Promise<(RunOutput | Error)[]> {
-    // The base batch implementation calls our invoke for each input, preserving
-    // concurrency limits and returnExceptions without bypassing trace policies.
-    return Runnable.prototype.batch.call(
-      this,
-      inputs,
-      options,
-      batchOptions
-    ) as Promise<(RunOutput | Error)[]>;
+    const configList = this._getOptionsList(options ?? {}, inputs.length);
+    const managers = await Promise.all(
+      configList.map(async (config, i) => {
+        const manager = await this.startTrace(inputs[i], config);
+        delete config.runId;
+        return manager;
+      })
+    );
+    let outputs: unknown[] = inputs;
+    try {
+      // Preserve RunnableSequence's step-wise batching so child runnables can
+      // use their native batch implementations and handle returnExceptions.
+      for (let i = 0; i < this.steps.length; i += 1) {
+        outputs = await raceWithSignal(
+          this.steps[i].batch(
+            outputs,
+            managers.map((manager, j) =>
+              patchConfig(configList[j], {
+                callbacks: manager?.getChild(
+                  this.omitSequenceTags ? undefined : `seq:step:${i + 1}`
+                ),
+              })
+            ),
+            batchOptions
+          ),
+          configList[0]?.signal
+        );
+      }
+    } catch (error) {
+      await Promise.all(
+        managers.map((manager) => manager?.handleChainError(error))
+      );
+      throw error;
+    }
+    await Promise.all(
+      managers.map((manager, i) => this.endTrace(outputs[i], manager))
+    );
+    return outputs as (RunOutput | Error)[];
   }
 
   override async *_streamIterator(input: RunInput, options?: RunnableConfig) {

--- a/libs/langgraph-core/src/pregel/runnable.ts
+++ b/libs/langgraph-core/src/pregel/runnable.ts
@@ -1,0 +1,201 @@
+import type { CallbackManagerForChainRun } from "@langchain/core/callbacks/manager";
+import {
+  ensureConfig,
+  getCallbackManagerForConfig,
+  patchConfig,
+  raceWithSignal,
+  Runnable,
+  RunnableSequence,
+  type RunnableBatchOptions,
+  type RunnableConfig,
+} from "@langchain/core/runnables";
+import { _coerceToDict, type TracePolicy } from "./utils/index.js";
+
+function tracePayload(
+  value: unknown,
+  processor: ((value: unknown) => unknown) | undefined
+): unknown {
+  if (processor === undefined) return value;
+  try {
+    return processor(value);
+  } catch (error) {
+    console.warn(
+      "Trace input/output processor raised; recording untransformed payload",
+      error
+    );
+    return value;
+  }
+}
+
+/**
+ * A node sequence with transforms at its own tracing boundaries. Keep execution
+ * and child callback propagation aligned with Core's RunnableSequence; only the
+ * values passed to handleChainStart/handleChainEnd are transformed.
+ * @internal
+ */
+export class RunnableSeq<
+  RunInput = unknown,
+  RunOutput = unknown,
+> extends RunnableSequence<RunInput, RunOutput> {
+  private tracePolicy?: TracePolicy;
+
+  constructor(
+    fields: ConstructorParameters<
+      typeof RunnableSequence<RunInput, RunOutput>
+    >[0] & {
+      tracePolicy?: TracePolicy;
+    }
+  ) {
+    const { tracePolicy, ...sequenceFields } = fields;
+    super(sequenceFields);
+    this.tracePolicy = tracePolicy;
+  }
+
+  private async startTrace(input: RunInput, config: RunnableConfig) {
+    // Evaluate outside optional chaining: processors run without callbacks too.
+    const payload = tracePayload(input, this.tracePolicy?.processInputs);
+    const manager = await getCallbackManagerForConfig(config);
+    return manager?.handleChainStart(
+      this.toJSON(),
+      _coerceToDict(payload, "input"),
+      config.runId,
+      undefined,
+      undefined,
+      undefined,
+      config.runName
+    );
+  }
+
+  private async endTrace(
+    output: unknown,
+    manager: CallbackManagerForChainRun | undefined
+  ) {
+    const payload = tracePayload(output, this.tracePolicy?.processOutputs);
+    await manager?.handleChainEnd(_coerceToDict(payload, "output"));
+  }
+
+  override async invoke(
+    input: RunInput,
+    options?: RunnableConfig
+  ): Promise<RunOutput> {
+    const config = ensureConfig(options);
+    const manager = await this.startTrace(input, config);
+    delete config.runId;
+    let nextInput = input;
+    let output: RunOutput;
+    try {
+      const steps = [this.first, ...this.middle];
+      for (let i = 0; i < steps.length; i += 1) {
+        nextInput = await raceWithSignal(
+          steps[i].invoke(
+            nextInput,
+            patchConfig(config, {
+              callbacks: manager?.getChild(
+                this.omitSequenceTags ? undefined : `seq:step:${i + 1}`
+              ),
+            })
+          ),
+          config.signal
+        );
+      }
+      if (config.signal?.aborted) {
+        // Use Core's abort-error normalization before invoking the last step.
+        await raceWithSignal(Promise.resolve(), config.signal);
+      }
+      output = await this.last.invoke(
+        nextInput,
+        patchConfig(config, {
+          callbacks: manager?.getChild(
+            this.omitSequenceTags ? undefined : `seq:step:${this.steps.length}`
+          ),
+        })
+      );
+    } catch (error) {
+      await manager?.handleChainError(error);
+      throw error;
+    }
+    await this.endTrace(output, manager);
+    return output;
+  }
+
+  override batch(
+    inputs: RunInput[],
+    options?: Partial<RunnableConfig> | Partial<RunnableConfig>[],
+    batchOptions?: RunnableBatchOptions & { returnExceptions?: false }
+  ): Promise<RunOutput[]>;
+  override batch(
+    inputs: RunInput[],
+    options?: Partial<RunnableConfig> | Partial<RunnableConfig>[],
+    batchOptions?: RunnableBatchOptions & { returnExceptions: true }
+  ): Promise<(RunOutput | Error)[]>;
+  override batch(
+    inputs: RunInput[],
+    options?: Partial<RunnableConfig> | Partial<RunnableConfig>[],
+    batchOptions?: RunnableBatchOptions
+  ): Promise<(RunOutput | Error)[]>;
+  override batch(
+    inputs: RunInput[],
+    options?: Partial<RunnableConfig> | Partial<RunnableConfig>[],
+    batchOptions?: RunnableBatchOptions
+  ): Promise<(RunOutput | Error)[]> {
+    // The base batch implementation calls our invoke for each input, preserving
+    // concurrency limits and returnExceptions without bypassing trace policies.
+    return Runnable.prototype.batch.call(
+      this,
+      inputs,
+      options,
+      batchOptions
+    ) as Promise<(RunOutput | Error)[]>;
+  }
+
+  override async *_streamIterator(input: RunInput, options?: RunnableConfig) {
+    const config = ensureConfig(options);
+    const manager = await this.startTrace(input, config);
+    delete config.runId;
+    const steps = this.steps;
+    let output: RunOutput | undefined;
+    let concatSupported = true;
+    async function* inputGenerator() {
+      yield input;
+    }
+    try {
+      let generator = steps[0].transform(
+        inputGenerator(),
+        patchConfig(config, {
+          callbacks: manager?.getChild(
+            this.omitSequenceTags ? undefined : "seq:step:1"
+          ),
+        })
+      );
+      for (let i = 1; i < steps.length; i += 1) {
+        generator = steps[i].transform(
+          generator,
+          patchConfig(config, {
+            callbacks: manager?.getChild(
+              this.omitSequenceTags ? undefined : `seq:step:${i + 1}`
+            ),
+          })
+        );
+      }
+      for await (const chunk of generator) {
+        config.signal?.throwIfAborted();
+        yield chunk as RunOutput;
+        if (concatSupported) {
+          if (output === undefined) output = chunk;
+          else {
+            try {
+              output = this._concatOutputChunks(output, chunk);
+            } catch {
+              output = undefined;
+              concatSupported = false;
+            }
+          }
+        }
+      }
+    } catch (error) {
+      await manager?.handleChainError(error);
+      throw error;
+    }
+    await this.endTrace(output, manager);
+  }
+}

--- a/libs/langgraph-core/src/pregel/utils/index.ts
+++ b/libs/langgraph-core/src/pregel/utils/index.ts
@@ -111,6 +111,48 @@ export type CachePolicy = {
   ttl?: number;
 };
 
+/**
+ * Controls the input and output payloads recorded on a node's own trace run.
+ * The graph's root run and child runs created by traced runnables are unaffected.
+ * Plain function nodes do not create an additional child run.
+ *
+ * Processors are synchronous and receive raw values, before callback payload
+ * normalization. They run even without tracing callbacks. If a processor throws,
+ * the original payload is recorded instead. Avoid mutating the supplied values:
+ * they are also used for execution and are not copied.
+ *
+ * These transforms also affect chain callbacks, including `streamEvents` and
+ * message streaming. Omitting outputs can suppress messages returned directly
+ * by nodes; omitting inputs can affect message deduplication.
+ *
+ * This policy is intended to reduce trace payload sizes, not redact secrets.
+ * For redaction across all runs, configure the LangSmith client instead.
+ *
+ * @example
+ * ```ts
+ * graph.addNode("before_model", beforeModel, {
+ *   tracePolicy: {
+ *     processInputs: omitPayload,
+ *     processOutputs: omitPayload,
+ *   },
+ * });
+ * ```
+ */
+export type TracePolicy = {
+  /** Transform the raw node input recorded on its trace run. */
+  processInputs?: (value: unknown) => unknown;
+  /** Transform the raw node output recorded on its trace run. */
+  processOutputs?: (value: unknown) => unknown;
+};
+
+/**
+ * Record an empty trace payload while retaining the node's span and timing.
+ * Use as `processInputs` and/or `processOutputs` in a {@link TracePolicy}.
+ */
+export function omitPayload(_value: unknown): Record<string, never> {
+  return {};
+}
+
 export function patchConfigurable(
   config: RunnableConfig | undefined,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/libs/langgraph-core/src/tests/trace_policy.test-d.ts
+++ b/libs/langgraph-core/src/tests/trace_policy.test-d.ts
@@ -1,0 +1,40 @@
+import { expectTypeOf, it } from "vitest";
+import { z } from "zod/v4";
+import {
+  omitPayload,
+  StateGraph,
+  type StateGraphAddNodeOptions,
+  type TracePolicy,
+} from "../index.js";
+import {
+  omitPayload as omitWebPayload,
+  type TracePolicy as WebTracePolicy,
+} from "../web.js";
+
+it("exports the same trace policy API from Node and browser entry points", () => {
+  expectTypeOf<TracePolicy>().toEqualTypeOf<WebTracePolicy>();
+  expectTypeOf(omitPayload).toEqualTypeOf(omitWebPayload);
+  expectTypeOf<StateGraphAddNodeOptions["tracePolicy"]>().toEqualTypeOf<
+    TracePolicy | undefined
+  >();
+});
+
+it("preserves node input inference when a trace policy is provided", () => {
+  new StateGraph(z.object({ value: z.number(), extra: z.string() })).addNode(
+    "node",
+    (state) => {
+      expectTypeOf(state).toEqualTypeOf<{ value: number }>();
+      return { value: state.value + 1 };
+    },
+    {
+      input: z.object({ value: z.number() }),
+      tracePolicy: {
+        processInputs: (value) => {
+          expectTypeOf(value).toBeUnknown();
+          return omitPayload(value);
+        },
+        processOutputs: omitPayload,
+      },
+    }
+  );
+});

--- a/libs/langgraph-core/src/tests/trace_policy.test.ts
+++ b/libs/langgraph-core/src/tests/trace_policy.test.ts
@@ -1,0 +1,337 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AIMessage, HumanMessage } from "@langchain/core/messages";
+import { RunnableLambda } from "@langchain/core/runnables";
+import type { Run } from "@langchain/core/tracers/base";
+import {
+  Annotation,
+  Command,
+  END,
+  MemorySaver,
+  MessagesAnnotation,
+  omitPayload,
+  START,
+  StateGraph,
+  type TracePolicy,
+} from "../web.js";
+import { gatherIterator } from "../utils.js";
+import { FakeTracer } from "./utils.js";
+
+const State = Annotation.Root({ value: Annotation<number> });
+const increment = (state: typeof State.State) => ({ value: state.value + 1 });
+
+function nodeRuns(tracer: FakeTracer, name = "node"): Run[] {
+  function flatten(runs: Run[]): Run[] {
+    return runs.flatMap((run) => [run, ...flatten(run.child_runs)]);
+  }
+  return flatten(tracer.runs).filter((run) => run.name === name);
+}
+
+function makeGraph(tracePolicy?: TracePolicy) {
+  return new StateGraph(State)
+    .addNode("node", increment, { tracePolicy })
+    .addEdge(START, "node")
+    .addEdge("node", END)
+    .compile();
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("TracePolicy", () => {
+  it.each([
+    { policy: undefined, inputs: { value: 1 }, outputs: { value: 2 } },
+    { policy: {}, inputs: { value: 1 }, outputs: { value: 2 } },
+    {
+      policy: { processInputs: omitPayload },
+      inputs: {},
+      outputs: { value: 2 },
+    },
+    {
+      policy: { processOutputs: omitPayload },
+      inputs: { value: 1 },
+      outputs: {},
+    },
+    {
+      policy: { processInputs: omitPayload, processOutputs: omitPayload },
+      inputs: {},
+      outputs: {},
+    },
+  ])(
+    "records the configured payloads: $policy",
+    async ({ policy, inputs, outputs }) => {
+      const tracer = new FakeTracer();
+      expect(
+        await makeGraph(policy).invoke({ value: 1 }, { callbacks: [tracer] })
+      ).toEqual({ value: 2 });
+      const [run] = nodeRuns(tracer);
+      expect(nodeRuns(tracer)).toHaveLength(1);
+      expect(run.inputs).toEqual(inputs);
+      expect(run.outputs).toEqual(outputs);
+      expect(run.child_runs).toEqual([]);
+      expect(tracer.runs[0].inputs).toEqual({ value: 1 });
+      expect(tracer.runs[0].outputs).toEqual({ value: 2 });
+      expect(run.end_time).toBeDefined();
+    }
+  );
+
+  it("transforms raw values without changing execution or checkpoints", async () => {
+    const processInputs = vi.fn(() => ({ summarizedInput: true }));
+    const processOutputs = vi.fn(() => ({ summarizedOutput: true }));
+    const result = new Command({ update: { value: 2 } });
+    const action = vi.fn(async (state: typeof State.State) => {
+      expect(state).toEqual({ value: 1 });
+      return result;
+    });
+    const graph = new StateGraph(State)
+      .addNode("node", action, {
+        tracePolicy: { processInputs, processOutputs },
+      })
+      .addEdge(START, "node")
+      .addEdge("node", END)
+      .compile({ checkpointer: new MemorySaver() });
+    const tracer = new FakeTracer();
+    const config = {
+      configurable: { thread_id: "trace-policy" },
+      callbacks: [tracer],
+    };
+    expect(await graph.invoke({ value: 1 }, config)).toEqual({ value: 2 });
+    expect((await graph.getState(config)).values).toEqual({ value: 2 });
+    expect(processInputs).toHaveBeenCalledExactlyOnceWith({ value: 1 });
+    expect(processOutputs).toHaveBeenCalledExactlyOnceWith(result);
+    const [run] = nodeRuns(tracer);
+    expect(run.inputs).toEqual({ summarizedInput: true });
+    expect(run.outputs).toEqual({ summarizedOutput: true });
+  });
+
+  it.each(["processInputs", "processOutputs"] as const)(
+    "falls back after %s errors, with and without callbacks",
+    async (key) => {
+      vi.stubEnv("LANGSMITH_TRACING", "false");
+      vi.stubEnv("LANGCHAIN_TRACING_V2", "false");
+      const failure = new Error("processor failed");
+      const processor = vi.fn(() => {
+        throw failure;
+      });
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const graph = makeGraph({ [key]: processor });
+      const tracer = new FakeTracer();
+      expect(await graph.invoke({ value: 1 }, { callbacks: [tracer] })).toEqual(
+        { value: 2 }
+      );
+      expect(await graph.invoke({ value: 1 })).toEqual({ value: 2 });
+      expect(processor).toHaveBeenCalledTimes(2);
+      expect(warn).toHaveBeenCalledTimes(2);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("untransformed payload"),
+        failure
+      );
+      expect(nodeRuns(tracer)[0].inputs).toEqual({ value: 1 });
+      expect(nodeRuns(tracer)[0].outputs).toEqual({ value: 2 });
+    }
+  );
+
+  it("preserves child spans, run hierarchy, tags, and metadata", async () => {
+    const tracer = new FakeTracer();
+    const child = RunnableLambda.from(increment).withConfig({
+      runName: "child",
+    });
+    const graph = new StateGraph(State)
+      .addNode("node", child, {
+        tracePolicy: {
+          processInputs: omitPayload,
+          processOutputs: omitPayload,
+        },
+        metadata: { nodeMetadata: true },
+      })
+      .addEdge(START, "node")
+      .addEdge("node", END)
+      .compile();
+    await graph.invoke(
+      { value: 1 },
+      { callbacks: [tracer], tags: ["user-tag"] }
+    );
+    const [run] = nodeRuns(tracer);
+    const [childRun] = nodeRuns(tracer, "child");
+    expect(run.inputs).toEqual({});
+    expect(run.outputs).toEqual({});
+    expect(run.parent_run_id).toBe(tracer.runs[0].id);
+    expect(childRun.parent_run_id).toBe(run.id);
+    expect(childRun.inputs).toEqual({ value: 1 });
+    expect(childRun.outputs).toEqual({ value: 2 });
+    expect(childRun.tags).toContain("user-tag");
+    expect(childRun.tags?.some((tag) => tag.startsWith("seq:step:"))).toBe(
+      false
+    );
+    expect(run.extra?.metadata).toMatchObject({ nodeMetadata: true });
+  });
+
+  it("preserves subgraph traces and other nodes' policies", async () => {
+    const tracer = new FakeTracer();
+    const graph = new StateGraph(State)
+      .addNode("nested", makeGraph(), {
+        tracePolicy: {
+          processInputs: omitPayload,
+          processOutputs: omitPayload,
+        },
+      })
+      .addNode("plain", increment)
+      .addEdge(START, "nested")
+      .addEdge("nested", "plain")
+      .addEdge("plain", END)
+      .compile();
+    expect(await graph.invoke({ value: 1 }, { callbacks: [tracer] })).toEqual({
+      value: 3,
+    });
+    expect(nodeRuns(tracer, "nested")[0].inputs).toEqual({});
+    expect(nodeRuns(tracer)[0].inputs).toEqual({ value: 1 });
+    expect(nodeRuns(tracer, "plain")[0].inputs).toEqual({ value: 2 });
+  });
+
+  it("keeps policies with tuple registration, node input schemas, and defaults", async () => {
+    const FullState = Annotation.Root({
+      value: Annotation<number>,
+      extra: Annotation<string>,
+    });
+    const tracer = new FakeTracer();
+    const processInputs = vi.fn(omitPayload);
+    const graph = new StateGraph(FullState)
+      .addNode([
+        ["node", increment, { input: State, tracePolicy: { processInputs } }],
+      ])
+      .setNodeDefaults({ retryPolicy: { maxAttempts: 1 } })
+      .addEdge(START, "node")
+      .addEdge("node", END)
+      .compile();
+    expect(
+      await graph.invoke({ value: 1, extra: "keep" }, { callbacks: [tracer] })
+    ).toEqual({ value: 2, extra: "keep" });
+    expect(processInputs).toHaveBeenCalledExactlyOnceWith({ value: 1 });
+    expect(nodeRuns(tracer)[0].inputs).toEqual({});
+  });
+
+  it("processes inputs on every retry and outputs only on success", async () => {
+    const tracer = new FakeTracer();
+    const processInputs = vi.fn(omitPayload);
+    const processOutputs = vi.fn(omitPayload);
+    const action = vi.fn(increment).mockImplementationOnce(() => {
+      throw new Error("retry");
+    });
+    const graph = new StateGraph(State)
+      .addNode("node", action, {
+        tracePolicy: { processInputs, processOutputs },
+        retryPolicy: {
+          maxAttempts: 2,
+          initialInterval: 1,
+          jitter: false,
+          logWarning: false,
+        },
+      })
+      .addEdge(START, "node")
+      .addEdge("node", END)
+      .compile();
+    expect(await graph.invoke({ value: 1 }, { callbacks: [tracer] })).toEqual({
+      value: 2,
+    });
+    expect(action).toHaveBeenCalledTimes(2);
+    expect(processInputs).toHaveBeenCalledTimes(2);
+    expect(processOutputs).toHaveBeenCalledTimes(1);
+    const runs = nodeRuns(tracer);
+    expect(runs).toHaveLength(2);
+    expect(runs[0].error).toContain("retry");
+    expect(runs[1].outputs).toEqual({});
+  });
+
+  it("preserves update streams while transforming node trace events", async () => {
+    const graph = makeGraph({
+      processInputs: omitPayload,
+      processOutputs: omitPayload,
+    });
+    const tracer = new FakeTracer();
+    expect(
+      await gatherIterator(
+        graph.stream(
+          { value: 1 },
+          { callbacks: [tracer], streamMode: "updates" }
+        )
+      )
+    ).toEqual([{ node: { value: 2 } }]);
+    expect(nodeRuns(tracer)[0].inputs).toEqual({});
+    expect(nodeRuns(tracer)[0].outputs).toEqual({});
+    const events = await gatherIterator(
+      graph.streamEvents({ value: 1 }, { version: "v2" })
+    );
+    expect(
+      events.find(
+        (event) => event.name === "node" && event.event === "on_chain_start"
+      )?.data.input
+    ).toEqual({});
+    expect(
+      events.find(
+        (event) => event.name === "node" && event.event === "on_chain_end"
+      )?.data.output
+    ).toEqual({});
+    expect(
+      events.find(
+        (event) => event.name === "LangGraph" && event.event === "on_chain_end"
+      )?.data.output
+    ).toEqual({ value: 2 });
+  });
+
+  it.each(["legacy", "protocol"] as const)(
+    "omits directly returned messages from %s message streams",
+    async (mode) => {
+      async function collectMessages(tracePolicy?: TracePolicy) {
+        const graph = new StateGraph(MessagesAnnotation)
+          .addNode("node", () => ({ messages: [new AIMessage("hello")] }), {
+            tracePolicy,
+          })
+          .addEdge(START, "node")
+          .addEdge("node", END)
+          .compile();
+        if (mode === "legacy") {
+          return gatherIterator(
+            graph.stream({ messages: [] }, { streamMode: "messages" })
+          );
+        }
+        const run = await graph.streamEvents(
+          { messages: [] },
+          { version: "v3" }
+        );
+        const events = await gatherIterator(run);
+        expect((await run.output).messages[0].content).toBe("hello");
+        return events.filter((event) => event.method === "messages");
+      }
+      const baseline = await collectMessages();
+      expect(baseline.length).toBeGreaterThan(0);
+      const omitted = await collectMessages({ processOutputs: omitPayload });
+      expect(omitted).toEqual([]);
+    }
+  );
+
+  it("matches Python input omission's effect on message deduplication", async () => {
+    function graph(tracePolicy?: TracePolicy) {
+      return new StateGraph(MessagesAnnotation)
+        .addNode("node", (state) => ({ messages: state.messages }), {
+          tracePolicy,
+        })
+        .addEdge(START, "node")
+        .addEdge("node", END)
+        .compile();
+    }
+    const input = {
+      messages: [new HumanMessage({ content: "old", id: "old-id" })],
+    };
+    expect(
+      await gatherIterator(graph().stream(input, { streamMode: "messages" }))
+    ).toEqual([]);
+    const replayed = await gatherIterator(
+      graph({ processInputs: omitPayload }).stream(input, {
+        streamMode: "messages",
+      })
+    );
+    expect(replayed).toHaveLength(1);
+    expect(replayed[0][0].content).toBe("old");
+  });
+});

--- a/libs/langgraph-core/src/web.ts
+++ b/libs/langgraph-core/src/web.ts
@@ -114,6 +114,8 @@ export {
   type RetryPolicy,
   type CachePolicy,
   type TimeoutPolicy,
+  type TracePolicy,
+  omitPayload,
 } from "./pregel/utils/index.js";
 export {
   Send,


### PR DESCRIPTION
* adds the compensating `tracePolicy` flag on nodes that was introduced in https://github.com/langchain-ai/langgraph/pull/8523
  * brings in a `RunnableSeq` class that extends the core runnable with additional config for tracing

((TO BE PUBLISHED AS RC))
* looking to get this out quickly to test in a real deployment, the appropriate fix will be a second stable release in `@langchain/core` that adds trace policy to RunnableSequence