### PR TITLE
fix(sdk): resume the protocol SSE stream from the last event_id on reconnect

### DIFF
--- a/.changeset/sdk-reconnect-event-id-resume.md
+++ b/.changeset/sdk-reconnect-event-id-resume.md
@@ -1,0 +1,13 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): resume the protocol SSE stream from the last `event_id` on reconnect
+
+A transport-level reconnect (network blip, idle-watchdog reopen) now carries
+the last durable `event_id` it saw as `last_event_id`, so the server resumes
+from the thread tape instead of replaying the whole conversation, and still
+delivers the terminal `run_done` a bare reconnect would miss once the tape has
+moved on. `seq` is connection-local and is never used as a cursor. Filter
+rotations open a fresh stream and keep full-replaying for the widened filter,
+so the cursor never leaks across them.

--- a/.changeset/sdk-reconnect-event-id-resume.md
+++ b/.changeset/sdk-reconnect-event-id-resume.md
@@ -4,10 +4,12 @@
 
 fix(sdk): resume the protocol SSE stream from the last `event_id` on reconnect
 
-A transport-level reconnect (network blip, idle-watchdog reopen) now carries
-the last durable `event_id` it saw as `last_event_id`, so the server resumes
-from the thread tape instead of replaying the whole conversation, and still
-delivers the terminal `run_done` a bare reconnect would miss once the tape has
-moved on. `seq` is connection-local and is never used as a cursor. Filter
-rotations open a fresh stream and keep full-replaying for the widened filter,
-so the cursor never leaks across them.
+A transport-level reconnect (network blip, idle-watchdog reopen) now sends the
+last durable `event_id` it saw as the standard `Last-Event-ID` header, so a
+server that supports it resumes from the thread's event stream instead of
+replaying the whole conversation, and still delivers the terminal `run_done` a
+bare reconnect would miss once the stream has moved on. The request body is
+unchanged, so servers with a strict body schema keep working and ignore the
+header. Only ids with the durable `ms-seq` shape are sent; `seq` is
+connection-local and never used as a cursor. Filter rotations open a fresh
+stream and keep full-replaying, so the cursor never crosses rotations.

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -451,6 +451,82 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
     await transport.close();
   });
 
+  it("resumes from the last event_id on reconnect, not the whole tape", async () => {
+    let streamOpens = 0;
+    const encoder = new TextEncoder();
+    const fetchImpl = vi.fn((input: URL | RequestInfo) => {
+      if (!String(input).includes("/stream/events")) {
+        return Promise.resolve(protocolSuccessResponse());
+      }
+      streamOpens += 1;
+      if (streamOpens === 1) {
+        return Promise.resolve(
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(
+                  encoder.encode(
+                    'event: values\ndata: {"type":"event","method":"values","seq":1,"event_id":"1788-0"}\n\n'
+                  )
+                );
+                controller.enqueue(
+                  encoder.encode(
+                    'event: lifecycle\ndata: {"type":"event","method":"lifecycle","seq":2,"event_id":"synth:r:lc||running"}\n\n'
+                  )
+                );
+                setTimeout(() => {
+                  controller.error(new TypeError("net::ERR_QUIC_PROTOCOL_ERROR"));
+                }, 10);
+              },
+            }),
+            { status: 200, headers: { "content-type": "text/event-stream" } }
+          )
+        );
+      }
+      return Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  'event: lifecycle\ndata: {"type":"event","method":"lifecycle","seq":3,"event_id":"synth:r:lc||completed"}\n\n'
+                )
+              );
+              controller.close();
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } }
+        )
+      );
+    }) as MockFetch;
+
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: THREAD_ID,
+      fetch: fetchImpl,
+      maxReconnectAttempts: 3,
+      reconnectDelayMs: () => 0,
+      idleReconnect: 0,
+    });
+
+    const handle = transport.openEventStream({ channels: ["values", "lifecycle"] });
+    await handle.ready;
+
+    const received: Array<{ event_id?: string }> = [];
+    for await (const message of handle.events) {
+      received.push(message as { event_id?: string });
+      if (received.some((m) => m.event_id === "synth:r:lc||completed")) break;
+    }
+
+    expect(streamOpens).toBe(2);
+    const streamBodies = streamEventBodies(fetchImpl);
+    expect(streamBodies).toHaveLength(2);
+    expect(streamBodies[0]).not.toHaveProperty("last_event_id");
+    expect(streamBodies[1]).toMatchObject({ last_event_id: "1788-0" });
+
+    await transport.close();
+  });
+
   it("honors caller since on the initial open but omits it on reconnect", async () => {
     let streamOpens = 0;
     const encoder = new TextEncoder();

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -25,6 +25,15 @@ function streamEventBodies(fetchImpl: MockFetch): Record<string, unknown>[] {
     .filter((body): body is Record<string, unknown> => body != null);
 }
 
+function streamEventLastEventIds(fetchImpl: MockFetch): Array<string | null> {
+  return fetchImpl.mock.calls
+    .filter((call: unknown[]) => String(call[0]).includes("/stream/events"))
+    .map((call: unknown[]) => {
+      const init = call[1] as RequestInit | undefined;
+      return new Headers(init?.headers).get("last-event-id");
+    });
+}
+
 describe("ProtocolSseTransportAdapter URL resolution", () => {
   it("preserves apiUrl path prefix for protocol commands", async () => {
     const { calls, fetch } = createFetchRecorder();
@@ -447,6 +456,7 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
     expect(streamBodies).toHaveLength(2);
     expect(streamBodies[0]).not.toHaveProperty("since");
     expect(streamBodies[1]).not.toHaveProperty("since");
+    expect(streamEventLastEventIds(fetchImpl)).toEqual([null, null]);
 
     await transport.close();
   });
@@ -522,7 +532,8 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
     const streamBodies = streamEventBodies(fetchImpl);
     expect(streamBodies).toHaveLength(2);
     expect(streamBodies[0]).not.toHaveProperty("last_event_id");
-    expect(streamBodies[1]).toMatchObject({ last_event_id: "1788-0" });
+    expect(streamBodies[1]).not.toHaveProperty("last_event_id");
+    expect(streamEventLastEventIds(fetchImpl)).toEqual([null, "1788-0"]);
 
     await transport.close();
   });

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -265,6 +265,10 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
         : undefined;
 
     let readySettled = false;
+    // Only `event_id` can seek the server's tape; `seq` is per-connection. A
+    // filter rotation opens a new stream (readySettled=false), so the cursor
+    // never crosses rotations.
+    let lastEventId: string | undefined;
 
     const startStream = async () => {
       let attempt = 0;
@@ -285,6 +289,9 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
                 ...(params.depth != null ? { depth: params.depth } : {}),
                 ...(!readySettled && initialSince != null
                   ? { since: initialSince }
+                  : {}),
+                ...(readySettled && lastEventId != null
+                  ? { last_event_id: lastEventId }
                   : {}),
               }),
               signal: ac.signal,
@@ -336,7 +343,16 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
               break;
             }
             if (isRecord(event.data)) {
-              streamQueue.push(event.data as Message);
+              const message = event.data as Message;
+              const eventId = (message as { event_id?: unknown }).event_id;
+              // `synth:` ids have no tape position; only real entry ids resume.
+              if (
+                typeof eventId === "string" &&
+                !eventId.startsWith("synth:")
+              ) {
+                lastEventId = eventId;
+              }
+              streamQueue.push(message);
             }
           }
           streamQueue.close();

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -35,6 +35,8 @@ import {
 } from "../../../utils/reconnect.js";
 import { DEFAULT_IDLE_RECONNECT } from "../../../utils/stream.js";
 
+const STREAM_ENTRY_ID = /^\d+-\d+(\.\d+)?$/;
+
 /**
  * Transport adapter that speaks the thread-centric protocol over HTTP
  * commands plus SSE event streams. Bound to a `threadId` at construction
@@ -265,9 +267,8 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
         : undefined;
 
     let readySettled = false;
-    // Only `event_id` can seek the server's tape; `seq` is per-connection. A
-    // filter rotation opens a new stream (readySettled=false), so the cursor
-    // never crosses rotations.
+    // Header, not body: server body schemas are strict and reject unknown
+    // keys. Only durable `ms-seq` ids are sent; anything else is rejected.
     let lastEventId: string | undefined;
 
     const startStream = async () => {
@@ -282,6 +283,9 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
               headers: {
                 "content-type": "application/json",
                 accept: "text/event-stream",
+                ...(readySettled && lastEventId != null
+                  ? { "last-event-id": lastEventId }
+                  : {}),
               },
               body: JSON.stringify({
                 channels: params.channels,
@@ -289,9 +293,6 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
                 ...(params.depth != null ? { depth: params.depth } : {}),
                 ...(!readySettled && initialSince != null
                   ? { since: initialSince }
-                  : {}),
-                ...(readySettled && lastEventId != null
-                  ? { last_event_id: lastEventId }
                   : {}),
               }),
               signal: ac.signal,
@@ -345,10 +346,9 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
             if (isRecord(event.data)) {
               const message = event.data as Message;
               const eventId = (message as { event_id?: unknown }).event_id;
-              // `synth:` ids have no tape position; only real entry ids resume.
               if (
                 typeof eventId === "string" &&
-                !eventId.startsWith("synth:")
+                STREAM_ENTRY_ID.test(eventId)
               ) {
                 lastEventId = eventId;
               }


### PR DESCRIPTION
## Summary

A transport-level reconnect of the protocol SSE stream (network blip, idle-watchdog reopen) now sends the last durable `event_id` it saw as the standard `Last-Event-ID` header, so a server that supports it resumes from the thread's event stream instead of replaying the whole conversation, and still delivers the terminal `run_done` a bare reconnect would miss once the stream has moved on.

## Details

- The cursor travels in the `Last-Event-ID` header, not the body. Both JS server schemas (`api/protocol.mts`, `experimental/embed/protocol.mts`) are `.strict()`, so a new body key fails every reconnect against them; a header is ignored by servers that do not implement resume and needs no schema change. CORS is not affected: the Python server allows all headers and hono's `cors()` echoes requested headers by default.
- Only ids with the durable `ms-seq` shape are sent. `seq` is connection-local and is never used as a cursor; synthetic ids (`synth:...`) have no position on the stream.
- The cursor is scoped to a single stream's own reconnects. A filter rotation opens a fresh stream with `readySettled=false`, so it keeps full-replaying for the widened filter and the cursor never crosses rotations.

Pairs with the server change in langchain-ai/langgraph-api: https://github.com/langchain-ai/langgraph-api/pull/4127, which reads `Last-Event-ID` (or `last_event_id` in the body) and resumes the thread stream from it.

## Tests

`resumes from the last event_id on reconnect, not the whole tape` in `transport/http.test.ts`: the first open emits a real id then a synthetic terminal and fails mid-stream; the reconnect must carry `Last-Event-ID` equal to the real id, the first open must not, and neither body carries a cursor. The existing mid-stream reconnect test additionally asserts that non-stream-shaped ids (`e1`, `e2`) produce no header.

Changeset: `@langchain/langgraph-sdk` patch.
