### PR TITLE
fix(langgraph-checkpoint-redis): scope vector search to the full namespace prefix

### DIFF
--- a/.changeset/redis-store-namespace-prefix-tokens.md
+++ b/.changeset/redis-store-namespace-prefix-tokens.md
@@ -2,4 +2,4 @@
 "@langchain/langgraph-checkpoint-redis": patch
 ---
 
-Scope `RedisStore` vector search to every label of the namespace prefix instead of only the first one, and build both search namespace clauses through a shared helper so vector and plain search filter identically.
+Scope `RedisStore` vector search to every label of the namespace prefix instead of only the first one, and build both search namespace clauses through a shared helper so vector and plain search filter identically. The helper now splits labels on the same punctuation RediSearch tokenizes on, so a namespace label can no longer inject query syntax into the prefix clause.

--- a/.changeset/redis-store-namespace-prefix-tokens.md
+++ b/.changeset/redis-store-namespace-prefix-tokens.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint-redis": patch
+---
+
+Scope `RedisStore` vector search to every label of the namespace prefix instead of only the first one, and build both search namespace clauses through a shared helper so vector and plain search filter identically.

--- a/libs/checkpoint-redis/src/store.ts
+++ b/libs/checkpoint-redis/src/store.ts
@@ -18,7 +18,10 @@ import {
   type SearchOperation,
 } from "@langchain/langgraph-checkpoint";
 
-import { escapeRediSearchTagValue } from "./utils.js";
+import {
+  buildNamespacePrefixQuery,
+  escapeRediSearchTagValue,
+} from "./utils.js";
 
 // Type guard functions for operations
 export function isPutOperation(op: Operation): op is PutOperation {
@@ -651,7 +654,6 @@ export class RedisStore {
       similarityThreshold?: number;
     }
   ): Promise<SearchItem[]> {
-    const prefix = namespacePrefix.join(".");
     const limit = options?.limit || 10;
     const offset = options?.offset || 0;
 
@@ -660,8 +662,7 @@ export class RedisStore {
       const [embedding] = await this.embeddings.embedDocuments([options.query]);
 
       // Build KNN query
-      // For prefix search, use wildcard since we want to match any document starting with this prefix
-      const queryStr = prefix ? `@prefix:${prefix.split(/[.-]/)[0]}*` : "*";
+      const queryStr = buildNamespacePrefixQuery(namespacePrefix);
       const vectorBytes = Buffer.from(new Float32Array(embedding).buffer);
 
       try {
@@ -742,15 +743,7 @@ export class RedisStore {
     }
 
     // Regular search without vectors
-    let queryStr = "*";
-    if (prefix) {
-      // For prefix search, we need to match all tokens from the namespace prefix
-      const tokens = prefix.split(/[.-]/).filter((t) => t.length > 0);
-      if (tokens.length > 0) {
-        // Match all tokens to ensure we get the right prefix
-        queryStr = `@prefix:(${tokens.join(" ")})`;
-      }
-    }
+    const queryStr = buildNamespacePrefixQuery(namespacePrefix);
 
     try {
       const results = await this.client.ft.search("store", queryStr, {

--- a/libs/checkpoint-redis/src/tests/store.test.ts
+++ b/libs/checkpoint-redis/src/tests/store.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { RedisStore, type RedisConnection } from "../store.js";
+
+function createStubClient() {
+  return {
+    ft: {
+      search: vi.fn().mockResolvedValue({ total: 0, documents: [] }),
+    },
+    json: {
+      get: vi.fn().mockResolvedValue(null),
+    },
+  };
+}
+
+const mockEmbeddings = {
+  embedDocuments: vi.fn().mockResolvedValue([[0.1, 0.2, 0.3]]),
+  embedQuery: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+};
+
+function createVectorStore(client: ReturnType<typeof createStubClient>) {
+  return new RedisStore(client as unknown as RedisConnection, {
+    index: { dims: 3, embed: mockEmbeddings },
+  });
+}
+
+describe("RedisStore search namespace scoping", () => {
+  it("should scope vector search to every label of the prefix", async () => {
+    const client = createStubClient();
+    const store = createVectorStore(client);
+
+    await store.search(["tenant", "acme"], { query: "notes" });
+
+    expect(client.ft.search).toHaveBeenCalledTimes(1);
+    const [index, query] = client.ft.search.mock.calls[0];
+    expect(index).toBe("store_vectors");
+    expect(query).toContain("@prefix:(tenant acme)");
+  });
+
+  it("should not widen a nested vector search to its first label", async () => {
+    const client = createStubClient();
+    const store = createVectorStore(client);
+
+    await store.search(["docs", "public"], { query: "guide" });
+
+    const [, query] = client.ft.search.mock.calls[0];
+    expect(query).not.toContain("@prefix:docs*");
+    expect(query).toContain("public");
+  });
+
+  it("should scope a plain search with the same clause", async () => {
+    const client = createStubClient();
+    const store = new RedisStore(client as unknown as RedisConnection);
+
+    await store.search(["tenant", "acme"]);
+
+    const [index, query] = client.ft.search.mock.calls[0];
+    expect(index).toBe("store");
+    expect(query).toBe("@prefix:(tenant acme)");
+  });
+
+  it("should search every namespace for an empty prefix", async () => {
+    const client = createStubClient();
+    const store = new RedisStore(client as unknown as RedisConnection);
+
+    await store.search([]);
+
+    const [, query] = client.ft.search.mock.calls[0];
+    expect(query).toBe("*");
+  });
+});

--- a/libs/checkpoint-redis/src/tests/utils.test.ts
+++ b/libs/checkpoint-redis/src/tests/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   assertSafeKeyComponent,
+  buildNamespacePrefixQuery,
   escapeRediSearchTagValue,
 } from "../utils.js";
 
@@ -193,5 +194,41 @@ describe("assertSafeKeyComponent", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       assertSafeKeyComponent("task_id", { $gt: "" } as any)
     ).toThrow(/"task_id"/);
+  });
+});
+
+describe("buildNamespacePrefixQuery", () => {
+  it("should match every document for an empty prefix", () => {
+    expect(buildNamespacePrefixQuery([])).toBe("*");
+  });
+
+  it("should scope a single label namespace", () => {
+    expect(buildNamespacePrefixQuery(["docs"])).toBe("@prefix:(docs)");
+  });
+
+  it("should keep every label of a nested namespace", () => {
+    expect(buildNamespacePrefixQuery(["docs", "public"])).toBe(
+      "@prefix:(docs public)"
+    );
+    expect(buildNamespacePrefixQuery(["tenant", "acme", "notes"])).toBe(
+      "@prefix:(tenant acme notes)"
+    );
+  });
+
+  it("should not widen the match to namespaces sharing only the first label", () => {
+    const query = buildNamespacePrefixQuery(["tenant", "acme"]);
+
+    expect(query).not.toContain("*");
+    expect(query).toContain("acme");
+  });
+
+  it("should tokenize labels the same way RediSearch indexes them", () => {
+    expect(buildNamespacePrefixQuery(["acme-corp"])).toBe(
+      "@prefix:(acme corp)"
+    );
+  });
+
+  it("should ignore empty tokens", () => {
+    expect(buildNamespacePrefixQuery(["docs", ""])).toBe("@prefix:(docs)");
   });
 });

--- a/libs/checkpoint-redis/src/tests/utils.test.ts
+++ b/libs/checkpoint-redis/src/tests/utils.test.ts
@@ -226,9 +226,48 @@ describe("buildNamespacePrefixQuery", () => {
     expect(buildNamespacePrefixQuery(["acme-corp"])).toBe(
       "@prefix:(acme corp)"
     );
+    expect(buildNamespacePrefixQuery(["user:123"])).toBe("@prefix:(user 123)");
+    expect(buildNamespacePrefixQuery(["team a", "docs"])).toBe(
+      "@prefix:(team a docs)"
+    );
   });
 
   it("should ignore empty tokens", () => {
     expect(buildNamespacePrefixQuery(["docs", ""])).toBe("@prefix:(docs)");
+  });
+
+  it("should match every document when every label is empty", () => {
+    expect(buildNamespacePrefixQuery(["", ""])).toBe("*");
+  });
+
+  it("should not let a label break out of the prefix clause", () => {
+    const query = buildNamespacePrefixQuery([
+      "tenant",
+      "acme) | @prefix:(victim",
+    ]);
+
+    expect(query).toBe("@prefix:(tenant acme prefix victim)");
+  });
+
+  it("should only emit terms the indexer could have produced", () => {
+    const query = buildNamespacePrefixQuery([
+      "a)b",
+      "c|d",
+      "e*f",
+      "g{h",
+      "i?j",
+      "k\\l",
+    ]);
+    const terms = query.slice("@prefix:(".length, -1).split(" ");
+
+    expect(terms).toEqual(["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"]);
+    expect(terms.every((term) => /^[^\s]+$/.test(term))).toBe(true);
+  });
+
+  it("should not widen to every namespace when a label has no index terms", () => {
+    const query = buildNamespacePrefixQuery(["::"]);
+
+    expect(query).not.toBe("*");
+    expect(query.slice("@prefix:(".length, -1)).toBe("\\:\\:");
   });
 });

--- a/libs/checkpoint-redis/src/utils.ts
+++ b/libs/checkpoint-redis/src/utils.ts
@@ -22,26 +22,47 @@ export function escapeRediSearchTagValue(value: string): string {
 }
 
 /**
+ * Punctuation that RediSearch strips when it tokenizes a TEXT field.
+ *
+ * Query terms have to be split on the same set the indexer uses. A term that
+ * still carries one of these characters does not address an indexed term: it
+ * either fails to parse or, worse, closes the surrounding `@prefix:(...)`
+ * clause and lets a caller-controlled namespace label inject query syntax
+ * (`"acme) | @prefix:(victim"` would otherwise OR in another tenant).
+ */
+const REDISEARCH_TEXT_PUNCTUATION = /[-\s,.:<>{}[\]"';!@#$%^&*()+=~|?/\\]/;
+
+/**
  * Builds the RediSearch clause that scopes a query to a namespace prefix.
  *
  * Namespaces are indexed as a single TEXT field, so the clause has to carry the
- * tokens of every label: dropping one widens the match to unrelated
- * namespaces. RediSearch tokenizes on punctuation, which is why labels are also
- * split on `.` and `-`.
+ * tokens of every label: dropping one widens the match to unrelated namespaces.
+ * Only terms the indexer could have produced are emitted, never raw label text.
  *
  * @param namespacePrefix - Namespace labels to scope the query to
- * @returns The RediSearch clause, or `*` when the prefix is empty
+ * @returns The RediSearch clause, or `*` when the prefix carries no labels
  */
 export function buildNamespacePrefixQuery(namespacePrefix: string[]): string {
   const tokens = namespacePrefix
-    .flatMap((label) => label.split(/[.-]/))
+    .flatMap((label) => label.split(REDISEARCH_TEXT_PUNCTUATION))
     .filter((token) => token.length > 0);
 
-  if (tokens.length === 0) {
+  if (tokens.length > 0) {
+    return `@prefix:(${tokens.join(" ")})`;
+  }
+
+  if (namespacePrefix.every((label) => label.length === 0)) {
     return "*";
   }
 
-  return `@prefix:(${tokens.join(" ")})`;
+  // A label made only of punctuation indexes no term, so no document can match
+  // it. Escaping keeps the clause parseable instead of falling back to `*`,
+  // which would widen the search to every namespace.
+  const escaped = namespacePrefix.map((label) =>
+    escapeRediSearchTagValue(label)
+  );
+
+  return `@prefix:(${escaped.join(" ")})`;
 }
 
 /**

--- a/libs/checkpoint-redis/src/utils.ts
+++ b/libs/checkpoint-redis/src/utils.ts
@@ -22,6 +22,29 @@ export function escapeRediSearchTagValue(value: string): string {
 }
 
 /**
+ * Builds the RediSearch clause that scopes a query to a namespace prefix.
+ *
+ * Namespaces are indexed as a single TEXT field, so the clause has to carry the
+ * tokens of every label: dropping one widens the match to unrelated
+ * namespaces. RediSearch tokenizes on punctuation, which is why labels are also
+ * split on `.` and `-`.
+ *
+ * @param namespacePrefix - Namespace labels to scope the query to
+ * @returns The RediSearch clause, or `*` when the prefix is empty
+ */
+export function buildNamespacePrefixQuery(namespacePrefix: string[]): string {
+  const tokens = namespacePrefix
+    .flatMap((label) => label.split(/[.-]/))
+    .filter((token) => token.length > 0);
+
+  if (tokens.length === 0) {
+    return "*";
+  }
+
+  return `@prefix:(${tokens.join(" ")})`;
+}
+
+/**
  * Characters that are interpreted as wildcards or escapes by Redis pattern
  * commands (KEYS, SCAN MATCH, PSUBSCRIBE, etc.). Embedding any of these in a
  * caller-controlled key component allows pattern injection: a `thread_id` of


### PR DESCRIPTION
`RedisStore.search()` built two different namespace clauses from the same `namespacePrefix`:

| path | clause for `["tenant", "acme"]` |
| --- | --- |
| plain search | `@prefix:(tenant acme)` |
| vector search | `@prefix:tenant*` |

The vector path used `prefix.split(/[.-]/)[0]`, so every label after the first was dropped from the KNN filter, and the trailing `*` widened what was left. A vector search scoped to `["docs", "public"]` matched every namespace under `docs`, and `["tenant", "acme"]` also matched `tenants`. Every other namespace-clause site in the file (`get`, the existing-key check in `put`, `FilterBuilder.buildRedisSearchQuery`, and plain `search`) passes all tokens, so the vector path was the odd one out.

Both search paths now build the clause through one exported helper, `buildNamespacePrefixQuery`, so vector and plain search scope identically.

The helper also splits labels on the full set of punctuation RediSearch tokenizes on instead of only `.` and `-`. `prefix` is a TEXT field, so a label like `user:123` previously produced a term the indexer never created, and a label carrying `)` or `|` was interpolated into the clause verbatim. Now the clause can only contain terms the index could actually hold, so an injected payload degrades into extra AND terms, which narrows the match rather than widening it. A label made only of punctuation falls back to an escaped clause that matches nothing instead of `*`.

The same inline construction still sits at three other sites in `store.ts` (`get`, the existing-key check in `put`, `FilterBuilder.buildRedisSearchQuery`). Routing those through the helper touches read and write paths, so it is deliberately left out of this diff.

This does not change the segment-boundary contract discussed in #2721 for the Postgres and in-memory stores. `prefix` is a TEXT field, so token matching here stays order- and position-independent; making it exact needs an index-level change (the MongoDB store already stores a `namespacePath` array and matches element-wise). Happy to follow up on that separately if that direction is wanted.

## Tests

`src/tests/store.test.ts` (new) stubs the Redis client and asserts the query each search path actually issues, so it covers the fixed code path without a server: vector search keeps every label, no `@prefix:docs*` widening, plain search is unchanged, and an empty prefix still matches everything. `src/tests/utils.test.ts` covers the helper, including the tokenization and injection cases.

Reverting only `store.ts` fails the two vector-search assertions; reverting only the split regex in the helper fails 4 helper assertions. With both fixes in place the package suite is green.

```
pnpm --filter @langchain/langgraph-checkpoint-redis test    # 41 passed
pnpm --filter @langchain/langgraph-checkpoint-redis build   # ok (publint + attw clean)
oxfmt --check                                               # 441 files, correct format
oxlint libs/checkpoint-redis/src                            # 0 warnings, 0 errors
```

## AI Disclosure

This bug was identified through code review with AI assistance.
