### PR TITLE
fix(sdk): restart root pump after stream failure

### DIFF
--- a/.changeset/root-pump-restart.md
+++ b/.changeset/root-pump-restart.md
@@ -1,0 +1,6 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+Restart the root stream pump after a thread stream failure so a later `submit()`
+can receive terminal lifecycle events instead of leaving `isLoading` stuck.

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -3505,6 +3505,68 @@ describe("StreamController", () => {
     await controller.dispose();
   });
 
+  it("restarts the root pump after a thread stream failure", async () => {
+    const errorListeners = new Set<(error: Error) => void>();
+    const subscriptions: ReturnType<typeof makePushableSubscription>[] = [];
+    let run = 0;
+    const submitRun = vi.fn(async () => ({ run_id: `run-${++run}` }));
+    const thread = {
+      subscribe: vi.fn(async () => {
+        const subscription = makePushableSubscription();
+        subscriptions.push(subscription);
+        return subscription;
+      }),
+      onError: vi.fn((listener: (error: Error) => void) => {
+        errorListeners.add(listener);
+        return vi.fn(() => {
+          errorListeners.delete(listener);
+        });
+      }),
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      ordering: {},
+      submitRun,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {}, next: ["agent"] })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, unknown>({
+      assistantId: "agent",
+      client: client as never,
+      threadId: "thread-1",
+    });
+    await controller.hydrationPromise;
+    await subscriptions[0]?.started;
+
+    const failedSubmit = controller.submit(null);
+    await waitForExpectation(() => expect(submitRun).toHaveBeenCalledTimes(1));
+
+    for (const listener of errorListeners) {
+      listener(new Error("Thread event stream failed: redis gone"));
+    }
+    subscriptions[0]?.close();
+    await failedSubmit;
+
+    const nextSubmit = controller.submit(null);
+    await waitForExpectation(() => expect(thread.subscribe).toHaveBeenCalledTimes(2));
+    await subscriptions[1]?.started;
+    subscriptions[1]?.push(lifecycleEvent("completed", 2));
+    await nextSubmit;
+
+    expect(client.threads.stream).toHaveBeenCalledTimes(1);
+    expect(submitRun).toHaveBeenCalledTimes(2);
+    expect(controller.rootStore.getSnapshot().error).toBeUndefined();
+    expect(controller.rootStore.getSnapshot().isLoading).toBe(false);
+
+    await controller.dispose();
+  });
+
   it("respond() surfaces a failed resumed run on rootStore.error", async () => {
     let onEvent: ((event: Event) => void) | undefined;
     const respondInput = vi.fn(async () => undefined);

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -1658,7 +1658,12 @@ export class StreamController<
    *   still required.
    */
   #ensureThread(threadId: string, deferRootPump = false): ThreadStream {
-    if (this.#thread != null) return this.#thread;
+    if (this.#thread != null) {
+      if (!deferRootPump && !this.#rootPumpDeferred && this.#rootPump == null) {
+        this.#startRootPump(this.#thread);
+      }
+      return this.#thread;
+    }
     this.#thread = this.#options.client.threads.stream(threadId, {
       assistantId: this.#options.assistantId,
       transport: this.#options.transport,
@@ -1838,6 +1843,8 @@ export class StreamController<
     );
     this.#threadErrorUnsubscribe = thread.onError((error) => {
       this.rootStore.setState((s) => ({ ...s, error, isLoading: false }));
+      this.#rootSubscription?.close();
+      this.#clearRootPump(pumpGeneration);
     });
 
     /**
@@ -1851,7 +1858,7 @@ export class StreamController<
     this.#rootEventListeners.add(this.#lifecycleLoading.listener);
     this.#rootEventListeners.add(this.#runLifecycleListener);
 
-    this.#rootPump = (async () => {
+    const pump = (async () => {
       try {
         /**
          * Root content pump: depth 1 is required because the controller
@@ -1957,6 +1964,16 @@ export class StreamController<
             break;
           }
           if (!subscription.isPaused) {
+            const snapshot = this.rootStore.getSnapshot();
+            if (snapshot.isLoading && snapshot.error == null) {
+              this.rootStore.setState((s) => ({
+                ...s,
+                error: new Error(
+                  "Thread event stream closed before the active run completed."
+                ),
+                isLoading: false,
+              }));
+            }
             break;
           }
           await subscription.waitForResume();
@@ -1967,6 +1984,25 @@ export class StreamController<
         /* thread closed or errored */
       }
     })();
+    this.#rootPump = pump;
+    void pump.finally(() => {
+      this.#clearRootPump(pumpGeneration, pump);
+    });
+  }
+
+  #clearRootPump(pumpGeneration: number, pump?: Promise<void>): void {
+    if (pumpGeneration !== this.#rootPumpGeneration) return;
+    if (pump != null && this.#rootPump !== pump) return;
+    this.#rootPumpGeneration += 1;
+    this.#rootSubscription = undefined;
+    this.#rootPump = undefined;
+    this.#rootPumpReady = undefined;
+    this.#threadEventUnsubscribe?.();
+    this.#threadEventUnsubscribe = undefined;
+    this.#threadErrorUnsubscribe?.();
+    this.#threadErrorUnsubscribe = undefined;
+    this.#rootEventListeners.delete(this.#lifecycleLoading.listener);
+    this.#rootEventListeners.delete(this.#runLifecycleListener);
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #2817.

When a ThreadStream reports a fatal stream error, StreamController now closes and clears its root pump state so the next submit opens a fresh root subscription instead of reusing the settled pump promise.

The root pump also reports an unexpected unpaused subscription close during an active run before clearing its pump state.

## Tests

- `pnpm --filter @langchain/langgraph-sdk test src/stream/controller.test.ts`
- `pnpm exec oxlint libs/sdk/src/stream/controller.ts libs/sdk/src/stream/controller.test.ts`
- `pnpm exec oxfmt --check libs/sdk/src/stream/controller.ts libs/sdk/src/stream/controller.test.ts .changeset/root-pump-restart.md`
- `pnpm --filter @langchain/langgraph-sdk build`