### PR TITLE
fix(checkpoint): stop search() prefix matching at namespace segments

### DIFF
--- a/.changeset/namespace-segment-boundary.md
+++ b/.changeset/namespace-segment-boundary.md
@@ -1,0 +1,8 @@
+---
+"@langchain/langgraph-checkpoint": patch
+"@langchain/langgraph-checkpoint-postgres": patch
+---
+
+fix(checkpoint): stop `search()` namespace prefix matching at segment boundaries (CVE-2026-71433 port)
+
+`InMemoryStore.search(["tenant","acme"])` no longer returns sibling `["tenant","acme-corp"]` items. Postgres `LIKE prefix%` is now exact-or-descendant (`= path OR LIKE path:%`). Namespace labels may not contain `:`. Empty prefix still means "search everything" on InMemoryStore. Closes #2721.

--- a/libs/checkpoint-postgres/src/store/index.ts
+++ b/libs/checkpoint-postgres/src/store/index.ts
@@ -28,6 +28,11 @@ import {
   StoreMigrationConfig,
 } from "./store-migrations.js";
 import { getStoreTablesWithSchema } from "./sql.js";
+import {
+  namespaceMatchRegex,
+  namespaceScopeClause,
+  namespaceScopeParams,
+} from "./modules/utils.js";
 
 export type * from "./modules/types.js";
 
@@ -326,19 +331,36 @@ export class PostgresStore extends BaseStore {
     const conditions: string[] = [];
     let paramIndex = 1;
 
-    // Add match conditions
+    // Add match conditions. Empty path constrains nothing. Paths without `*`
+    // stay index-friendly (`=` / `LIKE path:%`). `*` spans one segment and
+    // needs a POSIX regex because LIKE cannot exclude the `:` separator.
     if (matchConditions && matchConditions.length > 0) {
       for (const condition of matchConditions) {
-        if (condition.matchType === "prefix") {
-          const prefix = condition.path.join(":");
-          conditions.push(`namespace_path LIKE $${paramIndex}`);
-          params.push(`${prefix}%`);
+        if (
+          condition.matchType !== "prefix" &&
+          condition.matchType !== "suffix"
+        ) {
+          continue;
+        }
+        if (!condition.path.length) {
+          continue;
+        }
+        if (condition.path.includes("*")) {
+          conditions.push(`namespace_path ~ $${paramIndex}`);
+          params.push(namespaceMatchRegex(condition.path, condition.matchType));
           paramIndex += 1;
-        } else if (condition.matchType === "suffix") {
-          const suffix = condition.path.join(":");
-          conditions.push(`namespace_path LIKE $${paramIndex}`);
-          params.push(`%${suffix}`);
-          paramIndex += 1;
+        } else {
+          const { clause, nextIndex } = namespaceScopeClause(
+            "namespace_path",
+            paramIndex
+          );
+          conditions.push(clause);
+          const { exact, like } = namespaceScopeParams(
+            condition.path,
+            condition.matchType
+          );
+          params.push(exact, like);
+          paramIndex = nextIndex;
         }
       }
     }

--- a/libs/checkpoint-postgres/src/store/modules/search-operations.ts
+++ b/libs/checkpoint-postgres/src/store/modules/search-operations.ts
@@ -7,7 +7,11 @@ import { DatabaseCore } from "./database-core.js";
 import { VectorOperations } from "./vector-operations.js";
 import { QueryBuilder } from "./query-builder.js";
 import { SearchOptions, SearchItem } from "./types.js";
-import { validateNamespace } from "./utils.js";
+import {
+  validateNamespace,
+  namespaceScopeClause,
+  namespaceScopeParams,
+} from "./utils.js";
 
 /**
  * Handles all search operations: basic search, vector search, hybrid search.
@@ -24,7 +28,7 @@ export class SearchOperations {
   ): Promise<Item[]> {
     validateNamespace(operation.namespacePrefix);
 
-    const namespacePath = operation.namespacePrefix.join(":");
+    const { exact, like } = namespaceScopeParams(operation.namespacePrefix);
     const { filter, limit = 10, offset = 0, query } = operation;
 
     // If vector search is configured and query is provided, use vector similarity search
@@ -52,15 +56,16 @@ export class SearchOperations {
     }
 
     // Basic metadata search without query
+    const scope = namespaceScopeClause("namespace_path", 1);
     let sqlQuery = `
       SELECT namespace_path, key, value, created_at, updated_at
       FROM "${this.core.schema}".store
-      WHERE namespace_path LIKE $1
+      WHERE ${scope.clause}
         AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
     `;
 
-    const params: unknown[] = [`${namespacePath}%`];
-    let paramIndex = 2;
+    const params: unknown[] = [exact, like];
+    let paramIndex = scope.nextIndex;
 
     // Add filter conditions using advanced filtering
     if (filter && Object.keys(filter).length > 0) {
@@ -99,7 +104,7 @@ export class SearchOperations {
 
     validateNamespace(operation.namespacePrefix);
 
-    const namespacePath = operation.namespacePrefix.join(":");
+    const { exact, like } = namespaceScopeParams(operation.namespacePrefix);
     const { filter, limit = 10, offset = 0, query } = operation;
 
     // Generate query embedding
@@ -111,6 +116,7 @@ export class SearchOperations {
       );
     }
 
+    const scope = namespaceScopeClause("s.namespace_path", 1);
     let sqlQuery = `
       SELECT DISTINCT 
         s.namespace_path, 
@@ -118,18 +124,15 @@ export class SearchOperations {
         s.value, 
         s.created_at, 
         s.updated_at,
-        MIN(v.embedding <=> $2) as similarity_score
+        MIN(v.embedding <=> $3) as similarity_score
       FROM "${this.core.schema}".store s
       JOIN "${this.core.schema}".store_vectors v ON s.namespace_path = v.namespace_path AND s.key = v.key
-      WHERE s.namespace_path LIKE $1
+      WHERE ${scope.clause}
         AND (s.expires_at IS NULL OR s.expires_at > CURRENT_TIMESTAMP)
     `;
 
-    const params: unknown[] = [
-      `${namespacePath}%`,
-      `[${queryEmbedding.join(",")}]`,
-    ];
-    let paramIndex = 3;
+    const params: unknown[] = [exact, like, `[${queryEmbedding.join(",")}]`];
+    let paramIndex = scope.nextIndex + 1;
 
     // Add filter conditions
     if (filter && Object.keys(filter).length > 0) {
@@ -174,9 +177,10 @@ export class SearchOperations {
     return this.core.withClient(async (client) => {
       validateNamespace(namespacePrefix);
 
-      const namespacePath = namespacePrefix.join(":");
+      const { exact, like } = namespaceScopeParams(namespacePrefix);
       const { filter, limit = 10, offset = 0, query, refreshTtl } = options;
 
+      const scope = namespaceScopeClause("namespace_path", 1);
       let sqlQuery = `
         SELECT 
           namespace_path, 
@@ -185,21 +189,22 @@ export class SearchOperations {
           created_at, 
           updated_at,
           CASE 
-            WHEN $2::text IS NOT NULL THEN 
-              ts_rank(to_tsvector($3::regconfig, value::text), plainto_tsquery($3::regconfig, $2::text))
+            WHEN $3::text IS NOT NULL THEN 
+              ts_rank(to_tsvector($4::regconfig, value::text), plainto_tsquery($4::regconfig, $3::text))
             ELSE 0
           END as score
         FROM "${this.core.schema}".store
-        WHERE namespace_path LIKE $1
+        WHERE ${scope.clause}
           AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
       `;
 
       const params: unknown[] = [
-        `${namespacePath}%`,
+        exact,
+        like,
         query || null,
         this.core.textSearchLanguage,
       ];
-      let paramIndex = 4;
+      let paramIndex = 5;
 
       // Add filter conditions using advanced filtering
       if (filter && Object.keys(filter).length > 0) {
@@ -214,7 +219,7 @@ export class SearchOperations {
       // Add full-text search if query is provided
       if (query) {
         sqlQuery += ` AND (
-          to_tsvector($3::regconfig, value::text) @@ plainto_tsquery($3::regconfig, $2::text)
+          to_tsvector($4::regconfig, value::text) @@ plainto_tsquery($4::regconfig, $3::text)
           OR value::text ILIKE $${paramIndex}
         )`;
         params.push(`%${query}%`);
@@ -277,7 +282,7 @@ export class SearchOperations {
     return this.core.withClient(async (client) => {
       validateNamespace(namespacePrefix);
 
-      const namespacePath = namespacePrefix.join(":");
+      const { exact, like } = namespaceScopeParams(namespacePrefix);
       const {
         filter,
         limit = 10,
@@ -303,19 +308,20 @@ export class SearchOperations {
       switch (distanceMetric) {
         case "l2":
           distanceOp = "<->";
-          scoreTransform = "1 / (1 + MIN(v.embedding <-> $2))"; // Convert L2 distance to similarity
+          scoreTransform = "1 / (1 + MIN(v.embedding <-> $3))"; // Convert L2 distance to similarity
           break;
         case "inner_product":
           distanceOp = "<#>";
-          scoreTransform = "MIN(v.embedding <#> $2)"; // Inner product (higher is better)
+          scoreTransform = "MIN(v.embedding <#> $3)"; // Inner product (higher is better)
           break;
         case "cosine":
         default:
           distanceOp = "<=>";
-          scoreTransform = "1 - MIN(v.embedding <=> $2)"; // Convert cosine distance to similarity
+          scoreTransform = "1 - MIN(v.embedding <=> $3)"; // Convert cosine distance to similarity
           break;
       }
 
+      const scope = namespaceScopeClause("s.namespace_path", 1);
       let sqlQuery = `
         SELECT DISTINCT 
           s.namespace_path, 
@@ -326,22 +332,19 @@ export class SearchOperations {
           ${scoreTransform} as similarity_score
         FROM "${this.core.schema}".store s
         JOIN "${this.core.schema}".store_vectors v ON s.namespace_path = v.namespace_path AND s.key = v.key
-        WHERE s.namespace_path LIKE $1
+        WHERE ${scope.clause}
           AND (s.expires_at IS NULL OR s.expires_at > CURRENT_TIMESTAMP)
       `;
 
-      const params: unknown[] = [
-        `${namespacePath}%`,
-        `[${queryEmbedding.join(",")}]`,
-      ];
-      let paramIndex = 3;
+      const params: unknown[] = [exact, like, `[${queryEmbedding.join(",")}]`];
+      let paramIndex = 4;
 
       // Add similarity threshold
       if (similarityThreshold > 0) {
         if (distanceMetric === "inner_product") {
-          sqlQuery += ` AND v.embedding <#> $2 >= $${paramIndex}`;
+          sqlQuery += ` AND v.embedding <#> $3 >= $${paramIndex}`;
         } else {
-          sqlQuery += ` AND v.embedding ${distanceOp} $2 <= $${paramIndex}`;
+          sqlQuery += ` AND v.embedding ${distanceOp} $3 <= $${paramIndex}`;
         }
         params.push(
           distanceMetric === "cosine"
@@ -405,7 +408,7 @@ export class SearchOperations {
     return this.core.withClient(async (client) => {
       validateNamespace(namespacePrefix);
 
-      const namespacePath = namespacePrefix.join(":");
+      const { exact, like } = namespaceScopeParams(namespacePrefix);
       const {
         filter,
         limit = 10,
@@ -425,6 +428,7 @@ export class SearchOperations {
         );
       }
 
+      const scope = namespaceScopeClause("s.namespace_path", 1);
       let sqlQuery = `
         SELECT DISTINCT 
           s.namespace_path, 
@@ -433,28 +437,29 @@ export class SearchOperations {
           s.created_at, 
           s.updated_at,
           (
-            $3 * (1 - MIN(v.embedding <=> $2)) + 
-            (1 - $3) * ts_rank(to_tsvector($6::regconfig, s.value::text), plainto_tsquery($6::regconfig, $4))
+            $4 * (1 - MIN(v.embedding <=> $3)) + 
+            (1 - $4) * ts_rank(to_tsvector($7::regconfig, s.value::text), plainto_tsquery($7::regconfig, $5))
           ) as hybrid_score
         FROM "${this.core.schema}".store s
         JOIN "${this.core.schema}".store_vectors v ON s.namespace_path = v.namespace_path AND s.key = v.key
-        WHERE s.namespace_path LIKE $1
+        WHERE ${scope.clause}
           AND (s.expires_at IS NULL OR s.expires_at > CURRENT_TIMESTAMP)
           AND (
-            to_tsvector($6::regconfig, s.value::text) @@ plainto_tsquery($6::regconfig, $4)
-            OR v.embedding <=> $2 <= $5
+            to_tsvector($7::regconfig, s.value::text) @@ plainto_tsquery($7::regconfig, $5)
+            OR v.embedding <=> $3 <= $6
           )
       `;
 
       const params: unknown[] = [
-        `${namespacePath}%`,
+        exact,
+        like,
         `[${queryEmbedding.join(",")}]`,
         vectorWeight,
         query,
         1 - similarityThreshold,
         this.core.textSearchLanguage,
       ];
-      let paramIndex = 7;
+      let paramIndex = 8;
 
       // Add filter conditions
       if (filter && Object.keys(filter).length > 0) {

--- a/libs/checkpoint-postgres/src/store/modules/utils.test.ts
+++ b/libs/checkpoint-postgres/src/store/modules/utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { validateNamespace } from "./utils.js";
+import {
+  validateNamespace,
+  namespaceScopeParams,
+  namespaceScopeClause,
+  namespaceMatchRegex,
+} from "./utils.js";
 
 describe("validateNamespace", () => {
   it("accepts a simple, well-formed namespace", () => {
@@ -20,6 +25,13 @@ describe("validateNamespace", () => {
     expect(() => validateNamespace(["a.b"])).toThrow(/cannot contain periods/);
   });
 
+  it("rejects labels containing colons (path separator)", () => {
+    expect(() => validateNamespace(["a:b"])).toThrow(/cannot contain colons/);
+    expect(() => validateNamespace(["tenant", "user:42"])).toThrow(
+      /cannot contain colons/
+    );
+  });
+
   it("rejects the reserved 'langgraph' root label", () => {
     expect(() => validateNamespace(["langgraph", "users"])).toThrow(
       /Root label.*cannot be "langgraph"/
@@ -27,10 +39,11 @@ describe("validateNamespace", () => {
   });
 
   // The block below covers the LIKE-wildcard cross-namespace leak. Search
-  // operations match via `namespace_path LIKE ${prefix}%` (bound parameter),
-  // and `%` / `_` / `\` in caller-supplied labels are still interpreted as
-  // LIKE wildcards / escapes by Postgres regardless of binding. A namespace
-  // prefix of `["%"]` would otherwise match every namespace in the store.
+  // operations used to match via `namespace_path LIKE ${prefix}%` (bound
+  // parameter), and `%` / `_` / `\` in caller-supplied labels are still
+  // interpreted as LIKE wildcards / escapes by Postgres regardless of
+  // binding. A namespace prefix of `["%"]` would otherwise match every
+  // namespace in the store.
   describe("LIKE wildcard / escape character rejection", () => {
     it.each([
       ["%"],
@@ -47,10 +60,63 @@ describe("validateNamespace", () => {
     });
 
     it("does not reject benign characters that look similar", () => {
-      // colon is the namespace path separator, hyphen / digit / unicode are fine
       expect(() =>
-        validateNamespace(["tenant-1", "user:42", "プロジェクト"])
+        validateNamespace(["tenant-1", "プロジェクト"])
       ).not.toThrow();
     });
+  });
+});
+
+describe("namespaceScopeParams / namespaceScopeClause", () => {
+  it("builds exact-or-descendant params for a prefix", () => {
+    expect(namespaceScopeParams(["tenant", "acme"])).toEqual({
+      exact: "tenant:acme",
+      like: "tenant:acme:%",
+    });
+    expect(namespaceScopeClause("namespace_path", 1)).toEqual({
+      clause: "(namespace_path = $1 OR namespace_path LIKE $2)",
+      nextIndex: 3,
+    });
+  });
+
+  it("builds exact-or-ancestor params for a suffix", () => {
+    expect(namespaceScopeParams(["alice"], "suffix")).toEqual({
+      exact: "alice",
+      like: "%:alice",
+    });
+  });
+
+  it("does not let 'acme' also match 'acme-corp'", () => {
+    const { exact, like } = namespaceScopeParams(["tenant", "acme"]);
+    expect(exact).toBe("tenant:acme");
+    expect("tenant:acme-corp".startsWith(exact)).toBe(true);
+    expect("tenant:acme-corp".startsWith(like.slice(0, -1))).toBe(false);
+    expect("tenant:acme:child".startsWith("tenant:acme:")).toBe(true);
+  });
+});
+
+describe("namespaceMatchRegex", () => {
+  it("anchors prefix matches on segment boundaries", () => {
+    const pattern = namespaceMatchRegex(["foo"], "prefix");
+    expect(pattern).toBe("^foo(:|$)");
+    expect(new RegExp(pattern).test("foo")).toBe(true);
+    expect(new RegExp(pattern).test("foo:child")).toBe(true);
+    expect(new RegExp(pattern).test("foobar")).toBe(false);
+    expect(new RegExp(pattern).test("foo2")).toBe(false);
+  });
+
+  it("anchors suffix matches on segment boundaries", () => {
+    const pattern = namespaceMatchRegex(["alice"], "suffix");
+    expect(new RegExp(pattern).test("uid:users:alice")).toBe(true);
+    expect(new RegExp(pattern).test("alice")).toBe(true);
+    expect(new RegExp(pattern).test("uid:users:malice")).toBe(false);
+  });
+
+  it("lets * span exactly one segment", () => {
+    const pattern = namespaceMatchRegex(["uid", "*", "alice"], "prefix");
+    const re = new RegExp(pattern);
+    expect(re.test("uid:users:alice")).toBe(true);
+    expect(re.test("uid:users:alice:extra")).toBe(true);
+    expect(re.test("uid:a:b:alice")).toBe(false);
   });
 });

--- a/libs/checkpoint-postgres/src/store/modules/utils.ts
+++ b/libs/checkpoint-postgres/src/store/modules/utils.ts
@@ -1,7 +1,7 @@
 /**
  * Characters interpreted as wildcards (or escape) by Postgres `LIKE` patterns.
- * Search operations match namespaces via `namespace_path LIKE ${prefix}%`, so
- * any of these in a caller-supplied label silently changes the prefix match
+ * Search operations previously matched namespaces via `namespace_path LIKE ${prefix}%`,
+ * so any of these in a caller-supplied label silently changed the prefix match
  * into a glob. A namespace prefix of `["%"]` would match every namespace in
  * the store, exposing data across tenants. CWE-1336 / CWE-943.
  *
@@ -9,8 +9,68 @@
  * are safe on their own, but we reject these characters everywhere to keep the
  * Store API consistent (data written under such a namespace would never be
  * reachable via search anyway).
+ *
+ * Prefix scoping now uses `= path OR LIKE path:%` (see `namespaceScopeClause`)
+ * so sibling namespaces that share a string prefix are no longer returned.
+ * `#2721` / CVE-2026-71433. `%` / `_` / `\` are still rejected rather than
+ * escaped, matching #2512.
  */
 const LIKE_RESERVED_PATTERN = /[%_\\]/;
+
+/** Joiner used when persisting a namespace array as `namespace_path`. */
+export const NAMESPACE_SEPARATOR = ":";
+
+/**
+ * Build the two bound params for a segment-aware prefix (or suffix) match.
+ *
+ * Exact equality covers the namespace itself; `LIKE path:%` covers descendants
+ * without also matching siblings such as `acme` vs `acme-corp`.
+ */
+export function namespaceScopeParams(
+  segments: string[],
+  kind: "prefix" | "suffix" = "prefix"
+): { exact: string; like: string } {
+  const exact = segments.join(NAMESPACE_SEPARATOR);
+  if (kind === "suffix") {
+    return { exact, like: `%${NAMESPACE_SEPARATOR}${exact}` };
+  }
+  return { exact, like: `${exact}${NAMESPACE_SEPARATOR}%` };
+}
+
+/**
+ * SQL fragment: `column` equals the bound path, or is a descendant of it.
+ * Consumes two parameters starting at `startIndex`.
+ */
+export function namespaceScopeClause(
+  column: string,
+  startIndex: number
+): { clause: string; nextIndex: number } {
+  return {
+    clause: `(${column} = $${startIndex} OR ${column} LIKE $${startIndex + 1})`,
+    nextIndex: startIndex + 2,
+  };
+}
+
+/**
+ * POSIX regex matching a colon-joined namespace on whole segments.
+ *
+ * Needed when a listNamespaces path contains `*` (one segment). LIKE cannot
+ * express "any character except the separator". Prefix matches stay
+ * open-ended but must end on a separator; suffix matches anchor at the end.
+ */
+export function namespaceMatchRegex(
+  path: string[],
+  matchType: "prefix" | "suffix"
+): string {
+  const segments = path.map((part) =>
+    part === "*" ? "[^:]+" : part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  );
+  const body = segments.join(":");
+  if (matchType === "suffix") {
+    return `(^|:)${body}$`;
+  }
+  return `^${body}(:|$)`;
+}
 
 /**
  * Validates the provided namespace.
@@ -31,6 +91,11 @@ export function validateNamespace(namespace: string[]): void {
     if (label.includes(".")) {
       throw new Error(
         `Invalid namespace label '${label}' found in ${namespace}. Namespace labels cannot contain periods ('.').`
+      );
+    }
+    if (label.includes(":")) {
+      throw new Error(
+        `Invalid namespace label '${label}' found in ${namespace}. Namespace labels cannot contain colons (':'), which are the namespace path separator.`
       );
     }
     if (label === "") {

--- a/libs/checkpoint/src/store/base.ts
+++ b/libs/checkpoint/src/store/base.ts
@@ -14,10 +14,21 @@ export class InvalidNamespaceError extends Error {
 /**
  * Validates the provided namespace.
  * @param namespace The namespace to validate.
+ * @param options.allowEmpty When true, an empty namespace is permitted
+ *   (`search([])` means "search everything"). Put still rejects empty.
+ * @param options.allowReservedRoot When true, the `langgraph` root label is
+ *   permitted. Put still rejects it; search may read a namespace written via
+ *   `batch()` which bypasses put validation.
  * @throws {InvalidNamespaceError} If the namespace is invalid.
  */
-function validateNamespace(namespace: string[]): void {
+export function validateNamespace(
+  namespace: string[],
+  options: { allowEmpty?: boolean; allowReservedRoot?: boolean } = {}
+): void {
   if (namespace.length === 0) {
+    if (options.allowEmpty) {
+      return;
+    }
     throw new InvalidNamespaceError("Namespace cannot be empty.");
   }
   for (const label of namespace) {
@@ -32,13 +43,18 @@ function validateNamespace(namespace: string[]): void {
         `Invalid namespace label '${label}' found in ${namespace}. Namespace labels cannot contain periods ('.').`
       );
     }
+    if (label.includes(":")) {
+      throw new InvalidNamespaceError(
+        `Invalid namespace label '${label}' found in ${namespace}. Namespace labels cannot contain colons (':'), which are the namespace path separator.`
+      );
+    }
     if (label === "") {
       throw new InvalidNamespaceError(
         `Namespace labels cannot be empty strings. Got ${label} in ${namespace}`
       );
     }
   }
-  if (namespace[0] === "langgraph") {
+  if (namespace[0] === "langgraph" && !options.allowReservedRoot) {
     throw new InvalidNamespaceError(
       `Root label for namespace cannot be "langgraph". Got: ${namespace}`
     );
@@ -436,6 +452,10 @@ export abstract class BaseStore {
       query?: string;
     } = {}
   ): Promise<SearchItem[]> {
+    validateNamespace(namespacePrefix, {
+      allowEmpty: true,
+      allowReservedRoot: true,
+    });
     const { filter, limit = 10, offset = 0, query } = options;
     return (
       await this.batch<[SearchOperation]>([

--- a/libs/checkpoint/src/store/memory.ts
+++ b/libs/checkpoint/src/store/memory.ts
@@ -10,6 +10,7 @@ import {
   GetOperation,
   type IndexConfig,
   type SearchItem,
+  validateNamespace,
 } from "./base.js";
 import { tokenizePath, compareValues, getTextAtPath } from "./utils.js";
 
@@ -249,9 +250,22 @@ export class InMemoryStore extends BaseStore {
   }
 
   private filterItems(op: SearchOperation): Item[] {
+    if (op.namespacePrefix.length > 0) {
+      validateNamespace(op.namespacePrefix, { allowReservedRoot: true });
+    }
+    const prefix = op.namespacePrefix.join(":");
     const candidates: Item[] = [];
     for (const [namespace, items] of this.data.entries()) {
-      if (namespace.startsWith(op.namespacePrefix.join(":"))) {
+      // Exact match, or the separator immediately after the prefix, so
+      // "tenant:acme" does not also match sibling "tenant:acme-corp".
+      // Empty prefix is unconstrained (search everything). See #2721 /
+      // CVE-2026-71433. Do not use startsWith(prefix) or startsWith(prefix+":")
+      // without the empty-prefix arm — the latter turns search([]) into [].
+      if (
+        prefix === "" ||
+        namespace === prefix ||
+        namespace.startsWith(`${prefix}:`)
+      ) {
         candidates.push(...items.values());
       }
     }

--- a/libs/checkpoint/src/tests/namespace.test.ts
+++ b/libs/checkpoint/src/tests/namespace.test.ts
@@ -192,6 +192,81 @@ describe("InMemoryStore Namespace Operations", () => {
     expect(result).toEqual([]);
   });
 
+  it("should block colons in namespace labels", async () => {
+    const doc = { foo: "bar" };
+    await expect(store.put(["tenant", "acme:corp"], "k", doc)).rejects.toThrow(
+      InvalidNamespaceError
+    );
+    await expect(store.search(["tenant:acme"])).rejects.toThrow(
+      InvalidNamespaceError
+    );
+  });
+
+  it("should not leak sibling namespaces that share a string prefix (issue 2721 / CVE-2026-71433)", async () => {
+    await store.put(["tenant", "acme"], "note", { text: "acme's own note" });
+    await store.put(["tenant", "acme-corp"], "secret", {
+      text: "acme-corp CONFIDENTIAL",
+    });
+    await store.put(["tenant", "acmex"], "other", { text: "acmex" });
+    await store.put(["tenant", "acme", "child"], "nested", { text: "child" });
+
+    const scoped = await store.search(["tenant", "acme"], { limit: 100 });
+    const namespaces = scoped.map((item) => item.namespace.join(":")).sort();
+    expect(namespaces).toEqual(["tenant:acme", "tenant:acme:child"]);
+    expect(scoped.find((item) => item.key === "secret")).toBeUndefined();
+    expect(await store.get(["tenant", "acme"], "secret")).toBeNull();
+
+    const empty = await store.search([], { limit: 100 });
+    expect(empty).toHaveLength(4);
+
+    const fo = await store.search(["fo"], { limit: 100 });
+    expect(fo).toHaveLength(0);
+  });
+
+  it("search prefix match is segment-wise, including empty prefix", async () => {
+    const fixtures: string[][] = [
+      ["foo"],
+      ["foo", "child"],
+      ["foo", "child", "deep"],
+      ["foobar"],
+      ["foobar", "baz"],
+      ["foo2"],
+    ];
+    for (const ns of fixtures) {
+      await store.put(ns, "k", { v: 1 });
+    }
+
+    const isSegmentPrefix = (query: string[], ns: string[]): boolean => {
+      if (query.length === 0) return true;
+      if (query.length > ns.length) return false;
+      return query.every((part, i) => part === ns[i]);
+    };
+
+    const queries: string[][] = [
+      [],
+      ["foo"],
+      ["foo", "child"],
+      ["foobar"],
+      ["foo2"],
+      ["fo"],
+      ["foo", "nope"],
+    ];
+
+    for (const query of queries) {
+      const got = new Set(
+        (await store.search(query, { limit: 100 })).map((item) =>
+          item.namespace.join("\0")
+        )
+      );
+      const expected = new Set(
+        fixtures
+          .filter((ns) => isSegmentPrefix(query, ns))
+          .map((ns) => ns.join("\0"))
+      );
+      expect(got, `query ${JSON.stringify(query)}`).toEqual(expected);
+    }
+  });
+
   it("should block invalid namespaces", async () => {
     const doc = { foo: "bar" };
 


### PR DESCRIPTION
Closes #2721

Port of CVE-2026-71433 / langchain-ai/langgraph#8478 to the JS stores.

## Bug

`InMemoryStore.search()` compared the colon-joined namespace with a raw `startsWith`. `PostgresStore` used `namespace_path LIKE prefix%`. A read scoped to `["tenant","acme"]` also returned `["tenant","acme-corp"]`. `get` is exact, so the extra item is visible on search and then unreachable.

## Why the issue-body matcher is not enough

`namespace === prefix || namespace.startsWith(prefix + ":")` closes the sibling leak and turns `search([])` into `[]` on InMemoryStore, because `[].join(":")` is `""`. Confirmed on 1.1.5: 2 items → 0, silent. Empty prefix is documented as "search everything".

`:` was also legal in a JS label (`validateNamespace` only rejected `.`, the Python separator). `put(["a","b:c"])` then `put(["a","b","c"])` collide on the joined key.

## Fix

- InMemory: match exact, or require `:` after the prefix, or empty prefix (unconstrained)
- Postgres search (5 query sites): `namespace_path = $1 OR namespace_path LIKE $2` with `$2 = path || ':%'`
- Postgres `listNamespaces`: same for prefix/suffix; `*` uses a POSIX regex so it spans one segment
- Labels may not contain `:` on put or search (write and read)

Postgres `search([])` still throws `Namespace cannot be empty` — existing, not changed.

## Tests

```
pnpm --filter @langchain/langgraph-checkpoint test
pnpm --filter @langchain/langgraph-checkpoint-postgres test src/store/modules/utils.test.ts
```

113 + 20 passed. Includes the issue repro, empty-prefix, and a segment-wise property test that never touches the joined string.

## Agent disclosure

Written by an AI agent on behalf of @devtechedge, who has reviewed this pull request.