### PR TITLE
fix(sdk): show interrupts raised after a passive thread rejoin

### DIFF
--- a/.changeset/sdk-passive-rejoin-interrupts.md
+++ b/.changeset/sdk-passive-rejoin-interrupts.md
@@ -1,0 +1,14 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): show interrupts raised after a passive thread rejoin
+
+After a page refresh mid-run, `useStream` filtered every interrupt it did not
+already know from the hydrated thread state as replayed history, and waited
+for a `checkpoints` event to lift that filter. Current runtimes never emit
+that event and the replay buffer trims it on long runs, so interrupts raised
+after the refresh never appeared until the next reload. Unknown interrupts are
+now settled against the server's thread state when the run reaches a terminal
+lifecycle: the ones the server lists as pending are shown, the rest are
+dropped as history.

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -206,10 +206,13 @@ function namespacedLifecycleEvent(
   } as Event;
 }
 
-async function waitForExpectation(assertion: () => void): Promise<void> {
+async function waitForExpectation(
+  assertion: () => void,
+  timeoutMs = 500
+): Promise<void> {
   const started = Date.now();
   let lastError: unknown;
-  while (Date.now() - started < 500) {
+  while (Date.now() - started < timeoutMs) {
     try {
       assertion();
       return;
@@ -840,6 +843,137 @@ describe("StreamController", () => {
     expect(
       controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
     ).toEqual(["interrupt-active"]);
+
+    await controller.dispose();
+  });
+
+  function passiveRejoinFixture(
+    states: Array<Record<string, unknown> | Error>
+  ): {
+    controller: StreamController<State, unknown>;
+    emit: (event: Event) => void;
+    getState: ReturnType<typeof vi.fn>;
+  } {
+    let onEvent: ((event: Event) => void) | undefined;
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => {
+        onEvent = listener;
+        return vi.fn();
+      }),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    let calls = 0;
+    const getState = vi.fn(async () => {
+      const state = states[Math.min(calls, states.length - 1)];
+      calls += 1;
+      if (state instanceof Error) throw state;
+      return state;
+    });
+    const client = {
+      threads: { getState, stream: vi.fn(() => thread) },
+    };
+    const controller = new StreamController<State, unknown>({
+      assistantId: "human-in-the-loop",
+      client: client as never,
+      threadId: "thread-passive-rejoin",
+    });
+    return { controller, emit: (event) => onEvent?.(event), getState };
+  }
+
+  const runningAtRefresh = {
+    values: {},
+    next: ["ask"],
+    tasks: [],
+    checkpoint: { checkpoint_id: "checkpoint-at-refresh" },
+  };
+  const interruptedOn = (id: string) => ({
+    values: {},
+    next: ["ask"],
+    tasks: [{ interrupts: [{ id, value: { question: "approve?" } }] }],
+    checkpoint: { checkpoint_id: "checkpoint-after-refresh" },
+  });
+  const finishedIdle = { values: {}, next: [], tasks: [] };
+
+  it("shows an interrupt raised after a passive rejoin without a checkpoints event", async () => {
+    const { controller, emit, getState } = passiveRejoinFixture([
+      runningAtRefresh,
+      interruptedOn("raised-after-refresh"),
+    ]);
+    await controller.hydrationPromise;
+
+    emit(inputRequestedEvent("raised-after-refresh", {}, [], 12));
+    expect(controller.rootStore.getSnapshot().interrupts).toEqual([]);
+
+    emit(lifecycleEvent("interrupted", 13));
+    await waitForExpectation(() => {
+      expect(
+        controller.rootStore.getSnapshot().interrupts.map((item) => item.id)
+      ).toEqual(["raised-after-refresh"]);
+    });
+    expect(getState).toHaveBeenCalledTimes(2);
+
+    await controller.dispose();
+  });
+
+  it("waits for the server to commit the interrupt before showing it", async () => {
+    const { controller, emit, getState } = passiveRejoinFixture([
+      runningAtRefresh,
+      runningAtRefresh,
+      interruptedOn("raised-after-refresh"),
+    ]);
+    await controller.hydrationPromise;
+
+    emit(inputRequestedEvent("raised-after-refresh", {}, [], 12));
+    emit(lifecycleEvent("interrupted", 13));
+    await waitForExpectation(() => {
+      expect(
+        controller.rootStore.getSnapshot().interrupts.map((item) => item.id)
+      ).toEqual(["raised-after-refresh"]);
+    }, 3_000);
+    expect(getState).toHaveBeenCalledTimes(3);
+
+    await controller.dispose();
+  });
+
+  it("retries a failed state fetch while settling parked interrupts", async () => {
+    const { controller, emit, getState } = passiveRejoinFixture([
+      runningAtRefresh,
+      new Error("502 from the load balancer"),
+      interruptedOn("raised-after-refresh"),
+    ]);
+    await controller.hydrationPromise;
+
+    emit(inputRequestedEvent("raised-after-refresh", {}, [], 12));
+    emit(lifecycleEvent("interrupted", 13));
+    await waitForExpectation(() => {
+      expect(
+        controller.rootStore.getSnapshot().interrupts.map((item) => item.id)
+      ).toEqual(["raised-after-refresh"]);
+    }, 3_000);
+    expect(getState).toHaveBeenCalledTimes(3);
+
+    await controller.dispose();
+  });
+
+  it("drops replayed interrupts the server no longer lists", async () => {
+    const { controller, emit, getState } = passiveRejoinFixture([
+      runningAtRefresh,
+      finishedIdle,
+    ]);
+    await controller.hydrationPromise;
+
+    emit(inputRequestedEvent("resolved-long-ago", {}, [], 3));
+    emit(lifecycleEvent("interrupted", 4));
+    await waitForExpectation(() => expect(getState).toHaveBeenCalledTimes(2));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(controller.rootStore.getSnapshot().interrupts).toEqual([]);
+
+    emit(lifecycleEvent("interrupted", 5));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(getState).toHaveBeenCalledTimes(2);
 
     await controller.dispose();
   });

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -180,6 +180,12 @@ export const ROOT_PUMP_CHANNELS: readonly Channel[] = [
   "tools",
 ];
 
+// The server writes an interrupt into thread state shortly after it streams
+// the `input.requested` event, so a state fetch on the terminal lifecycle can
+// miss it; mirrors the server's own interrupt settle window.
+const PARKED_INTERRUPT_SETTLE_MS = 5_000;
+const PARKED_INTERRUPT_SETTLE_POLL_MS = 500;
+
 interface ResolvedInterrupt {
   interruptId: string;
   namespace: string[];
@@ -267,6 +273,9 @@ export class StreamController<
    * from the newly-started run and must be accepted.
    */
   #interruptReplayThroughSeq: number | undefined;
+  /** Unknown inputs waiting to be classified as live or replayed history. */
+  #pendingHydrationInterruptEvents: Event[] = [];
+  #parkedInterruptSettleInFlight = false;
   /**
    * Unknown interrupt events received between local command dispatch and its
    * response. The response supplies the sequence barrier needed to classify
@@ -443,7 +452,8 @@ export class StreamController<
         this.#submitGeneration += 1;
         this.#interruptCommandPending =
           this.#hydratedActiveInterruptIds != null;
-        this.#pendingInterruptEvents = [];
+        this.#pendingInterruptEvents = this.#pendingHydrationInterruptEvents;
+        this.#pendingHydrationInterruptEvents = [];
       },
       onRunStart: () => this.#markLocalRunStart(),
       onRunCreated: (runId) => {
@@ -1761,6 +1771,7 @@ export class StreamController<
     // will repopulate it from that thread's `state.tasks[].interrupts`.
     this.#hydratedActiveInterruptIds = null;
     this.#interruptReplayThroughSeq = undefined;
+    this.#pendingHydrationInterruptEvents = [];
     this.#discardPendingInterruptEvents();
     this.queueStore.setState(
       () => EMPTY_QUEUE as SubmissionQueueSnapshot<StateType>
@@ -1986,6 +1997,7 @@ export class StreamController<
      * resume targeting.
      */
     this.#recordInterrupt(event);
+    this.#settleParkedInterruptsOnTerminal(event);
   }
 
   /**
@@ -2380,10 +2392,16 @@ export class StreamController<
       this.#pendingInterruptEvents.push(event);
       return;
     }
+    const barrier = this.#interruptReplayThroughSeq;
+    if (isUnknownInterrupt && barrier == null) {
+      this.#pendingHydrationInterruptEvents.push(event);
+      return;
+    }
     const isHistoricalUnknownInterrupt =
       isUnknownInterrupt &&
-      (this.#interruptReplayThroughSeq == null ||
-        (eventSeq != null && eventSeq <= this.#interruptReplayThroughSeq));
+      barrier != null &&
+      eventSeq != null &&
+      eventSeq <= barrier;
     if (isHistoricalUnknownInterrupt) {
       return;
     }
@@ -2499,9 +2517,9 @@ export class StreamController<
    * drops the result if the thread swapped or a new submit/respond
    * started while the fetch was in flight.
    */
-  async #reconcilePendingInterruptsFromServer(): Promise<void> {
+  async #reconcilePendingInterruptsFromServer(): Promise<ThreadState<StateType> | null> {
     const threadId = this.#currentThreadId;
-    if (threadId == null || this.#disposed) return;
+    if (threadId == null || this.#disposed) return null;
     const generationAtFetch = this.#submitGeneration;
     try {
       const state = await this.#fetchHydrationState();
@@ -2510,9 +2528,9 @@ export class StreamController<
         this.#currentThreadId !== threadId ||
         this.#submitGeneration !== generationAtFetch
       ) {
-        return;
+        return null;
       }
-      if (!Array.isArray(state?.tasks)) return;
+      if (!Array.isArray(state?.tasks)) return null;
       const { activeInterrupts, activeIds } =
         collectActiveInterruptsFromTasks<InterruptType>(state.tasks);
       const pendingInterrupts = activeInterrupts.filter(
@@ -2525,8 +2543,79 @@ export class StreamController<
         interrupt: pendingInterrupts[0],
       }));
       this.#hydratedActiveInterruptIds = activeIds;
+      return state;
     } catch {
       /* best-effort — leave the optimistic interrupt list alone */
+      return null;
+    }
+  }
+
+  #settleParkedInterruptsOnTerminal(event: Event): void {
+    if (this.#pendingHydrationInterruptEvents.length === 0) return;
+    if (event.method !== "lifecycle") return;
+    if (!isRootNamespace(event.params.namespace)) return;
+    const status = (event as LifecycleEvent).params.data?.event;
+    if (
+      status !== "interrupted" &&
+      status !== "completed" &&
+      status !== "failed"
+    ) {
+      return;
+    }
+    void this.#settleParkedInterrupts();
+  }
+
+  /**
+   * Decide parked interrupts with server state instead of a stream marker.
+   *
+   * After a passive rejoin the stream cannot tell a replayed, already
+   * resolved `input.requested` from one the current run just raised: the
+   * SSE replays the thread buffer on connect with no marker for where the
+   * replay ends. `state.tasks[].interrupts` is authoritative: parked ids it
+   * lists are live, the rest are history.
+   */
+  async #settleParkedInterrupts(): Promise<void> {
+    if (this.#parkedInterruptSettleInFlight) return;
+    this.#parkedInterruptSettleInFlight = true;
+    try {
+      const threadId = this.#currentThreadId;
+      const generation = this.#submitGeneration;
+      const deadline = Date.now() + PARKED_INTERRUPT_SETTLE_MS;
+      for (;;) {
+        if (
+          this.#disposed ||
+          this.#currentThreadId !== threadId ||
+          this.#submitGeneration !== generation ||
+          this.#pendingHydrationInterruptEvents.length === 0
+        ) {
+          return;
+        }
+        const parkedIds = new Set(
+          this.#pendingHydrationInterruptEvents.map(
+            (event) =>
+              (event.params.data as { interrupt_id?: string }).interrupt_id
+          )
+        );
+        // A null state is a failed or unusable fetch; the terminal that
+        // started this loop will not come again, so keep trying until the
+        // deadline rather than stranding the parked interrupts.
+        const state = await this.#reconcilePendingInterruptsFromServer();
+        if (state != null) {
+          const settled = [...(this.#hydratedActiveInterruptIds ?? [])].some(
+            (id) => parkedIds.has(id)
+          );
+          if (settled || !isThreadStateActive(state)) {
+            this.#pendingHydrationInterruptEvents = [];
+            return;
+          }
+        }
+        if (Date.now() >= deadline) return;
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, PARKED_INTERRUPT_SETTLE_POLL_MS);
+        });
+      }
+    } finally {
+      this.#parkedInterruptSettleInFlight = false;
     }
   }
 

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -2616,9 +2616,9 @@ export class StreamController<
       } finally {
         this.#settleParkedInterruptsPromise = undefined;
       }
-    }
-    this.#settleParkedInterruptsPromise ??= makePromise()
-    return this.#settleParkedInterruptsPromise
+    };
+    this.#settleParkedInterruptsPromise ??= makePromise();
+    return this.#settleParkedInterruptsPromise;
   }
 
   /**

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -275,7 +275,7 @@ export class StreamController<
   #interruptReplayThroughSeq: number | undefined;
   /** Unknown inputs waiting to be classified as live or replayed history. */
   #pendingHydrationInterruptEvents: Event[] = [];
-  #parkedInterruptSettleInFlight = false;
+  #settleParkedInterruptsPromise: Promise<void> | undefined;
   /**
    * Unknown interrupt events received between local command dispatch and its
    * response. The response supplies the sequence barrier needed to classify
@@ -2575,48 +2575,50 @@ export class StreamController<
    * lists are live, the rest are history.
    */
   async #settleParkedInterrupts(): Promise<void> {
-    if (this.#parkedInterruptSettleInFlight) return;
-    this.#parkedInterruptSettleInFlight = true;
-    try {
-      const threadId = this.#currentThreadId;
-      const generation = this.#submitGeneration;
-      const deadline = Date.now() + PARKED_INTERRUPT_SETTLE_MS;
-      for (;;) {
-        if (
-          this.#disposed ||
-          this.#currentThreadId !== threadId ||
-          this.#submitGeneration !== generation ||
-          this.#pendingHydrationInterruptEvents.length === 0
-        ) {
-          return;
-        }
-        const parkedIds = new Set(
-          this.#pendingHydrationInterruptEvents.map(
-            (event) =>
-              (event.params.data as { interrupt_id?: string }).interrupt_id
-          )
-        );
-        // A null state is a failed or unusable fetch; the terminal that
-        // started this loop will not come again, so keep trying until the
-        // deadline rather than stranding the parked interrupts.
-        const state = await this.#reconcilePendingInterruptsFromServer();
-        if (state != null) {
-          const settled = [...(this.#hydratedActiveInterruptIds ?? [])].some(
-            (id) => parkedIds.has(id)
-          );
-          if (settled || !isThreadStateActive(state)) {
-            this.#pendingHydrationInterruptEvents = [];
+    const makePromise = async () => {
+      try {
+        const threadId = this.#currentThreadId;
+        const generation = this.#submitGeneration;
+        const deadline = Date.now() + PARKED_INTERRUPT_SETTLE_MS;
+        for (;;) {
+          if (
+            this.#disposed ||
+            this.#currentThreadId !== threadId ||
+            this.#submitGeneration !== generation ||
+            this.#pendingHydrationInterruptEvents.length === 0
+          ) {
             return;
           }
+          const parkedIds = new Set(
+            this.#pendingHydrationInterruptEvents.map(
+              (event) =>
+                (event.params.data as { interrupt_id?: string }).interrupt_id
+            )
+          );
+          // A null state is a failed or unusable fetch; the terminal that
+          // started this loop will not come again, so keep trying until the
+          // deadline rather than stranding the parked interrupts.
+          const state = await this.#reconcilePendingInterruptsFromServer();
+          if (state != null) {
+            const settled = [...(this.#hydratedActiveInterruptIds ?? [])].some(
+              (id) => parkedIds.has(id)
+            );
+            if (settled || !isThreadStateActive(state)) {
+              this.#pendingHydrationInterruptEvents = [];
+              return;
+            }
+          }
+          if (Date.now() >= deadline) return;
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, PARKED_INTERRUPT_SETTLE_POLL_MS);
+          });
         }
-        if (Date.now() >= deadline) return;
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, PARKED_INTERRUPT_SETTLE_POLL_MS);
-        });
+      } finally {
+        this.#settleParkedInterruptsPromise = undefined;
       }
-    } finally {
-      this.#parkedInterruptSettleInFlight = false;
     }
+    this.#settleParkedInterruptsPromise ??= makePromise()
+    return this.#settleParkedInterruptsPromise
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes LG-661. After a page refresh (or a second tab) while a run is in progress, an interrupt the run then raises never shows up in `useStream` until the next reload. `isLoading` still drops to false, so the agent looks stuck. Reproduced on a real server with a slow-then-interrupt graph: the original tab shows the interrupt, the refreshed tab shows `interrupts: []`.

## Why it happens

After hydrate, the controller treats every `input.requested` it does not already know from `state.tasks[].interrupts` as replayed history, because the SSE replays the whole thread buffer on connect and the stream has no marker for where replay ends. #2807 parks those unknown interrupts until a `checkpoints` event carrying the hydrated checkpoint id arrives, then releases everything newer.

That event never arrives:

- LangGraph Python emits the `checkpoints` stream mode as a `get_state()`-shaped snapshot. The server session only forwards a checkpoint envelope with a top-level string `id`, so nothing is forwarded. Zero `checkpoints` events on the wire in the reproduction, matching the customer's HAR.
- LangGraph.js has no `checkpoints` emission at all (`libs/langgraph/src`).
- The Redis replay buffer trims by age (120s), so on a long node the matching event is gone before the refresh even when it did exist.

So the parked interrupts wait forever.

## The fix

Decide parked interrupts with the server's thread state instead of a stream marker.

- Unknown interrupts are parked as before, now whether or not hydrate returned a checkpoint id (the release no longer needs it).
- When a root terminal lifecycle (`interrupted` / `completed` / `failed`) arrives with interrupts parked, `#settleParkedInterrupts` runs the existing `#reconcilePendingInterruptsFromServer`: ids the server lists as pending are shown, the rest are dropped as history. Payloads come from `state.tasks[].interrupts`, the same source hydrate uses, so a refreshed tab and a fresh load agree by construction.
- The server commits the interrupt to thread state slightly after it streams the event (the server has its own 5s settle poll for this), so the fetch retries every 500ms for up to 5s. One loop runs at a time, so a replay burst with many old terminals costs one loop, not one per event. The common path (no parked interrupts) makes no extra calls.
- Rebased on #2814, which reverts the `checkpoints` barrier from #2807. This PR carries the parking list itself; the barrier is gone, so the settle against server state is the only release path.

## Tests

`controller.test.ts`:

- shows an interrupt raised after a passive rejoin without a checkpoints event
- waits for the server to commit the interrupt before showing it (second fetch returns it)
- drops replayed interrupts the server no longer lists

All three fail on `main`. The two #2807 tests still pass. Full `libs/sdk` unit suite (794) and `libs/sdk-react` browser suite (244) pass.

Real-stack check (langgraph-api inmem, langgraph 1.2.6): submit a run, create a second `StreamController` on the same thread 1s in, let the run interrupt at 4s. Before: refreshed tab `interrupts: []`. After: refreshed tab shows the interrupt, `respond()` from that tab resumes the run, and it completes.

## Follow-ups (not in this PR)

- The `checkpoints` channel is dead on the wire for every current deployment; the server never forwards it because no runtime produces the `{id, parent_id, step, source}` envelope.
- `onCompleted` not firing after a refresh (also reported in the thread): `#runLifecycleListener` requires `isLoading` to be true, and the buffer's `running` event is trimmed on long runs.

Changeset: `@langchain/langgraph-sdk` patch.

