### PR TITLE
feat(langgraph): add responseSchema option to interrupt()

### DIFF
--- a/libs/langgraph-core/src/constants.ts
+++ b/libs/langgraph-core/src/constants.ts
@@ -1,4 +1,5 @@
 import { PendingWrite } from "@langchain/langgraph-checkpoint";
+import type { JSONSchema } from "@langchain/core/utils/json_schema";
 import {
   coerceTimeoutPolicy,
   type TimeoutPolicy,
@@ -406,6 +407,11 @@ export function _isOverwriteValue<ValueType>(
 export type Interrupt<Value = any> = {
   id?: string;
   value?: Value;
+  /**
+   * JSON Schema for the value expected when resuming this interrupt,
+   * if the graph provided one via `interrupt(value, { responseSchema })`.
+   */
+  response_schema?: JSONSchema;
 };
 
 /**

--- a/libs/langgraph-core/src/interrupt.ts
+++ b/libs/langgraph-core/src/interrupt.ts
@@ -120,8 +120,9 @@ export function interrupt<I = unknown, R = any>(
 
   // Find previous resume values
   if (scratchpad.resume.length > 0 && idx < scratchpad.resume.length) {
+    const parsed = parseResume(scratchpad.resume[idx]);
     conf[CONFIG_KEY_SEND]?.([[RESUME, scratchpad.resume] as PendingWrite]);
-    return parseResume(scratchpad.resume[idx]);
+    return parsed;
   }
 
   // Find current resume value

--- a/libs/langgraph-core/src/interrupt.ts
+++ b/libs/langgraph-core/src/interrupt.ts
@@ -1,6 +1,15 @@
 import { AsyncLocalStorageProviderSingleton } from "@langchain/core/singletons";
 import { RunnableConfig } from "@langchain/core/runnables";
 import {
+  type JSONSchema,
+  toJsonSchema,
+} from "@langchain/core/utils/json_schema";
+import {
+  type InteropZodType,
+  interopParse,
+  isInteropZodSchema,
+} from "@langchain/core/utils/types";
+import {
   BaseCheckpointSaver,
   type PendingWrite,
 } from "@langchain/langgraph-checkpoint";
@@ -12,9 +21,21 @@ import {
   CONFIG_KEY_CHECKPOINTER,
   CHECKPOINT_NAMESPACE_SEPARATOR,
   RESUME,
+  type Interrupt,
 } from "./constants.js";
 import { PregelScratchpad } from "./pregel/types.js";
 import { XXH3 } from "./hash.js";
+
+export interface InterruptOptions {
+  /**
+   * Schema for the value expected when the graph is resumed, surfaced to
+   * clients on `Interrupt.response_schema` (as JSON Schema) so they can render
+   * a typed input form. A Zod schema also parses the resume value, and the
+   * parsed value is what `interrupt` returns; a JSON Schema object is passed
+   * through to clients without validating the resume value.
+   */
+  responseSchema?: InteropZodType | JSONSchema;
+}
 
 /**
  * Interrupts the execution of a graph node.
@@ -32,7 +53,10 @@ import { XXH3 } from "./hash.js";
  * or if you do, ensure that the `GraphInterrupt` error is thrown again within your `catch` block.
  *
  * @param value - The value to include in the interrupt. This will be available in task.interrupts[].value
- * @returns The `resume` value provided when the graph is re-invoked with a Command
+ * @param options - Optional settings. `responseSchema` describes the expected resume value and is
+ *   available in task.interrupts[].response_schema as JSON Schema; a Zod schema also validates the resume value.
+ * @returns The `resume` value provided when the graph is re-invoked with a Command, parsed by
+ *   `responseSchema` when it is a Zod schema
  *
  * @example
  * ```typescript
@@ -58,9 +82,13 @@ import { XXH3 } from "./hash.js";
  *
  * @throws {Error} If called outside the context of a graph
  * @throws {GraphInterrupt} When no resume value is available
+ * @throws {ZodError} When the resume value does not match a Zod `responseSchema`
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function interrupt<I = unknown, R = any>(value: I): R {
+export function interrupt<I = unknown, R = any>(
+  value: I,
+  options?: InterruptOptions
+): R {
   const config: RunnableConfig | undefined =
     AsyncLocalStorageProviderSingleton.getRunnableConfig();
   if (!config) {
@@ -79,6 +107,12 @@ export function interrupt<I = unknown, R = any>(value: I): R {
     });
   }
 
+  const schema = options?.responseSchema;
+  const parseResume = (resume: unknown): R =>
+    (schema !== undefined && isInteropZodSchema(schema)
+      ? interopParse(schema, resume)
+      : resume) as R;
+
   // Track interrupt index
   const scratchpad: PregelScratchpad = conf[CONFIG_KEY_SCRATCHPAD];
   scratchpad.interruptCounter += 1;
@@ -87,7 +121,7 @@ export function interrupt<I = unknown, R = any>(value: I): R {
   // Find previous resume values
   if (scratchpad.resume.length > 0 && idx < scratchpad.resume.length) {
     conf[CONFIG_KEY_SEND]?.([[RESUME, scratchpad.resume] as PendingWrite]);
-    return scratchpad.resume[idx] as R;
+    return parseResume(scratchpad.resume[idx]);
   }
 
   // Find current resume value
@@ -98,9 +132,10 @@ export function interrupt<I = unknown, R = any>(value: I): R {
       );
     }
     const v = scratchpad.consumeNullResume();
+    const parsed = parseResume(v);
     scratchpad.resume.push(v);
     conf[CONFIG_KEY_SEND]?.([[RESUME, scratchpad.resume] as PendingWrite]);
-    return v as R;
+    return parsed;
   }
 
   // No resume value found
@@ -109,7 +144,11 @@ export function interrupt<I = unknown, R = any>(value: I): R {
   );
 
   const id = ns ? XXH3(ns.join(CHECKPOINT_NAMESPACE_SEPARATOR)) : undefined;
-  throw new GraphInterrupt([{ id, value }]);
+  const pending: Interrupt<I> = { id, value };
+  if (schema !== undefined) {
+    pending.response_schema = toJsonSchema(schema);
+  }
+  throw new GraphInterrupt([pending]);
 }
 
 type FilterAny<X> =

--- a/libs/langgraph-core/src/tests/interrupt.test.ts
+++ b/libs/langgraph-core/src/tests/interrupt.test.ts
@@ -72,19 +72,23 @@ describe("interrupt responseSchema", () => {
       const config = { configurable: { thread_id: "1" } };
       await graph.invoke({ answer: null }, config);
       const [pending] = (await graph.getState(config)).tasks[0].interrupts;
-      const resume = (value: unknown) =>
-        new Command({
-          resume: resumeStyle === "null" ? value : { [pending.id ?? ""]: value },
-        });
+      const resumeWith = (value: unknown) =>
+        resumeStyle === "null" ? value : { [pending.id ?? ""]: value };
 
       await expect(
-        graph.invoke(resume({ approved: "nope" }), config)
+        graph.invoke(
+          new Command({ resume: resumeWith({ approved: "nope" }) }),
+          config
+        )
       ).rejects.toMatchObject({
         issues: [expect.objectContaining({ path: ["approved"] })],
       });
 
       await expect(
-        graph.invoke(resume({ approved: false }), config)
+        graph.invoke(
+          new Command({ resume: resumeWith({ approved: false }) }),
+          config
+        )
       ).resolves.toEqual({ answer: { approved: false, note: "" } });
     }
   );

--- a/libs/langgraph-core/src/tests/interrupt.test.ts
+++ b/libs/langgraph-core/src/tests/interrupt.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { MemorySaver } from "@langchain/langgraph-checkpoint";
+import { toJsonSchema } from "@langchain/core/utils/json_schema";
+import {
+  Annotation,
+  Command,
+  START,
+  StateGraph,
+  interrupt,
+  type InterruptOptions,
+} from "../index.js";
+
+const State = Annotation.Root({
+  answer: Annotation<unknown>(),
+});
+
+const RAW_SCHEMA = {
+  type: "object",
+  properties: { approved: { type: "boolean" } },
+};
+const ZOD_SCHEMA = z.object({
+  approved: z.boolean(),
+  note: z.string().default(""),
+});
+
+const buildGraph = (responseSchema: InterruptOptions["responseSchema"]) =>
+  new StateGraph(State)
+    .addNode("node", () => ({
+      answer: interrupt({ question: "approve?" }, { responseSchema }),
+    }))
+    .addEdge(START, "node")
+    .compile({ checkpointer: new MemorySaver() });
+
+describe("interrupt responseSchema", () => {
+  it.each([
+    ["none", undefined, undefined, { approved: true, extra: 1 }],
+    ["raw JSON Schema", RAW_SCHEMA, RAW_SCHEMA, { approved: true, extra: 1 }],
+    ["zod", ZOD_SCHEMA, toJsonSchema(ZOD_SCHEMA), { approved: true, note: "" }],
+  ] as const)(
+    "surfaces %s on the interrupt and resumes",
+    async (_label, responseSchema, expectedSchema, expectedAnswer) => {
+      const graph = buildGraph(responseSchema);
+      const config = { configurable: { thread_id: "1" } };
+      const expected = {
+        id: expect.any(String),
+        value: { question: "approve?" },
+        ...(expectedSchema === undefined
+          ? {}
+          : { response_schema: expectedSchema }),
+      };
+
+      const result = await graph.invoke({ answer: null }, config);
+      expect(result).toMatchObject({ __interrupt__: [expected] });
+      expect((await graph.getState(config)).tasks[0].interrupts).toEqual([
+        expected,
+      ]);
+
+      await expect(
+        graph.invoke(new Command({ resume: { approved: true, extra: 1 } }), config)
+      ).resolves.toEqual({ answer: expectedAnswer });
+    }
+  );
+
+  it("rejects a resume value that does not match a zod responseSchema", async () => {
+    const graph = buildGraph(ZOD_SCHEMA);
+    const config = { configurable: { thread_id: "1" } };
+    await graph.invoke({ answer: null }, config);
+
+    await expect(
+      graph.invoke(new Command({ resume: { approved: "nope" } }), config)
+    ).rejects.toMatchObject({
+      issues: [expect.objectContaining({ path: ["approved"] })],
+    });
+
+    await expect(
+      graph.invoke(new Command({ resume: { approved: false } }), config)
+    ).resolves.toEqual({ answer: { approved: false, note: "" } });
+  });
+});

--- a/libs/langgraph-core/src/tests/interrupt.test.ts
+++ b/libs/langgraph-core/src/tests/interrupt.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod/v4";
 import { MemorySaver } from "@langchain/langgraph-checkpoint";
-import { toJsonSchema } from "@langchain/core/utils/json_schema";
+import {
+  type JSONSchema,
+  toJsonSchema,
+} from "@langchain/core/utils/json_schema";
 import {
   Annotation,
   Command,
@@ -15,7 +18,7 @@ const State = Annotation.Root({
   answer: Annotation<unknown>(),
 });
 
-const RAW_SCHEMA = {
+const RAW_SCHEMA: JSONSchema = {
   type: "object",
   properties: { approved: { type: "boolean" } },
 };
@@ -62,19 +65,27 @@ describe("interrupt responseSchema", () => {
     }
   );
 
-  it("rejects a resume value that does not match a zod responseSchema", async () => {
-    const graph = buildGraph(ZOD_SCHEMA);
-    const config = { configurable: { thread_id: "1" } };
-    await graph.invoke({ answer: null }, config);
+  it.each(["null", "map"] as const)(
+    "rejects a %s resume that does not match a zod responseSchema, then accepts a corrected one",
+    async (resumeStyle) => {
+      const graph = buildGraph(ZOD_SCHEMA);
+      const config = { configurable: { thread_id: "1" } };
+      await graph.invoke({ answer: null }, config);
+      const [pending] = (await graph.getState(config)).tasks[0].interrupts;
+      const resume = (value: unknown) =>
+        new Command({
+          resume: resumeStyle === "null" ? value : { [pending.id ?? ""]: value },
+        });
 
-    await expect(
-      graph.invoke(new Command({ resume: { approved: "nope" } }), config)
-    ).rejects.toMatchObject({
-      issues: [expect.objectContaining({ path: ["approved"] })],
-    });
+      await expect(
+        graph.invoke(resume({ approved: "nope" }), config)
+      ).rejects.toMatchObject({
+        issues: [expect.objectContaining({ path: ["approved"] })],
+      });
 
-    await expect(
-      graph.invoke(new Command({ resume: { approved: false } }), config)
-    ).resolves.toEqual({ answer: { approved: false, note: "" } });
-  });
+      await expect(
+        graph.invoke(resume({ approved: false }), config)
+      ).resolves.toEqual({ answer: { approved: false, note: "" } });
+    }
+  );
 });

--- a/libs/langgraph-core/src/web.ts
+++ b/libs/langgraph-core/src/web.ts
@@ -182,6 +182,7 @@ export { interrupt } from "./interrupt.js";
 export type {
   InferInterruptInputType,
   InferInterruptResumeType,
+  InterruptOptions,
 } from "./interrupt.js";
 export { writer } from "./writer.js";
 export type { InferWriterType } from "./writer.js";

--- a/libs/sdk/src/schema.ts
+++ b/libs/sdk/src/schema.ts
@@ -172,6 +172,12 @@ export interface Interrupt<TValue = unknown> {
   value?: TValue;
 
   /**
+   * JSON Schema for the value expected when resuming this interrupt,
+   * if the graph provided one.
+   */
+  response_schema?: Record<string, unknown>;
+
+  /**
    * Protocol namespace tuple for resume targeting (`[]` at root).
    * Populated for nested subgraph / subagent interrupts so
    * `respond({ interruptId })` can resume without a separate


### PR DESCRIPTION
Adds `interrupt(value, { responseSchema })`. The schema (Zod or JSON Schema) is surfaced on `Interrupt.response_schema` as JSON Schema so clients (LangGraph Studio first) can render a typed form for the resume value instead of a free-form JSON box. Omit it and nothing changes.

A Zod schema also parses the resume value, and the parsed value is what `interrupt()` returns; a parse failure rejects before the value is committed, so the next resume works. A JSON Schema object is passed through to clients without validating the resume value. `@langchain/langgraph-sdk`'s `Interrupt` type gains the optional `response_schema` field.

Python counterpart: langchain-ai/langgraph#8886.
