### PR TITLE
fix(sdk): coalesce locally resolved interrupts

### DIFF
--- a/.changeset/ten-cycles-kneel.md
+++ b/.changeset/ten-cycles-kneel.md
@@ -1,0 +1,9 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): coalesce locally resolved interrupts
+
+when resolving interrupts using `useStream`, there was a case where we prioritized the remote state values (which we lookup in React Strict mode on every page transition) over the local interrupt responses we know we've responded with.
+
+This has since been fixed to first prioritize the local cache of interrupts, resolved against the remote state values when a run hits a terminal event

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -2260,11 +2260,10 @@ describe("StreamController", () => {
     await controller.dispose();
   });
 
-  it("reconciles still-pending interrupts from getState after resume settles", async () => {
-    // When the server keeps siblings pending but does not re-emit
-    // input.requested (session map already holds the id), the resumed
-    // run's interrupted terminal must pull tasks[].interrupts so
-    // stream.interrupts is not left empty after sequential respond.
+  it("does not restore consumed interrupts from stale state after resume settles", async () => {
+    // A checkpoint can retain the original interrupt batch after the
+    // corresponding responses were accepted. Reconcile must preserve
+    // the local consumed-interrupt tombstones.
     const eventListeners = new Set<(event: Event) => void>();
     const ordering: ThreadStream["ordering"] = {};
     let respondCount = 0;
@@ -2289,7 +2288,7 @@ describe("StreamController", () => {
       .mockResolvedValue({
         values: {},
         next: ["review"],
-        // Server still reports both pending despite sequential respond.
+        // Server returns the original checkpoint batch despite both responses.
         tasks: [
           {
             interrupts: [
@@ -2354,11 +2353,100 @@ describe("StreamController", () => {
     emit(lifecycleEvent("interrupted", 21));
 
     await waitForExpectation(() => {
-      expect(
-        controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
-      ).toEqual(["int-1", "int-2"]);
+      expect(getState.mock.calls.length).toBeGreaterThan(1);
     });
-    expect(getState.mock.calls.length).toBeGreaterThan(1);
+    expect(
+      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+    ).toEqual([]);
+
+    await controller.dispose();
+  });
+
+  it("keeps a consumed interrupt hidden when reconcile returns the original batch", async () => {
+    const eventListeners = new Set<(event: Event) => void>();
+    const ordering: ThreadStream["ordering"] = {};
+    const threadInterrupts = [
+      {
+        interruptId: "int-1",
+        payload: { prompt: "First?" },
+        namespace: [],
+      },
+      {
+        interruptId: "int-2",
+        payload: { prompt: "Second?" },
+        namespace: [],
+      },
+    ];
+    const respondInput = vi.fn(async () => {
+      ordering.lastAppliedThroughSeq = 10;
+      threadInterrupts.splice(
+        threadInterrupts.findIndex(
+          (interrupt) => interrupt.interruptId === "int-1"
+        ),
+        1
+      );
+    });
+    const interruptTasks = [
+      {
+        interrupts: [
+          { id: "int-1", value: { prompt: "First?" } },
+          { id: "int-2", value: { prompt: "Second?" } },
+        ],
+      },
+    ];
+    const getState = vi.fn(async () => ({
+      values: {},
+      next: ["review"],
+      tasks: interruptTasks,
+    }));
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        eventListeners.add(listener);
+        return vi.fn(() => {
+          eventListeners.delete(listener);
+        });
+      }),
+      close: vi.fn(async () => undefined),
+      ordering,
+      interrupts: threadInterrupts,
+      respondInput,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState,
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, { prompt: string }>({
+      assistantId: "interrupt_graph",
+      client: client as never,
+      threadId: "thread-consumed-reconcile",
+    });
+    await controller.hydrationPromise;
+
+    const emit = (event: Event) => {
+      for (const listener of eventListeners) listener(event);
+    };
+    emit(inputRequestedEvent("int-1", { prompt: "First?" }, [], 1));
+    emit(inputRequestedEvent("int-2", { prompt: "Second?" }, [], 2));
+
+    await controller.respond({ approved: true }, { interruptId: "int-1" });
+    expect(
+      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+    ).toEqual(["int-2"]);
+
+    emit(lifecycleEvent("running", 11));
+    emit(lifecycleEvent("interrupted", 12));
+
+    await waitForExpectation(() => {
+      expect(getState.mock.calls.length).toBeGreaterThan(1);
+    });
+    expect(
+      controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
+    ).toEqual(["int-2"]);
 
     await controller.dispose();
   });

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -242,11 +242,9 @@ export class StreamController<
    * Interrupt ids this controller has locally marked resolved via
    * {@link respond} / {@link respondAll}. Used only to suppress
    * *historical* SSE replay of those `input.requested` events (there
-   * is no `input.responded` protocol event). Live events after the
-   * resume barrier — or a post-resume reconcile against
-   * `state.tasks[].interrupts` — clear an id from this set so a
-   * still-pending server interrupt can reappear on
-   * `rootStore.interrupts`.
+   * is no `input.responded` protocol event). A live event after the
+   * resume barrier clears an id from this set so an interrupt raised
+   * again by a later run can reappear on `rootStore.interrupts`.
    */
   readonly #resolvedInterrupts = new Set<string>();
   /**
@@ -2464,8 +2462,7 @@ export class StreamController<
    * mirror the removal into the root snapshot the framework hooks read.
    *
    * Tombstones are not permanent: a live `input.requested` after the
-   * resume barrier, or {@link #reconcilePendingInterruptsFromServer},
-   * clears the id when the server still reports it as pending.
+   * resume barrier clears the id when the same interrupt is raised again.
    */
   #markInterruptResolvedInRootStore(interruptId: string): void {
     this.#resolvedInterrupts.add(interruptId);
@@ -2492,10 +2489,11 @@ export class StreamController<
    * `state.tasks[].interrupts` after a resumed run settles.
    *
    * Sequential `respond()` of parallel interrupts optimistically clears
-   * each id client-side. When the server still has siblings pending and
-   * does not re-emit `input.requested` for them (session map already
-   * holds the id), this restore keeps `stream.interrupts` truthful so
-   * callers do not free-text `submit()` into an ambiguous resume.
+   * each targeted id client-side. The server checkpoint can continue to
+   * list the original interrupt batch after accepting a partial response,
+   * so locally-resolved ids remain filtered while untouched siblings are
+   * restored. This keeps `stream.interrupts` truthful without re-exposing
+   * an already-consumed interrupt.
    *
    * Uses the same transport-aware state fetch as {@link hydrate}, and
    * drops the result if the thread swapped or a new submit/respond
@@ -2517,13 +2515,14 @@ export class StreamController<
       if (!Array.isArray(state?.tasks)) return;
       const { activeInterrupts, activeIds } =
         collectActiveInterruptsFromTasks<InterruptType>(state.tasks);
-      for (const id of activeIds) {
-        this.#resolvedInterrupts.delete(id);
-      }
+      const pendingInterrupts = activeInterrupts.filter(
+        (interrupt) =>
+          interrupt.id == null || !this.#resolvedInterrupts.has(interrupt.id)
+      );
       this.rootStore.setState((s) => ({
         ...s,
-        interrupts: activeInterrupts,
-        interrupt: activeInterrupts[0],
+        interrupts: pendingInterrupts,
+        interrupt: pendingInterrupts[0],
       }));
       this.#hydratedActiveInterruptIds = activeIds;
     } catch {


### PR DESCRIPTION
* fixes a condition where a re-fetch action after a run is done would prioritize resolution in remote state instead of when values are locally resolved
  * this means that we couldn't optimistically show that interrupts were answered
