### PR TITLE
fix(checkpoint): enforce InMemory namespace segment boundaries

### DIFF
--- a/.changeset/inmemory-namespace-boundaries.md
+++ b/.changeset/inmemory-namespace-boundaries.md
@@ -1,0 +1,5 @@
+---
+"@langchain/langgraph-checkpoint": patch
+---
+
+Match InMemoryStore search prefixes at namespace segment boundaries and reject colon-containing labels. Preserve unrestricted empty-prefix searches.

--- a/libs/checkpoint/src/store/base.ts
+++ b/libs/checkpoint/src/store/base.ts
@@ -49,6 +49,7 @@ export function validateNamespace(
       );
     }
   }
+
   if (namespace[0] === "langgraph" && !options.allowReservedRoot) {
     throw new InvalidNamespaceError(
       `Root label for namespace cannot be "langgraph". Got: ${namespace}`

--- a/libs/checkpoint/src/store/base.ts
+++ b/libs/checkpoint/src/store/base.ts
@@ -14,10 +14,21 @@ export class InvalidNamespaceError extends Error {
 /**
  * Validates the provided namespace.
  * @param namespace The namespace to validate.
+ * @param options.allowEmpty When true, an empty namespace is permitted
+ *   (`search([])` means "search everything"). Put still rejects empty.
+ * @param options.allowReservedRoot When true, the `langgraph` root label is
+ *   permitted. Put still rejects it; search may read a namespace written via
+ *   `batch()` which bypasses put validation.
  * @throws {InvalidNamespaceError} If the namespace is invalid.
  */
-function validateNamespace(namespace: string[]): void {
+export function validateNamespace(
+  namespace: string[],
+  options: { allowEmpty?: boolean; allowReservedRoot?: boolean } = {}
+): void {
   if (namespace.length === 0) {
+    if (options.allowEmpty) {
+      return;
+    }
     throw new InvalidNamespaceError("Namespace cannot be empty.");
   }
   for (const label of namespace) {
@@ -32,13 +43,18 @@ function validateNamespace(namespace: string[]): void {
         `Invalid namespace label '${label}' found in ${namespace}. Namespace labels cannot contain periods ('.').`
       );
     }
+    if (label.includes(":")) {
+      throw new InvalidNamespaceError(
+        `Invalid namespace label '${label}' found in ${namespace}. Namespace labels cannot contain colons (':'), which are the namespace path separator.`
+      );
+    }
     if (label === "") {
       throw new InvalidNamespaceError(
         `Namespace labels cannot be empty strings. Got ${label} in ${namespace}`
       );
     }
   }
-  if (namespace[0] === "langgraph") {
+  if (namespace[0] === "langgraph" && !options.allowReservedRoot) {
     throw new InvalidNamespaceError(
       `Root label for namespace cannot be "langgraph". Got: ${namespace}`
     );
@@ -436,6 +452,10 @@ export abstract class BaseStore {
       query?: string;
     } = {}
   ): Promise<SearchItem[]> {
+    validateNamespace(namespacePrefix, {
+      allowEmpty: true,
+      allowReservedRoot: true,
+    });
     const { filter, limit = 10, offset = 0, query } = options;
     return (
       await this.batch<[SearchOperation]>([

--- a/libs/checkpoint/src/store/base.ts
+++ b/libs/checkpoint/src/store/base.ts
@@ -43,11 +43,6 @@ export function validateNamespace(
         `Invalid namespace label '${label}' found in ${namespace}. Namespace labels cannot contain periods ('.').`
       );
     }
-    if (label.includes(":")) {
-      throw new InvalidNamespaceError(
-        `Invalid namespace label '${label}' found in ${namespace}. Namespace labels cannot contain colons (':'), which are the namespace path separator.`
-      );
-    }
     if (label === "") {
       throw new InvalidNamespaceError(
         `Namespace labels cannot be empty strings. Got ${label} in ${namespace}`

--- a/libs/checkpoint/src/store/memory.ts
+++ b/libs/checkpoint/src/store/memory.ts
@@ -10,6 +10,7 @@ import {
   GetOperation,
   type IndexConfig,
   type SearchItem,
+  validateNamespace,
 } from "./base.js";
 import { tokenizePath, compareValues, getTextAtPath } from "./utils.js";
 
@@ -79,6 +80,11 @@ export class InMemoryStore extends BaseStore {
     // First pass - handle gets and prepare search/put operations
     for (let i = 0; i < operations.length; i += 1) {
       const op = operations[i];
+      if ("namespace" in op) {
+        validateNamespace(op.namespace, {
+          allowReservedRoot: true,
+        });
+      }
       if ("key" in op && "namespace" in op && !("value" in op)) {
         // GetOperation
         results.push(this.getOperation(op));
@@ -249,9 +255,22 @@ export class InMemoryStore extends BaseStore {
   }
 
   private filterItems(op: SearchOperation): Item[] {
+    if (op.namespacePrefix.length > 0) {
+      validateNamespace(op.namespacePrefix, { allowReservedRoot: true });
+    }
+    const prefix = op.namespacePrefix.join(":");
     const candidates: Item[] = [];
     for (const [namespace, items] of this.data.entries()) {
-      if (namespace.startsWith(op.namespacePrefix.join(":"))) {
+      // Exact match, or the separator immediately after the prefix, so
+      // "tenant:acme" does not also match sibling "tenant:acme-corp".
+      // Empty prefix is unconstrained (search everything). See #2721 /
+      // CVE-2026-71433. Do not use startsWith(prefix) or startsWith(prefix+":")
+      // without the empty-prefix arm — the latter turns search([]) into [].
+      if (
+        prefix === "" ||
+        namespace === prefix ||
+        namespace.startsWith(`${prefix}:`)
+      ) {
         candidates.push(...items.values());
       }
     }

--- a/libs/checkpoint/src/store/memory.ts
+++ b/libs/checkpoint/src/store/memory.ts
@@ -17,6 +17,7 @@ import { tokenizePath, compareValues, getTextAtPath } from "./utils.js";
 
 function validateMemoryNamespace(namespace: string[]): void {
   validateNamespace(namespace, { allowReservedRoot: true });
+
   if (namespace.some((label) => label.includes(":"))) {
     throw new InvalidNamespaceError(
       "Namespace labels cannot contain colons (':'), the InMemoryStore path separator."
@@ -90,6 +91,7 @@ export class InMemoryStore extends BaseStore {
     // First pass - handle gets and prepare search/put operations
     for (let i = 0; i < operations.length; i += 1) {
       const op = operations[i];
+
       if ("namespace" in op) {
         validateMemoryNamespace(op.namespace);
       }
@@ -266,6 +268,7 @@ export class InMemoryStore extends BaseStore {
     if (op.namespacePrefix.length > 0) {
       validateMemoryNamespace(op.namespacePrefix);
     }
+
     const prefix = op.namespacePrefix.join(":");
     const candidates: Item[] = [];
     for (const [namespace, items] of this.data.entries()) {

--- a/libs/checkpoint/src/store/memory.ts
+++ b/libs/checkpoint/src/store/memory.ts
@@ -11,8 +11,18 @@ import {
   type IndexConfig,
   type SearchItem,
   validateNamespace,
+  InvalidNamespaceError,
 } from "./base.js";
 import { tokenizePath, compareValues, getTextAtPath } from "./utils.js";
+
+function validateMemoryNamespace(namespace: string[]): void {
+  validateNamespace(namespace, { allowReservedRoot: true });
+  if (namespace.some((label) => label.includes(":"))) {
+    throw new InvalidNamespaceError(
+      "Namespace labels cannot contain colons (':'), the InMemoryStore path separator."
+    );
+  }
+}
 
 /**
  * In-memory key-value store with optional vector search.
@@ -81,9 +91,7 @@ export class InMemoryStore extends BaseStore {
     for (let i = 0; i < operations.length; i += 1) {
       const op = operations[i];
       if ("namespace" in op) {
-        validateNamespace(op.namespace, {
-          allowReservedRoot: true,
-        });
+        validateMemoryNamespace(op.namespace);
       }
       if ("key" in op && "namespace" in op && !("value" in op)) {
         // GetOperation
@@ -256,7 +264,7 @@ export class InMemoryStore extends BaseStore {
 
   private filterItems(op: SearchOperation): Item[] {
     if (op.namespacePrefix.length > 0) {
-      validateNamespace(op.namespacePrefix, { allowReservedRoot: true });
+      validateMemoryNamespace(op.namespacePrefix);
     }
     const prefix = op.namespacePrefix.join(":");
     const candidates: Item[] = [];

--- a/libs/checkpoint/src/tests/namespace.test.ts
+++ b/libs/checkpoint/src/tests/namespace.test.ts
@@ -259,9 +259,9 @@ describe("InMemoryStore Namespace Operations", () => {
         )
       );
       const expected = new Set(
-        fixtures
-          .filter((ns) => isSegmentPrefix(query, ns))
-          .map((ns) => ns.join("\0"))
+        fixtures.flatMap((ns) =>
+          isSegmentPrefix(query, ns) ? [ns.join("\0")] : []
+        )
       );
       expect(got, `query ${JSON.stringify(query)}`).toEqual(expected);
     }

--- a/libs/checkpoint/src/tests/namespace.test.ts
+++ b/libs/checkpoint/src/tests/namespace.test.ts
@@ -192,6 +192,81 @@ describe("InMemoryStore Namespace Operations", () => {
     expect(result).toEqual([]);
   });
 
+  it("should block colons in namespace labels", async () => {
+    const doc = { foo: "bar" };
+    await expect(store.put(["tenant", "acme:corp"], "k", doc)).rejects.toThrow(
+      InvalidNamespaceError
+    );
+    await expect(store.search(["tenant:acme"])).rejects.toThrow(
+      InvalidNamespaceError
+    );
+  });
+
+  it("should not leak sibling namespaces that share a string prefix (issue 2721 / CVE-2026-71433)", async () => {
+    await store.put(["tenant", "acme"], "note", { text: "acme's own note" });
+    await store.put(["tenant", "acme-corp"], "secret", {
+      text: "acme-corp CONFIDENTIAL",
+    });
+    await store.put(["tenant", "acmex"], "other", { text: "acmex" });
+    await store.put(["tenant", "acme", "child"], "nested", { text: "child" });
+
+    const scoped = await store.search(["tenant", "acme"], { limit: 100 });
+    const namespaces = scoped.map((item) => item.namespace.join(":")).sort();
+    expect(namespaces).toEqual(["tenant:acme", "tenant:acme:child"]);
+    expect(scoped.find((item) => item.key === "secret")).toBeUndefined();
+    expect(await store.get(["tenant", "acme"], "secret")).toBeNull();
+
+    const empty = await store.search([], { limit: 100 });
+    expect(empty).toHaveLength(4);
+
+    const fo = await store.search(["fo"], { limit: 100 });
+    expect(fo).toHaveLength(0);
+  });
+
+  it("search prefix match is segment-wise, including empty prefix", async () => {
+    const fixtures: string[][] = [
+      ["foo"],
+      ["foo", "child"],
+      ["foo", "child", "deep"],
+      ["foobar"],
+      ["foobar", "baz"],
+      ["foo2"],
+    ];
+    for (const ns of fixtures) {
+      await store.put(ns, "k", { v: 1 });
+    }
+
+    const isSegmentPrefix = (query: string[], ns: string[]): boolean => {
+      if (query.length === 0) return true;
+      if (query.length > ns.length) return false;
+      return query.every((part, i) => part === ns[i]);
+    };
+
+    const queries: string[][] = [
+      [],
+      ["foo"],
+      ["foo", "child"],
+      ["foobar"],
+      ["foo2"],
+      ["fo"],
+      ["foo", "nope"],
+    ];
+
+    for (const query of queries) {
+      const got = new Set(
+        (await store.search(query, { limit: 100 })).map((item) =>
+          item.namespace.join("\0")
+        )
+      );
+      const expected = new Set(
+        fixtures
+          .filter((ns) => isSegmentPrefix(query, ns))
+          .map((ns) => ns.join("\0"))
+      );
+      expect(got, `query ${JSON.stringify(query)}`).toEqual(expected);
+    }
+  });
+
   it("should block invalid namespaces", async () => {
     const doc = { foo: "bar" };
 
@@ -232,4 +307,21 @@ describe("InMemoryStore Namespace Operations", () => {
     const batchDeletedResult = await store.get(["valid", "namespace"], "key");
     expect(batchDeletedResult).toBeNull();
   });
+});
+
+
+it("rejects namespace aliases through direct batch reads, writes and deletes", async () => {
+  const store = new InMemoryStore();
+  await store.put(["tenant", "a", "notes"], "key", { own: true });
+
+  for (const operation of [
+    { namespace: ["tenant", "a:notes"], key: "key" },
+    { namespace: ["tenant", "a:notes"], key: "key", value: { own: false } },
+    { namespace: ["tenant", "a:notes"], key: "key", value: null },
+    { namespacePrefix: ["tenant", "a:notes"] },
+  ]) {
+    await expect(store.batch([operation])).rejects.toThrow(/colons/);
+  }
+
+  expect((await store.get(["tenant", "a", "notes"], "key"))?.value).toEqual({ own: true });
 });

--- a/libs/checkpoint/src/tests/namespace.test.ts
+++ b/libs/checkpoint/src/tests/namespace.test.ts
@@ -232,13 +232,16 @@ describe("InMemoryStore Namespace Operations", () => {
       ["foobar", "baz"],
       ["foo2"],
     ];
+
     for (const ns of fixtures) {
       await store.put(ns, "k", { v: 1 });
     }
 
     const isSegmentPrefix = (query: string[], ns: string[]): boolean => {
       if (query.length === 0) return true;
+
       if (query.length > ns.length) return false;
+
       return query.every((part, i) => part === ns[i]);
     };
 
@@ -258,11 +261,13 @@ describe("InMemoryStore Namespace Operations", () => {
           item.namespace.join("\0")
         )
       );
+
       const expected = new Set(
         fixtures.flatMap((ns) =>
           isSegmentPrefix(query, ns) ? [ns.join("\0")] : []
         )
       );
+
       expect(got, `query ${JSON.stringify(query)}`).toEqual(expected);
     }
   });


### PR DESCRIPTION
Fix InMemoryStore searches returning sibling namespaces whose labels share a character prefix. Searches now include only the exact namespace and descendants; empty prefixes remain unrestricted. Reject colon aliases through public search/write and direct batch operations.

The original PR remains open; this PR does not replace or close it automatically. Related report: #2721.

Validation:
- All 89 checkpoint unit tests pass.
- Four namespace regressions fail against original implementation 039c5441; the corresponding fixed tests pass.
- Bundled InMemory isolation checks pass inside Node 24 Docker.
- Scoped lint passes. Package typecheck reports six existing argument-count errors in memory-pollution.test.ts; the same errors reproduce on baseline 039c5441. Source typechecking passes.

The colon restriction is local to InMemoryStore, preserving MongoDB colon-label compatibility. This draft is ready for code review; merge still requires normal maintainer approval and CI. No anti-slop tooling is included.

Stack: this PR is based on #2825 (Postgres). It contains only the checkpoint/InMemory portion adapted from @devtechedge's #2803

Co-authored-by: Dev M [294291171+devtechedge@users.noreply.github.com](mailto:294291171+devtechedge@users.noreply.github.com)