### PR TITLE
feat(sdk): expose stream connection lifecycle

### DIFF
--- a/.changeset/fix-root-stream-recovery.md
+++ b/.changeset/fix-root-stream-recovery.md
@@ -1,0 +1,7 @@
+---
+"@langchain/langgraph-sdk": patch
+---
+
+Recover cleanly when a thread's root event stream terminates unexpectedly.
+
+If the stream fails or closes while a run is active, the controller now records the transport error and clears `isLoading` rather than leaving the UI in a permanently running state. Once the failed pump settles, a later submission can start a fresh root subscription without recreating the thread stream or replaying the failed command.

--- a/.changeset/stream-connection-lifecycle.md
+++ b/.changeset/stream-connection-lifecycle.md
@@ -6,4 +6,8 @@
 "@langchain/angular": minor
 ---
 
-Expose successful stream connections through `onConnected`, include the scheduled delay in `onReconnect`, and allow stream controllers to restart their root pump after a fatal transport failure.
+Expose connection lifecycle callbacks for built-in streaming transports.
+
+`onConnected` runs after the initial SSE or WebSocket connection becomes usable and after every successful reconnect. Its payload distinguishes an `initial` connection from a `reconnected` connection and includes the reconnect attempt number.
+
+`onReconnect` now also receives the scheduled `delayMs`, allowing applications to display accurate retry state before the next connection attempt. React, Vue, Svelte, and Angular stream hooks forward both callbacks.

--- a/.changeset/stream-connection-lifecycle.md
+++ b/.changeset/stream-connection-lifecycle.md
@@ -1,0 +1,9 @@
+---
+"@langchain/langgraph-sdk": minor
+"@langchain/react": minor
+"@langchain/vue": minor
+"@langchain/svelte": minor
+"@langchain/angular": minor
+---
+
+Expose successful stream connections through `onConnected`, include the scheduled delay in `onReconnect`, and allow stream controllers to restart their root pump after a fatal transport failure.

--- a/libs/sdk-angular/src/use-stream.ts
+++ b/libs/sdk-angular/src/use-stream.ts
@@ -449,7 +449,15 @@ export function useStream<
     maxReconnectAttempts?: number;
     streamIdleReconnect?: number | "auto";
     reconnectDelayMs?: (attempt: number) => number;
-    onReconnect?: (options: { attempt: number; cause: unknown }) => void;
+    onReconnect?: (options: {
+      attempt: number;
+      cause: unknown;
+      delayMs: number;
+    }) => void;
+    onConnected?: (options: {
+      kind: "initial" | "reconnected";
+      attempt: number;
+    }) => void | Promise<void>;
     onThreadId?: (threadId: string) => void;
     onCreated?: (info: RunExecutionInfo) => void;
     onCompleted?: (info: RunCompletedInfo) => void;

--- a/libs/sdk-angular/src/use-stream.ts
+++ b/libs/sdk-angular/src/use-stream.ts
@@ -518,6 +518,7 @@ export function useStream<
       : asBag.streamIdleReconnect,
     reconnectDelayMs: hasCustomAdapter ? undefined : asBag.reconnectDelayMs,
     onReconnect: hasCustomAdapter ? undefined : asBag.onReconnect,
+    onConnected: hasCustomAdapter ? undefined : asBag.onConnected,
     onThreadId: options.onThreadId,
     onCreated: options.onCreated,
     onCompleted: options.onCompleted,

--- a/libs/sdk-react/src/use-stream.ts
+++ b/libs/sdk-react/src/use-stream.ts
@@ -487,7 +487,15 @@ export function useStream<
     maxReconnectAttempts?: number;
     streamIdleReconnect?: number | "auto";
     reconnectDelayMs?: (attempt: number) => number;
-    onReconnect?: (options: { attempt: number; cause: unknown }) => void;
+    onReconnect?: (options: {
+      attempt: number;
+      cause: unknown;
+      delayMs: number;
+    }) => void;
+    onConnected?: (options: {
+      kind: "initial" | "reconnected";
+      attempt: number;
+    }) => void | Promise<void>;
     onThreadId?: (threadId: string) => void;
     onCreated?: (info: RunExecutionInfo) => void;
     onCompleted?: (info: RunCompletedInfo) => void;

--- a/libs/sdk-react/src/use-stream.ts
+++ b/libs/sdk-react/src/use-stream.ts
@@ -599,6 +599,7 @@ export function useStream<
           : asBag.streamIdleReconnect,
         reconnectDelayMs: hasCustomAdapter ? undefined : asBag.reconnectDelayMs,
         onReconnect: hasCustomAdapter ? undefined : asBag.onReconnect,
+        onConnected: hasCustomAdapter ? undefined : asBag.onConnected,
         onThreadId: options.onThreadId,
         onCreated: options.onCreated,
         onCompleted: options.onCompleted,

--- a/libs/sdk-svelte/src/use-stream.svelte.ts
+++ b/libs/sdk-svelte/src/use-stream.svelte.ts
@@ -454,7 +454,15 @@ export function useStream<
     maxReconnectAttempts?: number;
     streamIdleReconnect?: number | "auto";
     reconnectDelayMs?: (attempt: number) => number;
-    onReconnect?: (options: { attempt: number; cause: unknown }) => void;
+    onReconnect?: (options: {
+      attempt: number;
+      cause: unknown;
+      delayMs: number;
+    }) => void;
+    onConnected?: (options: {
+      kind: "initial" | "reconnected";
+      attempt: number;
+    }) => void | Promise<void>;
     onThreadId?: (threadId: string) => void;
     onCreated?: (info: RunExecutionInfo) => void;
     onCompleted?: (info: RunCompletedInfo) => void;

--- a/libs/sdk-svelte/src/use-stream.svelte.ts
+++ b/libs/sdk-svelte/src/use-stream.svelte.ts
@@ -516,6 +516,7 @@ export function useStream<
       : asBag.streamIdleReconnect,
     reconnectDelayMs: hasCustomAdapter ? undefined : asBag.reconnectDelayMs,
     onReconnect: hasCustomAdapter ? undefined : asBag.onReconnect,
+    onConnected: hasCustomAdapter ? undefined : asBag.onConnected,
     onThreadId: options.onThreadId,
     onCreated: options.onCreated,
     onCompleted: options.onCompleted,

--- a/libs/sdk-vue/src/use-stream.ts
+++ b/libs/sdk-vue/src/use-stream.ts
@@ -471,7 +471,15 @@ export function useStream<
     maxReconnectAttempts?: number;
     streamIdleReconnect?: number | "auto";
     reconnectDelayMs?: (attempt: number) => number;
-    onReconnect?: (options: { attempt: number; cause: unknown }) => void;
+    onReconnect?: (options: {
+      attempt: number;
+      cause: unknown;
+      delayMs: number;
+    }) => void;
+    onConnected?: (options: {
+      kind: "initial" | "reconnected";
+      attempt: number;
+    }) => void | Promise<void>;
     onThreadId?: (threadId: string) => void;
     onCreated?: (info: RunExecutionInfo) => void;
     onCompleted?: (info: RunCompletedInfo) => void;

--- a/libs/sdk-vue/src/use-stream.ts
+++ b/libs/sdk-vue/src/use-stream.ts
@@ -555,6 +555,7 @@ export function useStream<
       : asBag.streamIdleReconnect,
     reconnectDelayMs: hasCustomAdapter ? undefined : asBag.reconnectDelayMs,
     onReconnect: hasCustomAdapter ? undefined : asBag.onReconnect,
+    onConnected: hasCustomAdapter ? undefined : asBag.onConnected,
     onThreadId: options.onThreadId,
     onCreated: options.onCreated,
     onCompleted: options.onCompleted,

--- a/libs/sdk/src/client/stream/transport/http.test.ts
+++ b/libs/sdk/src/client/stream/transport/http.test.ts
@@ -366,6 +366,7 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
   it("reconnects after a mid-stream failure when a custom auth fetch is supplied", async () => {
     let streamOpens = 0;
     const onReconnect = vi.fn();
+    const onConnected = vi.fn();
     const encoder = new TextEncoder();
     const fetchImpl = vi.fn((input: URL | RequestInfo) => {
       if (!String(input).includes("/stream/events")) {
@@ -427,6 +428,7 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
       maxReconnectAttempts: 3,
       reconnectDelayMs: () => 0,
       onReconnect,
+      onConnected,
       idleReconnect: 0,
     });
 
@@ -440,7 +442,15 @@ describe("ProtocolSseTransportAdapter SSE reconnect with custom fetch", () => {
     }
 
     expect(received.map((m) => m.event_id)).toContain("e2");
-    expect(onReconnect).toHaveBeenCalledTimes(1);
+    expect(onReconnect).toHaveBeenCalledWith({
+      attempt: 1,
+      cause: expect.any(TypeError),
+      delayMs: 0,
+    });
+    expect(onConnected.mock.calls.map(([info]) => info)).toEqual([
+      { kind: "initial", attempt: 0 },
+      { kind: "reconnected", attempt: 1 },
+    ]);
     expect(streamOpens).toBe(2);
 
     const streamBodies = streamEventBodies(fetchImpl);

--- a/libs/sdk/src/client/stream/transport/http.ts
+++ b/libs/sdk/src/client/stream/transport/http.ts
@@ -66,6 +66,8 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
 
   private readonly onReconnect?: ProtocolSseTransportOptions["onReconnect"];
 
+  private readonly onConnected?: ProtocolSseTransportOptions["onConnected"];
+
   private readonly reconnectDelayMs: (attempt: number) => number;
 
   private readonly paths?: ProtocolTransportPaths;
@@ -94,6 +96,7 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
     // disable.
     this.idleReconnect = options.idleReconnect ?? DEFAULT_IDLE_RECONNECT;
     this.onReconnect = options.onReconnect;
+    this.onConnected = options.onConnected;
     this.reconnectDelayMs = options.reconnectDelayMs ?? reconnectDelayMs;
     this.threadId = options.threadId ?? "";
     this.paths = options.paths;
@@ -302,6 +305,11 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
             );
           }
 
+          await this.onConnected?.({
+            kind: attempt === 0 ? "initial" : "reconnected",
+            attempt,
+          });
+
           if (!readySettled) {
             readySettled = true;
             resolveReady();
@@ -380,8 +388,8 @@ export class ProtocolSseTransportAdapter implements TransportAdapter {
             streamQueue.close(toError(error));
             return;
           }
-          this.onReconnect?.({ attempt, cause: error });
           const delay = this.reconnectDelayMs(attempt);
+          this.onReconnect?.({ attempt, cause: error, delayMs: delay });
           if (delay > 0) {
             await new Promise<void>((resolve) => {
               setTimeout(resolve, delay);

--- a/libs/sdk/src/client/stream/transport/types.ts
+++ b/libs/sdk/src/client/stream/transport/types.ts
@@ -1,6 +1,7 @@
 import type { CommandResponse, ErrorResponse } from "@langchain/protocol";
 import type { AsyncCaller } from "../../../utils/async_caller.js";
 import type { IdleReconnectMode } from "../../../utils/stream.js";
+import type { ConnectedInfo, ReconnectInfo } from "../../../utils/reconnect.js";
 
 export type ProtocolRequestHook = (
   url: URL,
@@ -74,8 +75,10 @@ export interface ProtocolSseTransportOptions {
    * @see {@link IdleReconnectMode}
    */
   idleReconnect?: IdleReconnectMode;
-  /** Called before each SSE reconnect attempt (after backoff delay). */
-  onReconnect?: (options: { attempt: number; cause: unknown }) => void;
+  /** Called before each SSE reconnect attempt with its scheduled delay. */
+  onReconnect?: (options: ReconnectInfo) => void;
+  /** Called after the initial SSE connection and every successful reconnect. */
+  onConnected?: (options: ConnectedInfo) => void | Promise<void>;
   /**
    * Backoff before each SSE reconnect attempt. Defaults to
    * `reconnectDelayMs` from `utils/reconnect`.
@@ -100,10 +103,10 @@ export interface ProtocolWebSocketTransportOptions {
    * Set to 0 to disable automatic reconnection.
    */
   maxReconnectAttempts?: number;
-  /**
-   * Called before each reconnect attempt (after backoff delay).
-   */
-  onReconnect?: (options: { attempt: number; cause: unknown }) => void;
+  /** Called before each reconnect attempt with its scheduled delay. */
+  onReconnect?: (options: ReconnectInfo) => void;
+  /** Called after the initial connection and every successful reconnect. */
+  onConnected?: (options: ConnectedInfo) => void | Promise<void>;
   /**
    * Invoked after the socket has been re-established. Use to restore
    * server-side subscription state (see `ThreadStream`).

--- a/libs/sdk/src/client/stream/transport/websocket.test.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.test.ts
@@ -221,12 +221,14 @@ describe("ProtocolWebSocketTransportAdapter reconnection", () => {
   it("reconnects after an unexpected close and keeps the events iterator alive", async () => {
     let connections = 0;
     const reconnected = vi.fn();
+    const onConnected = vi.fn();
 
     const transport = new ProtocolWebSocketTransportAdapter({
       apiUrl: "http://localhost:8123",
       threadId: "thread-1",
       maxReconnectAttempts: 3,
       onReconnected: reconnected,
+      onConnected,
       webSocketFactory: (url) => {
         connections += 1;
         const socket = new FakeWebSocket(url);
@@ -262,6 +264,10 @@ describe("ProtocolWebSocketTransportAdapter reconnection", () => {
     await vi.runAllTimersAsync();
     expect(connections).toBe(2);
     expect(reconnected).toHaveBeenCalledTimes(1);
+    expect(onConnected.mock.calls.map(([info]) => info)).toEqual([
+      { kind: "initial", attempt: 0 },
+      { kind: "reconnected", attempt: 1 },
+    ]);
 
     const first = await firstPromise;
     expect(first.done).toBe(false);

--- a/libs/sdk/src/client/stream/transport/websocket.test.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.test.ts
@@ -227,6 +227,7 @@ describe("ProtocolWebSocketTransportAdapter reconnection", () => {
       apiUrl: "http://localhost:8123",
       threadId: "thread-1",
       maxReconnectAttempts: 3,
+      reconnectDelayMs: () => 0,
       onReconnected: reconnected,
       onConnected,
       webSocketFactory: (url) => {

--- a/libs/sdk/src/client/stream/transport/websocket.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.ts
@@ -150,8 +150,7 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
     this.onReconnected = handler;
   }
 
-  async open(): Promise<void> {
-    const reconnecting = this.reconnectInFlight != null;
+  async open(reconnecting = false): Promise<void> {
     if (this.closed) {
       throw new Error("Protocol WebSocket transport is closed.");
     }
@@ -416,7 +415,7 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
       }
 
       try {
-        await this.open();
+        await this.open(true);
         if (this.onReconnected) {
           await this.onReconnected();
         }

--- a/libs/sdk/src/client/stream/transport/websocket.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.ts
@@ -150,7 +150,8 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
     this.onReconnected = handler;
   }
 
-  async open(reconnecting = false): Promise<void> {
+  async open(): Promise<void> {
+    const reconnecting = this.reconnectInFlight != null;
     if (this.closed) {
       throw new Error("Protocol WebSocket transport is closed.");
     }
@@ -389,9 +390,11 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
       return;
     }
 
-    this.reconnectInFlight = this.#runReconnectLoop(cause).finally(() => {
-      this.reconnectInFlight = null;
-    });
+    this.reconnectInFlight = Promise.resolve()
+      .then(() => this.#runReconnectLoop(cause))
+      .finally(() => {
+        this.reconnectInFlight = null;
+      });
   }
 
   async #runReconnectLoop(initialCause: unknown): Promise<void> {
@@ -415,7 +418,7 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
       }
 
       try {
-        await this.open(true);
+        await this.open();
         if (this.onReconnected) {
           await this.onReconnected();
         }

--- a/libs/sdk/src/client/stream/transport/websocket.ts
+++ b/libs/sdk/src/client/stream/transport/websocket.ts
@@ -26,6 +26,7 @@ import { MaxWebSocketReconnectAttemptsError } from "../error.js";
 import {
   DEFAULT_MAX_RECONNECT_ATTEMPTS,
   reconnectDelayMs,
+  type ReconnectInfo,
 } from "../../../utils/reconnect.js";
 
 const WEB_SOCKET_CONNECTING = 0;
@@ -43,10 +44,8 @@ export interface WebSocketReconnectOptions {
    */
   maxReconnectAttempts?: number;
 
-  /**
-   * Invoked before each reconnect attempt (after backoff).
-   */
-  onReconnect?: (options: { attempt: number; cause: unknown }) => void;
+  /** Invoked before each reconnect attempt with its scheduled delay. */
+  onReconnect?: (options: ReconnectInfo) => void;
 }
 
 /**
@@ -81,6 +80,8 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
 
   private readonly onReconnect?: ProtocolWebSocketTransportOptions["onReconnect"];
 
+  private readonly onConnected?: ProtocolWebSocketTransportOptions["onConnected"];
+
   private readonly reconnectDelayMs: (attempt: number) => number;
 
   private onReconnected?: () => void | Promise<void>;
@@ -106,6 +107,7 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
     this.maxReconnectAttempts =
       options.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS;
     this.onReconnect = options.onReconnect;
+    this.onConnected = options.onConnected;
     this.onReconnected = options.onReconnected;
     this.reconnectDelayMs = options.reconnectDelayMs ?? reconnectDelayMs;
   }
@@ -149,6 +151,7 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
   }
 
   async open(): Promise<void> {
+    const reconnecting = this.reconnectInFlight != null;
     if (this.closed) {
       throw new Error("Protocol WebSocket transport is closed.");
     }
@@ -187,6 +190,10 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
       socket.addEventListener("open", onOpen, { once: true });
       socket.addEventListener("error", onError, { once: true });
     });
+
+    if (!reconnecting) {
+      await this.onConnected?.({ kind: "initial", attempt: 0 });
+    }
   }
 
   async send(
@@ -396,9 +403,8 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
         return;
       }
 
-      this.onReconnect?.({ attempt, cause: lastError });
-
       const delay = this.reconnectDelayMs(attempt);
+      this.onReconnect?.({ attempt, cause: lastError, delayMs: delay });
       if (delay > 0) {
         await new Promise<void>((resolve) => {
           setTimeout(resolve, delay);
@@ -414,6 +420,7 @@ export class ProtocolWebSocketTransportAdapter implements TransportAdapter {
         if (this.onReconnected) {
           await this.onReconnected();
         }
+        await this.onConnected?.({ kind: "reconnected", attempt });
         return;
       } catch (error) {
         lastError = error;

--- a/libs/sdk/src/client/stream/types.ts
+++ b/libs/sdk/src/client/stream/types.ts
@@ -24,6 +24,8 @@ import type { AgentServerAdapter } from "./transport.js";
 import {
   DEFAULT_MAX_RECONNECT_ATTEMPTS,
   reconnectDelayMs,
+  type ConnectedInfo,
+  type ReconnectInfo,
 } from "../../utils/reconnect.js";
 
 export {
@@ -166,10 +168,10 @@ export interface ThreadStreamOptions {
    * Defaults to {@link reconnectDelayMs}.
    */
   reconnectDelayMs?: (attempt: number) => number;
-  /**
-   * Built-in transports only: invoked before each reconnect attempt.
-   */
-  onReconnect?: (options: { attempt: number; cause: unknown }) => void;
+  /** Built-in transports only: invoked before each reconnect attempt. */
+  onReconnect?: (options: ReconnectInfo) => void;
+  /** Built-in transports only: invoked after every usable connection. */
+  onConnected?: (options: ConnectedInfo) => void | Promise<void>;
 }
 
 export interface SessionOrderingState {

--- a/libs/sdk/src/client/threads/index.ts
+++ b/libs/sdk/src/client/threads/index.ts
@@ -528,6 +528,7 @@ export class ThreadsClient<
         maxReconnectAttempts,
         reconnectDelayMs: options.reconnectDelayMs,
         onReconnect: options.onReconnect,
+        onConnected: options.onConnected,
       };
 
       transport =

--- a/libs/sdk/src/stream/controller.test.ts
+++ b/libs/sdk/src/stream/controller.test.ts
@@ -3505,6 +3505,65 @@ describe("StreamController", () => {
     await controller.dispose();
   });
 
+  it("restarts the root pump after a thread stream failure", async () => {
+    const errorListeners = new Set<(error: Error) => void>();
+    const subscriptions: ReturnType<typeof makePushableSubscription>[] = [];
+    let run = 0;
+    const submitRun = vi.fn(async () => ({ run_id: `run-${++run}` }));
+    const thread = {
+      subscribe: vi.fn(async () => {
+        const subscription = makePushableSubscription();
+        subscriptions.push(subscription);
+        return subscription;
+      }),
+      onError: vi.fn((listener: (error: Error) => void) => {
+        errorListeners.add(listener);
+        return vi.fn(() => errorListeners.delete(listener));
+      }),
+      onEvent: vi.fn(() => vi.fn()),
+      close: vi.fn(async () => undefined),
+      interrupts: [],
+      ordering: {},
+      submitRun,
+      startLifecycleWatcher: vi.fn(() => undefined),
+    } as unknown as ThreadStream;
+    const client = {
+      threads: {
+        getState: vi.fn(async () => ({ values: {}, next: ["agent"] })),
+        stream: vi.fn(() => thread),
+      },
+    };
+
+    const controller = new StreamController<State, unknown>({
+      assistantId: "agent",
+      client: client as never,
+      threadId: "thread-1",
+    });
+    await controller.hydrationPromise;
+    await subscriptions[0]?.started;
+
+    const failedSubmit = controller.submit(null);
+    await waitForExpectation(() => expect(submitRun).toHaveBeenCalledTimes(1));
+    for (const listener of errorListeners) {
+      listener(new Error("Thread event stream failed: redis gone"));
+    }
+    await failedSubmit;
+    await waitForExpectation(() => expect(errorListeners.size).toBe(0));
+
+    const nextSubmit = controller.submit(null);
+    await waitForExpectation(() => expect(thread.subscribe).toHaveBeenCalledTimes(2));
+    await subscriptions[1]?.started;
+    subscriptions[1]?.push(lifecycleEvent("completed", 2));
+    await nextSubmit;
+
+    expect(client.threads.stream).toHaveBeenCalledTimes(1);
+    expect(submitRun).toHaveBeenCalledTimes(2);
+    expect(controller.rootStore.getSnapshot().error).toBeUndefined();
+    expect(controller.rootStore.getSnapshot().isLoading).toBe(false);
+
+    await controller.dispose();
+  });
+
   it("respond() surfaces a failed resumed run on rootStore.error", async () => {
     let onEvent: ((event: Event) => void) | undefined;
     const respondInput = vi.fn(async () => undefined);

--- a/libs/sdk/src/stream/controller.ts
+++ b/libs/sdk/src/stream/controller.ts
@@ -1658,7 +1658,12 @@ export class StreamController<
    *   still required.
    */
   #ensureThread(threadId: string, deferRootPump = false): ThreadStream {
-    if (this.#thread != null) return this.#thread;
+    if (this.#thread != null) {
+      if (!deferRootPump && !this.#rootPumpDeferred && this.#rootPump == null) {
+        this.#startRootPump(this.#thread);
+      }
+      return this.#thread;
+    }
     this.#thread = this.#options.client.threads.stream(threadId, {
       assistantId: this.#options.assistantId,
       transport: this.#options.transport,
@@ -1668,6 +1673,7 @@ export class StreamController<
       streamIdleReconnect: this.#options.streamIdleReconnect,
       reconnectDelayMs: this.#options.reconnectDelayMs,
       onReconnect: this.#options.onReconnect,
+      onConnected: this.#options.onConnected,
     });
     this.registry.bind(this.#thread);
     if (deferRootPump) {
@@ -1838,6 +1844,7 @@ export class StreamController<
     );
     this.#threadErrorUnsubscribe = thread.onError((error) => {
       this.rootStore.setState((s) => ({ ...s, error, isLoading: false }));
+      this.#rootSubscription?.close();
     });
 
     /**
@@ -1851,7 +1858,7 @@ export class StreamController<
     this.#rootEventListeners.add(this.#lifecycleLoading.listener);
     this.#rootEventListeners.add(this.#runLifecycleListener);
 
-    this.#rootPump = (async () => {
+    const pump = (async () => {
       try {
         /**
          * Root content pump: depth 1 is required because the controller
@@ -1957,6 +1964,16 @@ export class StreamController<
             break;
           }
           if (!subscription.isPaused) {
+            const snapshot = this.rootStore.getSnapshot();
+            if (snapshot.isLoading && snapshot.error == null) {
+              this.rootStore.setState((s) => ({
+                ...s,
+                error: new Error(
+                  "Thread event stream closed before the active run completed."
+                ),
+                isLoading: false,
+              }));
+            }
             break;
           }
           await subscription.waitForResume();
@@ -1967,6 +1984,21 @@ export class StreamController<
         /* thread closed or errored */
       }
     })();
+    this.#rootPump = pump;
+    void pump.finally(() => {
+      if (pumpGeneration !== this.#rootPumpGeneration) return;
+      if (this.#rootPump !== pump) return;
+      this.#rootPumpGeneration += 1;
+      this.#rootSubscription = undefined;
+      this.#rootPump = undefined;
+      this.#rootPumpReady = undefined;
+      this.#threadEventUnsubscribe?.();
+      this.#threadEventUnsubscribe = undefined;
+      this.#threadErrorUnsubscribe?.();
+      this.#threadErrorUnsubscribe = undefined;
+      this.#rootEventListeners.delete(this.#lifecycleLoading.listener);
+      this.#rootEventListeners.delete(this.#runLifecycleListener);
+    });
   }
 
   /**

--- a/libs/sdk/src/stream/types.ts
+++ b/libs/sdk/src/stream/types.ts
@@ -239,6 +239,8 @@ export interface AgentServerOptions<
   reconnectDelayMs?: ThreadStreamOptions["reconnectDelayMs"];
   /** Built-in transports only: invoked before each reconnect attempt. */
   onReconnect?: ThreadStreamOptions["onReconnect"];
+  /** Built-in transports only: invoked after every usable connection. */
+  onConnected?: ThreadStreamOptions["onConnected"];
 }
 
 /**
@@ -273,6 +275,7 @@ export interface CustomAdapterOptions<
   streamIdleReconnect?: never;
   reconnectDelayMs?: never;
   onReconnect?: never;
+  onConnected?: never;
 }
 
 /**
@@ -388,6 +391,8 @@ export interface StreamControllerOptions<
   reconnectDelayMs?: ThreadStreamOptions["reconnectDelayMs"];
   /** Built-in transports only: invoked before each reconnect attempt. */
   onReconnect?: ThreadStreamOptions["onReconnect"];
+  /** Built-in transports only: invoked after every usable connection. */
+  onConnected?: ThreadStreamOptions["onConnected"];
   /** Called when a thread id is first produced (new-thread submits). */
   onThreadId?: (threadId: string) => void;
   /**

--- a/libs/sdk/src/utils/reconnect.ts
+++ b/libs/sdk/src/utils/reconnect.ts
@@ -4,6 +4,17 @@
  * legacy and v2 clients do not diverge.
  */
 
+export interface ReconnectInfo {
+  attempt: number;
+  cause: unknown;
+  delayMs: number;
+}
+
+export interface ConnectedInfo {
+  kind: "initial" | "reconnected";
+  attempt: number;
+}
+
 /** Default max reconnect / retry attempts after an unexpected disconnect. */
 export const DEFAULT_MAX_RECONNECT_ATTEMPTS = 5;
 


### PR DESCRIPTION
Fixes #2817

### Summary

- expose `onConnected` after initial and restored SSE/WebSocket connections
- include the scheduled delay in `onReconnect` so UIs can render retry state
- restart a settled root event pump on later submissions and clear `isLoading` when an active stream closes fatally
- forward lifecycle callbacks through React, Vue, Svelte, and Angular stream hooks

### Testing

- `pnpm --filter @langchain/langgraph-sdk test -- src/client/stream/transport/http.test.ts src/client/stream/transport/websocket.test.ts src/stream/controller.test.ts` (800 tests passed; no type errors)
- `pnpm exec oxlint <changed source files>`
- `pnpm exec oxfmt --check <changed files>`
- `pnpm turbo build:internal --filter=@langchain/langgraph-sdk --filter=@langchain/react --filter=@langchain/vue --filter=@langchain/svelte --filter=@langchain/angular` (11 tasks successful; existing fixture TS2883 diagnostics were emitted during declaration generation)

Made by [Open SWE](https://openswe.vercel.app/agents/094c8665-f733-5261-a25f-17392be76491) · openai:gpt-5.6-sol (high)

## References
- Plan: https://openswe.vercel.app/agents/094c8665-f733-5261-a25f-17392be76491/plan

Co-authored-by: Huangshuo Kuang <141250392+kkkhs@users.noreply.github.com>