### PR TITLE
feat(sdk): back submission queues with server runs

### DIFF
--- a/.changeset/server-native-submission-queue.md
+++ b/.changeset/server-native-submission-queue.md
@@ -1,0 +1,9 @@
+---
+"@langchain/langgraph-sdk": minor
+"@langchain/react": minor
+"@langchain/vue": minor
+"@langchain/svelte": minor
+"@langchain/angular": minor
+---
+
+Back the stream controller's enqueue strategy with protocol run.start acceptance, run-ID-correlated observation, paginated pending-run hydration, and server cancellation. Preserve stable queue keys and message IDs, detach accepted runs on thread switches, and require an explicit serverQueue observation/cancellation capability with matching transport authentication. Track running and pending runs separately, reconcile delayed acceptance, and resume subscriptions even when the lifecycle watcher sees a queued run first. Preserve ordinary stream-only submits.

--- a/libs/sdk-angular/docs/submission-queue.md
+++ b/libs/sdk-angular/docs/submission-queue.md
@@ -7,6 +7,7 @@ signals + imperatives:
 
 ```typescript
 import { Component } from "@angular/core";
+import { Client } from "@langchain/langgraph-sdk";
 import {
   injectStream,
   injectSubmissionQueue,
@@ -35,9 +36,11 @@ import {
   `,
 })
 export class ChatComponent {
+  readonly client = new Client({ apiUrl: "http://localhost:2024" });
   readonly stream = injectStream({
     assistantId: "agent",
-    apiUrl: "http://localhost:2024",
+    client: this.client,
+    serverQueue: this.client.runs,
   });
   readonly queue = injectSubmissionQueue(this.stream);
 
@@ -58,30 +61,48 @@ export class ChatComponent {
 
 | Field | Type | Notes |
 |---|---|---|
-| `entries` | `Signal<QueueEntry[]>` | Ordered list of pending payloads. Each entry carries an `id`, the original `input`, and the `options` it was submitted with. |
+| `entries` | `Signal<SubmissionQueueEntry[]>` | Ordered list of pending payloads. Each entry carries an `id`, the submitted `values`, and the `options` it was submitted with. |
 | `size` | `Signal<number>` | Convenience for `entries().length`. |
-| `cancel(id)` | `(id: string) => void` | Remove a specific entry from the queue. |
-| `clear()` | `() => void` | Drop all pending entries. |
+| `cancel(id)` | `(id: string) => Promise<boolean>` | Remove a specific entry from the queue. |
+| `clear()` | `() => Promise<void>` | Drop all pending entries. |
 
 ## Multitask strategies
 
 The `multitaskStrategy` option on `submit` controls what happens when
 a run is already in flight:
 
-- `"reject"` (default) — throw synchronously.
+- `"reject"` — reject the submit promise when a local run is active.
 - `"interrupt"` — stop the current run and start the new one.
-- `"rollback"` — discard the current run's streamed state and restart.
-- `"enqueue"` — append to the queue; drain sequentially.
+- `"rollback"` (default) — discard the current run's streamed state and restart.
+- `"enqueue"` — send immediately to the server queue.
 
-Only `"enqueue"` populates `injectSubmissionQueue`.
+Local `"enqueue"` submissions and hydrated pending server runs populate `injectSubmissionQueue`.
 
-## Thread swaps cancel the queue
+## Thread swaps detach the queue
 
-Swapping `threadId` (via the signal passed to `injectStream`) cancels
-all pending runs and clears the queue automatically — you don't have
-to call `queue.clear()` yourself.
+Swapping `threadId` clears the local mirror without cancelling accepted server runs.
 
 ## Related
 
 - [`injectStream` options](./inject-stream.md#options)
 - [Selectors](./selectors.md#ref-counting)
+
+## Server queue semantics
+
+`submit(input, { multitaskStrategy: "enqueue" })` sends the input to the server immediately, even while another run is streaming. Its promise resolves on **server acceptance**, not completion; acceptance failures reject and also reach the per-submit `onError` callback and `stream.error`. The existing content stream stays attached. The server decides execution order; concurrent HTTP requests are not guaranteed to be accepted in invocation order.
+
+Each entry has `{ id, runId?, values, options?, createdAt }`. Use `id` as the stable UI key and cancellation argument. `runId` is absent during acceptance and then contains the real server run ID. Message IDs are assigned before sending and preserved in `values`; queued inputs remain separate from the active run's optimistic state. Entries leave the queue when their own run starts or terminates. Queue completion callbacks are correlated using per-run status/join requests, not another run's terminal event.
+
+Running runs are tracked separately for stop/completion and never appear as pending entries. Pending runs are restored from all pages of `runs.list` on hydration and refreshed on built-in transport reconnects. The SDK checks pending run status roughly once per second and joins running runs without cancelling on disconnect. Restored entries use the server run ID as their UI key. `values` is `undefined` if the server does not return `kwargs.input`; stored input is not guaranteed. Only available config/metadata are restored, not JavaScript callbacks. Hydration includes pending runs submitted by other clients on the same thread.
+
+`cancel(id): Promise<boolean>` cancels that entry's server run, waiting for acceptance if necessary. `clear(): Promise<void>` cancels the current queue snapshot with explicit run IDs, leaving later submissions and unrelated active runs alone. Cancellation failures reject and leave entries available for retry. A run may start between observation and cancellation; cancelling that entry can then interrupt it.
+
+Switching threads or unmounting clears only this client's mirror and detaches observers. **Accepted runs keep executing on their original thread.** Reopening that thread restores its pending queue. To cancel before leaving, explicitly await `clear()`.
+
+Server queues are **opt-in**: pass `serverQueue: client.runs` to the stream options, or implement `transport.serverQueue` on a custom adapter. The capability supplies `list`, `get`, `join`, `cancel`, and `cancelMany`; it must target the same server with the same authentication and fetch policy as the protocol transport. There is no implicit REST fallback. Without it, hydration makes no queue requests and enqueue rejects. Custom adapters can refresh via controller hydration when reconnecting.
+
+Enqueue uses the existing protocol `run.start` command, which configures v2 stream modes, subgraphs, and resumability on both JS and Python servers. It does not use REST `runs.create`. Ordinary (non-enqueue) submissions retain their stream-only completion path and do not acquire GET/join requirements. If their terminal stream event is permanently lost, use reconnect or stop; queue polling is not a general replacement for stream lifecycle delivery.
+
+`stop()` with this capability looks up the current server-running run rather than cancelling pending entries. When no run is running yet, it waits for in-flight local queue acceptances and checks once more. This is not an atomic server-side “cancel whichever run starts next” operation: a run still pending at that check is left alone. Use `cancel(entry.id)` to cancel a specific pending submission. Cancellation failures from `stop()` do not prevent client-side stopping.
+
+With the capability enabled, passive completion callbacks come from observed server run IDs, not anonymous terminal events. Runs created by another client after hydration are discovered on a root running event or reconnect; runs that begin and finish entirely outside these observation windows are not guaranteed callbacks. The embedded protocol-only server does not expose the full queue observation API and is not a supported `serverQueue: client.runs` target.

--- a/libs/sdk-angular/src/tests/components/QueueStream.ts
+++ b/libs/sdk-angular/src/tests/components/QueueStream.ts
@@ -23,6 +23,7 @@ interface StreamState {
         {{ stream.isLoading() ? "Loading..." : "Not loading" }}
       </div>
       <div data-testid="message-count">{{ stream.messages().length }}</div>
+      <div data-testid="queue-error">{{ str(stream.error()) }}</div>
       <div data-testid="queue-size">{{ queue.size() }}</div>
       <div data-testid="queue-entries">
         {{ queueEntriesStr() }}
@@ -78,7 +79,7 @@ export class QueueStreamComponent {
   }
 
   onSubmitFirst() {
-    this.submitEnqueue("Msg1");
+    void this.stream.submit({ messages: [new HumanMessage("Msg1")] });
   }
 
   private submitEnqueue(content: string) {
@@ -86,7 +87,7 @@ export class QueueStreamComponent {
       messages: [new HumanMessage(content)],
     }, {
       multitaskStrategy: "enqueue",
-    });
+    }).catch(() => undefined);
   }
 
   onSubmitThree() {

--- a/libs/sdk-angular/src/tests/stream.queue.test.ts
+++ b/libs/sdk-angular/src/tests/stream.queue.test.ts
@@ -3,136 +3,27 @@ import { render } from "vitest-browser-angular";
 
 import { QueueStreamComponent } from "./components/QueueStream.js";
 
-/**
- * Runtime coverage for `injectSubmissionQueue` — Angular mirror of
- * the client-side submission queue. Mirrors React's `stream.queue`
- * suite 1:1.
- */
-
-it("records rapid submits in the submission queue", async () => {
+it("ordinary submits still complete on a protocol-only server", async () => {
   const screen = await render(QueueStreamComponent);
-
-  await screen.getByTestId("submit-first").click();
-
-  await expect
-    .element(screen.getByTestId("loading"), { timeout: 5_000 })
-    .toHaveTextContent("Loading...");
-
-  await screen.getByTestId("submit-three").click();
-
-  await expect
-    .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-    .toHaveTextContent("3");
+  try {
+    await screen.getByTestId("submit-first").click();
+    await expect.element(screen.getByTestId("message-count"), { timeout: 5_000 }).toHaveTextContent("2");
+    await expect.element(screen.getByTestId("loading"), { timeout: 5_000 }).toHaveTextContent("Not loading");
+    await expect.element(screen.getByTestId("queue-size")).toHaveTextContent("0");
+  } finally {
+    await screen.unmount();
+  }
 });
 
-it("exposes queued submission payloads via entries", async () => {
+it("rejects enqueue without an explicit server queue capability", async () => {
   const screen = await render(QueueStreamComponent);
-
-  await screen.getByTestId("submit-first").click();
-
-  await expect
-    .element(screen.getByTestId("loading"), { timeout: 5_000 })
-    .toHaveTextContent("Loading...");
-
-  await screen.getByTestId("submit-three").click();
-
-  await expect
-    .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-    .toHaveTextContent("3");
-
-  await expect
-    .element(screen.getByTestId("queue-entries"))
-    .toHaveTextContent("Msg2,Msg3,Msg4");
-});
-
-it("drains the queue sequentially once the active run terminates", async () => {
-  const screen = await render(QueueStreamComponent);
-
-  await screen.getByTestId("submit-first").click();
-  await screen.getByTestId("submit-three").click();
-
-  await expect
-    .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-    .toHaveTextContent("0");
-
-  await expect
-    .element(screen.getByTestId("loading"), { timeout: 5_000 })
-    .toHaveTextContent("Not loading");
-
-  // Each run adds a single AI reply ("Done.") so 4 human + 4 AI = 8.
-  await expect
-    .element(screen.getByTestId("message-count"), { timeout: 5_000 })
-    .toHaveTextContent("8");
-});
-
-it("removes a queued entry via cancel()", async () => {
-  const screen = await render(QueueStreamComponent);
-
-  await screen.getByTestId("submit-first").click();
-
-  await expect
-    .element(screen.getByTestId("loading"), { timeout: 5_000 })
-    .toHaveTextContent("Loading...");
-
-  await screen.getByTestId("submit-three").click();
-
-  await expect
-    .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-    .toHaveTextContent("3");
-  await expect
-    .element(screen.getByTestId("queue-entries"))
-    .toHaveTextContent("Msg2,Msg3,Msg4");
-
-  await screen.getByTestId("cancel-first").click();
-
-  await expect
-    .element(screen.getByTestId("queue-entries"), { timeout: 5_000 })
-    .toHaveTextContent("Msg3,Msg4");
-});
-
-it("empties the queue via clear()", async () => {
-  const screen = await render(QueueStreamComponent);
-
-  await screen.getByTestId("submit-first").click();
-
-  await expect
-    .element(screen.getByTestId("loading"), { timeout: 5_000 })
-    .toHaveTextContent("Loading...");
-
-  await screen.getByTestId("submit-three").click();
-
-  await expect
-    .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-    .toHaveTextContent("3");
-
-  await screen.getByTestId("clear-queue").click();
-
-  await expect
-    .element(screen.getByTestId("queue-entries"), { timeout: 5_000 })
-    .toHaveTextContent("");
-  await expect
-    .element(screen.getByTestId("queue-size"))
-    .toHaveTextContent("0");
-});
-
-it("clears the queue when the controller switches thread", async () => {
-  const screen = await render(QueueStreamComponent);
-
-  await screen.getByTestId("submit-first").click();
-
-  await expect
-    .element(screen.getByTestId("loading"), { timeout: 5_000 })
-    .toHaveTextContent("Loading...");
-
-  await screen.getByTestId("submit-three").click();
-
-  await expect
-    .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-    .toHaveTextContent("3");
-
-  await screen.getByTestId("switch-thread").click();
-
-  await expect
-    .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-    .toHaveTextContent("0");
+  try {
+    await screen.getByTestId("submit-first").click();
+    await screen.getByTestId("submit-three").click();
+    await expect.element(screen.getByTestId("queue-error"), { timeout: 5_000 }).toHaveTextContent("serverQueue capability");
+    await expect.element(screen.getByTestId("queue-size")).toHaveTextContent("0");
+    await expect.element(screen.getByTestId("message-count"), { timeout: 5_000 }).toHaveTextContent("2");
+  } finally {
+    await screen.unmount();
+  }
 });

--- a/libs/sdk-angular/src/use-stream.ts
+++ b/libs/sdk-angular/src/use-stream.ts
@@ -508,6 +508,7 @@ export function useStream<
     client: client as unknown as Client<StateType>,
     threadId: untracked(() => threadIdInput()),
     transport,
+    serverQueue: options.serverQueue,
     fetch: hasCustomAdapter ? undefined : asBag.fetch,
     webSocketFactory: hasCustomAdapter ? undefined : asBag.webSocketFactory,
     maxReconnectAttempts: hasCustomAdapter

--- a/libs/sdk-react/docs/submission-queue.md
+++ b/libs/sdk-react/docs/submission-queue.md
@@ -1,6 +1,6 @@
 # Submission queue
 
-`multitaskStrategy: "enqueue"` lets the user fire additional submits while another run is in flight. The queue is fully client-side — entries drain sequentially as the active run terminates — and is observable through the `useSubmissionQueue` companion hook.
+`multitaskStrategy: "enqueue"` lets the user fire additional submits while another run is in flight. The queue is server-backed and observable through the `useSubmissionQueue` companion hook.
 
 ## Table of contents
 
@@ -18,10 +18,26 @@ Pass `multitaskStrategy` to `submit()` to control what happens when a submit lan
 | ------------- | ------------------------------------------------------------------------------------------------------- |
 | `"rollback"`  | Default. Aborts the active run and immediately dispatches the new one.                                  |
 | `"reject"`    | Drops the new submit. The returned promise rejects.                                                     |
-| `"enqueue"`   | Appends the submit to the client-side queue. Entries drain sequentially once the active run terminates. |
+| `"enqueue"`   | Sends the submit immediately to the server queue without replacing the active stream. |
 | `"interrupt"` | Currently falls back to `"rollback"` semantics client-side, pending server-side support.                |
 
 ## Enqueueing runs
+
+Opt in when constructing the stream. Keep the client stable (for example, at module scope) and configure authentication/fetch there so commands and queue requests share it:
+
+```tsx
+import { Client } from "@langchain/langgraph-sdk";
+import { useStream } from "@langchain/react";
+
+const client = new Client({ apiUrl: "http://localhost:2024" });
+
+function Chat() {
+  const stream = useStream({ assistantId: "agent", client, serverQueue: client.runs });
+  return <button onClick={() => stream.submit({}, { multitaskStrategy: "enqueue" })}>Queue</button>;
+}
+```
+
+For a fetch/auth shim, construct the client with `callerOptions: { fetch: authenticatedFetch }` and any `defaultHeaders`/`onRequest` hook. A hook-level `fetch` override affects protocol traffic only; configure the queue capability with that same fetch explicitly.
 
 ```tsx
 import { HumanMessage } from "@langchain/core/messages";
@@ -32,7 +48,7 @@ void stream.submit(
 );
 ```
 
-Nothing special happens on the return value — the promise resolves when the enqueued run eventually completes. You can fire several in a row; they dispatch in call order.
+The promise resolves when the server accepts the submission. Use `onCompleted` to observe run completion.
 
 ## `useSubmissionQueue`
 
@@ -84,18 +100,38 @@ function Composer({ stream }: { stream: AnyStream }) {
 
 | Field        | Type                              | Description                                     |
 | ------------ | --------------------------------- | ----------------------------------------------- |
-| `entries`    | `readonly SubmissionQueueEntry[]` | All pending entries, in dispatch order.         |
+| `entries`    | `readonly SubmissionQueueEntry[]` | All pending entries, ordered by creation time.         |
 | `size`       | `number`                          | Alias for `entries.length`.                     |
-| `cancel(id)` | `(id: string) => boolean`         | Removes one entry by id; returns `true` on hit. |
-| `clear()`    | `() => void`                      | Empties the queue.                              |
+| `cancel(id)` | `(id: string) => Promise<boolean>`         | Removes one entry by id; returns `true` on hit. |
+| `clear()`    | `() => Promise<void>`                      | Empties the queue.                              |
 
-Each `SubmissionQueueEntry` carries `{ id, input, options, enqueuedAt }` so you can render the queued input ahead of its dispatch.
+Each `SubmissionQueueEntry` carries `{ id, runId?, values, options?, createdAt }`.
 
 ## Cancelling and clearing
 
-- `cancel(id)` removes a single entry. The run is never dispatched.
+- `cancel(id)` cancels the accepted server run for one entry.
 - `clear()` empties the queue but does not affect the active run. Pair with `stream.stop()` if you also need to abort the in-flight work.
 
 ## Thread switches
 
-Switching `threadId` clears the queue — entries were targeted at the previous thread, so dispatching them against the new one would be surprising. This mirrors the legacy `StreamOrchestrator` behaviour.
+Switching `threadId` detaches from the previous queue without cancelling accepted server runs.
+
+## Server queue semantics
+
+`submit(input, { multitaskStrategy: "enqueue" })` sends the input to the server immediately, even while another run is streaming. Its promise resolves on **server acceptance**, not completion; acceptance failures reject and also reach the per-submit `onError` callback and `stream.error`. The existing content stream stays attached. The server decides execution order; concurrent HTTP requests are not guaranteed to be accepted in invocation order.
+
+Each entry has `{ id, runId?, values, options?, createdAt }`. Use `id` as the stable UI key and cancellation argument. `runId` is absent during acceptance and then contains the real server run ID. Message IDs are assigned before sending and preserved in `values`; queued inputs remain separate from the active run's optimistic state. Entries leave the queue when their own run starts or terminates. Queue completion callbacks are correlated using per-run status/join requests, not another run's terminal event.
+
+Running runs are tracked separately for stop/completion and never appear as pending entries. Pending runs are restored from all pages of `runs.list` on hydration and refreshed on built-in transport reconnects. The SDK checks pending run status roughly once per second and joins running runs without cancelling on disconnect. Restored entries use the server run ID as their UI key. `values` is `undefined` if the server does not return `kwargs.input`; stored input is not guaranteed. Only available config/metadata are restored, not JavaScript callbacks. Hydration includes pending runs submitted by other clients on the same thread.
+
+`cancel(id): Promise<boolean>` cancels that entry's server run, waiting for acceptance if necessary. `clear(): Promise<void>` cancels the current queue snapshot with explicit run IDs, leaving later submissions and unrelated active runs alone. Cancellation failures reject and leave entries available for retry. A run may start between observation and cancellation; cancelling that entry can then interrupt it.
+
+Switching threads or unmounting clears only this client's mirror and detaches observers. **Accepted runs keep executing on their original thread.** Reopening that thread restores its pending queue. To cancel before leaving, explicitly await `clear()`.
+
+Server queues are **opt-in**: pass `serverQueue: client.runs` to the stream options, or implement `transport.serverQueue` on a custom adapter. The capability supplies `list`, `get`, `join`, `cancel`, and `cancelMany`; it must target the same server with the same authentication and fetch policy as the protocol transport. There is no implicit REST fallback. Without it, hydration makes no queue requests and enqueue rejects. Custom adapters can refresh via controller hydration when reconnecting.
+
+Enqueue uses the existing protocol `run.start` command, which configures v2 stream modes, subgraphs, and resumability on both JS and Python servers. It does not use REST `runs.create`. Ordinary (non-enqueue) submissions retain their stream-only completion path and do not acquire GET/join requirements. If their terminal stream event is permanently lost, use reconnect or stop; queue polling is not a general replacement for stream lifecycle delivery.
+
+`stop()` with this capability looks up the current server-running run rather than cancelling pending entries. When no run is running yet, it waits for in-flight local queue acceptances and checks once more. This is not an atomic server-side “cancel whichever run starts next” operation: a run still pending at that check is left alone. Use `cancel(entry.id)` to cancel a specific pending submission. Cancellation failures from `stop()` do not prevent client-side stopping.
+
+With the capability enabled, passive completion callbacks come from observed server run IDs, not anonymous terminal events. Runs created by another client after hydration are discovered on a root running event or reconnect; runs that begin and finish entirely outside these observation windows are not guaranteed callbacks. The embedded protocol-only server does not expose the full queue observation API and is not a supported `serverQueue: client.runs` target.

--- a/libs/sdk-react/src/tests/components/QueueStream.tsx
+++ b/libs/sdk-react/src/tests/components/QueueStream.tsx
@@ -14,18 +14,7 @@ interface Props {
   assistantId?: string;
 }
 
-/**
- * Test harness for the client-side submission queue exposed via
- * {@link useSubmissionQueue}. Mirrors the legacy `QueueStream`
- * fixture 1:1 so the cut-over suite covers the same behaviours:
- * - entries accumulate when submitting with `multitaskStrategy:
- *   "enqueue"` while a run is in flight
- * - `entries` carry the original input payload so the UI can render
- *   pending submissions before they are dispatched
- * - `cancel(id)` / `clear()` remove pending entries
- * - `switchThread()` drops every queued entry (handled by
- *   controller re-bind).
- */
+/** Tests ordinary submits and explicit rejection on a protocol-only server. */
 export function QueueStream({
   apiUrl,
   assistantId = "slow_graph",
@@ -44,7 +33,7 @@ export function QueueStream({
     void stream.submit(
       { messages: [new HumanMessage(content)] },
       { multitaskStrategy: "enqueue" },
-    );
+    ).catch(() => undefined);
 
   return (
     <div>
@@ -60,6 +49,7 @@ export function QueueStream({
         ))}
       </div>
 
+      <div data-testid="queue-error">{String(stream.error ?? "")}</div>
       <div data-testid="queue-size">{queue.size}</div>
       <div data-testid="queue-entries">
         {queue.entries
@@ -71,7 +61,7 @@ export function QueueStream({
           .join(",")}
       </div>
 
-      <button data-testid="submit-first" onClick={() => submitEnqueue("Msg1")}>
+      <button data-testid="submit-first" onClick={() => void stream.submit({ messages: [new HumanMessage("Msg1")] })}>
         Submit First
       </button>
       <button

--- a/libs/sdk-react/src/tests/stream.queue.test.tsx
+++ b/libs/sdk-react/src/tests/stream.queue.test.tsx
@@ -4,165 +4,26 @@ import { render } from "vitest-browser-react";
 import { QueueStream } from "./components/QueueStream.js";
 import { apiUrl, cleanupRender } from "./test-utils.js";
 
-/**
- * Runtime coverage for `useSubmissionQueue` — the client-side mirror
- * of the submission queue. The hook surface and the controller's
- * `queueStore` together record every `submit()` that arrives with
- * `multitaskStrategy: "enqueue"` while another run is in flight so
- * consumers can render pending submissions and give users cancel /
- * clear affordances before the controller drains them.
- */
-
-it("records rapid submits in the submission queue", async () => {
+it("ordinary submits still complete on a protocol-only server", async () => {
   const screen = await render(<QueueStream apiUrl={apiUrl} />);
-
   try {
     await screen.getByTestId("submit-first").click();
-
-    await expect
-      .element(screen.getByTestId("loading"), { timeout: 5_000 })
-      .toHaveTextContent("Loading...");
-
-    await screen.getByTestId("submit-three").click();
-
-    await expect
-      .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-      .toHaveTextContent("3");
+    await expect.element(screen.getByTestId("message-count"), { timeout: 5_000 }).toHaveTextContent("2");
+    await expect.element(screen.getByTestId("loading"), { timeout: 5_000 }).toHaveTextContent("Not loading");
+    await expect.element(screen.getByTestId("queue-size")).toHaveTextContent("0");
   } finally {
     await cleanupRender(screen);
   }
 });
 
-it("exposes queued submission payloads via entries", async () => {
+it("rejects enqueue without an explicit server queue capability", async () => {
   const screen = await render(<QueueStream apiUrl={apiUrl} />);
-
-  try {
-    await screen.getByTestId("submit-first").click();
-
-    await expect
-      .element(screen.getByTestId("loading"), { timeout: 5_000 })
-      .toHaveTextContent("Loading...");
-
-    await screen.getByTestId("submit-three").click();
-
-    await expect
-      .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-      .toHaveTextContent("3");
-
-    await expect
-      .element(screen.getByTestId("queue-entries"))
-      .toHaveTextContent("Msg2,Msg3,Msg4");
-  } finally {
-    await cleanupRender(screen);
-  }
-});
-
-it("drains the queue sequentially once the active run terminates", async () => {
-  const screen = await render(<QueueStream apiUrl={apiUrl} />);
-
   try {
     await screen.getByTestId("submit-first").click();
     await screen.getByTestId("submit-three").click();
-
-    await expect
-      .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-      .toHaveTextContent("0");
-
-    await expect
-      .element(screen.getByTestId("loading"), { timeout: 5_000 })
-      .toHaveTextContent("Not loading");
-
-    // Each enqueued submission landed in the message history after
-    // the controller drained the queue. The graph adds a single
-    // AIMessage per run (`Done.`) so we expect 8 messages total:
-    // 4 human + 4 AI.
-    await expect
-      .element(screen.getByTestId("message-count"), { timeout: 5_000 })
-      .toHaveTextContent("8");
-  } finally {
-    await cleanupRender(screen);
-  }
-});
-
-it("removes a queued entry via cancel()", async () => {
-  const screen = await render(<QueueStream apiUrl={apiUrl} />);
-
-  try {
-    await screen.getByTestId("submit-first").click();
-
-    await expect
-      .element(screen.getByTestId("loading"), { timeout: 5_000 })
-      .toHaveTextContent("Loading...");
-
-    await screen.getByTestId("submit-three").click();
-
-    await expect
-      .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-      .toHaveTextContent("3");
-    await expect
-      .element(screen.getByTestId("queue-entries"))
-      .toHaveTextContent("Msg2,Msg3,Msg4");
-
-    await screen.getByTestId("cancel-first").click();
-
-    await expect
-      .element(screen.getByTestId("queue-entries"), { timeout: 5_000 })
-      .toHaveTextContent("Msg3,Msg4");
-  } finally {
-    await cleanupRender(screen);
-  }
-});
-
-it("empties the queue via clear()", async () => {
-  const screen = await render(<QueueStream apiUrl={apiUrl} />);
-
-  try {
-    await screen.getByTestId("submit-first").click();
-
-    await expect
-      .element(screen.getByTestId("loading"), { timeout: 5_000 })
-      .toHaveTextContent("Loading...");
-
-    await screen.getByTestId("submit-three").click();
-
-    await expect
-      .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-      .toHaveTextContent("3");
-
-    await screen.getByTestId("clear-queue").click();
-
-    await expect
-      .element(screen.getByTestId("queue-entries"), { timeout: 5_000 })
-      .toHaveTextContent("");
-    await expect
-      .element(screen.getByTestId("queue-size"))
-      .toHaveTextContent("0");
-  } finally {
-    await cleanupRender(screen);
-  }
-});
-
-it("clears the queue when the controller switches thread", async () => {
-  const screen = await render(<QueueStream apiUrl={apiUrl} />);
-
-  try {
-    await screen.getByTestId("submit-first").click();
-
-    await expect
-      .element(screen.getByTestId("loading"), { timeout: 5_000 })
-      .toHaveTextContent("Loading...");
-
-    await screen.getByTestId("submit-three").click();
-
-    await expect
-      .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-      .toHaveTextContent("3");
-
-    await screen.getByTestId("switch-thread").click();
-
-    await expect
-      .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-      .toHaveTextContent("0");
+    await expect.element(screen.getByTestId("queue-error"), { timeout: 5_000 }).toHaveTextContent("serverQueue capability");
+    await expect.element(screen.getByTestId("queue-size")).toHaveTextContent("0");
+    await expect.element(screen.getByTestId("message-count"), { timeout: 5_000 }).toHaveTextContent("2");
   } finally {
     await cleanupRender(screen);
   }

--- a/libs/sdk-react/src/use-stream.ts
+++ b/libs/sdk-react/src/use-stream.ts
@@ -563,7 +563,12 @@ export function useStream<
   // Recreated only when its identity inputs change; the previous
   // instance is disposed by the `activate()` effect when `controller`
   // changes.
-  const controllerDeps = [client, assistantId, transport] as const;
+  const controllerDeps = [
+    client,
+    assistantId,
+    transport,
+    options.serverQueue,
+  ] as const;
   const controllerRef = useRef<{
     deps: typeof controllerDeps;
     controller: StreamController<StateType, InterruptType, ConfigurableType>;
@@ -589,6 +594,7 @@ export function useStream<
         client: client as unknown as Client<StateType>,
         threadId: options.threadId ?? null,
         transport,
+        serverQueue: options.serverQueue,
         fetch: hasCustomAdapter ? undefined : asBag.fetch,
         webSocketFactory: hasCustomAdapter ? undefined : asBag.webSocketFactory,
         maxReconnectAttempts: hasCustomAdapter

--- a/libs/sdk-svelte/docs/submission-queue.md
+++ b/libs/sdk-svelte/docs/submission-queue.md
@@ -5,8 +5,10 @@ When `submit()` is called while a run is already in flight, pass `multitaskStrat
 ```svelte
 <script lang="ts">
   import { useStream, useSubmissionQueue } from "@langchain/svelte";
+  import { Client } from "@langchain/langgraph-sdk";
 
-  const stream = useStream({ assistantId: "agent", apiUrl: "http://localhost:2024" });
+  const client = new Client({ apiUrl: "http://localhost:2024" });
+  const stream = useStream({ assistantId: "agent", client, serverQueue: client.runs });
   const queue = useSubmissionQueue(stream);
 
   function queueTurn() {
@@ -34,3 +36,23 @@ When `submit()` is called while a run is already in flight, pass `multitaskStrat
 ```
 
 `queue.size`, `queue.entries`, and `queue.clear` / `queue.cancel` are reactive — Svelte will re-render as entries come and go.
+
+## Server queue semantics
+
+`submit(input, { multitaskStrategy: "enqueue" })` sends the input to the server immediately, even while another run is streaming. Its promise resolves on **server acceptance**, not completion; acceptance failures reject and also reach the per-submit `onError` callback and `stream.error`. The existing content stream stays attached. The server decides execution order; concurrent HTTP requests are not guaranteed to be accepted in invocation order.
+
+Each entry has `{ id, runId?, values, options?, createdAt }`. Use `id` as the stable UI key and cancellation argument. `runId` is absent during acceptance and then contains the real server run ID. Message IDs are assigned before sending and preserved in `values`; queued inputs remain separate from the active run's optimistic state. Entries leave the queue when their own run starts or terminates. Queue completion callbacks are correlated using per-run status/join requests, not another run's terminal event.
+
+Running runs are tracked separately for stop/completion and never appear as pending entries. Pending runs are restored from all pages of `runs.list` on hydration and refreshed on built-in transport reconnects. The SDK checks pending run status roughly once per second and joins running runs without cancelling on disconnect. Restored entries use the server run ID as their UI key. `values` is `undefined` if the server does not return `kwargs.input`; stored input is not guaranteed. Only available config/metadata are restored, not JavaScript callbacks. Hydration includes pending runs submitted by other clients on the same thread.
+
+`cancel(id): Promise<boolean>` cancels that entry's server run, waiting for acceptance if necessary. `clear(): Promise<void>` cancels the current queue snapshot with explicit run IDs, leaving later submissions and unrelated active runs alone. Cancellation failures reject and leave entries available for retry. A run may start between observation and cancellation; cancelling that entry can then interrupt it.
+
+Switching threads or unmounting clears only this client's mirror and detaches observers. **Accepted runs keep executing on their original thread.** Reopening that thread restores its pending queue. To cancel before leaving, explicitly await `clear()`.
+
+Server queues are **opt-in**: pass `serverQueue: client.runs` to the stream options, or implement `transport.serverQueue` on a custom adapter. The capability supplies `list`, `get`, `join`, `cancel`, and `cancelMany`; it must target the same server with the same authentication and fetch policy as the protocol transport. There is no implicit REST fallback. Without it, hydration makes no queue requests and enqueue rejects. Custom adapters can refresh via controller hydration when reconnecting.
+
+Enqueue uses the existing protocol `run.start` command, which configures v2 stream modes, subgraphs, and resumability on both JS and Python servers. It does not use REST `runs.create`. Ordinary (non-enqueue) submissions retain their stream-only completion path and do not acquire GET/join requirements. If their terminal stream event is permanently lost, use reconnect or stop; queue polling is not a general replacement for stream lifecycle delivery.
+
+`stop()` with this capability looks up the current server-running run rather than cancelling pending entries. When no run is running yet, it waits for in-flight local queue acceptances and checks once more. This is not an atomic server-side “cancel whichever run starts next” operation: a run still pending at that check is left alone. Use `cancel(entry.id)` to cancel a specific pending submission. Cancellation failures from `stop()` do not prevent client-side stopping.
+
+With the capability enabled, passive completion callbacks come from observed server run IDs, not anonymous terminal events. Runs created by another client after hydration are discovered on a root running event or reconnect; runs that begin and finish entirely outside these observation windows are not guaranteed callbacks. The embedded protocol-only server does not expose the full queue observation API and is not a supported `serverQueue: client.runs` target.

--- a/libs/sdk-svelte/src/tests/components/QueueStream.svelte
+++ b/libs/sdk-svelte/src/tests/components/QueueStream.svelte
@@ -33,7 +33,7 @@
     void stream.submit(
       { messages: [new HumanMessage(content)] },
       { multitaskStrategy: "enqueue" },
-    );
+    ).catch(() => undefined);
   }
 
   const entriesText = $derived(
@@ -57,11 +57,12 @@
     {stream.isLoading ? "Loading..." : "Not loading"}
   </div>
   <div data-testid="message-count">{stream.messages.length}</div>
+  <div data-testid="queue-error">{String(stream.error ?? "")}</div>
   <div data-testid="queue-size">{queue.size}</div>
   <div data-testid="queue-entries">{entriesText}</div>
   <button
     data-testid="submit-first"
-    onclick={() => enqueue("Msg1")}
+    onclick={() => void stream.submit({ messages: [new HumanMessage("Msg1")] })}
   >
     Submit First
   </button>

--- a/libs/sdk-svelte/src/tests/stream.queue.test.ts
+++ b/libs/sdk-svelte/src/tests/stream.queue.test.ts
@@ -5,130 +5,27 @@ import QueueStream from "./components/QueueStream.svelte";
 
 const serverUrl = inject("serverUrl");
 
-it("records rapid submits in the submission queue", async () => {
+it("ordinary submits still complete on a protocol-only server", async () => {
   const screen = await render(QueueStream, { apiUrl: serverUrl });
-
-  await screen.getByTestId("submit-first").click();
-
-  await expect
-    .element(screen.getByTestId("loading"), { timeout: 5_000 })
-    .toHaveTextContent("Loading...");
-
-  await screen.getByTestId("submit-three").click();
-
-  await expect
-    .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-    .toHaveTextContent("3");
+  try {
+    await screen.getByTestId("submit-first").click();
+    await expect.element(screen.getByTestId("message-count"), { timeout: 5_000 }).toHaveTextContent("2");
+    await expect.element(screen.getByTestId("loading"), { timeout: 5_000 }).toHaveTextContent("Not loading");
+    await expect.element(screen.getByTestId("queue-size")).toHaveTextContent("0");
+  } finally {
+    await screen.unmount();
+  }
 });
 
-it("exposes queued submission payloads via entries", async () => {
+it("rejects enqueue without an explicit server queue capability", async () => {
   const screen = await render(QueueStream, { apiUrl: serverUrl });
-
-  await screen.getByTestId("submit-first").click();
-
-  await expect
-    .element(screen.getByTestId("loading"), { timeout: 5_000 })
-    .toHaveTextContent("Loading...");
-
-  await screen.getByTestId("submit-three").click();
-
-  await expect
-    .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-    .toHaveTextContent("3");
-
-  await expect
-    .element(screen.getByTestId("queue-entries"))
-    .toHaveTextContent("Msg2,Msg3,Msg4");
-});
-
-it("drains the queue sequentially once the active run terminates", async () => {
-  const screen = await render(QueueStream, { apiUrl: serverUrl });
-
-  await screen.getByTestId("submit-first").click();
-  await screen.getByTestId("submit-three").click();
-
-  await expect
-    .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-    .toHaveTextContent("0");
-
-  await expect
-    .element(screen.getByTestId("loading"), { timeout: 5_000 })
-    .toHaveTextContent("Not loading");
-
-  // Each run adds a single AI reply ("Done.") so 4 human + 4 AI = 8.
-  await expect
-    .element(screen.getByTestId("message-count"), { timeout: 5_000 })
-    .toHaveTextContent("8");
-});
-
-it("removes a queued entry via cancel()", async () => {
-  const screen = await render(QueueStream, { apiUrl: serverUrl });
-
-  await screen.getByTestId("submit-first").click();
-
-  await expect
-    .element(screen.getByTestId("loading"), { timeout: 5_000 })
-    .toHaveTextContent("Loading...");
-
-  await screen.getByTestId("submit-three").click();
-
-  await expect
-    .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-    .toHaveTextContent("3");
-  await expect
-    .element(screen.getByTestId("queue-entries"))
-    .toHaveTextContent("Msg2,Msg3,Msg4");
-
-  await screen.getByTestId("cancel-first").click();
-
-  await expect
-    .element(screen.getByTestId("queue-entries"), { timeout: 5_000 })
-    .toHaveTextContent("Msg3,Msg4");
-});
-
-it("empties the queue via clear()", async () => {
-  const screen = await render(QueueStream, { apiUrl: serverUrl });
-
-  await screen.getByTestId("submit-first").click();
-
-  await expect
-    .element(screen.getByTestId("loading"), { timeout: 5_000 })
-    .toHaveTextContent("Loading...");
-
-  await screen.getByTestId("submit-three").click();
-
-  await expect
-    .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-    .toHaveTextContent("3");
-
-  await screen.getByTestId("clear-queue").click();
-
-  await expect
-    .element(screen.getByTestId("queue-entries"), { timeout: 5_000 })
-    .toHaveTextContent("");
-  await expect
-    .element(screen.getByTestId("queue-size"))
-    .toHaveTextContent("0");
-});
-
-it("clears the queue when the controller switches thread", async () => {
-  const screen = await render(QueueStream, { apiUrl: serverUrl });
-
-  await screen.getByTestId("submit-first").click();
-
-  await expect
-    .element(screen.getByTestId("loading"), { timeout: 5_000 })
-    .toHaveTextContent("Loading...");
-
-  await screen.getByTestId("submit-three").click();
-
-  await expect
-    .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-    .toHaveTextContent("3");
-
-  await screen.getByTestId("switch-thread").click();
-
-  await expect
-    .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-    .toHaveTextContent("0");
+  try {
+    await screen.getByTestId("submit-first").click();
+    await screen.getByTestId("submit-three").click();
+    await expect.element(screen.getByTestId("queue-error"), { timeout: 5_000 }).toHaveTextContent("serverQueue capability");
+    await expect.element(screen.getByTestId("queue-size")).toHaveTextContent("0");
+    await expect.element(screen.getByTestId("message-count"), { timeout: 5_000 }).toHaveTextContent("2");
+  } finally {
+    await screen.unmount();
+  }
 });

--- a/libs/sdk-svelte/src/use-stream.svelte.ts
+++ b/libs/sdk-svelte/src/use-stream.svelte.ts
@@ -506,6 +506,7 @@ export function useStream<
     client: client as unknown as Client<StateType>,
     threadId: initialThreadId,
     transport,
+    serverQueue: options.serverQueue,
     fetch: hasCustomAdapter ? undefined : asBag.fetch,
     webSocketFactory: hasCustomAdapter ? undefined : asBag.webSocketFactory,
     maxReconnectAttempts: hasCustomAdapter

--- a/libs/sdk-vue/docs/submission-queue.md
+++ b/libs/sdk-vue/docs/submission-queue.md
@@ -7,10 +7,14 @@ exposes the queue as a set of refs + imperatives:
 ```vue
 <script setup lang="ts">
 import { useStream, useSubmissionQueue } from "@langchain/vue";
+import { Client } from "@langchain/langgraph-sdk";
+
+const client = new Client({ apiUrl: "http://localhost:2024" });
 
 const stream = useStream({
   assistantId: "agent",
-  apiUrl: "http://localhost:2024",
+  client,
+  serverQueue: client.runs,
 });
 const queue = useSubmissionQueue(stream);
 
@@ -51,11 +55,29 @@ function onSubmit() {
 |---|---|---|
 | `entries` | `Readonly<ShallowRef<SubmissionQueueEntry[]>>` | Current queue, oldest first. |
 | `size` | `ComputedRef<number>` | Convenience — `entries.value.length`. |
-| `cancel(id)` | `(id: string) => void` | Remove a specific entry. |
-| `clear()` | `() => void` | Remove all pending entries. |
+| `cancel(id)` | `(id: string) => Promise<boolean>` | Remove a specific entry. |
+| `clear()` | `() => Promise<void>` | Remove all pending entries. |
 
 ## Thread switching
 
-Swapping the reactive `threadId` passed to `useStream` cancels all
-pending runs and clears the queue automatically — no manual
-bookkeeping required.
+Swapping the reactive `threadId` clears the local mirror without cancelling accepted server runs.
+
+## Server queue semantics
+
+`submit(input, { multitaskStrategy: "enqueue" })` sends the input to the server immediately, even while another run is streaming. Its promise resolves on **server acceptance**, not completion; acceptance failures reject and also reach the per-submit `onError` callback and `stream.error`. The existing content stream stays attached. The server decides execution order; concurrent HTTP requests are not guaranteed to be accepted in invocation order.
+
+Each entry has `{ id, runId?, values, options?, createdAt }`. Use `id` as the stable UI key and cancellation argument. `runId` is absent during acceptance and then contains the real server run ID. Message IDs are assigned before sending and preserved in `values`; queued inputs remain separate from the active run's optimistic state. Entries leave the queue when their own run starts or terminates. Queue completion callbacks are correlated using per-run status/join requests, not another run's terminal event.
+
+Running runs are tracked separately for stop/completion and never appear as pending entries. Pending runs are restored from all pages of `runs.list` on hydration and refreshed on built-in transport reconnects. The SDK checks pending run status roughly once per second and joins running runs without cancelling on disconnect. Restored entries use the server run ID as their UI key. `values` is `undefined` if the server does not return `kwargs.input`; stored input is not guaranteed. Only available config/metadata are restored, not JavaScript callbacks. Hydration includes pending runs submitted by other clients on the same thread.
+
+`cancel(id): Promise<boolean>` cancels that entry's server run, waiting for acceptance if necessary. `clear(): Promise<void>` cancels the current queue snapshot with explicit run IDs, leaving later submissions and unrelated active runs alone. Cancellation failures reject and leave entries available for retry. A run may start between observation and cancellation; cancelling that entry can then interrupt it.
+
+Switching threads or unmounting clears only this client's mirror and detaches observers. **Accepted runs keep executing on their original thread.** Reopening that thread restores its pending queue. To cancel before leaving, explicitly await `clear()`.
+
+Server queues are **opt-in**: pass `serverQueue: client.runs` to the stream options, or implement `transport.serverQueue` on a custom adapter. The capability supplies `list`, `get`, `join`, `cancel`, and `cancelMany`; it must target the same server with the same authentication and fetch policy as the protocol transport. There is no implicit REST fallback. Without it, hydration makes no queue requests and enqueue rejects. Custom adapters can refresh via controller hydration when reconnecting.
+
+Enqueue uses the existing protocol `run.start` command, which configures v2 stream modes, subgraphs, and resumability on both JS and Python servers. It does not use REST `runs.create`. Ordinary (non-enqueue) submissions retain their stream-only completion path and do not acquire GET/join requirements. If their terminal stream event is permanently lost, use reconnect or stop; queue polling is not a general replacement for stream lifecycle delivery.
+
+`stop()` with this capability looks up the current server-running run rather than cancelling pending entries. When no run is running yet, it waits for in-flight local queue acceptances and checks once more. This is not an atomic server-side “cancel whichever run starts next” operation: a run still pending at that check is left alone. Use `cancel(entry.id)` to cancel a specific pending submission. Cancellation failures from `stop()` do not prevent client-side stopping.
+
+With the capability enabled, passive completion callbacks come from observed server run IDs, not anonymous terminal events. Runs created by another client after hydration are discovered on a root running event or reconnect; runs that begin and finish entirely outside these observation windows are not guaranteed callbacks. The embedded protocol-only server does not expose the full queue observation API and is not a supported `serverQueue: client.runs` target.

--- a/libs/sdk-vue/src/tests/components/QueueStream.tsx
+++ b/libs/sdk-vue/src/tests/components/QueueStream.tsx
@@ -33,7 +33,7 @@ export const QueueStream = defineComponent({
       void stream.submit(
         { messages: [new HumanMessage(content)] },
         { multitaskStrategy: "enqueue" },
-      );
+      ).catch(() => undefined);
     };
 
     const entriesText = () =>
@@ -64,10 +64,11 @@ export const QueueStream = defineComponent({
           ))}
         </div>
 
+        <div data-testid="queue-error">{String(stream.error.value ?? "")}</div>
         <div data-testid="queue-size">{queue.size.value}</div>
         <div data-testid="queue-entries">{entriesText()}</div>
 
-        <button data-testid="submit-first" onClick={() => enqueue("Msg1")}>
+        <button data-testid="submit-first" onClick={() => void stream.submit({ messages: [new HumanMessage("Msg1")] })}>
           Submit First
         </button>
         <button

--- a/libs/sdk-vue/src/tests/stream.queue.test.tsx
+++ b/libs/sdk-vue/src/tests/stream.queue.test.tsx
@@ -4,180 +4,26 @@ import { render } from "vitest-browser-vue";
 import { QueueStream } from "./components/QueueStream.js";
 import { apiUrl } from "./test-utils.js";
 
-/**
- * Runtime coverage for `useSubmissionQueue` — Vue mirror of the
- * client-side submission queue suite.
- */
-
-it("records rapid submits in the submission queue", async () => {
+it("ordinary submits still complete on a protocol-only server", async () => {
   const screen = await render(QueueStream, { props: { apiUrl } });
-
   try {
     await screen.getByTestId("submit-first").click();
-
-    await expect
-      .element(screen.getByTestId("loading"), { timeout: 5_000 })
-      .toHaveTextContent("Loading...");
-
-    await screen.getByTestId("submit-three").click();
-
-    await expect
-      .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-      .toHaveTextContent("3");
+    await expect.element(screen.getByTestId("message-count"), { timeout: 5_000 }).toHaveTextContent("2");
+    await expect.element(screen.getByTestId("loading"), { timeout: 5_000 }).toHaveTextContent("Not loading");
+    await expect.element(screen.getByTestId("queue-size")).toHaveTextContent("0");
   } finally {
     await screen.unmount();
   }
 });
 
-it("exposes queued submission payloads via entries", async () => {
+it("rejects enqueue without an explicit server queue capability", async () => {
   const screen = await render(QueueStream, { props: { apiUrl } });
-
-  try {
-    await screen.getByTestId("submit-first").click();
-
-    await expect
-      .element(screen.getByTestId("loading"), { timeout: 5_000 })
-      .toHaveTextContent("Loading...");
-
-    await screen.getByTestId("submit-three").click();
-
-    await expect
-      .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-      .toHaveTextContent("3");
-
-    await expect
-      .element(screen.getByTestId("queue-entries"))
-      .toHaveTextContent("Msg2,Msg3,Msg4");
-  } finally {
-    await screen.unmount();
-  }
-});
-
-it("drains the queue sequentially once the active run terminates", async () => {
-  const screen = await render(QueueStream, { props: { apiUrl } });
-
   try {
     await screen.getByTestId("submit-first").click();
     await screen.getByTestId("submit-three").click();
-
-    await expect
-      .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-      .toHaveTextContent("0");
-
-    await expect
-      .element(screen.getByTestId("loading"), { timeout: 5_000 })
-      .toHaveTextContent("Not loading");
-
-    // Each run adds a single AI reply ("Done.") so 4 human + 4 AI = 8.
-    await expect
-      .element(screen.getByTestId("message-count"), { timeout: 5_000 })
-      .toHaveTextContent("8");
-  } finally {
-    await screen.unmount();
-  }
-});
-
-it("removes a queued entry via cancel()", async () => {
-  const screen = await render(QueueStream, { props: { apiUrl } });
-
-  try {
-    await screen.getByTestId("submit-first").click();
-
-    await expect
-      .element(screen.getByTestId("loading"), { timeout: 5_000 })
-      .toHaveTextContent("Loading...");
-
-    await screen.getByTestId("submit-three").click();
-
-    await expect
-      .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-      .toHaveTextContent("3");
-    await expect
-      .element(screen.getByTestId("queue-entries"))
-      .toHaveTextContent("Msg2,Msg3,Msg4");
-
-    await screen.getByTestId("cancel-first").click();
-
-    await expect
-      .element(screen.getByTestId("queue-entries"), { timeout: 5_000 })
-      .toHaveTextContent("Msg3,Msg4");
-
-    await expect
-      .element(screen.getByTestId("loading"), { timeout: 10_000 })
-      .toHaveTextContent("Not loading");
-    await expect
-      .element(screen.getByTestId("messages"))
-      .not.toHaveTextContent("Msg2");
-    await expect.element(screen.getByTestId("messages")).toHaveTextContent("Msg3");
-    await expect.element(screen.getByTestId("messages")).toHaveTextContent("Msg4");
-  } finally {
-    await screen.unmount();
-  }
-});
-
-it("empties the queue via clear()", async () => {
-  const screen = await render(QueueStream, { props: { apiUrl } });
-
-  try {
-    await screen.getByTestId("submit-first").click();
-
-    await expect
-      .element(screen.getByTestId("loading"), { timeout: 5_000 })
-      .toHaveTextContent("Loading...");
-
-    await screen.getByTestId("submit-three").click();
-
-    await expect
-      .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-      .toHaveTextContent("3");
-
-    await screen.getByTestId("clear-queue").click();
-
-    await expect
-      .element(screen.getByTestId("queue-entries"), { timeout: 5_000 })
-      .toHaveTextContent("");
-    await expect
-      .element(screen.getByTestId("queue-size"))
-      .toHaveTextContent("0");
-
-    await expect
-      .element(screen.getByTestId("loading"), { timeout: 10_000 })
-      .toHaveTextContent("Not loading");
-    await expect
-      .element(screen.getByTestId("messages"))
-      .not.toHaveTextContent("Msg2");
-    await expect
-      .element(screen.getByTestId("messages"))
-      .not.toHaveTextContent("Msg3");
-    await expect
-      .element(screen.getByTestId("messages"))
-      .not.toHaveTextContent("Msg4");
-  } finally {
-    await screen.unmount();
-  }
-});
-
-it("clears the queue when the controller switches thread", async () => {
-  const screen = await render(QueueStream, { props: { apiUrl } });
-
-  try {
-    await screen.getByTestId("submit-first").click();
-
-    await expect
-      .element(screen.getByTestId("loading"), { timeout: 5_000 })
-      .toHaveTextContent("Loading...");
-
-    await screen.getByTestId("submit-three").click();
-
-    await expect
-      .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-      .toHaveTextContent("3");
-
-    await screen.getByTestId("switch-thread").click();
-
-    await expect
-      .element(screen.getByTestId("queue-size"), { timeout: 5_000 })
-      .toHaveTextContent("0");
+    await expect.element(screen.getByTestId("queue-error"), { timeout: 5_000 }).toHaveTextContent("serverQueue capability");
+    await expect.element(screen.getByTestId("queue-size")).toHaveTextContent("0");
+    await expect.element(screen.getByTestId("message-count"), { timeout: 5_000 }).toHaveTextContent("2");
   } finally {
     await screen.unmount();
   }

--- a/libs/sdk-vue/src/use-stream.ts
+++ b/libs/sdk-vue/src/use-stream.ts
@@ -545,6 +545,7 @@ export function useStream<
     client: client as unknown as Client<StateType>,
     threadId: initialThreadId,
     transport,
+    serverQueue: options.serverQueue,
     fetch: hasCustomAdapter ? undefined : asBag.fetch,
     webSocketFactory: hasCustomAdapter ? undefined : asBag.webSocketFactory,
     maxReconnectAttempts: hasCustomAdapter

--- a/libs/sdk/docs/runs.md
+++ b/libs/sdk/docs/runs.md
@@ -78,6 +78,16 @@ const run = await client.runs.create(threadId, assistantId, {
 
 `threadId` can be `null` for stateless "one-off" runs.
 
+### Server-backed stream submission queue
+
+`StreamController.submit(input, { multitaskStrategy: "enqueue" })` uses the protocol `run.start` command immediately (not `runs.create`) when explicitly configured with `serverQueue: client.runs` without replacing its protocol-v2 content subscription. The promise resolves on acceptance, not completion, and rejects on acceptance failure. `queueStore` exposes pending entries with stable UI `id`, optional accepted `runId`, `values`, `options`, and `createdAt`. Input message IDs are assigned before dispatch; queued values do not overwrite the active optimistic batch.
+
+The controller tracks running runs separately and hydrates all pending pages using `runs.list`, refreshes on built-in reconnects, and observes each accepted run using `get`/`join` rather than an unrelated root terminal. Stored `Run.kwargs` is optional: selecting `kwargs` can recover input/config, but `values` remains undefined if the server omits input.
+
+`cancelQueued(id)` uses the accepted server run ID; `clearQueue()` uses `cancelMany` with explicit IDs from the current snapshot. Failures reject without silently removing entries. Cancellation can race execution and interrupt a run that has just started. Thread switching/disposal only detach the mirror; accepted runs remain on the server.
+
+Pass `serverQueue` explicitly in controller/framework options, or provide `transport.serverQueue` on a custom `AgentServerAdapter`. The capability must use the same server, auth and fetch policy as the transport; no implicit HTTP fallback is used. Ordinary submits retain stream-only completion and add no REST calls. See the [framework queue guide](../../sdk-react/docs/submission-queue.md#server-queue-semantics) for lifecycle and compatibility details.
+
 ### `createBatch(payloads, options?)`
 
 Create many runs in one request:

--- a/libs/sdk/src/client/stream/index.test.ts
+++ b/libs/sdk/src/client/stream/index.test.ts
@@ -1,5 +1,5 @@
 import type { Event } from "@langchain/protocol";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   ProtocolError,
@@ -12,6 +12,7 @@ import {
   ToolCallAssembler,
   parseToolOutput,
 } from "./handles/tools.js";
+import { Client } from "../../index.js";
 import type { ThreadExtension } from "./types.js";
 import {
   MockSseTransport,
@@ -21,6 +22,92 @@ import {
 } from "./test/utils.js";
 
 describe("ThreadStream", () => {
+  it("resumes paused subscriptions when a server-queued run starts without a local command", async () => {
+    const transport = new MockTransport();
+    const thread = new ThreadStream(transport, { assistantId: "agent" });
+    const subscription = await thread.subscribe({ channels: ["lifecycle", "values"] });
+    transport.pushEvent(eventOf("lifecycle", { event: "completed" }, { seq: 10, eventId: "first-terminal" }));
+    await nextValue(subscription);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(subscription.isPaused).toBe(true);
+    transport.pushEvent(eventOf("lifecycle", { event: "running" }, { seq: 11, eventId: "queued-running" }));
+    await subscription.waitForResume();
+    expect((await nextValue(subscription)).params.data).toEqual({ event: "running" });
+    expect(subscription.isPaused).toBe(false);
+    transport.pushEvent(eventOf("values", { count: 2 }, { seq: 12, eventId: "queued-values" }));
+    expect((await nextValue(subscription)).params.data).toEqual({ count: 2 });
+    expect(transport.sentCommands.filter((command) => command.method === "run.start")).toEqual([]);
+    await thread.close();
+  });
+
+  it("resumes when the lifecycle watcher sees running before the content pump", async () => {
+    const watcher = new MockSseTransport();
+    class SplitTransport extends MockSseTransport {
+      override openEventStream(params: Parameters<MockSseTransport["openEventStream"]>[0]) {
+        return params.channels.length === 2 && params.channels.includes("input")
+          ? watcher.openEventStream(params)
+          : super.openEventStream(params);
+      }
+    }
+    const transport = new SplitTransport();
+    const thread = new ThreadStream(transport, { assistantId: "agent" });
+    const subscription = await thread.subscribe({ channels: ["lifecycle", "values"] });
+    thread.startLifecycleWatcher();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    transport.pushEvent(eventOf("lifecycle", { event: "completed" }, { seq: 10, eventId: "terminal" }));
+    await nextValue(subscription);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(subscription.isPaused).toBe(true);
+    const running = eventOf("lifecycle", { event: "running" }, { seq: 11, eventId: "next-running" });
+    watcher.pushEvent(running);
+    await subscription.waitForResume();
+    transport.pushEvent(running);
+    expect((await nextValue(subscription)).params.data).toEqual({ event: "running" });
+    transport.pushEvent(eventOf("values", { count: 2 }, { seq: 12, eventId: "next-values" }));
+    expect((await nextValue(subscription)).params.data).toEqual({ count: 2 });
+    await thread.close();
+  });
+
+  it("enqueue sends run.start without clearing interrupts or resuming a paused pump", async () => {
+    const transport = new MockSseTransport();
+    const thread = new ThreadStream(transport, { assistantId: "agent" });
+    const subscription = await thread.subscribe({ channels: ["lifecycle", "input"] });
+    transport.pushEvent(eventOf("input.requested", { interrupt_id: "pending", payload: {} }, { seq: 1, eventId: "input" }));
+    await nextValue(subscription);
+    transport.pushEvent(eventOf("lifecycle", { event: "interrupted" }, { seq: 2, eventId: "terminal" }));
+    await nextValue(subscription);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const opened = transport.totalStreamCount;
+    await thread.submitRun({ input: { count: 2 }, multitaskStrategy: "enqueue", forkFrom: "checkpoint" });
+    expect(subscription.isPaused).toBe(true);
+    expect(thread.interrupts).toHaveLength(1);
+    expect(thread.interrupted).toBe(true);
+    expect(transport.streamHandles.slice(0, opened).every((handle) => !handle.closed)).toBe(true);
+    expect(transport.sentCommands.at(-1)).toMatchObject({ method: "run.start", params: { multitaskStrategy: "enqueue", config: { configurable: { checkpoint_id: "checkpoint" } } } });
+    await thread.close();
+  });
+
+  it("enqueue uses the protocol command route and its explicit fetch/auth configuration", async () => {
+    const restFetch = vi.fn();
+    const protocolFetch = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      const command = JSON.parse(String(init?.body));
+      return new Response(JSON.stringify({ type: "success", id: command.id, result: { run_id: "accepted" } }), { headers: { "content-type": "application/json" } });
+    });
+    const client = new Client({ apiUrl: "https://protocol.example", apiKey: "test-key", defaultHeaders: { "x-tenant": "tenant" }, callerOptions: { fetch: restFetch }, onRequest: (_url, init) => { const headers = new Headers(init.headers); headers.set("x-hook", "hook"); return { ...init, headers }; } });
+    const thread = client.threads.stream("thread", { assistantId: "agent", fetch: protocolFetch, maxReconnectAttempts: 0 });
+    await thread.submitRun({ input: {}, multitaskStrategy: "enqueue" });
+    await thread.close();
+    expect(restFetch).not.toHaveBeenCalled();
+    const commandCall = protocolFetch.mock.calls.find(([url]) => String(url).endsWith("/commands"));
+    expect(commandCall).toBeDefined();
+    const [url, init] = commandCall!;
+    expect(String(url)).toBe("https://protocol.example/threads/thread/commands");
+    expect(JSON.parse(String(init?.body))).toMatchObject({ method: "run.start", params: { assistant_id: "agent", multitaskStrategy: "enqueue" } });
+    expect(new Headers(init?.headers).get("x-api-key")).toBe("test-key");
+    expect(new Headers(init?.headers).get("x-tenant")).toBe("tenant");
+    expect(new Headers(init?.headers).get("x-hook")).toBe("hook");
+  });
+
   it("routes subscribed events by channel and namespace", async () => {
     const transport = new MockTransport();
     const thread = new ThreadStream(transport, { assistantId: "test-agent" });

--- a/libs/sdk/src/client/stream/index.ts
+++ b/libs/sdk/src/client/stream/index.ts
@@ -884,6 +884,10 @@ export class ThreadStream<
     } else {
       this.interrupts.length = 0;
     }
+    this.#resumeSubscriptions();
+  }
+
+  #resumeSubscriptions(): void {
     if (this.#terminalPauseTimer != null) {
       clearTimeout(this.#terminalPauseTimer);
       this.#terminalPauseTimer = undefined;
@@ -1358,7 +1362,7 @@ export class ThreadStream<
      */
     multitaskStrategy?: "reject" | "rollback" | "interrupt" | "enqueue";
   }): Promise<RunResult> {
-    this.#prepareForNextRun();
+    if (params.multitaskStrategy !== "enqueue") this.#prepareForNextRun();
     // See `this.run.start` for the gating rationale — the lifecycle
     // watcher must register synchronously (so subagent discovery and
     // its downstream `useToolCalls` / `useMessages` subscriptions
@@ -1603,6 +1607,12 @@ export class ThreadStream<
   #applyThreadLevelEffects(event: Event): void {
     if (event.method === "lifecycle") {
       const lifecycle = event as LifecycleEvent;
+      if (
+        lifecycle.params.namespace.length === 0 &&
+        lifecycle.params.data.event === "running"
+      ) {
+        this.#resumeSubscriptions();
+      }
       if (lifecycle.params.data.event === "interrupted") {
         this.interrupted = true;
       }

--- a/libs/sdk/src/client/stream/transport.ts
+++ b/libs/sdk/src/client/stream/transport.ts
@@ -1,3 +1,4 @@
+import type { RunsClient } from "../runs/index.js";
 import type {
   Command,
   CommandResponse,
@@ -109,6 +110,14 @@ export interface TransportAdapter {
  * `AgentServerAdapter`.
  */
 export interface AgentServerAdapter extends TransportAdapter {
+  /** Optional server queue API; methods must honor the explicit thread id across rebinds. */
+  serverQueue?: Pick<RunsClient, "list" | "get" | "cancel" | "cancelMany"> & {
+    join(
+      threadId: string,
+      runId: string,
+      options?: { signal?: AbortSignal; cancelOnDisconnect?: boolean }
+    ): Promise<unknown>;
+  };
   /**
    * Fetch the latest checkpointed state for the bound thread via
    * `GET /threads/:threadId/state` (or an adapter-specific override).

--- a/libs/sdk/src/schema.ts
+++ b/libs/sdk/src/schema.ts
@@ -339,6 +339,9 @@ export interface Run {
   /** Run metadata */
   metadata: Metadata;
 
+  /** Optional stored run arguments, available when the server returns/selects kwargs. */
+  kwargs?: { input?: unknown; config?: Config };
+
   /** Strategy to handle concurrent runs on the same thread */
   multitask_strategy: Optional<MultitaskStrategy>;
 }

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -1067,6 +1067,120 @@ describe("StreamController", () => {
     await submitPromise;
   });
 
+  it("accepts queued runs via protocol without replacing the active stream", async () => {
+    const listeners = new Set<(event: Event) => void>();
+    let queuedStatus = "pending";
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn((listener: (event: Event) => void) => { listeners.add(listener); return () => listeners.delete(listener); }),
+      onError: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [], ordering: {},
+      submitRun: vi.fn(async (params: { multitaskStrategy?: string }) => ({ run_id: params.multitaskStrategy === "enqueue" ? "queued" : "active" })),
+      startLifecycleWatcher: vi.fn(),
+    } as unknown as ThreadStream;
+    const run = (id: string, status: string) => ({ run_id: id, thread_id: "thread", created_at: new Date().toISOString(), status });
+    const runs = {
+      create: vi.fn(async () => run("queued", "pending")),
+      list: vi.fn(async () => []),
+      get: vi.fn(async (_threadId: string, id: string) => run(id, queuedStatus)),
+      join: vi.fn(async () => undefined),
+      cancel: vi.fn(async () => undefined),
+    };
+    const client = { runs, threads: { getState: vi.fn(async () => ({ values: {}, tasks: [] })), stream: vi.fn(() => thread) } };
+    const onCreated = vi.fn();
+    const onCompleted = vi.fn();
+    const controller = new StreamController({ assistantId: "agent", client: client as never, serverQueue: runs as never, threadId: "thread", onCreated, onCompleted });
+    await controller.hydrationPromise;
+    const active = controller.submit({});
+    await waitForExpectation(() => expect(onCreated).toHaveBeenCalledWith({ runId: "active" }));
+    await controller.submit({ count: 2 }, { multitaskStrategy: "enqueue" });
+    expect(runs.create).not.toHaveBeenCalled();
+    expect(thread.submitRun).toHaveBeenCalledTimes(2);
+    expect(thread.close).not.toHaveBeenCalled();
+    expect(controller.rootStore.getSnapshot().isLoading).toBe(true);
+    for (const listener of listeners) listener(lifecycleEvent("completed", 20));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(onCompleted).toHaveBeenCalledWith({ runId: "active", reason: "success" });
+    expect(controller.queueStore.getSnapshot()[0].runId).toBe("queued");
+    await active;
+    await waitForExpectation(() => expect(onCompleted).toHaveBeenCalledWith({ runId: "active", reason: "success" }));
+    queuedStatus = "success";
+    await waitForExpectation(() => expect(onCompleted).toHaveBeenCalledWith({ runId: "queued", reason: "success" }), 2000);
+    expect(thread.submitRun).toHaveBeenCalledTimes(2);
+    await controller.dispose();
+  });
+
+  it("tracks hydrated running A while B remains pending and stops only A", async () => {
+    const subscription = makePushableSubscription();
+    const listeners = new Set<(event: Event) => void>();
+    let status = "running";
+    const run = (id: string, value: string) => ({ run_id: id, status: value, created_at: new Date().toISOString() });
+    const runs = {
+      list: vi.fn(async (_id: string, options?: { status?: string }) => options?.status === "running" ? [run("A", status)] : [run("B", "pending")]),
+      get: vi.fn(async (_id: string, id: string) => run(id, id === "A" ? status : "pending")),
+      join: vi.fn(async () => undefined),
+      cancel: vi.fn(async () => undefined),
+      cancelMany: vi.fn(),
+    };
+    const thread = {
+      subscribe: vi.fn(async () => subscription),
+      onEvent: vi.fn((listener: (event: Event) => void) => { listeners.add(listener); return () => listeners.delete(listener); }),
+      onError: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => subscription.close()),
+      interrupts: [], ordering: {}, startLifecycleWatcher: vi.fn(),
+    };
+    const client = { threads: { getState: vi.fn(async () => ({ values: {}, next: [], tasks: [] })), stream: vi.fn(() => thread) } };
+    const onCompleted = vi.fn();
+    const controller = new StreamController({ assistantId: "agent", client: client as never, serverQueue: runs as never, threadId: "thread", onCompleted });
+    await controller.hydrationPromise;
+    expect(controller.rootStore.getSnapshot().isLoading).toBe(true);
+    expect(controller.queueStore.getSnapshot().map((entry) => entry.runId)).toEqual(["B"]);
+    await controller.stop();
+    expect(runs.cancel).toHaveBeenCalledExactlyOnceWith("thread", "A");
+    for (const listener of listeners) listener(lifecycleEvent("running", 10));
+    status = "success";
+    await waitForExpectation(() => expect(onCompleted).toHaveBeenCalledExactlyOnceWith({ runId: "A", reason: "success" }), 2000);
+    expect(controller.rootStore.getSnapshot().isLoading).toBe(false);
+    subscription.push(lifecycleEvent("completed", 11));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(onCompleted).toHaveBeenCalledTimes(1);
+    expect(controller.queueStore.getSnapshot().map((entry) => entry.runId)).toEqual(["B"]);
+    await controller.dispose();
+  });
+
+  it("restores pending runs on reload, refreshes on reconnect, and detaches on thread switch", async () => {
+    const thread = {
+      subscribe: vi.fn(async () => makeNeverEndingSubscription()),
+      onEvent: vi.fn(() => vi.fn()), onError: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined), interrupts: [], ordering: {},
+      startLifecycleWatcher: vi.fn(),
+    } as unknown as ThreadStream;
+    const runs = {
+      list: vi.fn(async (threadId: string, options?: { status?: string }) => threadId === "original" && options?.status === "pending" ? [{ run_id: "restored", created_at: new Date().toISOString(), status: "pending" }] : []),
+      get: vi.fn(() => new Promise(() => undefined)),
+      cancel: vi.fn(), cancelMany: vi.fn(),
+    };
+    let reconnect!: (info: { attempt: number; cause: unknown }) => void;
+    const client = { runs, threads: {
+      getState: vi.fn(async () => ({ values: {}, next: [], tasks: [] })),
+      stream: vi.fn((_threadId: string, options: { onReconnect: typeof reconnect }) => { reconnect = options.onReconnect; return thread; }),
+    } };
+    const onReconnect = vi.fn();
+    const controller = new StreamController({ client: client as never, serverQueue: runs as never, assistantId: "agent", threadId: "original", onReconnect });
+    await controller.hydrationPromise;
+    expect(controller.queueStore.getSnapshot()[0]).toMatchObject({ id: "restored", runId: "restored", values: undefined });
+    expect(thread.startLifecycleWatcher).toHaveBeenCalled();
+    reconnect({ attempt: 1, cause: "offline" });
+    await waitForExpectation(() => expect(runs.list).toHaveBeenCalledTimes(4));
+    expect(onReconnect).toHaveBeenCalledWith({ attempt: 1, cause: "offline" });
+    await controller.hydrate("other");
+    expect(controller.queueStore.getSnapshot()).toEqual([]);
+    expect(runs.cancel).not.toHaveBeenCalled();
+    expect(runs.cancelMany).not.toHaveBeenCalled();
+    await controller.dispose();
+  });
+
   it("does not hide the active run's interrupt when a follow-up submit is enqueued", async () => {
     const eventListeners = new Set<(event: Event) => void>();
     let resolveSubmit: (() => void) | undefined;
@@ -1083,7 +1197,8 @@ describe("StreamController", () => {
       close: vi.fn(async () => undefined),
       interrupts: [],
       ordering,
-      submitRun: vi.fn(async () => {
+      submitRun: vi.fn(async (params: { multitaskStrategy?: string }) => {
+        if (params.multitaskStrategy === "enqueue") return { run_id: "queued" };
         await new Promise<void>((resolve) => {
           resolveSubmit = resolve;
         });
@@ -1093,6 +1208,11 @@ describe("StreamController", () => {
       startLifecycleWatcher: vi.fn(() => undefined),
     } as unknown as ThreadStream;
     const client = {
+      runs: {
+        create: vi.fn(async () => ({ run_id: "queued", created_at: new Date().toISOString() })),
+        list: vi.fn(async () => []),
+        get: vi.fn(() => new Promise(() => undefined)),
+      },
       threads: {
         getState: vi.fn(async () => ({ values: {}, tasks: [] })),
         stream: vi.fn(() => thread),
@@ -1103,6 +1223,7 @@ describe("StreamController", () => {
     const controller = new StreamController<State, unknown>({
       assistantId: "human-in-the-loop",
       client: client as never,
+      serverQueue: client.runs as never,
       threadId: "thread-enqueue-interrupt",
       onCreated,
     });

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -68,6 +68,7 @@ import {
   type MessageMetadata,
   type MessageMetadataMap,
 } from "./message-metadata-tracker.js";
+import { queueRuns } from "./server-queue.js";
 import { LifecycleLoadingTracker } from "./lifecycle-loading-tracker.js";
 import { RootMessageProjection } from "./root-message-projection.js";
 import {
@@ -462,6 +463,7 @@ export class StreamController<
         this.#notifyCreated(runId);
       },
       onRunCompleted: (reason, runId) => this.#notifyCompleted(reason, runId),
+      canClearLoading: () => !this.#lifecycleLoading.hasRunningAfterTerminal,
       onRunEnd: () => {
         // Stop buffering new events, but keep any already-queued
         // `input.requested` frames. A fast run can emit its interrupt
@@ -589,19 +591,12 @@ export class StreamController<
        * left `threadId` null while `messages` still showed the previous
        * conversation (`useStream` fire-and-forgets `hydrate()`).
        */
+      this.#submitter.detach();
       const teardown = this.#teardownThread();
       this.rootStore.setState(() => ({
         ...this.#createInitialSnapshot(),
         threadId: this.#currentThreadId,
       }));
-      /**
-       * Drop queued submissions — they were targeted at the previous
-       * thread so dispatching them against the new thread would be
-       * surprising. Mirrors the legacy `StreamOrchestrator` behaviour.
-       */
-      this.queueStore.setState(
-        () => EMPTY_QUEUE as SubmissionQueueSnapshot<StateType>
-      );
       await teardown;
     }
 
@@ -641,6 +636,8 @@ export class StreamController<
     let threadActive = true;
     try {
       const state = await this.#fetchHydrationState();
+      if (this.#disposed || this.#currentThreadId !== hydratedThreadId) return;
+      await this.#submitter.hydrateQueue(hydratedThreadId);
       // The await above yields. If the thread id changed or was cleared while
       // we were suspended (host cleared it, hydrate(null), or the component
       // unmounted during navigation), this hydrate is stale: applying its
@@ -649,7 +646,10 @@ export class StreamController<
       // null. Bail before touching any state. Hydration is settled in finally.
       if (this.#disposed || this.#currentThreadId !== hydratedThreadId) return;
       threadExists = state != null;
-      threadActive = isThreadStateActive(state);
+      threadActive =
+        isThreadStateActive(state) ||
+        this.#submitter.queuedActiveRunId != null ||
+        this.queueStore.getSnapshot().length > 0;
       // A prior hydrate-404 may have marked this id missing; clear it
       // now that the server row exists (e.g. another client created it).
       this.#missingThreadIds.delete(hydratedThreadId);
@@ -1197,18 +1197,26 @@ export class StreamController<
    */
   async stop(options?: StreamStopOptions): Promise<void> {
     const shouldCancel = options?.cancel ?? true;
+    const stop = this.#submitter.stop();
     if (shouldCancel) {
       const threadId = this.#currentThreadId;
       const runId = this.#activeRunId;
-      if (threadId != null && runId != null) {
-        try {
+      try {
+        if (queueRuns(this.#options)) {
+          await this.#submitter.cancelRunning();
+        } else if (
+          threadId != null &&
+          runId != null &&
+          typeof this.#options.transport !== "object"
+        ) {
           await this.#options.client.runs.cancel(threadId, runId);
-        } catch {
-          /* server cancel failures must not block client disconnect */
         }
+      } catch {
+        await stop;
+        return;
       }
     }
-    await this.#submitter.stop();
+    await stop;
   }
 
   /**
@@ -1243,8 +1251,9 @@ export class StreamController<
     if (runId != null && runId === this.#activeRunId) {
       this.#activeRunId = undefined;
     }
+    const generation = this.#rootPumpGeneration;
     setTimeout(() => {
-      if (this.#disposed) return;
+      if (this.#disposed || generation !== this.#rootPumpGeneration) return;
       try {
         this.#options.onCompleted?.(
           runId == null ? { reason } : { runId, reason }
@@ -1259,6 +1268,7 @@ export class StreamController<
     if (this.#localRunDepth > 0) return;
     if (event.method !== "lifecycle") return;
     if (!isRootNamespace(event.params.namespace)) return;
+    if (queueRuns(this.#options)) return;
     if (!this.rootStore.getSnapshot().isLoading) return;
     const lifecycle = (event as LifecycleEvent).params.data as {
       event?: string;
@@ -1268,24 +1278,12 @@ export class StreamController<
     this.#notifyCompleted(reason);
   };
 
-  /**
-   * Cancel a queued submission by id. Returns `true` when the entry
-   * was found and removed, `false` otherwise.
-   *
-   * Today this only removes the entry from the client-side mirror —
-   * once the server exposes queue cancel (roadmap A0.3) the
-   * controller will additionally issue a cancel call against the
-   * active transport.
-   *
-   * @param id - Client-side queue entry id to remove.
-   */
+  /** Cancel the server run for a queue entry; failures leave the entry available to retry. */
   async cancelQueued(id: string): Promise<boolean> {
     return this.#submitter.cancelQueued(id);
   }
 
-  /**
-   * Drop every queued submission. Server-side cancel arrives with A0.3.
-   */
+  /** Cancel the current queue snapshot without cancelling unrelated runs. */
   async clearQueue(): Promise<void> {
     await this.#submitter.clearQueue();
   }
@@ -1530,7 +1528,7 @@ export class StreamController<
     if (this.#disposed) return;
     this.#cancelPendingDispose();
     this.#disposed = true;
-    this.#submitter.abortActiveRun();
+    this.#submitter.detach();
     await this.#teardownThread();
     await this.registry.dispose();
     this.#threadListeners.clear();
@@ -1667,7 +1665,11 @@ export class StreamController<
       maxReconnectAttempts: this.#options.maxReconnectAttempts,
       streamIdleReconnect: this.#options.streamIdleReconnect,
       reconnectDelayMs: this.#options.reconnectDelayMs,
-      onReconnect: this.#options.onReconnect,
+      onReconnect: (info) => {
+        if (this.#currentThreadId === threadId)
+          void this.#submitter.hydrateQueue(threadId);
+        this.#options.onReconnect?.(info);
+      },
     });
     this.registry.bind(this.#thread);
     if (deferRootPump) {
@@ -1993,6 +1995,16 @@ export class StreamController<
     }
     this.#subgraphs.push(event);
     this.#lifecycleLoading.handle(event);
+    if (
+      queueRuns(this.#options) &&
+      this.#localRunDepth === 0 &&
+      event.method === "lifecycle" &&
+      isRootNamespace(event.params.namespace) &&
+      event.params.data.event === "running" &&
+      this.#currentThreadId != null
+    ) {
+      void this.#submitter.hydrateQueue(this.#currentThreadId);
+    }
 
     /**
      * `input.requested` events (including HITL inside a subagent /

--- a/libs/sdk/src/stream/lifecycle-loading-tracker.ts
+++ b/libs/sdk/src/stream/lifecycle-loading-tracker.ts
@@ -109,6 +109,10 @@ export class LifecycleLoadingTracker<T extends LoadingSnapshot> {
    * The seq guards are per-thread: a new thread's lifecycle events
    * are not stale relative to the old thread's.
    */
+  get hasRunningAfterTerminal(): boolean {
+    return this.#lastRunningLifecycleSeq > this.#lastTerminalLifecycleSeq;
+  }
+
   reset(): void {
     this.#lastTerminalLifecycleSeq = -1;
     this.#lastRunningLifecycleSeq = -1;

--- a/libs/sdk/src/stream/server-queue.test.ts
+++ b/libs/sdk/src/stream/server-queue.test.ts
@@ -1,0 +1,361 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Client } from "../client.js";
+import type { Run } from "../schema.js";
+import type { StreamControllerOptions } from "./types.js";
+import type { SubmissionQueueSnapshot } from "./submit-coordinator.js";
+import { StreamStore } from "./store.js";
+import { ServerQueue, awaitRunTerminal } from "./server-queue.js";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+function run(id: string, status: Run["status"] = "pending"): Run {
+  return { run_id: id, thread_id: "thread", assistant_id: "agent", created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-01T00:00:00Z", status, metadata: {}, multitask_strategy: "enqueue" };
+}
+
+const queues: ServerQueue<Record<string, unknown>>[] = [];
+function harness() {
+  let nextId = 0;
+  const records = new Map<string, Run>();
+  const runs = {
+    create: vi.fn(async () => { const result = run(`run-${++nextId}`); records.set(result.run_id, result); return result; }),
+    list: vi.fn(async () => [] as Run[]),
+    get: vi.fn(async (_thread: string, id: string) => records.get(id) ?? run(id)),
+    join: vi.fn(async () => undefined),
+    cancel: vi.fn(async () => undefined),
+    cancelMany: vi.fn(async () => undefined),
+  };
+  const options = { client: { runs }, serverQueue: runs, assistantId: "agent", onCreated: vi.fn(), onCompleted: vi.fn() } as unknown as StreamControllerOptions;
+  const store = new StreamStore<SubmissionQueueSnapshot>([]);
+  store.setState(() => []);
+  const onError = vi.fn();
+  const queue = new ServerQueue(options, store, onError);
+  queues.push(queue);
+  const enqueue = (threadId: string, input: unknown, submitOptions?: Parameters<typeof queue.enqueue>[2]) => queue.enqueue(threadId, input, submitOptions, runs.create);
+    return { queue, enqueue, runs, records, options, store, onError };
+}
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => { for (const queue of queues.splice(0)) queue.detach(); vi.useRealTimers(); });
+
+describe("server submission queue", () => {
+  it("sends immediately, retains the provisional key and mints stable message ids", async () => {
+    const h = harness();
+    const acceptance = deferred<Run>();
+    h.runs.create.mockReturnValueOnce(acceptance.promise);
+    const submit = h.enqueue("thread", { messages: [{ role: "user", content: "next" }] }, { metadata: { source: "chat" }, forkFrom: "checkpoint" });
+    const provisional = h.store.getSnapshot()[0];
+    expect(h.runs.create).toHaveBeenCalledWith(expect.objectContaining({ multitaskStrategy: "enqueue", forkFrom: "checkpoint", config: { configurable: { thread_id: "thread" } } }));
+    expect(provisional.runId).toBeUndefined();
+    const payload = (h.runs.create.mock.calls[0] as unknown as [{ input: unknown }])[0].input;
+    expect(payload).toEqual(provisional.values);
+    expect(payload).toMatchObject({ messages: [{ id: expect.any(String) }] });
+    acceptance.resolve(run("accepted"));
+    await submit;
+    expect(h.store.getSnapshot()[0]).toMatchObject({ id: provisional.id, runId: "accepted", options: { metadata: { source: "chat" } } });
+    expect(h.options.onCreated).toHaveBeenCalledExactlyOnceWith({ runId: "accepted" });
+  });
+
+  it("correlates completion to each run rather than another run's terminal", async () => {
+    const h = harness();
+    await h.enqueue("thread", {});
+    await h.enqueue("thread", {});
+    h.records.set("run-2", run("run-2", "success"));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(h.options.onCompleted).toHaveBeenCalledExactlyOnceWith({ runId: "run-2", reason: "success" });
+    expect(h.store.getSnapshot().map((entry) => entry.runId)).toEqual(["run-1"]);
+    h.records.set("run-1", run("run-1", "interrupted"));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(h.options.onCompleted).toHaveBeenLastCalledWith({ runId: "run-1", reason: "interrupt" });
+  });
+
+  it("joins running runs without cancel-on-disconnect and reports their failures", async () => {
+    const h = harness();
+    const onError = vi.fn();
+    await h.enqueue("thread", {}, { onError });
+    h.records.set("run-1", run("run-1", "running"));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(h.store.getSnapshot()).toEqual([]);
+    expect(h.runs.join).toHaveBeenCalledWith("thread", "run-1", expect.objectContaining({ cancelOnDisconnect: false }));
+    h.records.set("run-1", run("run-1", "error"));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: "Run run-1 error" }));
+    expect(h.options.onCompleted).toHaveBeenCalledExactlyOnceWith({ runId: "run-1", reason: "error" });
+  });
+
+  it("removes only a failed acceptance and rejects with its error", async () => {
+    const h = harness();
+    await h.enqueue("thread", {});
+    const error = new Error("not authorized");
+    const onError = vi.fn();
+    h.runs.create.mockRejectedValueOnce(error);
+    await expect(h.enqueue("thread", {}, { onError })).rejects.toBe(error);
+    expect(h.store.getSnapshot()).toHaveLength(1);
+    expect(onError).toHaveBeenCalledExactlyOnceWith(error);
+    expect(h.onError).toHaveBeenCalledWith(error);
+  });
+
+  it("cancels the accepted id even when requested before acceptance", async () => {
+    const h = harness();
+    const acceptance = deferred<Run>();
+    h.runs.create.mockReturnValueOnce(acceptance.promise);
+    const submit = h.enqueue("thread", {});
+    const cancel = h.queue.cancel(h.store.getSnapshot()[0].id);
+    expect(h.runs.cancel).not.toHaveBeenCalled();
+    acceptance.resolve(run("accepted"));
+    await submit;
+    await expect(cancel).resolves.toBe(true);
+    expect(h.runs.cancel).toHaveBeenCalledExactlyOnceWith("thread", "accepted");
+    expect(h.store.getSnapshot()).toEqual([]);
+  });
+
+  it("keeps failed cancellation retryable and scopes bulk cancellation to a snapshot", async () => {
+    const h = harness();
+    await h.enqueue("thread", {});
+    const id = h.store.getSnapshot()[0].id;
+    h.runs.cancel.mockRejectedValueOnce(new Error("offline"));
+    await expect(h.queue.cancel(id)).rejects.toThrow("offline");
+    expect(h.store.getSnapshot()).toHaveLength(1);
+    const cancellation = deferred<undefined>();
+    h.runs.cancelMany.mockReturnValueOnce(cancellation.promise);
+    const clear = h.queue.clear();
+    await h.enqueue("thread", {});
+    cancellation.resolve(undefined);
+    await clear;
+    expect(h.runs.cancelMany).toHaveBeenCalledExactlyOnceWith({ threadId: "thread", runIds: ["run-1"] });
+    expect(h.store.getSnapshot().map((entry) => entry.runId)).toEqual(["run-2"]);
+    expect(await h.queue.cancel("missing")).toBe(false);
+  });
+
+  it("hydrates all pending pages and optional stored input after reload", async () => {
+    const h = harness();
+    const firstPage = Array.from({ length: 100 }, (_, i) => run(`restored-${i}`));
+    h.runs.list.mockResolvedValueOnce([]).mockResolvedValueOnce(firstPage).mockResolvedValueOnce([{ ...run("last"), kwargs: { input: { count: 2 } }, metadata: { source: "another-tab" } }]);
+    await h.queue.refresh("thread");
+    expect(h.runs.list).toHaveBeenNthCalledWith(3, "thread", expect.objectContaining({ offset: 100, limit: 100, status: "pending", select: expect.arrayContaining(["kwargs"]) }));
+    expect(h.store.getSnapshot()).toHaveLength(101);
+    expect(h.store.getSnapshot()[0].values).toBeUndefined();
+    expect(h.store.getSnapshot().at(-1)).toMatchObject({ id: "last", runId: "last", values: { count: 2 }, options: { metadata: { source: "another-tab" } } });
+    h.runs.list.mockResolvedValueOnce([]).mockResolvedValueOnce([run("last")]);
+    await h.queue.refresh("thread");
+    expect(h.store.getSnapshot()).toHaveLength(101);
+  });
+
+  it("clears accepted entries even if a simultaneous acceptance fails", async () => {
+    const h = harness();
+    await h.enqueue("thread", {});
+    const acceptance = deferred<Run>();
+    h.runs.create.mockReturnValueOnce(acceptance.promise);
+    const submit = h.enqueue("thread", {});
+    const rejected = expect(submit).rejects.toThrow("rejected");
+    const clear = h.queue.clear();
+    acceptance.reject(new Error("rejected"));
+    await rejected;
+    await clear;
+    expect(h.runs.cancelMany).toHaveBeenCalledWith({ threadId: "thread", runIds: ["run-1"] });
+    expect(h.store.getSnapshot()).toEqual([]);
+  });
+
+  it("ignores old observer completion after a thread switch", async () => {
+    const h = harness();
+    const status = deferred<Run>();
+    h.runs.get.mockReturnValueOnce(status.promise);
+    await h.enqueue("thread", {});
+    h.queue.detach();
+    await h.enqueue("new-thread", {});
+    status.resolve(run("run-1", "success"));
+    await vi.advanceTimersByTimeAsync(1);
+    expect(h.options.onCompleted).not.toHaveBeenCalled();
+    expect(h.store.getSnapshot()[0].runId).toBe("run-2");
+  });
+
+  it("preserves local callbacks and keys across hydration", async () => {
+    const h = harness();
+    const onError = vi.fn();
+    await h.enqueue("thread", { count: 3 }, { onError });
+    const entry = h.store.getSnapshot()[0];
+    h.runs.list.mockResolvedValueOnce([]).mockResolvedValueOnce([run("run-1")]);
+    await h.queue.refresh("thread");
+    expect(h.store.getSnapshot()).toEqual([entry]);
+  });
+
+  it("does not restore cancelled runs from a stale list response", async () => {
+    const h = harness();
+    await h.enqueue("thread", {});
+    const listing = deferred<Run[]>();
+    h.runs.list.mockResolvedValueOnce([]).mockReturnValueOnce(listing.promise);
+    const refresh = h.queue.refresh("thread");
+    await h.queue.clear();
+    listing.resolve([run("run-1")]);
+    await refresh;
+    expect(h.store.getSnapshot()).toEqual([]);
+  });
+
+  it("detaches in-flight acceptance and hydration without cancelling server runs", async () => {
+    const h = harness();
+    const acceptance = deferred<Run>();
+    const listing = deferred<Run[]>();
+    h.runs.create.mockReturnValueOnce(acceptance.promise);
+    h.runs.list.mockReturnValueOnce(listing.promise);
+    const submit = h.enqueue("old-thread", {});
+    const refresh = h.queue.refresh("old-thread");
+    h.queue.detach();
+    await h.queue.refresh("new-thread");
+    acceptance.resolve(run("old"));
+    listing.resolve([run("old")]);
+    await Promise.all([submit, refresh]);
+    expect(h.store.getSnapshot()).toEqual([]);
+    expect(h.options.onCreated).not.toHaveBeenCalled();
+    expect(h.runs.cancel).not.toHaveBeenCalled();
+    expect(h.runs.cancelMany).not.toHaveBeenCalled();
+  });
+
+  it("retries a disconnected run observer without losing the queue", async () => {
+    const h = harness();
+    h.runs.get.mockRejectedValueOnce(new Error("offline"));
+    await h.enqueue("thread", {});
+    expect(h.store.getSnapshot()).toHaveLength(1);
+    h.records.set("run-1", run("run-1", "success"));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(h.options.onCompleted).toHaveBeenCalledWith({ runId: "run-1", reason: "success" });
+  });
+
+  it("never uses HTTP runs for custom adapters without a runs capability", async () => {
+    const h = harness();
+    h.options.serverQueue = undefined;
+      h.options.transport = {} as never;
+    await h.queue.refresh("thread");
+    await expect(h.enqueue("thread", {})).rejects.toThrow("serverQueue");
+    expect(h.runs.list).not.toHaveBeenCalled();
+    expect(h.runs.create).not.toHaveBeenCalled();
+    h.options.transport = { serverQueue: h.runs } as never;
+    await h.enqueue("thread", {});
+    expect(h.runs.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("hydrates running A independently from pending B and completes each once", async () => {
+    const h = harness();
+    h.records.set("A", run("A", "running"));
+    h.records.set("B", run("B"));
+    h.runs.list.mockResolvedValueOnce([run("A", "running")]).mockResolvedValueOnce([run("B")]);
+    await h.queue.refresh("thread");
+    expect(h.queue.activeRunId).toBe("A");
+    expect(h.queue.tracksRun("A")).toBe(true);
+    expect(h.queue.tracksRun("B")).toBe(true);
+    expect(h.store.getSnapshot().map((entry) => entry.runId)).toEqual(["B"]);
+    h.records.set("A", run("A", "success"));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(h.options.onCompleted).toHaveBeenCalledExactlyOnceWith({ runId: "A", reason: "success" });
+    expect(h.queue.activeRunId).toBeUndefined();
+    h.records.set("B", run("B", "success"));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(h.options.onCompleted).toHaveBeenLastCalledWith({ runId: "B", reason: "success" });
+    expect(h.options.onCompleted).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not resurrect a provisional entry after hydration observed its terminal", async () => {
+    const h = harness();
+    const acceptance = deferred<Run>();
+    const onError = vi.fn();
+    h.runs.create.mockReturnValueOnce(acceptance.promise);
+    const submit = h.enqueue("thread", {}, { onError });
+    h.runs.list.mockResolvedValueOnce([]).mockResolvedValueOnce([run("accepted")]);
+    h.records.set("accepted", run("accepted", "error"));
+    await h.queue.refresh("thread");
+    await vi.advanceTimersByTimeAsync(1);
+    expect(h.options.onCompleted).toHaveBeenCalledTimes(1);
+    acceptance.resolve(run("accepted"));
+    await submit;
+    expect(h.store.getSnapshot()).toEqual([]);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(h.options.onCompleted).toHaveBeenCalledTimes(1);
+    expect(h.options.onCreated).toHaveBeenCalledExactlyOnceWith({ runId: "accepted" });
+  });
+
+  it("stop resolves the server running run during acceptance and polling gaps, not pending B", async () => {
+    const h = harness();
+    const acceptance = deferred<Run>();
+    h.runs.create.mockReturnValueOnce(acceptance.promise);
+    const submit = h.enqueue("thread", {});
+    h.runs.list.mockResolvedValueOnce([run("A", "running")]);
+    await h.queue.cancelRunning("thread");
+    expect(h.runs.cancel).toHaveBeenCalledExactlyOnceWith("thread", "A");
+    acceptance.resolve(run("A"));
+    await submit;
+    await h.enqueue("thread", {});
+    h.runs.list.mockResolvedValueOnce([run("A", "running")]);
+    await h.queue.cancelRunning("thread");
+    expect(h.runs.cancel).toHaveBeenLastCalledWith("thread", "A");
+    expect(h.runs.cancelMany).not.toHaveBeenCalled();
+  });
+
+  it("stop waits for in-flight acceptance only when no run is currently running", async () => {
+    const h = harness();
+    const acceptance = deferred<Run>();
+    h.runs.create.mockReturnValueOnce(acceptance.promise);
+    const submit = h.enqueue("thread", {});
+    h.runs.list.mockResolvedValueOnce([]).mockResolvedValueOnce([run("A", "running")]);
+    const stop = h.queue.cancelRunning("thread");
+    await vi.advanceTimersByTimeAsync(1);
+    expect(h.runs.cancel).not.toHaveBeenCalled();
+    acceptance.resolve(run("A"));
+    await Promise.all([submit, stop]);
+    expect(h.runs.cancel).toHaveBeenCalledExactlyOnceWith("thread", "A");
+  });
+
+  it("uses the configured client auth, hooks and fetch for queue observation/cancellation", async () => {
+    const fetch = vi.fn(async (url: RequestInfo | URL) => {
+      const path = new URL(String(url)).pathname;
+      const body = path.endsWith("/runs") ? [] : path.endsWith("/join") ? {} : path.endsWith("/cancel") ? null : run("A", "success");
+      return new Response(JSON.stringify(body), { headers: { "content-type": "application/json" } });
+    });
+    const client = new Client<Record<string, unknown>>({ apiUrl: "https://queue.example", apiKey: "test-key", callerOptions: { fetch, maxRetries: 0 }, defaultHeaders: { "x-tenant": "tenant" }, onRequest: (_url, init) => { const headers = new Headers(init.headers); headers.set("x-hook", "hook"); return { ...init, headers }; } });
+    const options = { client, assistantId: "agent", serverQueue: client.runs };
+    const store = new StreamStore<SubmissionQueueSnapshot>([]);
+    const queue = new ServerQueue(options, store, vi.fn());
+    queues.push(queue);
+    await queue.refresh("thread");
+    await queue.enqueue("thread", {}, undefined, async () => ({ run_id: "A" }));
+    await client.runs.join("thread", "A", { cancelOnDisconnect: false });
+    await client.runs.cancel("thread", "A");
+    await client.runs.cancelMany({ threadId: "thread", runIds: ["B"] });
+    expect(fetch.mock.calls.length).toBeGreaterThanOrEqual(5);
+    for (const [url, init] of fetch.mock.calls as unknown as [string, RequestInit][]) {
+      expect(new URL(String(url)).origin).toBe("https://queue.example");
+      expect(new Headers(init.headers).get("x-api-key")).toBe("test-key");
+      expect(new Headers(init.headers).get("x-tenant")).toBe("tenant");
+      expect(new Headers(init.headers).get("x-hook")).toBe("hook");
+    }
+  });
+
+  it("does not clear active B when A's terminal status arrives late", async () => {
+    const h = harness();
+    h.runs.list.mockResolvedValueOnce([run("A", "running")]).mockResolvedValueOnce([run("B")]);
+    h.records.set("A", run("A", "running"));
+    await h.queue.refresh("thread");
+    h.runs.list.mockResolvedValueOnce([run("B", "running")]);
+    h.records.set("A", run("A", "success"));
+    h.records.set("B", run("B", "running"));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(h.queue.activeRunId).toBe("B");
+    expect(h.options.onCompleted).toHaveBeenCalledExactlyOnceWith({ runId: "A", reason: "success" });
+  });
+
+  it("does not settle a running run until its per-run status is terminal", async () => {
+    const h = harness();
+    const abort = new AbortController();
+    h.records.set("active", run("active", "running"));
+    const completion = vi.fn();
+    const pending = awaitRunTerminal(h.runs, "thread", "active", abort.signal).then(completion);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(completion).not.toHaveBeenCalled();
+    h.records.set("active", run("active", "success"));
+    await vi.advanceTimersByTimeAsync(1000);
+    await pending;
+    expect(completion).toHaveBeenCalledExactlyOnceWith({ event: "completed" });
+  });
+});

--- a/libs/sdk/src/stream/server-queue.ts
+++ b/libs/sdk/src/stream/server-queue.ts
@@ -1,0 +1,476 @@
+import { v7 as uuidv7 } from "@langchain/core/utils/uuid";
+import type { AgentServerAdapter } from "../client/stream/transport.js";
+import type { ThreadStream } from "../client/stream/index.js";
+import type { Run } from "../schema.js";
+import { prepareOptimisticInput } from "./optimistic-input.js";
+import type { StreamStore } from "./store.js";
+import type { StreamControllerOptions, StreamSubmitOptions } from "./types.js";
+import type {
+  SubmissionQueueEntry,
+  SubmissionQueueSnapshot,
+} from "./submit-coordinator.js";
+
+type Runs = NonNullable<AgentServerAdapter["serverQueue"]>;
+type Terminal = {
+  event: "completed" | "failed" | "interrupted" | "aborted";
+  error?: string;
+};
+
+function notify(callback: () => void): void {
+  try {
+    callback();
+  } catch {
+    return;
+  }
+}
+
+function delay(signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const done = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", done);
+      resolve();
+    };
+    const timer = setTimeout(done, 1000);
+    signal.addEventListener("abort", done, { once: true });
+    if (signal.aborted) done();
+  });
+}
+
+export function queueRuns<StateType extends object>(
+  options: StreamControllerOptions<StateType>
+): Runs | undefined {
+  return (
+    options.serverQueue ??
+    (typeof options.transport === "object"
+      ? options.transport.serverQueue
+      : undefined)
+  );
+}
+
+export async function awaitRunTerminal(
+  runs: Runs,
+  threadId: string,
+  runId: string,
+  signal: AbortSignal
+): Promise<Terminal> {
+  while (!signal.aborted) {
+    const run = await runs.get(threadId, runId, { signal });
+    if (run.status === "success") return { event: "completed" };
+    if (run.status === "interrupted") return { event: "interrupted" };
+    if (run.status === "error" || run.status === "timeout") {
+      return { event: "failed", error: `Run ${runId} ${run.status}` };
+    }
+    await runs.join(threadId, runId, { signal, cancelOnDisconnect: false });
+    await delay(signal);
+  }
+  return { event: "aborted" };
+}
+
+/** Mirrors accepted server runs without replacing the thread's content stream. */
+export class ServerQueue<StateType extends object> {
+  readonly #options: StreamControllerOptions<StateType>;
+  readonly #store: StreamStore<SubmissionQueueSnapshot<StateType>>;
+  readonly #onError: (error: unknown) => void;
+  readonly #onActivity: () => void;
+  #abort = new AbortController();
+  #threadId: string | undefined;
+  #watches = new Map<string, AbortController>();
+  #acceptances = new Map<string, Promise<{ run_id?: string }>>();
+  #refresh: Promise<void> | undefined;
+  #removed = new Set<string>();
+  #runOptions = new Map<string, StreamSubmitOptions<StateType> | undefined>();
+  #activeRunId: string | undefined;
+  #terminals = new Map<string, Terminal>();
+  #localRuns = new Set<string>();
+
+  constructor(
+    options: StreamControllerOptions<StateType>,
+    store: StreamStore<SubmissionQueueSnapshot<StateType>>,
+    onError: (error: unknown) => void,
+    onActivity: () => void = () => undefined
+  ) {
+    this.#options = options;
+    this.#store = store;
+    this.#onError = onError;
+    this.#onActivity = onActivity;
+  }
+
+  get activeRunId(): string | undefined {
+    return this.#activeRunId;
+  }
+
+  claimLocalRun(threadId: string, runId: string): void {
+    this.#bind(threadId);
+    this.#localRuns.add(runId);
+    this.#watches.get(runId)?.abort();
+    this.#watches.delete(runId);
+    if (this.#activeRunId === runId) this.#activeRunId = undefined;
+    this.#runOptions.delete(runId);
+  }
+
+  tracksRun(runId: string | undefined): boolean {
+    return (
+      runId != null && (this.#watches.has(runId) || this.#removed.has(runId))
+    );
+  }
+
+  detach(): void {
+    this.#abort.abort();
+    for (const abort of this.#watches.values()) abort.abort();
+    this.#watches.clear();
+    this.#acceptances.clear();
+    this.#removed.clear();
+    this.#runOptions.clear();
+    this.#activeRunId = undefined;
+    this.#terminals.clear();
+    this.#localRuns.clear();
+    this.#refresh = undefined;
+    this.#abort = new AbortController();
+    this.#threadId = undefined;
+    this.#store.setState(() => []);
+  }
+
+  #bind(threadId: string): AbortSignal {
+    if (this.#threadId !== threadId) {
+      this.detach();
+      this.#threadId = threadId;
+    }
+    return this.#abort.signal;
+  }
+
+  async enqueue(
+    threadId: string,
+    input: unknown,
+    options: StreamSubmitOptions<StateType> | undefined,
+    dispatch: (
+      params: Parameters<ThreadStream["submitRun"]>[0]
+    ) => Promise<{ run_id?: string }>
+  ): Promise<void> {
+    const signal = this.#bind(threadId);
+    const runs = queueRuns(this.#options);
+    let id: string | undefined;
+    try {
+      if (!runs)
+        throw new Error(
+          "Server-backed enqueue requires an explicit serverQueue capability."
+        );
+      const values =
+        input != null && typeof input === "object" && !Array.isArray(input)
+          ? prepareOptimisticInput(
+              input as Record<string, unknown>,
+              this.#options.messagesKey ?? "messages",
+              uuidv7
+            ).dispatchInput
+          : input;
+      id = uuidv7();
+      const entry: SubmissionQueueEntry<StateType> = {
+        id,
+        values: values as Partial<StateType> | null | undefined,
+        options,
+        createdAt: new Date(),
+      };
+      this.#store.setState((entries) => [...entries, entry]);
+      const acceptance = dispatch({
+        input: values ?? null,
+        config: {
+          ...options?.config,
+          configurable: {
+            ...options?.config?.configurable,
+            thread_id: threadId,
+          },
+        },
+        metadata: options?.metadata,
+        multitaskStrategy: "enqueue",
+        forkFrom: options?.forkFrom,
+      });
+      this.#acceptances.set(id, acceptance);
+      const run = await acceptance;
+      if (signal.aborted) return;
+      const runId = run.run_id;
+      if (!runId) throw new Error("Run acceptance did not include a run id");
+      if (!this.#terminals.has(runId)) this.#runOptions.set(runId, options);
+      this.#store.setState((entries) =>
+        entries
+          .filter((item) =>
+            this.#removed.has(runId)
+              ? item.id !== id && item.runId !== runId
+              : item.id === id || item.runId !== runId
+          )
+          .map((item) =>
+            item.id === id
+              ? {
+                  ...item,
+                  runId,
+                }
+              : item
+          )
+      );
+      notify(() => this.#options.onCreated?.({ runId }));
+      const terminal = this.#terminals.get(runId);
+      if (terminal?.event === "failed")
+        notify(() => options?.onError?.(new Error(terminal.error)));
+      this.#watch(runs, threadId, runId, signal);
+    } catch (error) {
+      if (signal.aborted) return;
+      this.#store.setState((entries) =>
+        entries.filter((entry) => entry.id !== id)
+      );
+      this.#onError(error);
+      notify(() => options?.onError?.(error));
+      throw error;
+    } finally {
+      if (!signal.aborted && id != null) this.#acceptances.delete(id);
+    }
+  }
+
+  refresh(threadId: string): Promise<void> {
+    const signal = this.#bind(threadId);
+    const runs = queueRuns(this.#options);
+    if (!runs) return Promise.resolve();
+    if (this.#refresh) return this.#refresh;
+    const refresh = this.#hydrate(runs, threadId, signal)
+      .catch((error) => {
+        if (!signal.aborted) this.#onError(error);
+      })
+      .finally(() => {
+        if (this.#refresh === refresh) this.#refresh = undefined;
+      });
+    this.#refresh = refresh;
+    return refresh;
+  }
+
+  async #hydrate(
+    runs: Runs,
+    threadId: string,
+    signal: AbortSignal
+  ): Promise<void> {
+    const running = await runs.list(threadId, {
+      status: "running",
+      limit: 100,
+      signal,
+    });
+    if (signal.aborted) return;
+    for (const run of running) {
+      if (this.#removed.has(run.run_id) || this.#localRuns.has(run.run_id))
+        continue;
+      this.#activeRunId = run.run_id;
+      this.#watch(runs, threadId, run.run_id, signal);
+    }
+    if (this.#activeRunId) this.#onActivity();
+    const pending: Run[] = [];
+    for (let offset = 0; !signal.aborted; offset += 100) {
+      const page = await runs.list(threadId, {
+        status: "pending",
+        limit: 100,
+        offset,
+        signal,
+        select: [
+          "run_id",
+          "thread_id",
+          "assistant_id",
+          "created_at",
+          "status",
+          "metadata",
+          "kwargs",
+          "multitask_strategy",
+        ],
+      });
+      pending.push(...page);
+      if (page.length < 100) break;
+    }
+    if (signal.aborted) return;
+    this.#store.setState((entries) => {
+      const known = new Set(entries.map((entry) => entry.runId));
+      const restored = pending
+        .filter(
+          (run) =>
+            !this.#localRuns.has(run.run_id) &&
+            !known.has(run.run_id) &&
+            !this.#removed.has(run.run_id) &&
+            !this.#watches.has(run.run_id)
+        )
+        .map((run) => ({
+          id: run.run_id,
+          runId: run.run_id,
+          values: run.kwargs?.input as Partial<StateType> | null | undefined,
+          options: {
+            metadata: run.metadata ?? undefined,
+            config: run.kwargs?.config,
+            multitaskStrategy: "enqueue" as const,
+          },
+          createdAt: new Date(run.created_at),
+        }));
+      return [...entries, ...restored].sort(
+        (a, b) => a.createdAt.getTime() - b.createdAt.getTime()
+      );
+    });
+    for (const run of pending) this.#watch(runs, threadId, run.run_id, signal);
+    for (const entry of this.#store.getSnapshot()) {
+      if (entry.runId) this.#watch(runs, threadId, entry.runId, signal);
+    }
+  }
+
+  #watch(
+    runs: Runs,
+    threadId: string,
+    runId: string,
+    scope: AbortSignal
+  ): void {
+    if (
+      this.#localRuns.has(runId) ||
+      this.#watches.has(runId) ||
+      this.#removed.has(runId) ||
+      scope.aborted
+    )
+      return;
+    const abort = new AbortController();
+    this.#watches.set(runId, abort);
+    if (!this.#runOptions.has(runId))
+      this.#runOptions.set(
+        runId,
+        this.#store.getSnapshot().find((entry) => entry.runId === runId)
+          ?.options
+      );
+    void (async () => {
+      while (!abort.signal.aborted && !scope.aborted) {
+        try {
+          const run = await runs.get(threadId, runId, { signal: abort.signal });
+          if (abort.signal.aborted || scope.aborted) return;
+          if (run.status === "pending") {
+            await delay(abort.signal);
+            continue;
+          }
+          if (run.status === "running") {
+            this.#activeRunId = runId;
+            this.#onActivity();
+          }
+          this.#removed.add(runId);
+          this.#store.setState((entries) =>
+            entries.filter((entry) => entry.runId !== runId)
+          );
+          const terminal = await awaitRunTerminal(
+            runs,
+            threadId,
+            runId,
+            abort.signal
+          );
+          if (abort.signal.aborted || scope.aborted) return;
+          this.#terminals.set(runId, terminal);
+          if (terminal.event === "failed") {
+            const error = new Error(terminal.error);
+            this.#onError(error);
+            notify(() => this.#runOptions.get(runId)?.onError?.(error));
+          }
+          notify(() =>
+            this.#options.onCompleted?.({
+              runId,
+              reason:
+                terminal.event === "completed"
+                  ? "success"
+                  : terminal.event === "interrupted"
+                    ? "interrupt"
+                    : "error",
+            })
+          );
+          return;
+        } catch (error) {
+          if (abort.signal.aborted || scope.aborted) return;
+          this.#onError(error);
+          await delay(abort.signal);
+        }
+      }
+    })().finally(() => {
+      if (this.#watches.get(runId) === abort) {
+        this.#watches.delete(runId);
+        this.#runOptions.delete(runId);
+        if (this.#activeRunId === runId) {
+          void runs
+            .list(threadId, { status: "running", limit: 100, signal: scope })
+            .then((running) => {
+              if (scope.aborted || this.#activeRunId !== runId) return;
+              this.#activeRunId = running.find(
+                (run) => run.run_id !== runId
+              )?.run_id;
+              this.#onActivity();
+              for (const run of running)
+                this.#watch(runs, threadId, run.run_id, scope);
+            })
+            .catch((error) => {
+              if (!scope.aborted) this.#onError(error);
+            });
+        }
+      }
+    });
+  }
+
+  async cancelRunning(threadId: string): Promise<void> {
+    const signal = this.#bind(threadId);
+    const runs = queueRuns(this.#options);
+    if (!runs) return;
+    let running = await runs.list(threadId, {
+      status: "running",
+      limit: 100,
+      signal,
+    });
+    if (!running.length && this.#acceptances.size) {
+      await Promise.allSettled(this.#acceptances.values());
+      if (signal.aborted) return;
+      running = await runs.list(threadId, {
+        status: "running",
+        limit: 100,
+        signal,
+      });
+    }
+    if (signal.aborted) return;
+    await Promise.all(running.map((run) => runs.cancel(threadId, run.run_id)));
+  }
+
+  async cancel(id: string): Promise<boolean> {
+    const entry = this.#store.getSnapshot().find((item) => item.id === id);
+    if (!entry || !this.#threadId) return false;
+    const threadId = this.#threadId;
+    const signal = this.#abort.signal;
+    const runs = queueRuns(this.#options)!;
+    const runId = entry.runId ?? (await this.#acceptances.get(id))?.run_id;
+    if (!runId) return false;
+    await runs.cancel(threadId, runId);
+    if (!signal.aborted) this.#remove(new Set([runId]));
+    return true;
+  }
+
+  async clear(): Promise<void> {
+    const entries = this.#store.getSnapshot();
+    if (!entries.length || !this.#threadId) return;
+    const threadId = this.#threadId;
+    const signal = this.#abort.signal;
+    const runs = queueRuns(this.#options)!;
+    const ids = await Promise.allSettled(
+      entries.map(
+        async (entry) =>
+          entry.runId ?? (await this.#acceptances.get(entry.id))?.run_id
+      )
+    );
+    const runIds = ids.flatMap((result) =>
+      result.status === "fulfilled" && result.value != null
+        ? [result.value]
+        : []
+    );
+    if (!runIds.length) return;
+    await runs.cancelMany({ threadId, runIds });
+    if (!signal.aborted) this.#remove(new Set(runIds));
+  }
+
+  #remove(ids: Set<string>): void {
+    this.#store.setState((entries) =>
+      entries.filter((entry) => !entry.runId || !ids.has(entry.runId))
+    );
+    for (const id of ids) {
+      this.#removed.add(id);
+      this.#watches.get(id)?.abort();
+      this.#watches.delete(id);
+      this.#runOptions.delete(id);
+      if (this.#activeRunId === id) this.#activeRunId = undefined;
+    }
+  }
+}

--- a/libs/sdk/src/stream/submit-coordinator.test.ts
+++ b/libs/sdk/src/stream/submit-coordinator.test.ts
@@ -109,7 +109,9 @@ function makeHarness(
   );
 
   const submitDeferreds: Array<ReturnType<typeof deferred<{ run_id?: string }>>> = [];
-  const submitRun = vi.fn(() => {
+  let queuedRunId = 0;
+  const submitRun = vi.fn((params?: { multitaskStrategy?: string; input?: unknown }) => {
+    if (params?.multitaskStrategy === "enqueue") return Promise.resolve({ run_id: `queued-${++queuedRunId}` });
     const d = deferred<{ run_id?: string }>();
     submitDeferreds.push(d);
     return d.promise;
@@ -182,12 +184,19 @@ function makeHarness(
 
   const options: StreamControllerOptions<State> = {
     assistantId: "assistant-1",
-    client: {} as never,
+    client: { runs: {
+      create: vi.fn(async () => ({ run_id: `queued-${++queuedRunId}`, created_at: new Date().toISOString() })),
+      list: vi.fn(async () => []),
+      cancel: vi.fn(async () => undefined),
+      cancelMany: vi.fn(async () => undefined),
+      get: vi.fn(() => new Promise(() => undefined)),
+    } } as never,
     threadId: initial.threadId ?? null,
     onCreated,
     onThreadId,
   };
 
+  options.serverQueue = options.client.runs;
   const coordinator = new SubmitCoordinator<State>({
     options,
     rootStore,
@@ -378,7 +387,7 @@ describe("SubmitCoordinator", () => {
       await expect(second).resolves.toBeUndefined();
     });
 
-    it("does not echo an enqueued submission until it drains", async () => {
+    it("keeps queued input separate from the active optimistic batch", async () => {
       const beginOptimistic = vi.fn(() => ({
         dispatchInput: { messages: [] },
         handle: { echoedIds: [], restoreKeys: [] },
@@ -400,7 +409,8 @@ describe("SubmitCoordinator", () => {
       await vi.runAllTimersAsync();
       await first;
 
-      expect(beginOptimistic).toHaveBeenCalledTimes(2);
+      expect(beginOptimistic).toHaveBeenCalledTimes(1);
+      h.coordinator.detach();
     });
   });
 
@@ -625,8 +635,7 @@ describe("SubmitCoordinator", () => {
 
       expect(h.queueStore.getSnapshot()).toHaveLength(1);
       expect(h.queueStore.getSnapshot()[0].values).toEqual({ count: 2 });
-      // Only the first submit dispatched; the queued one waits.
-      expect(h.submitRun).toHaveBeenCalledTimes(1);
+      expect(h.submitRun).toHaveBeenCalledTimes(2);
 
       // Cleanly resolve the first run.
       h.resolveSubmit();
@@ -643,8 +652,8 @@ describe("SubmitCoordinator", () => {
 
       expect(h.queueStore.getSnapshot()).toHaveLength(1);
       expect(h.queueStore.getSnapshot()[0].values).toEqual({ count: 2 });
-      expect(h.submitRun).toHaveBeenCalledTimes(1);
-      expect(h.submitRun.mock.calls[0]?.[0]?.input).toEqual({ count: 1 });
+      expect(h.submitRun).toHaveBeenCalledTimes(2);
+      expect(h.submitRun).toHaveBeenCalledWith(expect.objectContaining({ input: { count: 1 } }));
 
       await h.terminalRegistered();
       h.resolveSubmit({ run_id: "run-1" });
@@ -653,34 +662,49 @@ describe("SubmitCoordinator", () => {
       await first;
     });
 
-    it("drains the queue after the active run terminates", async () => {
+    it("does not dispatch an accepted run again after the active run terminates", async () => {
       const h = makeHarness();
       const first = h.coordinator.submit({ count: 1 });
       await h.terminalRegistered();
-
-      await h.coordinator.submit(
-        { count: 2 },
-        { multitaskStrategy: "enqueue" }
-      );
-      expect(h.queueStore.getSnapshot()).toHaveLength(1);
-
+      await h.coordinator.submit({ count: 2 }, { multitaskStrategy: "enqueue" });
+      expect(h.submitRun).toHaveBeenCalledWith( expect.objectContaining({ input: { count: 2 }, multitaskStrategy: "enqueue" }));
       h.resolveSubmit({ run_id: "run-1" });
-      h.resolveTerminal({ event: "completed" });
+      h.resolveTerminal();
       await vi.runAllTimersAsync();
       await first;
-
-      // Drain runs on next macrotask; advance fake timers.
-      await vi.runAllTimersAsync();
-      // The queued submit now in-flight; ack it so we don't leak.
-      const second = await h.currentTerminal();
-      expect(second).toBeDefined();
       expect(h.submitRun).toHaveBeenCalledTimes(2);
-      expect(h.queueStore.getSnapshot()).toHaveLength(0);
-
-      h.resolveSubmit({ run_id: "run-2" });
-      h.resolveTerminal({ event: "completed" });
-      await vi.runAllTimersAsync();
+      expect(h.queueStore.getSnapshot()[0].runId).toMatch(/^queued-/);
+      h.coordinator.detach();
     });
+
+  });
+
+  it("ordinary submissions do not require REST observation even when client.runs exists", async () => {
+    const h = makeHarness();
+    h.options.serverQueue = undefined;
+    h.options.fetch = vi.fn() as never;
+    const submit = h.coordinator.submit({ count: 1 });
+    await h.terminalRegistered();
+    h.resolveSubmit({ run_id: "ordinary" });
+    h.resolveTerminal();
+    await submit;
+    expect(h.rootStore.getSnapshot().isLoading).toBe(false);
+    expect(h.options.client.runs.get).not.toHaveBeenCalled();
+    expect(h.options.client.runs.list).not.toHaveBeenCalled();
+    expect(h.options.client.runs.create).not.toHaveBeenCalled();
+  });
+
+  it("an old submit settling cannot clear a newer submit's loading state", async () => {
+    const h = makeHarness();
+    const first = h.coordinator.submit({ count: 1 });
+    await h.terminalRegistered();
+    const second = h.coordinator.submit({ count: 2 });
+    await first;
+    expect(h.rootStore.getSnapshot().isLoading).toBe(true);
+    h.resolveSubmit({ run_id: "second" });
+    h.resolveTerminal();
+    await second;
+    expect(h.rootStore.getSnapshot().isLoading).toBe(false);
   });
 
   describe("queue management", () => {

--- a/libs/sdk/src/stream/submit-coordinator.ts
+++ b/libs/sdk/src/stream/submit-coordinator.ts
@@ -1,60 +1,7 @@
-/**
- * Owns the run-submission lifecycle for a single
- * {@link StreamController}.
- *
- * # What this module is
- *
- * The {@link SubmitCoordinator} is the piece of the controller that
- * dispatches runs (`submit()`), enforces multitask strategies, queues
- * deferred submissions, races dispatch against terminal lifecycle
- * events, and surfaces errors back through the per-submit `onError`
- * callback and the root snapshot.
- *
- * Conceptually a submit looks like:
- *
- *   1. Optionally rebind to a different thread (`options.threadId`).
- *   2. Mint a thread id if one isn't bound yet.
- *   3. Wait for the controller's root pump to be ready (so the
- *      transport is subscribed before the run is dispatched —
- *      otherwise we could miss replayed events).
- *   4. Apply the {@link StreamSubmitOptions.multitaskStrategy} to
- *      decide whether to abort, enqueue, reject, or proceed.
- *   5. Race the dispatch promise (`thread.submitRun()`) against the next root
- *      terminal lifecycle event.
- *   6. Settle the resulting state (loading flag, error slot) and
- *      drain the next queued submission, if any.
- *
- * # Why it lives in its own class
- *
- * The submit lifecycle is the most state-heavy part of the
- * controller — six promises, an abort controller, a queue, a
- * terminal-vs-command race, and bidirectional callback wiring with
- * the controller. Splitting it out keeps `controller.ts` focused on
- * subscription / projection wiring while letting the submit logic
- * evolve independently.
- *
- * # Why we race "command" against "terminal"
- *
- * For fast runs, the server's terminal lifecycle event can arrive
- * *before* the dispatch HTTP response has resolved. Racing the two
- * lets us detect terminal early and not block waiting for a now-stale
- * dispatch response. The dispatch response is still consumed (via
- * `.then(notifyCreated).catch(reportError)`) so `onCreated` still
- * fires and dispatch errors still surface through `onError`.
- *
- * # Queue semantics (`multitaskStrategy: "enqueue"`)
- *
- * When a run is already in flight, an `"enqueue"` submit is recorded
- * into {@link queueStore} and the call returns immediately. After the
- * active run terminates, `#drainQueue` schedules the head of the
- * queue as a fresh submit on the next macrotask. Each drained
- * submission has its own `multitaskStrategy` cleared so it doesn't
- * recursively re-enqueue.
- *
- * @see StreamController - The owner; injects every collaborator dep.
- */
+/** Coordinates local dispatch and the server-backed submission queue. */
 import { v7 as uuidv7 } from "@langchain/core/utils/uuid";
 import type { ThreadStream } from "../client/stream/index.js";
+import { ServerQueue } from "./server-queue.js";
 import { StreamStore } from "./store.js";
 import type { OptimisticHandle } from "./optimistic-input.js";
 import type {
@@ -90,11 +37,13 @@ function terminalReason(event: TerminalResult["event"]): RunExecutionReason {
 export interface SubmissionQueueEntry<
   StateType extends object = Record<string, unknown>,
 > {
-  /** Stable id minted on enqueue (uuidv7 — sortable by creation time). */
+  /** Stable UI id; retained when the server accepts a local submission. */
   readonly id: string;
+  /** Server run id; absent while acceptance is pending. */
+  readonly runId?: string;
   /** Original submit input, narrowed to the partial state shape. */
   readonly values: Partial<StateType> | null | undefined;
-  /** Original submit options, minus the strategy slot which is reset on drain. */
+  /** Local submit options, or the available stored options after hydration. */
   readonly options?: StreamSubmitOptions<StateType>;
   /** Wall-clock timestamp at enqueue. */
   readonly createdAt: Date;
@@ -144,8 +93,6 @@ export class SubmitCoordinator<
   readonly #options: StreamControllerOptions<StateType>;
   /** Root snapshot store; written for `isLoading`, `error`, `interrupts`. */
   readonly #rootStore: StreamStore<RootSnapshot<StateType, InterruptType>>;
-  /** Pending submissions awaiting the active run to terminate. */
-  readonly #queueStore: StreamStore<SubmissionQueueSnapshot<StateType>>;
   /** Probes the controller's `disposed` flag from deferred work. */
   readonly #getDisposed: () => boolean;
   /** Reads the controller's currently-bound thread id. */
@@ -216,6 +163,9 @@ export class SubmitCoordinator<
    * starting a new one).
    */
   #runAbort: AbortController | undefined;
+  readonly #serverQueue: ServerQueue<StateType>;
+  #generation = 0;
+  readonly #canClearLoading: () => boolean;
 
   constructor(params: {
     options: StreamControllerOptions<StateType>;
@@ -239,6 +189,7 @@ export class SubmitCoordinator<
     onRunCreated?: (runId: string) => void;
     onRunCompleted?: (reason: RunExecutionReason, runId?: string) => void;
     onRunEnd?: () => void;
+    canClearLoading?: () => boolean;
     beginOptimistic?: (
       input: unknown
     ) => { dispatchInput: unknown; handle: OptimisticHandle } | undefined;
@@ -248,8 +199,23 @@ export class SubmitCoordinator<
     ) => void;
   }) {
     this.#options = params.options;
+    this.#canClearLoading = params.canClearLoading ?? (() => true);
+    this.#serverQueue = new ServerQueue(
+      params.options,
+      params.queueStore,
+      (error) => {
+        this.#rootStore.setState((state) => ({ ...state, error }));
+      },
+      () => {
+        if (!this.#runAbort) {
+          this.#rootStore.setState((state) => ({
+            ...state,
+            isLoading: this.#serverQueue.activeRunId != null,
+          }));
+        }
+      }
+    );
     this.#rootStore = params.rootStore;
-    this.#queueStore = params.queueStore;
     this.#getDisposed = params.getDisposed;
     this.#getCurrentThreadId = params.getCurrentThreadId;
     this.#setCurrentThreadId = params.setCurrentThreadId;
@@ -281,8 +247,7 @@ export class SubmitCoordinator<
    *     dispatches immediately.
    *   - `"reject"`              — throws synchronously when a run is
    *     already in flight.
-   *   - `"enqueue"`             — defers via {@link #enqueueSubmission};
-   *     the call returns without dispatching.
+   *   - `"enqueue"`             — sends immediately and resolves on acceptance.
    *   - `"interrupt"`           — falls through to the default path
    *
    * Errors are routed through both the per-submit `onError` callback
@@ -362,8 +327,25 @@ export class SubmitCoordinator<
         "submit() rejected: a run is already in flight and multitaskStrategy is 'reject'."
       );
     }
-    if (hasActiveRun && strategy === "enqueue") {
-      this.#enqueueSubmission(input, options);
+    if (strategy === "enqueue") {
+      const generation = this.#generation;
+      try {
+        await this.#serverQueue.enqueue(
+          currentThreadId,
+          input,
+          options as StreamSubmitOptions<StateType>,
+          (params) => thread.submitRun(params)
+        );
+      } catch (error) {
+        if (pendingServerCreate && generation === this.#generation) {
+          this.#abandonDeferredRootPump();
+        }
+        throw error;
+      }
+      if (generation === this.#generation && !this.#getDisposed()) {
+        this.#startDeferredRootPump();
+        this.#forgetSelfCreatedThreadId(activeThreadId);
+      }
       return;
     }
 
@@ -375,6 +357,7 @@ export class SubmitCoordinator<
     // Rollback: abort the previous run before starting a new one.
     this.#runAbort?.abort();
     const abort = new AbortController();
+    const generation = this.#generation;
     this.#runAbort = abort;
 
     // Claim the in-flight slot before awaiting the root pump so
@@ -397,8 +380,14 @@ export class SubmitCoordinator<
     let pendingCompletionReason: RunExecutionReason | undefined;
     let completionNotified = false;
     let settleEvent: TerminalResult["event"] | undefined;
+    let observedTerminal = false;
     const notifyCompletion = (reason: RunExecutionReason): void => {
-      if (completionNotified) return;
+      if (
+        completionNotified ||
+        generation !== this.#generation ||
+        this.#getDisposed()
+      )
+        return;
       if (createdRunId == null) {
         pendingCompletionReason = reason;
         return;
@@ -424,10 +413,7 @@ export class SubmitCoordinator<
       // synchronous coercion failure (e.g. a malformed message entry)
       // settles the submit lifecycle through the catch/finally below —
       // exactly like a dispatch failure — instead of wedging `isLoading`
-      // / `#runAbort` and stranding later enqueue/reject submits behind a
-      // phantom in-flight run. Runs only on the dispatched path — an
-      // `"enqueue"`d submission returns above and echoes when it drains,
-      // keeping one optimistic batch bound to exactly one run lifecycle.
+      // / `#runAbort`.
       // `dispatchInput` carries the minted ids the server must echo for
       // reconciliation, so the run is dispatched with it (not raw input).
       const prepared = this.#beginOptimistic(input);
@@ -455,10 +441,7 @@ export class SubmitCoordinator<
         config: boundConfig,
         metadata: (options?.metadata ?? undefined) as Record<string, unknown>,
         forkFrom: options?.forkFrom,
-        multitaskStrategy:
-          options?.multitaskStrategy === "enqueue"
-            ? "enqueue"
-            : options?.multitaskStrategy,
+        multitaskStrategy: options?.multitaskStrategy,
       });
       // Start the deferred root pump *after* the dispatch HTTP
       // response lands — that's when the thread row exists server-
@@ -473,6 +456,7 @@ export class SubmitCoordinator<
       // dispatch failure means there's no thread to pump anyway.
       void commandPromise.then(
         () => {
+          if (generation !== this.#generation || this.#getDisposed()) return;
           this.#startDeferredRootPump();
           this.#forgetSelfCreatedThreadId(activeThreadId);
         },
@@ -485,14 +469,20 @@ export class SubmitCoordinator<
           // Tear down so the next submit re-runs `#ensureThread`
           // from scratch. Keep the self-created mark so the retry
           // still defers the pump (the server row was never created).
-          if (pendingServerCreate) {
+          if (pendingServerCreate && generation === this.#generation) {
             this.#abandonDeferredRootPump();
           }
         }
       );
       const notifyCreated = (result: { run_id?: unknown }) => {
-        if (typeof result.run_id !== "string") return;
+        if (
+          generation !== this.#generation ||
+          this.#getDisposed() ||
+          typeof result.run_id !== "string"
+        )
+          return;
         createdRunId = result.run_id;
+        this.#serverQueue.claimLocalRun(activeThreadId, createdRunId);
         this.#onRunCreated(createdRunId);
         if (pendingCompletionReason != null) {
           notifyCompletion(pendingCompletionReason);
@@ -525,6 +515,7 @@ export class SubmitCoordinator<
       terminal ??= await terminalPromise;
       terminalSettled = true;
       settleEvent = terminal.event;
+      observedTerminal = true;
       if (terminal.event === "failed" && !abort.signal.aborted) {
         const runError = new Error(
           terminal.error ?? "Run failed with no error message"
@@ -541,22 +532,27 @@ export class SubmitCoordinator<
       if (!abort.signal.aborted) settleEvent = "failed";
       reportError(error);
     } finally {
-      // Always settle loading and clear our slot of the abort
-      // controller. Schedule queue drain on the next macrotask so any
-      // late state updates from this run finish flushing first.
-      this.#rootStore.setState((s) => ({ ...s, isLoading: false }));
-      if (this.#runAbort === abort) this.#runAbort = undefined;
-      // Reconcile optimistic state: flip pending messages to sent/failed
-      // and roll back un-echoed non-message keys. `aborted` covers a
-      // rollback-resubmit or `stop()` cancelling this run.
-      if (optimisticHandle != null) {
-        this.#settleOptimistic(
-          optimisticHandle,
-          abort.signal.aborted ? "aborted" : (settleEvent ?? "failed")
-        );
+      if (generation === this.#generation) {
+        if (this.#runAbort === abort) {
+          if (this.#canClearLoading() || !observedTerminal) {
+            this.#rootStore.setState((s) => ({
+              ...s,
+              isLoading: this.#serverQueue.activeRunId != null,
+            }));
+          }
+          this.#runAbort = undefined;
+        }
+        // Reconcile optimistic state: flip pending messages to sent/failed
+        // and roll back un-echoed non-message keys. `aborted` covers a
+        // rollback-resubmit or `stop()` cancelling this run.
+        if (optimisticHandle != null) {
+          this.#settleOptimistic(
+            optimisticHandle,
+            abort.signal.aborted ? "aborted" : (settleEvent ?? "failed")
+          );
+        }
+        this.#onRunEnd();
       }
-      this.#onRunEnd();
-      setTimeout(() => this.#drainQueue(), 0);
     }
   }
 
@@ -646,8 +642,10 @@ export class SubmitCoordinator<
     // ignores stale `interrupted` events until root `running` is seen.
     // Watched in the background — we never gate the returned promise on the
     // resumed run's terminal.
+    const generation = this.#generation;
     const terminalPromise = this.#awaitResumedRunTerminal(abort.signal);
     void terminalPromise.then((terminal) => {
+      if (generation !== this.#generation) return;
       if (this.#runAbort === abort) this.#runAbort = undefined;
       if (terminal.event === "failed" && !abort.signal.aborted) {
         reportError(
@@ -655,8 +653,6 @@ export class SubmitCoordinator<
         );
       }
       settleOptimisticOnce(abort.signal.aborted ? "aborted" : terminal.event);
-      // Drain any submission enqueued while the resumed run was active.
-      setTimeout(() => this.#drainQueue(), 0);
     });
 
     try {
@@ -693,75 +689,31 @@ export class SubmitCoordinator<
     this.#runAbort = undefined;
   }
 
-  /**
-   * Cancel a queued submission by id.
-   *
-   * @param id - Client-side queue entry id to remove.
-   * @returns `true` when the entry was found and dropped, `false` otherwise.
-   */
+  get queuedActiveRunId(): string | undefined {
+    return this.#serverQueue.activeRunId;
+  }
+
+  async cancelRunning(): Promise<void> {
+    const threadId = this.#getCurrentThreadId();
+    if (threadId) await this.#serverQueue.cancelRunning(threadId);
+  }
+
+  async hydrateQueue(threadId: string): Promise<void> {
+    await this.#serverQueue.refresh(threadId);
+  }
+
+  detach(): void {
+    this.#generation += 1;
+    this.abortActiveRun();
+    this.#serverQueue.detach();
+  }
+
   async cancelQueued(id: string): Promise<boolean> {
-    const current = this.#queueStore.getSnapshot();
-    const next = current.filter((entry) => entry.id !== id);
-    if (next.length === current.length) return false;
-    this.#queueStore.setState(() => next);
-    return true;
+    return this.#serverQueue.cancel(id);
   }
 
-  /**
-   * Drop every queued submission. Server-side cancel arrives with A0.3.
-   */
   async clearQueue(): Promise<void> {
-    this.#queueStore.setState(
-      () => EMPTY_QUEUE as SubmissionQueueSnapshot<StateType>
-    );
-  }
-
-  /**
-   * Append a submission to the queue without dispatching.
-   *
-   * The drained submission is later run via {@link #drainQueue} after
-   * the active run terminates.
-   */
-  #enqueueSubmission(
-    input: unknown,
-    options?: StreamSubmitOptions<StateType, ConfigurableType>
-  ): void {
-    const entry: SubmissionQueueEntry<StateType> = {
-      id: uuidv7(),
-      values: (input ?? undefined) as Partial<StateType> | null | undefined,
-      options: options as StreamSubmitOptions<StateType> | undefined,
-      createdAt: new Date(),
-    };
-    this.#queueStore.setState((current) => [...current, entry]);
-  }
-
-  /**
-   * Drain the head of the queue if no run is active.
-   *
-   * Called from the `finally` block of `submit()` on the next
-   * macrotask (so the just-finished run's state flushes first).
-   * Strips the strategy off the dequeued options to prevent infinite
-   * re-enqueueing.
-   */
-  #drainQueue(): void {
-    if (this.#getDisposed()) return;
-    if (this.#runAbort != null && !this.#runAbort.signal.aborted) return;
-    const current = this.#queueStore.getSnapshot();
-    if (current.length === 0) return;
-    const [next, ...rest] = current;
-    this.#queueStore.setState(() => rest);
-    const nextOptions: StreamSubmitOptions<StateType, ConfigurableType> = {
-      ...((next.options ?? {}) as StreamSubmitOptions<
-        StateType,
-        ConfigurableType
-      >),
-      multitaskStrategy: undefined,
-    };
-    void this.submit(next.values, nextOptions).catch(() => {
-      /* submit() already routes errors through the per-submit onError
-       * hook and the root store; swallow here so a failing drain does
-       * not surface as an unhandled rejection. */
-    });
+    await this.#serverQueue.clear();
   }
 }
 

--- a/libs/sdk/src/stream/types.ts
+++ b/libs/sdk/src/stream/types.ts
@@ -152,6 +152,8 @@ export interface UseStreamCommonOptions<
   StateType extends object,
   ThreadIdType = string | null,
 > {
+  /** Explicit server run observation/cancellation capability, using the same auth and fetch as the transport. */
+  serverQueue?: AgentServerAdapter["serverQueue"];
   threadId?: ThreadIdType;
   onThreadId?: (threadId: string) => void;
   /**
@@ -358,6 +360,8 @@ export interface StreamControllerOptions<
   assistantId: string;
   /** Client used to construct `ThreadStream`s. */
   client: Client<StateType>;
+  /** Opt in to server queue observation and cancellation using the configured run client. */
+  serverQueue?: AgentServerAdapter["serverQueue"];
   /** Initial thread id; if `null`, one is generated on first submit. */
   threadId?: string | null;
   /**
@@ -440,8 +444,9 @@ export interface StreamSubmitOptions<
    * - `"interrupt"` — server-side cancel of the in-flight run, then
    *   start the new one.
    * - `"enqueue"` — do NOT abort the active run; the new submission
-   *   lands in {@link StreamController.queueStore} and is forwarded
-   *   once the current run terminates.
+   *   is sent immediately to the server queue. Resolves on acceptance;
+   *   {@link StreamController.queueStore} mirrors pending runs. Requires the
+   *   explicit `serverQueue` observation and cancellation capability.
    * - `"reject"` — error out client-side when a run is already in
    *   flight.
    *


### PR DESCRIPTION
## Summary

Replace browser-local submission scheduling with server-accepted runs. Enqueue sends protocol `run.start` immediately without replacing the active content stream; the server owns execution ordering.

- Track accepted run IDs, observe completion per run, and restore pending/running runs on hydration and reconnect.
- Implement server cancellation for individual queue entries and a queue snapshot; detach on navigation without cancelling accepted runs.
- Preserve provisional queue keys and message IDs, reconcile delayed acceptance, and resume subscriptions when the lifecycle watcher receives the next run first.
- Add explicit `serverQueue` observation/cancellation capabilities to the shared controller and React/Vue/Svelte/Angular bindings, with documentation and release changesets.

## Compatibility

- Server-backed enqueue requires an explicit `serverQueue` capability (for example, an appropriately authenticated Runs client). This avoids silently adding REST requirements to protocol-only/custom transports.
- Enqueue resolves on server acceptance and rejects acceptance failures. Ordinary submissions retain stream-based completion.
- Restored input/configuration depend on optional server `kwargs`.
- Queue cancellation can race promotion to running; Stop targets server-reported running runs rather than cancelling unrelated pending work.
- Open SWE integration changes are not included.

## Validation

- 203 focused SDK tests passed; the final coordinator rerun passed all 36 tests.
- SDK and four framework TypeScript checks passed.
- SDK build/package validation, lint, formatting, and diff checks passed.
- Browser tests were blocked by a missing Chrome executable. Live JS/Python Agent Server end-to-end queue validation remains outstanding.

Made by [Open SWE](https://openswe.vercel.app/agents/2c24cd1b-bfe5-59b3-b3a6-2826fd76a408) · openai:gpt-6-astra (medium)