### PR TITLE
fix(checkpoint): handle prototype-named texts in vector indexing

### DIFF
--- a/.changeset/safe-vector-text-keys.md
+++ b/.changeset/safe-vector-text-keys.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint": patch
+---
+
+Fix InMemoryStore vector indexing failing for texts such as `constructor`, `toString`, and `__proto__`. Preserve embedding deduplication across fields and documents.

--- a/libs/checkpoint/src/store/memory.ts
+++ b/libs/checkpoint/src/store/memory.ts
@@ -343,7 +343,8 @@ export class InMemoryStore extends BaseStore {
       return {};
     }
 
-    const toEmbed: { [text: string]: [string[], string, string][] } = {};
+    const toEmbed: { [text: string]: [string[], string, string][] } =
+      Object.create(null);
 
     for (const op of ops) {
       if (op.value !== null && op.index !== false) {

--- a/libs/checkpoint/src/tests/vector.test.ts
+++ b/libs/checkpoint/src/tests/vector.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Embeddings, EmbeddingsParams } from "@langchain/core/embeddings";
 import { InMemoryStore } from "../store/memory.js";
 
@@ -70,6 +70,63 @@ describe("InMemoryStore Vector Search", () => {
     const docOrder = results.map((r) => r.key);
     expect(docOrder).toContain("doc2");
     expect(docOrder).toContain("doc3");
+  });
+
+  it.each(["constructor", "toString", "hasOwnProperty", "__proto__"])(
+    "should index text matching the prototype property %s",
+    async (text) => {
+      const storeWithFields = new InMemoryStore({
+        index: { dims: embeddings.dims, embeddings, fields: ["text"] },
+      });
+
+      await storeWithFields.put(["test"], "doc1", { text });
+
+      expect((await storeWithFields.get(["test"], "doc1"))?.value).toEqual({
+        text,
+      });
+      const results = await storeWithFields.search(["test"], { query: text });
+      expect(results).toHaveLength(1);
+      expect(results[0].key).toBe("doc1");
+      expect(results[0].score).toBeCloseTo(1);
+    }
+  );
+
+  it("should deduplicate prototype-named texts across wildcard fields and documents", async () => {
+    const embedDocuments = vi.spyOn(embeddings, "embedDocuments");
+    const storeWithFields = new InMemoryStore({
+      index: { dims: embeddings.dims, embeddings, fields: ["texts[*]"] },
+    });
+    const documents = [
+      { texts: ["constructor", "__proto__", "constructor"] },
+      { texts: ["__proto__", "ordinary text", "constructor"] },
+    ];
+
+    await storeWithFields.batch(
+      documents.map((value, i) => ({
+        namespace: ["test"],
+        key: `doc${i}`,
+        value,
+      }))
+    );
+
+    expect(embedDocuments).toHaveBeenCalledTimes(1);
+    expect(embedDocuments).toHaveBeenCalledWith([
+      "constructor",
+      "__proto__",
+      "ordinary text",
+    ]);
+    for (const [i, value] of documents.entries()) {
+      expect((await storeWithFields.get(["test"], `doc${i}`))?.value).toEqual(
+        value
+      );
+    }
+    for (const query of ["constructor", "__proto__"]) {
+      const results = await storeWithFields.search(["test"], { query });
+      expect(results.map(({ key }) => key).sort()).toEqual(["doc0", "doc1"]);
+      for (const result of results) {
+        expect(result.score).toBeCloseTo(1);
+      }
+    }
   });
 
   it("should update embeddings when documents are updated", async () => {


### PR DESCRIPTION
When an indexed field contains a text such as `constructor`, `toString`, or `__proto__`, `InMemoryStore.put()` throws `TypeError: toEmbed[texts[0]].push is not a function` before storing the item. The text-to-embedding map is a plain object, so inherited properties bypass its array initialization.

Use a null-prototype object for this map. Regression tests cover single-value indexing, wildcard extraction, and duplicate texts within and across documents in one batch. They verify readback, one embedding per unique text, and vector search scores for every document. Includes a checkpoint patch changeset.

Validation:
- Before the fix: all 5 new regression cases fail; the 7 existing vector tests pass.
- After the fix: all 115 checkpoint tests pass, using local embeddings with no external API calls.
- Checkpoint build (including declaration generation, attw and publint), repository lint, format check, and `git diff --check` pass.
