### PR TITLE
revert(sdk): appropriately track persisted seq for stream replay (#2807)

### DIFF
--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -4,8 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { StreamController } from "./controller.js";
 import { messagesProjection } from "./projections/messages.js";
-import { ThreadStream } from "../client/stream/index.js";
-import { MockSseTransport } from "../client/stream/test/utils.js";
+import type { ThreadStream } from "../client/stream/index.js";
 
 interface State {
   messages?: unknown[];
@@ -841,88 +840,6 @@ describe("StreamController", () => {
     expect(
       controller.rootStore.getSnapshot().interrupts.map((i) => i.id)
     ).toEqual(["interrupt-active"]);
-
-    await controller.dispose();
-  });
-
-  it("accepts a replayed interrupt newer than the hydrated state", async () => {
-    const transport = new MockSseTransport({
-      threadId: "thread-refresh-active",
-    });
-    const thread = new ThreadStream(transport, {
-      assistantId: "human-in-the-loop",
-    });
-    transport.pushEvent(inputRequestedEvent("resolved-before-refresh", {}, [], 9));
-    transport.pushEvent(checkpointsEvent(1, 10, "checkpoint-at-refresh"));
-    transport.pushEvent(inputRequestedEvent("pending-at-refresh", {}, [], 12));
-
-    const client = {
-      threads: {
-        getState: vi.fn(async () => ({
-          values: {},
-          next: ["review"],
-          tasks: [],
-          checkpoint: { checkpoint_id: "checkpoint-at-refresh" },
-          metadata: { step: 1 },
-        })),
-        stream: vi.fn(() => thread),
-      },
-    };
-
-    const controller = new StreamController<State, unknown>({
-      assistantId: "human-in-the-loop",
-      client: client as never,
-      threadId: "thread-refresh-active",
-    });
-    await controller.hydrationPromise;
-
-    await waitForExpectation(() => {
-      expect(
-        controller.rootStore.getSnapshot().interrupts.map((item) => item.id)
-      ).toEqual(["pending-at-refresh"]);
-    });
-
-    await controller.dispose();
-  });
-
-  it("buffers unknown inputs until replay reaches the hydrated checkpoint", async () => {
-    let onEvent: ((event: Event) => void) | undefined;
-    const thread = {
-      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
-      onEvent: vi.fn((listener: (event: Event) => void) => {
-        onEvent = listener;
-        return vi.fn();
-      }),
-      close: vi.fn(async () => undefined),
-      interrupts: [],
-      startLifecycleWatcher: vi.fn(() => undefined),
-    } as unknown as ThreadStream;
-    const client = {
-      threads: {
-        getState: vi.fn(async () => ({
-          values: {},
-          next: ["review"],
-          tasks: [],
-          checkpoint: { checkpoint_id: "checkpoint-at-refresh" },
-        })),
-        stream: vi.fn(() => thread),
-      },
-    };
-    const controller = new StreamController<State, unknown>({
-      assistantId: "human-in-the-loop",
-      client: client as never,
-      threadId: "thread-refresh-cross-stream-order",
-    });
-    await controller.hydrationPromise;
-
-    onEvent?.(inputRequestedEvent("pending-at-refresh", {}, [], 12));
-    expect(controller.rootStore.getSnapshot().interrupts).toEqual([]);
-
-    onEvent?.(inputRequestedEvent("resolved-before-refresh", {}, [], 9));
-    onEvent?.(checkpointsEvent(1, 10, "checkpoint-at-refresh"));
-    expect(
-      controller.rootStore.getSnapshot().interrupts.map((item) => item.id)
-    ).toEqual(["pending-at-refresh"]);
 
     await controller.dispose();
   });

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -260,17 +260,13 @@ export class StreamController<
    * than {@link #interruptReplayThroughSeq} bypass the allowlist.
    */
   #hydratedActiveInterruptIds: Set<string> | null = null;
-  /** Checkpoint whose replay establishes the hydrate-time interrupt cutoff. */
-  #hydratedInterruptCheckpointId: string | undefined;
   /**
-   * Highest event sequence represented by hydration or already applied when
-   * the latest run command was accepted. Interrupts outside the hydrate-time
-   * allowlist remain filtered through this sequence, while newer events are
-   * live output and must be accepted.
+   * Highest event sequence already applied when the latest run command
+   * was accepted. Interrupts outside the hydrate-time allowlist remain
+   * filtered through this sequence, while newer events are live output
+   * from the newly-started run and must be accepted.
    */
   #interruptReplayThroughSeq: number | undefined;
-  /** Unknown inputs waiting for replay to reach the hydrated checkpoint. */
-  #pendingHydrationInterruptEvents: Event[] = [];
   /**
    * Unknown interrupt events received between local command dispatch and its
    * response. The response supplies the sequence barrier needed to classify
@@ -447,9 +443,7 @@ export class StreamController<
         this.#submitGeneration += 1;
         this.#interruptCommandPending =
           this.#hydratedActiveInterruptIds != null;
-        this.#pendingInterruptEvents = this.#pendingHydrationInterruptEvents;
-        this.#pendingHydrationInterruptEvents = [];
-        this.#hydratedInterruptCheckpointId = undefined;
+        this.#pendingInterruptEvents = [];
       },
       onRunStart: () => this.#markLocalRunStart(),
       onRunCreated: (runId) => {
@@ -762,8 +756,6 @@ export class StreamController<
         // active run's replay boundary.
         if (this.#submitGeneration === generationAtFetch) {
           this.#hydratedActiveInterruptIds = activeIds;
-          this.#hydratedInterruptCheckpointId =
-            state.checkpoint?.checkpoint_id ?? undefined;
           this.#interruptReplayThroughSeq = undefined;
         }
       }
@@ -1768,9 +1760,7 @@ export class StreamController<
     // Drop the hydrate-window allowlist — the next thread's hydrate
     // will repopulate it from that thread's `state.tasks[].interrupts`.
     this.#hydratedActiveInterruptIds = null;
-    this.#hydratedInterruptCheckpointId = undefined;
     this.#interruptReplayThroughSeq = undefined;
-    this.#pendingHydrationInterruptEvents = [];
     this.#discardPendingInterruptEvents();
     this.queueStore.setState(
       () => EMPTY_QUEUE as SubmissionQueueSnapshot<StateType>
@@ -1986,7 +1976,6 @@ export class StreamController<
     }
     this.#subgraphs.push(event);
     this.#lifecycleLoading.handle(event);
-    this.#advanceInterruptReplayBarrierFromCheckpoint(event);
 
     /**
      * `input.requested` events (including HITL inside a subagent /
@@ -2391,14 +2380,6 @@ export class StreamController<
       this.#pendingInterruptEvents.push(event);
       return;
     }
-    if (
-      isUnknownInterrupt &&
-      this.#interruptReplayThroughSeq == null &&
-      this.#hydratedInterruptCheckpointId != null
-    ) {
-      this.#pendingHydrationInterruptEvents.push(event);
-      return;
-    }
     const isHistoricalUnknownInterrupt =
       isUnknownInterrupt &&
       (this.#interruptReplayThroughSeq == null ||
@@ -2419,33 +2400,6 @@ export class StreamController<
       const interrupts = [...s.interrupts, interrupt];
       return { ...s, interrupts, interrupt: interrupts[0] };
     });
-  }
-
-  /** Establish the hydration cutoff when ordered replay reaches its checkpoint. */
-  #advanceInterruptReplayBarrierFromCheckpoint(event: Event): void {
-    if (
-      event.method !== "checkpoints" ||
-      this.#hydratedInterruptCheckpointId == null ||
-      !isRootNamespace(event.params.namespace)
-    ) {
-      return;
-    }
-    const data = event.params.data as { id?: unknown } | null;
-    if (
-      data?.id !== this.#hydratedInterruptCheckpointId ||
-      typeof event.seq !== "number"
-    ) {
-      return;
-    }
-    this.#interruptReplayThroughSeq = event.seq;
-    this.#hydratedInterruptCheckpointId = undefined;
-    const pendingEvents = this.#pendingHydrationInterruptEvents.sort(
-      (a, b) => (a.seq ?? 0) - (b.seq ?? 0)
-    );
-    this.#pendingHydrationInterruptEvents = [];
-    for (const pendingEvent of pendingEvents) {
-      this.#recordInterrupt(pendingEvent);
-    }
   }
 
   /**


### PR DESCRIPTION
This reverts commit dfa43320b5c13c8ae3462080164a7cbcfe02bb1d.
