### PR TITLE
fix(sdk): skip onSuccess for a run abandoned by clear() or stop()

### DIFF
--- a/.changeset/sdk-abandoned-run-onsuccess.md
+++ b/.changeset/sdk-abandoned-run-onsuccess.md
@@ -1,0 +1,14 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+fix(sdk): skip onSuccess for a run abandoned by clear() or stop()
+
+`StreamManager` decided whether to call `onSuccess` by reading the shared
+`abortRef`, which `clear()` and `stop()` replace with a fresh controller right
+after aborting the old one. A run abandoned by either call, whose stream then
+ended normally (as `streamWithRetry` does when the abort lands during its
+reconnect backoff), saw the fresh controller as not aborted and ran `onSuccess`
+anyway. In `useStream` this refetched the previous thread's history into the
+thread now on screen after a thread switch. The run now checks its own
+controller.

--- a/libs/sdk/src/ui/manager.test.ts
+++ b/libs/sdk/src/ui/manager.test.ts
@@ -4,6 +4,7 @@ import type { BaseMessage as CoreBaseMessage } from "@langchain/core/messages";
 import { StreamManager } from "./manager.js";
 import { MessageTupleManager } from "./messages.js";
 import { SubagentManager } from "./subagents.js";
+import type { Message } from "../types.messages.js";
 
 type TestState = {
   messages: Array<{ id: string; content: string; type: string }>;
@@ -1071,6 +1072,60 @@ describe("StreamManager", () => {
       expect(onError).not.toHaveBeenCalled();
       expect(onSuccess).toHaveBeenCalled();
       expect(streamManager.values).toEqual({ messages: [], count: 42 });
+    });
+  });
+
+  describe("abandoned run after clear()/stop()", () => {
+    type State = { messages: Message[] };
+
+    // The interrupt aborts this run's controller mid-stream; the stream then
+    // returns normally instead of throwing AbortError, like streamWithRetry
+    // does when the abort lands during its reconnect backoff.
+    const runAbandoned = async (
+      interrupt: (manager: StreamManager<State>) => void | Promise<void>
+    ) => {
+      const manager = new StreamManager<State>(new MessageTupleManager(), {
+        throttle: false,
+      });
+      const onSuccess = vi.fn();
+      const onFinish = vi.fn();
+
+      await manager.start(
+        async () => {
+          async function* gen() {
+            yield { event: "values" as const, data: { messages: [] } };
+            await interrupt(manager);
+          }
+          return gen();
+        },
+        {
+          getMessages: (values) => values.messages,
+          setMessages: (current, messages) => ({ ...current, messages }),
+          initialValues: { messages: [] },
+          callbacks: {},
+          onSuccess,
+          onError: vi.fn(),
+          onFinish,
+        }
+      );
+
+      return { onSuccess, onFinish };
+    };
+
+    it("should skip onSuccess when the stream ends normally after clear()", async () => {
+      const { onSuccess, onFinish } = await runAbandoned((m) => m.clear());
+
+      expect(onFinish).toHaveBeenCalledTimes(1);
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it("should skip onSuccess when the stream ends normally after stop()", async () => {
+      const { onSuccess, onFinish } = await runAbandoned((m) =>
+        m.stop({ messages: [] }, {})
+      );
+
+      expect(onFinish).toHaveBeenCalledTimes(1);
+      expect(onSuccess).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/sdk/src/ui/manager.ts
+++ b/libs/sdk/src/ui/manager.ts
@@ -783,9 +783,10 @@ export class StreamManager<
     try {
       this.queueSize = Math.max(0, this.queueSize - 1);
       this.setState({ isLoading: true, error: undefined });
-      this.abortRef = new AbortController();
+      const abort = new AbortController();
+      this.abortRef = abort;
 
-      const run = await action(this.abortRef.signal);
+      const run = await action(abort.signal);
       let clearedPreviousInterrupts = false;
 
       let streamError: StreamError | undefined;
@@ -1115,7 +1116,7 @@ export class StreamManager<
       // Skip onSuccess when the stream was aborted (e.g., by multitask interrupt).
       // This avoids unnecessary HTTP calls (like history fetching) that would
       // delay the next queued stream from starting.
-      if (!this.abortRef.signal.aborted) {
+      if (!abort.signal.aborted) {
         const values = await options.onSuccess?.();
         if (typeof values !== "undefined" && this.queueSize === 0) {
           this.setStreamValues(values);


### PR DESCRIPTION
`StreamManager.enqueue` stores the run's `AbortController` on the shared `this.abortRef` field and, after the stream loop, checks `this.abortRef.signal.aborted` to decide whether to call `onSuccess`.

`clear()` and `stop()` abort the current controller and then immediately replace `this.abortRef` with a fresh one. A run abandoned by either of them therefore reads the replacement controller when its loop ends, sees it as not aborted, and calls `onSuccess` anyway.

This only surfaces when the abandoned stream ends normally after the abort instead of throwing `AbortError`. `streamWithRetry` does exactly that when the abort lands during its reconnect backoff (it returns rather than throws), i.e. after a dropped connection. A healthy stream throws and is dropped cleanly, which is why the bug looks intermittent.

**Symptom in `useStream`.** `clear()` runs when `threadId` changes, and `onSuccess` refetches the thread's history and fires `onFinish`. Switching threads while a reconnecting run is in flight loads the previous thread's history into the thread now on screen.

**Fix.** Keep the run's own `AbortController` in a local and check that signal after the loop. Three lines in `manager.ts`, no other behaviour change.

**Tests.** Two new cases in `manager.test.ts` start a run whose stream returns once it is interrupted, call `clear()` (respectively `stop()`) mid-stream, and assert that `onFinish` fires but `onSuccess` does not. They fail on `main` and pass with the fix. The first commit adds the tests on their own so the failure can be reproduced by checking it out.
