### PR TITLE
fix(sdk): send langsmith_tracer in runs.stream() request body

### DIFF
--- a/.changeset/runs-stream-langsmith-tracer.md
+++ b/.changeset/runs-stream-langsmith-tracer.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+Send `langsmith_tracer` in the `runs.stream()` request body, so LangSmith trace routing set on a streaming run reaches the server instead of being silently dropped. Matches `runs.create()` and `runs.wait()`, which already send it.

--- a/libs/sdk/src/client/runs/index.ts
+++ b/libs/sdk/src/client/runs/index.ts
@@ -99,6 +99,12 @@ export class RunsClient<
       if_not_exists: payload?.ifNotExists,
       checkpoint_during: payload?.checkpointDuring,
       durability: payload?.durability,
+      langsmith_tracer: payload?._langsmithTracer
+        ? {
+            project_name: payload?._langsmithTracer?.projectName,
+            example_id: payload?._langsmithTracer?.exampleId,
+          }
+        : undefined,
     };
 
     yield* this.streamWithRetry({

--- a/libs/sdk/src/client/runs/stream.test.ts
+++ b/libs/sdk/src/client/runs/stream.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import type { LangChainTracer } from "@langchain/core/tracers/tracer_langchain";
 import { Client } from "../../client.js";
 
 type MockFetch = ReturnType<typeof vi.fn> & typeof fetch;
@@ -186,6 +187,38 @@ describe("Client streaming with retry", () => {
       const [, init] = mockFetch.mock.calls[0];
       const body = JSON.parse(init.body as string);
       expect(body.checkpoint_id).toBe("1f0aaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    });
+
+    test("sends _langsmithTracer as langsmith_tracer in the request body", async () => {
+      const chunks = [{ id: "1", event: "values", data: {} }];
+
+      mockFetch.mockResolvedValueOnce(
+        new Response(createSSEResponseBody(chunks), {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        })
+      );
+
+      const stream = client.runs.stream("thread-1", "assistant-1", {
+        input: { message: "test input" },
+        // Only `projectName` / `exampleId` are read off the tracer, so a
+        // minimal stand-in is enough. A real `new LangChainTracer()` would
+        // resolve the shared LangSmith client singleton, which this suite's
+        // fake timers and mocked fetch have no business touching.
+        _langsmithTracer: {
+          projectName: "my-project",
+          exampleId: "1f0bbbbb-cccc-dddd-eeee-ffffffffffff",
+        } as unknown as LangChainTracer,
+      });
+
+      await gatherStream(stream);
+
+      const [, init] = mockFetch.mock.calls[0];
+      const body = JSON.parse(init.body as string);
+      expect(body.langsmith_tracer).toEqual({
+        project_name: "my-project",
+        example_id: "1f0bbbbb-cccc-dddd-eeee-ffffffffffff",
+      });
     });
 
     test("passes streamMode including tools in request body", async () => {


### PR DESCRIPTION
## Summary

`RunsStreamPayload` extends `RunsInvokePayload` (`libs/sdk/src/types.ts:171`, `:48`), which declares `_langsmithTracer` (`types.ts:168`). But `RunsClient.stream()` builds its wire body at `runs/index.ts:79-101` and never reads it, so the value is dropped on the client:

```ts
client.runs.stream(threadId, assistantId, { input, _langsmithTracer: tracer });
```

This type-checks and runs, and the caller gets no signal that the tracer settings went nowhere.

## Reproduction

The same tracer passed to all three methods on a real `Client`, with a stub `callerOptions.fetch` capturing the outgoing request body:

| endpoint | `langsmith_tracer` in body — before | after |
|---|---|---|
| `/threads/t1/runs/stream` | **false** | true |
| `/threads/t1/runs` | true | true |
| `/threads/t1/runs/wait` | true | true |

## Why this looks like a plain omission rather than intent

1. `RunsClient.create()` (`runs/index.ts:159`) and `RunsClient.wait()` (`:250`) in the same class both send `langsmith_tracer`, from the same `payload?._langsmithTracer` field.
2. The server accepts it on the endpoints `stream()` posts to. `/runs/stream` (`libs/langgraph-api/src/api/runs.mts:181`) and `/threads/:thread_id/runs/stream` (`:342`) validate against the same `schemas.RunCreate` as `/runs` (`:268`) and `/runs/wait` (`:257`), and `langsmith_tracer` is part of that schema (`schemas.mts:248`).
3. The server also acts on it for those endpoints: the shared `createValidRun` (`runs.mts:26`) folds it into `config.configurable.langsmith_project` / `langsmith_example_id` (`:60-64`), which the streaming executor reads back when it builds the tracer (`stream.mts:225` in `streamState`, `:509` in `streamStateV2`).
4. The Python SDK sends it from `stream()`, `create()` and `wait()` alike.

So this isn't porting a v2 capability back onto the v1 generators — the v1 endpoints already take the field, and one of three otherwise-parallel request bodies in `RunsClient` just doesn't send it.

## The change

The serialisation block `create()` and `wait()` already use, placed where they place it (at the end of the literal):

```ts
langsmith_tracer: payload?._langsmithTracer
  ? {
      project_name: payload?._langsmithTracer?.projectName,
      example_id: payload?._langsmithTracer?.exampleId,
    }
  : undefined,
```

Kept character-for-character identical to the other two rather than tidied, so all three stay trivially diffable.

## Tests

Added `sends _langsmithTracer as langsmith_tracer in the request body` to the existing `describe("runs.stream()")` block in `src/client/runs/stream.test.ts`, reusing that file's SSE harness.

**Reverse-verified**: with the change reverted, the new test fails — `AssertionError: expected undefined to deeply equal { project_name: 'my-project', … }`. With it applied it passes, and no existing assertion in that file changes state. `oxlint`, `oxfmt --check`, `tsc --noEmit -p libs/sdk` and the SDK build are clean.

When no tracer is supplied the serialised body is byte-for-byte what it was before.

A changeset is included (`@langchain/langgraph-sdk`: patch).

## Scope notes

- `_langsmithTracer` is marked `@internal`, and nothing inside this repo passes it — the callers this affects are ones using `client.runs.stream()` directly.
- This forwards `project_name` / `example_id` only, which is what the `LangsmithTracer` wire schema carries; `LangChainTracer.replicas` is not forwarded here, nor by `create()`/`wait()`.
- `createBatch()` also accepts `_langsmithTracer` and drops it, but it drops most camelCase keys (it only maps `assistantId`). That's a larger separate issue and isn't folded in here.
- All three call sites build the wire object inline rather than using the `LangSmithTracer` type from `@langchain/protocol` — happy to migrate all three in a follow-up if you'd prefer that.

Following up on the note in #2762.

---

*This contribution was prepared with AI assistance.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
