### PR TITLE
fix(sdk): recover from a server-side thread stream drop instead of freezing

### DIFF
--- a/.changeset/sdk-reconnect-on-clean-close.md
+++ b/.changeset/sdk-reconnect-on-clean-close.md
@@ -1,0 +1,18 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): recover from a server-side thread stream drop instead of freezing
+
+The protocol SSE transport now reconnects when the server closes the event
+stream cleanly. The thread stream is open-ended, so a clean close only happens
+when the server's own upstream consumer died or it is restarting; before, the
+client treated it as the end of the thread and the UI froze mid-run with no
+error. A connection that delivered events also resets the reconnect budget, so
+long-lived pages survive repeated deploys. `maxReconnectAttempts: 0` keeps the
+old end-on-close behavior.
+
+Unsolicited server error frames (no command id) and a shared stream that gives
+up reconnecting now reach `stream.error`: `ThreadStream.onError` exposes them,
+`useStream` sets `error`, clears `isLoading`, and settles the in-flight
+`submit()` as failed.

--- a/libs/sdk/src/client/stream/index.ts
+++ b/libs/sdk/src/client/stream/index.ts
@@ -625,6 +625,7 @@ export class ThreadStream<
   // to consume discovery and interrupt events without opening extra
   // server subscriptions.
   readonly #onEventListeners = new Set<(event: Event) => void>();
+  readonly #onErrorListeners = new Set<(error: Error) => void>();
 
   #messagesIterable?: AsyncIterable<StreamingMessageHandle>;
   #valuesProjection?: AsyncIterable<unknown> & PromiseLike<unknown>;
@@ -1411,6 +1412,18 @@ export class ThreadStream<
   }
 
   /**
+   * Register a listener for stream-level failures: an unsolicited server
+   * error frame, or the transport giving up on reconnecting. Returns an
+   * unsubscribe function.
+   */
+  onError(listener: (error: Error) => void): () => void {
+    this.#onErrorListeners.add(listener);
+    return () => {
+      this.#onErrorListeners.delete(listener);
+    };
+  }
+
+  /**
    * Lazily open the wildcard discovery watcher stream.
    *
    * Idempotent. Used by both transports, but through different
@@ -1620,6 +1633,16 @@ export class ThreadStream<
     }
   }
 
+  #fireOnError(error: Error): void {
+    for (const listener of this.#onErrorListeners) {
+      try {
+        listener(error);
+      } catch {
+        // A throwing listener must not block delivery to the others.
+      }
+    }
+  }
+
   async close(): Promise<void> {
     if (this.#closed) {
       return;
@@ -1657,6 +1680,7 @@ export class ThreadStream<
     const lifecycleWatcherStartPromise = this.#lifecycleWatcherStartPromise;
     this.#lifecycleWatcherStartPromise = undefined;
     this.#onEventListeners.clear();
+    this.#onErrorListeners.clear();
     for (const subscription of this.#subscriptions.values()) {
       subscription.close();
     }
@@ -2094,6 +2118,7 @@ export class ThreadStream<
     for (const subscription of this.#subscriptions.values()) {
       subscription.close();
     }
+    this.#fireOnError(normalized);
   }
 
   /**
@@ -2412,6 +2437,9 @@ export class ThreadStream<
     const pending =
       messageId === undefined ? undefined : this.#pending.get(messageId);
     if (!pending) {
+      if (message.type === "error" && message.id == null) {
+        this.#fireOnError(new ProtocolError(message));
+      }
       return;
     }
     if (messageId !== undefined) {

--- a/libs/sdk/src/client/stream/shared-stream.test.ts
+++ b/libs/sdk/src/client/stream/shared-stream.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { ProtocolError } from "./error.js";
 import { ThreadStream } from "./index.js";
 import { MockSseTransport, eventOf, nextValue } from "./test/utils.js";
 
@@ -459,6 +460,44 @@ describe("ThreadStream (SSE shared stream)", () => {
 
     const narrowed = await nextValue(narrow);
     expect(narrowed).toMatchObject({ event_id: "evt_inside" });
+
+    await thread.close();
+  });
+  it("reports an unsolicited server error frame to onError listeners", async () => {
+    const transport = new MockSseTransport();
+    const thread = new ThreadStream(transport, { assistantId: "a" });
+    const errors: Error[] = [];
+    thread.onError((err) => errors.push(err));
+    await thread.subscribe({ channels: ["values"] });
+
+    transport.pushMessage({
+      type: "error",
+      id: null,
+      error: "unknown_error",
+      message: "Thread event stream failed: redis gone",
+    });
+    await flush();
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(ProtocolError);
+    expect((errors[0] as ProtocolError).code).toBe("unknown_error");
+    expect(errors[0].message).toBe("Thread event stream failed: redis gone");
+    expect(transport.activeStreamCount).toBe(1);
+
+    await thread.close();
+  });
+
+  it("reports a failed shared stream to onError listeners", async () => {
+    const transport = new MockSseTransport();
+    const thread = new ThreadStream(transport, { assistantId: "a" });
+    const errors: Error[] = [];
+    thread.onError((err) => errors.push(err));
+    await thread.subscribe({ channels: ["values"] });
+
+    transport.failStream(0, new Error("gave up reconnecting"));
+    await flush();
+
+    expect(errors.map((e) => e.message)).toEqual(["gave up reconnecting"]);
 
     await thread.close();
   });

--- a/libs/sdk/src/client/stream/test/utils.ts
+++ b/libs/sdk/src/client/stream/test/utils.ts
@@ -139,7 +139,7 @@ export class MockSseTransport implements TransportAdapter {
   private readonly buffer: Event[] = [];
   private readonly streams = new Set<{
     record: MockSseStreamRecord;
-    push: (event: Event) => void;
+    push: (message: Message) => void;
     pushError: (err: unknown) => void;
   }>();
 
@@ -261,7 +261,7 @@ export class MockSseTransport implements TransportAdapter {
 
     const stream = {
       record,
-      push: (event: Event) => {
+      push: (event: Message) => {
         if (record.closed) return;
         const waiter = waiters.shift();
         if (waiter) {
@@ -309,9 +309,17 @@ export class MockSseTransport implements TransportAdapter {
             if (record.closed) {
               return { done: true, value: undefined };
             }
-            return await new Promise<IteratorResult<Message>>((resolve) => {
-              waiters.push(resolve);
-            });
+            const result = await new Promise<IteratorResult<Message>>(
+              (resolve) => {
+                waiters.push(resolve);
+              }
+            );
+            if (rejectedWith !== undefined) {
+              const err = rejectedWith;
+              rejectedWith = undefined;
+              throw err;
+            }
+            return result;
           },
           return: async () => {
             close();
@@ -334,6 +342,17 @@ export class MockSseTransport implements TransportAdapter {
       if (matchesSubscription(event, stream.record.params)) {
         stream.push(event);
       }
+    }
+  }
+
+  /**
+   * Deliver a non-event protocol message (e.g. an unsolicited error frame)
+   * to every open stream, bypassing the subscription filter.
+   */
+  pushMessage(message: Message): void {
+    for (const stream of this.streams) {
+      if (stream.record.closed) continue;
+      stream.push(message);
     }
   }
 

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -597,6 +597,118 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
     await transport.close();
   });
 
+  function cleanCloseFetch(options: { keepOpenFrom: number }) {
+    let streamOpens = 0;
+    const encoder = new TextEncoder();
+    const fetchImpl = vi.fn((input: URL | RequestInfo) => {
+      if (!String(input).includes("/stream/events")) {
+        return Promise.resolve(protocolSuccessResponse());
+      }
+      streamOpens += 1;
+      const seq = streamOpens;
+      return Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  `event: values\ndata: {"type":"event","method":"values","seq":${seq},"event_id":"e${seq}"}\n\n`
+                )
+              );
+              if (seq < options.keepOpenFrom) controller.close();
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } }
+        )
+      );
+    }) as MockFetch;
+    return { fetchImpl, streamOpens: () => streamOpens };
+  }
+
+  async function collectEventIds(
+    handle: ReturnType<ProtocolSseTransportAdapter["openEventStream"]>,
+    until: string
+  ): Promise<string[]> {
+    const received: string[] = [];
+    for await (const message of handle.events) {
+      received.push((message as { event_id: string }).event_id);
+      if (received.includes(until)) break;
+    }
+    return received;
+  }
+
+  it("reconnects when the server closes the stream cleanly", async () => {
+    const onReconnect = vi.fn();
+    const { fetchImpl, streamOpens } = cleanCloseFetch({ keepOpenFrom: 2 });
+
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: THREAD_ID,
+      fetch: fetchImpl,
+      maxReconnectAttempts: 3,
+      reconnectDelayMs: () => 0,
+      onReconnect,
+      idleReconnect: 0,
+    });
+
+    const handle = transport.openEventStream({ channels: ["values"] });
+    await handle.ready;
+
+    expect(await collectEventIds(handle, "e2")).toEqual(["e1", "e2"]);
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+    expect(streamOpens()).toBe(2);
+
+    await transport.close();
+  });
+
+  it("resets the reconnect budget once a connection has delivered events", async () => {
+    const onReconnect = vi.fn();
+    const { fetchImpl, streamOpens } = cleanCloseFetch({ keepOpenFrom: 3 });
+
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: THREAD_ID,
+      fetch: fetchImpl,
+      maxReconnectAttempts: 1,
+      reconnectDelayMs: () => 0,
+      onReconnect,
+      idleReconnect: 0,
+    });
+
+    const handle = transport.openEventStream({ channels: ["values"] });
+    await handle.ready;
+
+    expect(await collectEventIds(handle, "e3")).toEqual(["e1", "e2", "e3"]);
+    expect(onReconnect.mock.calls.map((c) => c[0].attempt)).toEqual([1, 1]);
+    expect(streamOpens()).toBe(3);
+
+    await transport.close();
+  });
+
+  it("ends the stream on a clean close when maxReconnectAttempts is 0", async () => {
+    const { fetchImpl, streamOpens } = cleanCloseFetch({ keepOpenFrom: 2 });
+
+    const transport = new ProtocolSseTransportAdapter({
+      apiUrl: "http://localhost:8123",
+      threadId: THREAD_ID,
+      fetch: fetchImpl,
+      maxReconnectAttempts: 0,
+      idleReconnect: 0,
+    });
+
+    const handle = transport.openEventStream({ channels: ["values"] });
+    await handle.ready;
+
+    const received: string[] = [];
+    for await (const message of handle.events) {
+      received.push((message as { event_id: string }).event_id);
+    }
+    expect(received).toEqual(["e1"]);
+    expect(streamOpens()).toBe(1);
+
+    await transport.close();
+  });
+
   it("keeps reconnect disabled when maxReconnectAttempts is explicitly 0", async () => {
     const sentinel = new TypeError("net::ERR_QUIC_PROTOCOL_ERROR");
     let streamOpens = 0;

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -268,6 +268,7 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
 
     const startStream = async () => {
       let attempt = 0;
+      let receivedEvent = false;
 
       while (!ac.signal.aborted && !this.closed) {
         try {
@@ -336,12 +337,27 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
               break;
             }
             if (isRecord(event.data)) {
+              receivedEvent = true;
               streamQueue.push(event.data as Message);
             }
           }
-          streamQueue.close();
-          return;
+          if (
+            ac.signal.aborted ||
+            this.closed ||
+            this.maxReconnectAttempts <= 0
+          ) {
+            streamQueue.close();
+            return;
+          }
+          // The thread stream is open-ended: the server only ends it when
+          // its own upstream consumer died or it is shutting down, so a
+          // clean close is a disconnect, not the end of the thread.
+          throw new Error("Event stream closed by the server");
         } catch (error) {
+          if (receivedEvent) {
+            attempt = 0;
+            receivedEvent = false;
+          }
           if (ac.signal.aborted || this.closed) {
             if (!readySettled) {
               rejectReady(error);

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -235,6 +235,7 @@ describe("StreamController", () => {
     let onEvent: ((event: Event) => void) | undefined;
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -281,6 +282,7 @@ describe("StreamController", () => {
     let onEvent: ((event: Event) => void) | undefined;
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -345,6 +347,7 @@ describe("StreamController", () => {
     const rootSubscription = makePushableSubscription();
     const thread = {
       subscribe: vi.fn(async () => rootSubscription),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -450,6 +453,7 @@ describe("StreamController", () => {
     const rootSubscription = makePushableSubscription();
     const thread = {
       subscribe: vi.fn(async () => rootSubscription),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -523,6 +527,7 @@ describe("StreamController", () => {
     const onCompleted = vi.fn();
     const thread = {
       subscribe: vi.fn(async () => rootSubscription),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -563,6 +568,7 @@ describe("StreamController", () => {
   it("prefers transport.getState over client.threads.getState", async () => {
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -601,6 +607,7 @@ describe("StreamController", () => {
     let onEvent: ((event: Event) => void) | undefined;
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -650,6 +657,7 @@ describe("StreamController", () => {
     let onEvent: ((event: Event) => void) | undefined;
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -696,6 +704,7 @@ describe("StreamController", () => {
   it("hydrate seeds nested task interrupt namespaces from checkpoint_ns", async () => {
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -746,6 +755,7 @@ describe("StreamController", () => {
     const respondInput = vi.fn(async () => undefined);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [
@@ -799,6 +809,7 @@ describe("StreamController", () => {
     let onEvent: ((event: Event) => void) | undefined;
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -857,6 +868,7 @@ describe("StreamController", () => {
     let onEvent: ((event: Event) => void) | undefined;
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -984,6 +996,7 @@ describe("StreamController", () => {
     const ordering: ThreadStream["ordering"] = {};
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         eventListeners.add(listener);
         return vi.fn(() => {
@@ -1060,6 +1073,7 @@ describe("StreamController", () => {
     const ordering: ThreadStream["ordering"] = {};
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         eventListeners.add(listener);
         return vi.fn(() => {
@@ -1120,6 +1134,7 @@ describe("StreamController", () => {
     const ordering: ThreadStream["ordering"] = {};
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         eventListeners.add(listener);
         return vi.fn(() => {
@@ -1191,6 +1206,7 @@ describe("StreamController", () => {
     });
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         eventListeners.add(listener);
         return vi.fn(() => {
@@ -1266,6 +1282,7 @@ describe("StreamController", () => {
     let onEvent: ((event: Event) => void) | undefined;
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -1307,6 +1324,7 @@ describe("StreamController", () => {
     const startLifecycleWatcher = vi.fn(() => undefined);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -1413,6 +1431,7 @@ describe("StreamController", () => {
     );
     const thread = {
       subscribe,
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -1462,6 +1481,7 @@ describe("StreamController", () => {
     const startLifecycleWatcher = vi.fn(() => undefined);
     const thread = {
       subscribe,
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -1508,6 +1528,7 @@ describe("StreamController", () => {
     const submitRun = vi.fn(async () => ({ run_id: "run-1" }));
     const thread = {
       subscribe,
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -1551,6 +1572,7 @@ describe("StreamController", () => {
     const submitRun = vi.fn(async () => ({ run_id: "run-1" }));
     const thread = {
       subscribe: vi.fn(async () => rootSubscription),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -1620,6 +1642,7 @@ describe("StreamController", () => {
     const submitRun = vi.fn(async () => ({ run_id: "run-1" }));
     const thread = {
       subscribe: vi.fn(async () => rootSubscription),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -1692,6 +1715,7 @@ describe("StreamController", () => {
     const subscribe = vi.fn(async () => makeNeverEndingSubscription());
     const thread = {
       subscribe,
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -1725,6 +1749,7 @@ describe("StreamController", () => {
     const startLifecycleWatcher = vi.fn(() => undefined);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -1782,6 +1807,7 @@ describe("StreamController", () => {
     };
     const thread = {
       subscribe: vi.fn(async () => hungSubscription),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -1892,6 +1918,7 @@ describe("StreamController", () => {
     };
     const thread = {
       subscribe: vi.fn(async () => hungSubscription),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -1959,6 +1986,7 @@ describe("StreamController", () => {
     let onEvent: ((event: Event) => void) | undefined;
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -2001,6 +2029,7 @@ describe("StreamController", () => {
     const startLifecycleWatcher = vi.fn(() => undefined);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -2036,6 +2065,7 @@ describe("StreamController", () => {
 
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -2086,6 +2116,7 @@ describe("StreamController", () => {
 
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -2132,6 +2163,7 @@ describe("StreamController", () => {
     const respondInput = vi.fn(async () => undefined);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -2185,6 +2217,7 @@ describe("StreamController", () => {
     const respondInput = vi.fn(async () => undefined);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [
@@ -2251,6 +2284,7 @@ describe("StreamController", () => {
     const respondInput = vi.fn(async () => undefined);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -2317,6 +2351,7 @@ describe("StreamController", () => {
     });
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         eventListeners.add(listener);
         return vi.fn(() => {
@@ -2434,6 +2469,7 @@ describe("StreamController", () => {
       });
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         eventListeners.add(listener);
         return vi.fn(() => {
@@ -2535,6 +2571,7 @@ describe("StreamController", () => {
     }));
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         eventListeners.add(listener);
         return vi.fn(() => {
@@ -2619,6 +2656,7 @@ describe("StreamController", () => {
     });
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         eventListeners.add(listener);
         return vi.fn(() => {
@@ -2716,6 +2754,7 @@ describe("StreamController", () => {
       });
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         eventListeners.add(listener);
         return vi.fn(() => {
@@ -2741,6 +2780,7 @@ describe("StreamController", () => {
     } as unknown as ThreadStream;
     const otherThread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],
@@ -2811,6 +2851,7 @@ describe("StreamController", () => {
     const nestedNamespace = ["subgraph:child", "tools:tc-1"];
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [
@@ -2856,6 +2897,7 @@ describe("StreamController", () => {
     const respondInput = vi.fn(async () => undefined);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [
@@ -2901,6 +2943,7 @@ describe("StreamController", () => {
     const respondInput = vi.fn(async () => undefined);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [
@@ -2947,6 +2990,7 @@ describe("StreamController", () => {
     const respondInput = vi.fn(async () => undefined);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -3002,6 +3046,7 @@ describe("StreamController", () => {
     const respondInput = vi.fn(async () => undefined);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -3052,6 +3097,7 @@ describe("StreamController", () => {
     const respondInput = vi.fn(async () => undefined);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -3116,6 +3162,7 @@ describe("StreamController", () => {
     const respondInput = vi.fn(async () => undefined);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -3158,6 +3205,7 @@ describe("StreamController", () => {
     const respondInput = vi.fn(async () => undefined);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -3210,6 +3258,7 @@ describe("StreamController", () => {
     const respondInput = vi.fn(async () => undefined);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -3275,6 +3324,7 @@ describe("StreamController", () => {
     const respondInput = vi.fn(async () => undefined);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -3335,6 +3385,7 @@ describe("StreamController", () => {
     );
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -3404,11 +3455,62 @@ describe("StreamController", () => {
     await controller.dispose();
   });
 
+  it("surfaces a thread stream failure on rootStore.error and settles submit()", async () => {
+    const errorListeners = new Set<(error: Error) => void>();
+    const submitRun = vi.fn(async () => ({ run_id: "run-1" }));
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn((listener: (error: Error) => void) => {
+        errorListeners.add(listener);
+        return vi.fn(() => {
+          errorListeners.delete(listener);
+        });
+      }),
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      ordering: {},
+      submitRun,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {}, tasks: [] })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, unknown>({
+      assistantId: "agent",
+      client: client as never,
+      threadId: "thread-1",
+    });
+    await controller.hydrationPromise;
+
+    const submitPromise = controller.submit(null);
+    await waitForExpectation(() => expect(submitRun).toHaveBeenCalled());
+    expect(controller.rootStore.getSnapshot().isLoading).toBe(true);
+
+    for (const listener of errorListeners) {
+      listener(new Error("Thread event stream failed: redis gone"));
+    }
+
+    await submitPromise;
+    const snapshot = controller.rootStore.getSnapshot();
+    expect(snapshot.isLoading).toBe(false);
+    expect((snapshot.error as Error | undefined)?.message).toBe(
+      "Thread event stream failed: redis gone"
+    );
+
+    await controller.dispose();
+  });
+
   it("respond() surfaces a failed resumed run on rootStore.error", async () => {
     let onEvent: ((event: Event) => void) | undefined;
     const respondInput = vi.fn(async () => undefined);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -3471,6 +3573,7 @@ describe("StreamController", () => {
     });
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -3510,6 +3613,7 @@ describe("StreamController", () => {
     const respondInput = vi.fn(async () => undefined);
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -3568,6 +3672,7 @@ describe("StreamController", () => {
     let onEvent: ((event: Event) => void) | undefined;
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn((listener: (event: Event) => void) => {
         onEvent = listener;
         return vi.fn();
@@ -3977,6 +4082,7 @@ describe("StreamController", () => {
     );
     const thread = {
       subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onError: vi.fn(() => vi.fn()),
       onEvent: vi.fn(() => vi.fn()),
       close: vi.fn(async () => undefined),
       interrupts: [],

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -242,6 +242,7 @@ export class StreamController<
    */
   #rootPumpDeferred = false;
   #threadEventUnsubscribe: (() => void) | undefined;
+  #threadErrorUnsubscribe: (() => void) | undefined;
   #disposed = false;
   #pendingDisposeTimer: ReturnType<typeof setTimeout> | null = null;
   /**
@@ -1735,6 +1736,8 @@ export class StreamController<
     this.registry.bind(undefined);
     this.#threadEventUnsubscribe?.();
     this.#threadEventUnsubscribe = undefined;
+    this.#threadErrorUnsubscribe?.();
+    this.#threadErrorUnsubscribe = undefined;
     /**
      * Persistent lifecycle driver is scoped to the current thread
      * stream. Remove it so a swap to a new thread starts with a clean
@@ -1833,6 +1836,9 @@ export class StreamController<
     this.#threadEventUnsubscribe = thread.onEvent((event) =>
       this.#onWildcardEvent(event)
     );
+    this.#threadErrorUnsubscribe = thread.onError((error) => {
+      this.rootStore.setState((s) => ({ ...s, error, isLoading: false }));
+    });
 
     /**
      * Persistent isLoading driver. Drives `isLoading` from
@@ -2692,6 +2698,7 @@ export class StreamController<
         settled = true;
         unsubscribeRoot?.();
         unsubscribeThread?.();
+        unsubscribeError?.();
         signal.removeEventListener("abort", finishAborted);
         resolve(result);
       }
@@ -2724,6 +2731,9 @@ export class StreamController<
       };
       const unsubscribeRoot = this.#rootBus.subscribe(onEvent);
       const unsubscribeThread = this.#thread?.onEvent(onEvent);
+      const unsubscribeError = this.#thread?.onError((error) =>
+        finish({ event: "failed", error: error.message })
+      );
       if (signal.aborted) {
         finishAborted();
       } else {


### PR DESCRIPTION
## Summary

When the server closed the protocol SSE stream cleanly, the transport treated it as the end of the thread: no reconnect, no error, and a `useStream` UI froze mid-run with `isLoading` stuck and nothing in `stream.error`. The thread stream is open-ended by contract, so a clean close only ever means the server's upstream consumer died or the server is restarting. The transport now reconnects on it, and stream-level failures reach `stream.error`.

## Details

- `ProtocolSseTransportAdapter`: a clean close of the event stream takes the same path as a dropped connection (backoff, `onReconnect`, `maxReconnectAttempts`). `maxReconnectAttempts: 0` keeps the old end-on-close behavior. A connection that delivered at least one event resets the attempt counter, so a page that lives through several deploys does not die on the fifth one.
- Both reference servers in this repo (`libs/langgraph-api/src/api/protocol.mts`, `experimental/embed/protocol.mts`) hold the SSE open until the client aborts, and the Python server ends it only when its thread consumer dies, so no server uses a clean close to mean "done".
- `ThreadStream.onError(listener)`: unsolicited error frames (`id: null`) were dropped because command routing found no pending request for them. They are now delivered to `onError`, as is a shared stream that exhausts its reconnects. Subscriptions stay open on an error frame so the reconnected stream keeps feeding the run.
- `StreamController`: on a thread error it sets `error`, clears `isLoading`, and settles the in-flight `submit()` as failed.

## Tests

- `transport/http.test.ts`: reconnects on a clean close; resets the reconnect budget after a connection delivered events; still ends on a clean close with `maxReconnectAttempts: 0`.
- `shared-stream.test.ts`: an unsolicited error frame reaches `onError` as a `ProtocolError` and leaves the stream open; a failed shared stream reaches `onError`.
- `controller.test.ts`: a thread error lands on `rootStore.error`, clears `isLoading`, and settles `submit()`.
- Full `libs/sdk` unit suite (797) and the `libs/sdk-react` browser suite (244) pass.

Validated on the real stack (langgraph-api postgres runtime, core server killed with `kill -9` mid-run): without the fix the client got two events and then silence; with the fix it got `ProtocolError unknown_error "Thread event stream failed: ..."`, reconnected, and received the rest of the run through `lifecycle: completed`.

Changeset: `@langchain/langgraph-sdk` patch.
